### PR TITLE
Add CLI adapters for Claude and Codex

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -1,0 +1,45 @@
+import type { ChildProcess } from "node:child_process";
+
+export type AgentStatus = "success" | "error";
+
+export type AgentErrorType =
+  | "max_turns"
+  | "execution_error"
+  | "cli_not_found"
+  | "unknown";
+
+export interface AgentResult {
+  sessionId: string | undefined;
+  responseText: string;
+  status: AgentStatus;
+  errorType: AgentErrorType | undefined;
+  /** stderr output from the CLI process, useful for error diagnostics. */
+  stderrText: string;
+}
+
+export interface AgentStream {
+  /** Async iterator that yields output chunks as they arrive. */
+  [Symbol.asyncIterator](): AsyncIterator<string>;
+
+  /**
+   * Resolves when the process exits with the final structured result.
+   * Consuming the iterator is optional; `result` always resolves.
+   */
+  result: Promise<AgentResult>;
+
+  /** The underlying child process, exposed for cancellation. */
+  child: ChildProcess;
+}
+
+export interface AgentAdapter {
+  invoke(prompt: string, options?: InvokeOptions): AgentStream;
+  resume(
+    sessionId: string,
+    prompt: string,
+    options?: InvokeOptions,
+  ): AgentStream;
+}
+
+export interface InvokeOptions {
+  cwd?: string;
+}

--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "vitest";
+import { buildClaudeArgs, parseClaudeResponse } from "./claude-adapter.js";
+
+// ---------------------------------------------------------------------------
+// parseClaudeResponse
+// ---------------------------------------------------------------------------
+describe("parseClaudeResponse", () => {
+  test("parses successful response", () => {
+    const json = JSON.stringify({
+      session_id: "sess-abc-123",
+      result: "Hello, world!",
+      subtype: "success",
+      is_error: false,
+    });
+
+    expect(parseClaudeResponse(json)).toEqual({
+      sessionId: "sess-abc-123",
+      responseText: "Hello, world!",
+      status: "success",
+      errorType: undefined,
+      stderrText: "",
+    });
+  });
+
+  test("parses error_max_turns response", () => {
+    const json = JSON.stringify({
+      session_id: "sess-xyz",
+      result: "Reached maximum number of turns",
+      subtype: "error_max_turns",
+      is_error: true,
+    });
+
+    expect(parseClaudeResponse(json)).toEqual({
+      sessionId: "sess-xyz",
+      responseText: "Reached maximum number of turns",
+      status: "error",
+      errorType: "max_turns",
+      stderrText: "",
+    });
+  });
+
+  test("parses error_during_execution response", () => {
+    const json = JSON.stringify({
+      session_id: "sess-err",
+      result: "Command failed",
+      subtype: "error_during_execution",
+      is_error: true,
+    });
+
+    expect(parseClaudeResponse(json)).toEqual({
+      sessionId: "sess-err",
+      responseText: "Command failed",
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "",
+    });
+  });
+
+  test("maps unknown error subtype to 'unknown'", () => {
+    const json = JSON.stringify({
+      session_id: "sess-unk",
+      result: "Something went wrong",
+      subtype: "error_something_new",
+      is_error: true,
+    });
+
+    const result = parseClaudeResponse(json);
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("unknown");
+  });
+
+  test("treats empty session_id as undefined", () => {
+    const json = JSON.stringify({
+      session_id: "",
+      result: "response",
+      subtype: "success",
+      is_error: false,
+    });
+
+    expect(parseClaudeResponse(json).sessionId).toBeUndefined();
+  });
+
+  test("treats null result as empty string", () => {
+    const json = JSON.stringify({
+      session_id: "sess-1",
+      result: null,
+      subtype: "success",
+      is_error: false,
+    });
+
+    expect(parseClaudeResponse(json).responseText).toBe("");
+  });
+
+  test("throws on invalid JSON", () => {
+    expect(() => parseClaudeResponse("not json")).toThrow();
+  });
+
+  test("preserves multiline result text", () => {
+    const json = JSON.stringify({
+      session_id: "sess-ml",
+      result: "line 1\nline 2\nline 3",
+      subtype: "success",
+      is_error: false,
+    });
+
+    expect(parseClaudeResponse(json).responseText).toBe(
+      "line 1\nline 2\nline 3",
+    );
+  });
+
+  test("preserves unicode in result text", () => {
+    const json = JSON.stringify({
+      session_id: "sess-u",
+      result: "한국어 테스트 🎉",
+      subtype: "success",
+      is_error: false,
+    });
+
+    expect(parseClaudeResponse(json).responseText).toBe("한국어 테스트 🎉");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildClaudeArgs
+// ---------------------------------------------------------------------------
+describe("buildClaudeArgs", () => {
+  test("builds basic args with auto permission mode", () => {
+    const args = buildClaudeArgs("do something", {
+      permissionMode: "auto",
+    });
+
+    expect(args).toEqual([
+      "-p",
+      "do something",
+      "--output-format",
+      "json",
+      "--permission-mode",
+      "auto",
+    ]);
+  });
+
+  test("builds args with bypass permission mode", () => {
+    const args = buildClaudeArgs("prompt", {
+      permissionMode: "bypass",
+    });
+
+    expect(args).toContain("--permission-mode");
+    expect(args).toContain("bypassPermissions");
+  });
+
+  test("includes --model when model is specified", () => {
+    const args = buildClaudeArgs("prompt", {
+      model: "opus",
+      permissionMode: "auto",
+    });
+
+    expect(args).toContain("--model");
+    expect(args).toContain("opus");
+  });
+
+  test("omits --model when model is undefined", () => {
+    const args = buildClaudeArgs("prompt", {
+      permissionMode: "auto",
+    });
+
+    expect(args).not.toContain("--model");
+  });
+
+  test("includes --resume when sessionId is given", () => {
+    const args = buildClaudeArgs(
+      "continue",
+      { permissionMode: "auto" },
+      "sess-123",
+    );
+
+    expect(args).toContain("--resume");
+    expect(args).toContain("sess-123");
+  });
+
+  test("omits --resume when sessionId is undefined", () => {
+    const args = buildClaudeArgs("prompt", {
+      permissionMode: "auto",
+    });
+
+    expect(args).not.toContain("--resume");
+  });
+
+  test("combines all options together", () => {
+    const args = buildClaudeArgs(
+      "full prompt",
+      { model: "sonnet", permissionMode: "bypass" },
+      "sess-xyz",
+    );
+
+    expect(args).toEqual([
+      "-p",
+      "full prompt",
+      "--output-format",
+      "json",
+      "--model",
+      "sonnet",
+      "--permission-mode",
+      "bypassPermissions",
+      "--resume",
+      "sess-xyz",
+    ]);
+  });
+});

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -1,0 +1,120 @@
+import type {
+  AgentAdapter,
+  AgentErrorType,
+  AgentResult,
+  InvokeOptions,
+} from "./agent.js";
+import { spawnAgent } from "./spawn-agent.js";
+
+/**
+ * Shape of the final JSON object emitted by `claude -p --output-format json`.
+ */
+export interface ClaudeJsonResponse {
+  session_id: string;
+  result: string;
+  subtype: string;
+  is_error: boolean;
+}
+
+export function parseClaudeResponse(json: string): AgentResult {
+  const parsed: ClaudeJsonResponse = JSON.parse(json);
+  return {
+    sessionId: parsed.session_id || undefined,
+    responseText: parsed.result ?? "",
+    status: parsed.is_error ? "error" : "success",
+    errorType: parsed.is_error ? claudeErrorType(parsed.subtype) : undefined,
+    stderrText: "",
+  };
+}
+
+function claudeErrorType(subtype: string): AgentErrorType {
+  switch (subtype) {
+    case "error_max_turns":
+      return "max_turns";
+    case "error_during_execution":
+      return "execution_error";
+    default:
+      return "unknown";
+  }
+}
+
+export type ClaudePermissionMode = "auto" | "bypass";
+
+export interface ClaudeAdapterOptions {
+  model?: string;
+  permissionMode?: ClaudePermissionMode;
+}
+
+export function buildClaudeArgs(
+  prompt: string,
+  opts: { model?: string; permissionMode: ClaudePermissionMode },
+  sessionId?: string,
+): string[] {
+  const args = ["-p", prompt, "--output-format", "json"];
+  if (opts.model) {
+    args.push("--model", opts.model);
+  }
+  if (opts.permissionMode === "bypass") {
+    args.push("--permission-mode", "bypassPermissions");
+  } else {
+    args.push("--permission-mode", "auto");
+  }
+  if (sessionId) {
+    args.push("--resume", sessionId);
+  }
+  return args;
+}
+
+function parseClaudeOutput(
+  output: string,
+  code: number | null,
+  stderrText: string,
+): AgentResult {
+  if (code !== 0 && output.trim() === "") {
+    return {
+      sessionId: undefined,
+      responseText: `claude exited with code ${code}`,
+      status: "error",
+      errorType: "unknown",
+      stderrText,
+    };
+  }
+  try {
+    const result = parseClaudeResponse(output);
+    return { ...result, stderrText };
+  } catch {
+    return {
+      sessionId: undefined,
+      responseText: output,
+      status: "error",
+      errorType: "unknown",
+      stderrText,
+    };
+  }
+}
+
+export function createClaudeAdapter(
+  opts: ClaudeAdapterOptions = {},
+): AgentAdapter {
+  const model = opts.model;
+  const permissionMode = opts.permissionMode ?? "auto";
+
+  return {
+    invoke(prompt, options?: InvokeOptions) {
+      return spawnAgent({
+        command: "claude",
+        args: buildClaudeArgs(prompt, { model, permissionMode }),
+        cwd: options?.cwd,
+        parseResult: parseClaudeOutput,
+      });
+    },
+    resume(sessionId, prompt, options?: InvokeOptions) {
+      return spawnAgent({
+        command: "claude",
+        args: buildClaudeArgs(prompt, { model, permissionMode }, sessionId),
+        cwd: options?.cwd,
+        parseResult: parseClaudeOutput,
+      });
+    },
+  };
+}

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -1,0 +1,486 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildCodexInvokeArgs,
+  buildCodexResumeArgs,
+  extractCodexResumeResponse,
+  parseCodexJsonl,
+  parseCodexPlainText,
+} from "./codex-adapter.js";
+
+// ---------------------------------------------------------------------------
+// parseCodexJsonl — real `codex exec --json` JSONL format
+// ---------------------------------------------------------------------------
+describe("parseCodexJsonl", () => {
+  test("extracts thread_id and agent_message from JSONL events", () => {
+    const lines = [
+      JSON.stringify({
+        type: "thread.started",
+        thread_id: "019d46a1-d07f-7bc3-b96d-d50d44001c82",
+      }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "reasoning", text: "Thinking..." },
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_1", type: "agent_message", text: "4" },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 100, cached_input_tokens: 0, output_tokens: 5 },
+      }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(lines)).toEqual({
+      sessionId: "019d46a1-d07f-7bc3-b96d-d50d44001c82",
+      responseText: "4",
+      status: "success",
+      errorType: undefined,
+      stderrText: "",
+    });
+  });
+
+  test("uses last agent_message when multiple are present", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-2" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "first" },
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_1", type: "agent_message", text: "final answer" },
+      }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(lines).responseText).toBe("final answer");
+  });
+
+  test("ignores reasoning items for responseText", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-3" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "reasoning", text: "Let me think..." },
+      }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(lines).responseText).toBe("");
+  });
+
+  test("detects turn.failed and returns error", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-fail" }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "turn.failed",
+        error: { message: "unexpected status 400" },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.status).toBe("error");
+    expect(result.responseText).toBe("unexpected status 400");
+    expect(result.sessionId).toBe("sess-fail");
+  });
+
+  test("handles JSONL with only thread.started (no items)", () => {
+    const lines = JSON.stringify({
+      type: "thread.started",
+      thread_id: "sess-4",
+    });
+
+    const result = parseCodexJsonl(lines);
+    expect(result.sessionId).toBe("sess-4");
+    expect(result.responseText).toBe("");
+    expect(result.status).toBe("success");
+  });
+
+  test("ignores blank lines in input", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-6" }),
+      "",
+      "  ",
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "ok" },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.sessionId).toBe("sess-6");
+    expect(result.responseText).toBe("ok");
+  });
+
+  test("throws on invalid JSON line", () => {
+    expect(() => parseCodexJsonl("not json")).toThrow();
+  });
+
+  test("handles missing thread.started (sessionId is undefined)", () => {
+    const lines = JSON.stringify({
+      type: "item.completed",
+      item: { id: "item_0", type: "agent_message", text: "no thread" },
+    });
+
+    const result = parseCodexJsonl(lines);
+    expect(result.sessionId).toBeUndefined();
+    expect(result.responseText).toBe("no thread");
+  });
+
+  test("captures first thread_id only", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "first-id" }),
+      JSON.stringify({ type: "thread.started", thread_id: "second-id" }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(lines).sessionId).toBe("first-id");
+  });
+
+  test("ignores unknown event types gracefully", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-unk" }),
+      JSON.stringify({ type: "some.future.event", data: 123 }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "hello" },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.responseText).toBe("hello");
+    expect(result.status).toBe("success");
+  });
+
+  test("detects error events with retry messages", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-retry" }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "error",
+        message: "stream error: unexpected status 400; retrying 1/5",
+      }),
+      JSON.stringify({
+        type: "turn.failed",
+        error: { message: "unexpected status 400" },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.status).toBe("error");
+    expect(result.sessionId).toBe("sess-retry");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCodexResumeResponse
+// ---------------------------------------------------------------------------
+describe("extractCodexResumeResponse", () => {
+  const BANNER = [
+    "OpenAI Codex v0.46.0 (research preview)",
+    "--------",
+    "workdir: /some/path",
+    "model: gpt-5.4",
+    "provider: openai",
+    "approval: never",
+    "sandbox: read-only",
+    "reasoning effort: high",
+    "reasoning summaries: auto",
+    "session id: 019d46a1-d07f-7bc3-b96d-d50d44001c82",
+    "--------",
+  ].join("\n");
+
+  test("extracts response from full resume output", () => {
+    const text = [
+      BANNER,
+      "user",
+      "What is 2+2?",
+      "codex",
+      "4",
+      "tokens used",
+      "229",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe("4");
+  });
+
+  test("extracts multiline response", () => {
+    const text = [
+      BANNER,
+      "user",
+      "Explain briefly",
+      "codex",
+      "Line 1",
+      "Line 2",
+      "Line 3",
+      "tokens used",
+      "500",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe("Line 1\nLine 2\nLine 3");
+  });
+
+  test("returns trimmed text when no codex marker found", () => {
+    expect(extractCodexResumeResponse("  raw output  ")).toBe("raw output");
+  });
+
+  test("handles missing tokens used footer", () => {
+    const text = [BANNER, "user", "prompt", "codex", "answer only"].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe("answer only");
+  });
+
+  test("handles empty response between markers", () => {
+    const text = [
+      BANNER,
+      "user",
+      "prompt",
+      "codex",
+      "",
+      "tokens used",
+      "100",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseCodexPlainText
+// ---------------------------------------------------------------------------
+describe("parseCodexPlainText", () => {
+  test("parses successful plain text response with banner stripping", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "workdir: /path",
+      "model: gpt-5.4",
+      "session id: sess-1",
+      "--------",
+      "user",
+      "Question",
+      "codex",
+      "Answer",
+      "tokens used",
+      "100",
+    ].join("\n");
+
+    const result = parseCodexPlainText(text, 0, "");
+    expect(result.responseText).toBe("Answer");
+    expect(result.status).toBe("success");
+  });
+
+  test("returns raw text on failure (no banner stripping)", () => {
+    const result = parseCodexPlainText("Error: something broke", 1, "");
+    expect(result.responseText).toBe("Error: something broke");
+    expect(result.status).toBe("error");
+  });
+
+  test("detects 'max turns' keyword as max_turns error", () => {
+    const result = parseCodexPlainText("Error: max turns reached", 1, "");
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("max_turns");
+  });
+
+  test("detects 'turn limit' keyword as max_turns error", () => {
+    const result = parseCodexPlainText("Stopped: turn limit exceeded", 1, "");
+    expect(result.errorType).toBe("max_turns");
+  });
+
+  test("detects 'error during execution' keyword", () => {
+    const result = parseCodexPlainText(
+      "error during execution of command",
+      1,
+      "",
+    );
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("execution_error");
+  });
+
+  test("detects 'execution error' keyword", () => {
+    const result = parseCodexPlainText("An execution error occurred", 1, "");
+    expect(result.errorType).toBe("execution_error");
+  });
+
+  test("keyword detection is case-insensitive", () => {
+    expect(parseCodexPlainText("MAX TURNS reached", 1, "").errorType).toBe(
+      "max_turns",
+    );
+    expect(parseCodexPlainText("Error During Execution", 1, "").errorType).toBe(
+      "execution_error",
+    );
+  });
+
+  test("detects error keywords from stderr when stdout is clean", () => {
+    const result = parseCodexPlainText(
+      "no keywords here",
+      1,
+      "error during execution",
+    );
+    expect(result.errorType).toBe("execution_error");
+  });
+
+  test("returns unknown error for non-zero exit without keywords", () => {
+    const result = parseCodexPlainText("something failed", 1, "");
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("unknown");
+  });
+
+  test("handles null exit code as error", () => {
+    const result = parseCodexPlainText("killed", null, "");
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("unknown");
+  });
+
+  test("handles empty output on success", () => {
+    const result = parseCodexPlainText("", 0, "");
+    expect(result.responseText).toBe("");
+    expect(result.status).toBe("success");
+  });
+
+  test("handles empty output on failure", () => {
+    const result = parseCodexPlainText("", 1, "");
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("unknown");
+  });
+
+  test("sessionId is always undefined for plain text", () => {
+    expect(parseCodexPlainText("response", 0, "").sessionId).toBeUndefined();
+    expect(parseCodexPlainText("error", 1, "").sessionId).toBeUndefined();
+  });
+
+  test("includes stderrText in result", () => {
+    const result = parseCodexPlainText("output", 0, "some warning");
+    expect(result.stderrText).toBe("some warning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCodexInvokeArgs
+// ---------------------------------------------------------------------------
+describe("buildCodexInvokeArgs", () => {
+  test("builds invoke args with default options", () => {
+    const args = buildCodexInvokeArgs("do something", {});
+
+    expect(args).toEqual([
+      "exec",
+      "-s",
+      "danger-full-access",
+      "--json",
+      "do something",
+    ]);
+  });
+
+  test("includes -m when model is specified", () => {
+    const args = buildCodexInvokeArgs("prompt", { model: "gpt-5.4" });
+
+    expect(args).toContain("-m");
+    expect(args).toContain("gpt-5.4");
+    // prompt comes after model
+    expect(args.indexOf("gpt-5.4")).toBeLessThan(args.indexOf("prompt"));
+  });
+
+  test("omits -m when model is undefined", () => {
+    const args = buildCodexInvokeArgs("prompt", {});
+    expect(args).not.toContain("-m");
+    expect(args).not.toContain("--model");
+  });
+
+  test("does not include -a flag (not supported by CLI)", () => {
+    const args = buildCodexInvokeArgs("prompt", {});
+    expect(args).not.toContain("-a");
+    expect(args).not.toContain("never");
+  });
+
+  test("includes -c reasoning effort when specified", () => {
+    const args = buildCodexInvokeArgs("prompt", {
+      reasoningEffort: "high",
+    });
+
+    expect(args).toContain("-c");
+    expect(args).toContain("model_reasoning_effort=high");
+    // -c value comes before the prompt
+    expect(args.indexOf("model_reasoning_effort=high")).toBeLessThan(
+      args.indexOf("prompt"),
+    );
+  });
+
+  test("omits reasoning effort when undefined", () => {
+    const args = buildCodexInvokeArgs("prompt", {});
+    const reArgs = args.filter((a) => a.includes("model_reasoning_effort"));
+    expect(reArgs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildCodexResumeArgs
+// ---------------------------------------------------------------------------
+describe("buildCodexResumeArgs", () => {
+  test("always includes -c sandbox_mode=danger-full-access", () => {
+    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+
+    expect(args).toContain("-c");
+    expect(args).toContain("sandbox_mode=danger-full-access");
+  });
+
+  test("includes -c model override when model is specified", () => {
+    const args = buildCodexResumeArgs("sess-abc", "continue", {
+      model: "gpt-5.3-codex",
+    });
+
+    expect(args).toContain("-c");
+    expect(args).toContain('model="gpt-5.3-codex"');
+  });
+
+  test("omits model override when model is undefined", () => {
+    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+
+    const modelArgs = args.filter((a) => a.startsWith('model="'));
+    expect(modelArgs).toHaveLength(0);
+  });
+
+  test("places session ID and prompt after config flags", () => {
+    const args = buildCodexResumeArgs("sess-abc", "continue", {
+      model: "gpt-5.4",
+    });
+
+    const sessIdx = args.indexOf("sess-abc");
+    const promptIdx = args.indexOf("continue");
+    expect(sessIdx).toBeGreaterThan(0);
+    expect(promptIdx).toBe(sessIdx + 1);
+    // Both should come after all -c flags
+    const lastCIdx = args.lastIndexOf("-c");
+    expect(sessIdx).toBeGreaterThan(lastCIdx + 1);
+  });
+
+  test("does not include --json (resume outputs plain text)", () => {
+    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+    expect(args).not.toContain("--json");
+  });
+
+  test("does not include -s flag (uses -c for sandbox instead)", () => {
+    const args = buildCodexResumeArgs("sess-1", "prompt", {});
+    expect(args).not.toContain("-s");
+  });
+
+  test("does not include -m flag (uses -c for model instead)", () => {
+    const args = buildCodexResumeArgs("sess-1", "prompt", {
+      model: "gpt-5.4",
+    });
+    expect(args).not.toContain("-m");
+  });
+
+  test("includes -c reasoning effort when specified", () => {
+    const args = buildCodexResumeArgs("sess-1", "prompt", {
+      reasoningEffort: "medium",
+    });
+
+    expect(args).toContain("model_reasoning_effort=medium");
+  });
+
+  test("omits reasoning effort when undefined", () => {
+    const args = buildCodexResumeArgs("sess-1", "prompt", {});
+    const reArgs = args.filter((a) => a.includes("model_reasoning_effort"));
+    expect(reArgs).toHaveLength(0);
+  });
+});

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -1,0 +1,292 @@
+import type {
+  AgentAdapter,
+  AgentErrorType,
+  AgentResult,
+  InvokeOptions,
+} from "./agent.js";
+import { spawnAgent } from "./spawn-agent.js";
+
+// ---------------------------------------------------------------------------
+// JSONL event types emitted by `codex exec --json`
+// ---------------------------------------------------------------------------
+
+/**
+ * `{"type":"thread.started","thread_id":"UUID"}`
+ */
+interface ThreadStartedEvent {
+  type: "thread.started";
+  thread_id: string;
+}
+
+/**
+ * `{"type":"item.completed","item":{"id":"item_N","type":"agent_message"|"reasoning","text":"..."}}`
+ */
+interface ItemCompletedEvent {
+  type: "item.completed";
+  item: { id: string; type: string; text: string };
+}
+
+/**
+ * `{"type":"turn.failed","error":{"message":"..."}}`
+ */
+interface TurnFailedEvent {
+  type: "turn.failed";
+  error: { message: string };
+}
+
+/**
+ * `{"type":"error","message":"..."}`
+ */
+interface ErrorEvent {
+  type: "error";
+  message: string;
+}
+
+export type CodexJsonEvent =
+  | ThreadStartedEvent
+  | ItemCompletedEvent
+  | TurnFailedEvent
+  | ErrorEvent
+  | { type: string };
+
+// ---------------------------------------------------------------------------
+// JSONL parser (codex exec --json)
+// ---------------------------------------------------------------------------
+
+export function parseCodexJsonl(jsonl: string): AgentResult {
+  const lines = jsonl
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  let sessionId: string | undefined;
+  let responseText = "";
+  let failed = false;
+  let failMessage = "";
+
+  for (const line of lines) {
+    const event: CodexJsonEvent = JSON.parse(line);
+
+    if (event.type === "thread.started") {
+      const e = event as ThreadStartedEvent;
+      if (!sessionId) {
+        sessionId = e.thread_id;
+      }
+    }
+
+    if (event.type === "item.completed") {
+      const e = event as ItemCompletedEvent;
+      if (e.item.type === "agent_message") {
+        responseText = e.item.text;
+      }
+    }
+
+    if (event.type === "turn.failed") {
+      const e = event as TurnFailedEvent;
+      failed = true;
+      failMessage = e.error.message;
+    }
+  }
+
+  if (failed) {
+    return {
+      sessionId,
+      responseText: failMessage,
+      status: "error",
+      errorType: detectCodexError(failMessage),
+      stderrText: "",
+    };
+  }
+
+  return {
+    sessionId,
+    responseText,
+    status: "success",
+    errorType: undefined,
+    stderrText: "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plain text parser (codex exec resume)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the assistant response from `codex exec resume` plain text output.
+ *
+ * The output looks like:
+ * ```
+ * OpenAI Codex v0.46.0 (research preview)
+ * --------
+ * workdir: ...
+ * model: ...
+ * ...
+ * session id: UUID
+ * --------
+ * user
+ * <prompt>
+ * codex
+ * <response>
+ * tokens used
+ * <count>
+ * ```
+ *
+ * We extract the text between the last "codex\n" marker and the
+ * trailing "tokens used\n" footer.
+ */
+export function extractCodexResumeResponse(text: string): string {
+  const codexMarker = "\ncodex\n";
+  const footerMarker = "\ntokens used\n";
+
+  const codexIdx = text.lastIndexOf(codexMarker);
+  if (codexIdx === -1) {
+    // Fallback: no recognizable structure, return trimmed text.
+    return text.trim();
+  }
+
+  const start = codexIdx + codexMarker.length;
+  const footerIdx = text.indexOf(footerMarker, start);
+  const end = footerIdx === -1 ? text.length : footerIdx;
+
+  return text.slice(start, end).trim();
+}
+
+export function parseCodexPlainText(
+  text: string,
+  exitCode: number | null,
+  stderrText: string,
+): AgentResult {
+  const failed = exitCode !== 0;
+  const responseText = failed ? text.trim() : extractCodexResumeResponse(text);
+  let errorType: AgentErrorType | undefined;
+  if (failed) {
+    errorType = detectCodexError(text + stderrText);
+  }
+  return {
+    sessionId: undefined,
+    responseText,
+    status: failed ? "error" : "success",
+    errorType,
+    stderrText,
+  };
+}
+
+function detectCodexError(text: string): AgentErrorType {
+  const lower = text.toLowerCase();
+  if (lower.includes("max turns") || lower.includes("turn limit")) {
+    return "max_turns";
+  }
+  if (
+    lower.includes("error during execution") ||
+    lower.includes("execution error")
+  ) {
+    return "execution_error";
+  }
+  return "unknown";
+}
+
+// ---------------------------------------------------------------------------
+// CLI args builders
+// ---------------------------------------------------------------------------
+
+export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high";
+
+export interface CodexAdapterOptions {
+  model?: string;
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+export function buildCodexInvokeArgs(
+  prompt: string,
+  opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
+): string[] {
+  const args = ["exec", "-s", "danger-full-access", "--json"];
+  if (opts.model) {
+    args.push("-m", opts.model);
+  }
+  if (opts.reasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${opts.reasoningEffort}`);
+  }
+  args.push(prompt);
+  return args;
+}
+
+export function buildCodexResumeArgs(
+  sessionId: string,
+  prompt: string,
+  opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
+): string[] {
+  const args = ["exec", "resume", "-c", "sandbox_mode=danger-full-access"];
+  if (opts.model) {
+    args.push("-c", `model="${opts.model}"`);
+  }
+  if (opts.reasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${opts.reasoningEffort}`);
+  }
+  args.push(sessionId, prompt);
+  return args;
+}
+
+// ---------------------------------------------------------------------------
+// parseResult callbacks
+// ---------------------------------------------------------------------------
+
+function parseCodexInvokeOutput(
+  output: string,
+  code: number | null,
+  stderrText: string,
+): AgentResult {
+  try {
+    const parsed = parseCodexJsonl(output);
+    const result = { ...parsed, stderrText };
+    if (code !== 0 && result.status === "success") {
+      return {
+        ...result,
+        status: "error",
+        errorType: detectCodexError(output + stderrText),
+      };
+    }
+    return result;
+  } catch {
+    return {
+      sessionId: undefined,
+      responseText: output,
+      status: code === 0 ? "success" : "error",
+      errorType: code === 0 ? undefined : "unknown",
+      stderrText,
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
+export function createCodexAdapter(
+  opts: CodexAdapterOptions = {},
+): AgentAdapter {
+  const model = opts.model;
+  const reasoningEffort = opts.reasoningEffort ?? "high";
+
+  return {
+    invoke(prompt, options?: InvokeOptions) {
+      return spawnAgent({
+        command: "codex",
+        args: buildCodexInvokeArgs(prompt, { model, reasoningEffort }),
+        cwd: options?.cwd,
+        parseResult: parseCodexInvokeOutput,
+      });
+    },
+    resume(sessionId, prompt, options?: InvokeOptions) {
+      return spawnAgent({
+        command: "codex",
+        args: buildCodexResumeArgs(sessionId, prompt, {
+          model,
+          reasoningEffort,
+        }),
+        cwd: options?.cwd,
+        parseResult: parseCodexPlainText,
+      });
+    },
+  };
+}

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1,0 +1,702 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import EventEmitter from "node:events";
+import { PassThrough } from "node:stream";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+const { spawnAgent } = await import("./spawn-agent.js");
+const { createClaudeAdapter } = await import("./claude-adapter.js");
+const { createCodexAdapter } = await import("./codex-adapter.js");
+
+const mockSpawn = vi.mocked(spawn);
+
+function createMockChild(): ChildProcess {
+  const child = new EventEmitter() as ChildProcess;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = null;
+  child.stdio = [null, child.stdout, child.stderr, null, null];
+  child.pid = 12345;
+  child.connected = false;
+  child.signalCode = null;
+  child.exitCode = null;
+  child.killed = false;
+  child.kill = vi.fn();
+  child.send = vi.fn();
+  child.disconnect = vi.fn();
+  child.unref = vi.fn();
+  child.ref = vi.fn();
+  child.serialize = "json";
+  child[Symbol.dispose] = vi.fn();
+  return child;
+}
+
+function emitStdout(child: ChildProcess, data: string): void {
+  (child.stdout as PassThrough).write(data);
+}
+
+function emitStderr(child: ChildProcess, data: string): void {
+  (child.stderr as PassThrough).write(data);
+}
+
+function endStdout(child: ChildProcess): void {
+  (child.stdout as PassThrough).end();
+}
+
+afterEach(() => {
+  mockSpawn.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// spawnAgent basics
+// ---------------------------------------------------------------------------
+describe("spawnAgent", () => {
+  test("passes command, args, and cwd to spawn", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    spawnAgent({
+      command: "test-cli",
+      args: ["--flag", "value"],
+      cwd: "/some/dir",
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    expect(mockSpawn).toHaveBeenCalledWith("test-cli", ["--flag", "value"], {
+      cwd: "/some/dir",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  });
+
+  test("resolves result with parsed stdout on exit 0", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "echo",
+      args: [],
+      parseResult: (output, code) => ({
+        sessionId: "s1",
+        responseText: output,
+        status: code === 0 ? "success" : "error",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    emitStdout(child, "hello ");
+    emitStdout(child, "world");
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result).toEqual({
+      sessionId: "s1",
+      responseText: "hello world",
+      status: "success",
+      errorType: undefined,
+      stderrText: "",
+    });
+  });
+
+  test("resolves result with non-zero exit code", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "fail",
+      args: [],
+      parseResult: (_output, code) => ({
+        sessionId: undefined,
+        responseText: "failed",
+        status: code === 0 ? "success" : "error",
+        errorType: "unknown",
+        stderrText: "",
+      }),
+    });
+
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+  });
+
+  test("resolves cli_not_found on ENOENT error", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "nonexistent",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const err = new Error("spawn nonexistent ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    child.emit("error", err);
+
+    const result = await stream.result;
+    expect(result).toEqual({
+      sessionId: undefined,
+      responseText: "nonexistent CLI not found",
+      status: "error",
+      errorType: "cli_not_found",
+      stderrText: "",
+    });
+  });
+
+  test("rejects on non-ENOENT spawn error", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const err = new Error("permission denied") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    child.emit("error", err);
+
+    await expect(stream.result).rejects.toThrow("permission denied");
+  });
+
+  test("passes only stdout to parseResult output param", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    let capturedOutput = "";
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output, _code, stderrText) => {
+        capturedOutput = output;
+        return {
+          sessionId: undefined,
+          responseText: output,
+          status: "success",
+          errorType: undefined,
+          stderrText,
+        };
+      },
+    });
+
+    emitStdout(child, "stdout data");
+    emitStderr(child, "stderr noise");
+    child.emit("close", 0);
+
+    await stream.result;
+    expect(capturedOutput).toBe("stdout data");
+  });
+
+  test("passes stderr to parseResult stderrText param", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    let capturedStderr = "";
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output, _code, stderrText) => {
+        capturedStderr = stderrText;
+        return {
+          sessionId: undefined,
+          responseText: output,
+          status: "success",
+          errorType: undefined,
+          stderrText,
+        };
+      },
+    });
+
+    emitStdout(child, "out");
+    emitStderr(child, "err msg");
+    child.emit("close", 0);
+
+    await stream.result;
+    expect(capturedStderr).toBe("err msg");
+  });
+
+  test("handles empty output (no stdout data before close)", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output, code) => ({
+        sessionId: undefined,
+        responseText: output,
+        status: code === 0 ? "success" : "error",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.responseText).toBe("");
+    expect(result.status).toBe("success");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Streaming
+// ---------------------------------------------------------------------------
+describe("streaming", () => {
+  test("async iterator yields all stdout data", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const chunks: string[] = [];
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    })();
+
+    const pt = child.stdout as PassThrough;
+    pt.write("chunk1");
+    pt.write("chunk2");
+    pt.write("chunk3");
+    pt.end();
+
+    child.emit("close", 0);
+    await iteratorDone;
+
+    // PassThrough may coalesce synchronous writes into one chunk,
+    // so verify concatenated content rather than chunk boundaries.
+    expect(chunks.join("")).toBe("chunk1chunk2chunk3");
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("result resolves even if iterator is not consumed", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => ({
+        sessionId: undefined,
+        responseText: output,
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    emitStdout(child, "data");
+    endStdout(child);
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.responseText).toBe("data");
+  });
+
+  test("exposes child process for cancellation", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    expect(stream.child).toBe(child);
+    expect(stream.child.kill).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2E: Claude adapter full flow
+// ---------------------------------------------------------------------------
+describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
+  test("invoke sends correct args and returns parsed result", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter({
+      model: "opus",
+      permissionMode: "auto",
+    });
+
+    const stream = adapter.invoke("write tests");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      expect.arrayContaining(["-p", "write tests", "--model", "opus"]),
+      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
+    );
+
+    const responseJson = JSON.stringify({
+      session_id: "sess-new",
+      result: "Done!",
+      subtype: "success",
+      is_error: false,
+    });
+    emitStdout(child, responseJson);
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.sessionId).toBe("sess-new");
+    expect(result.responseText).toBe("Done!");
+    expect(result.status).toBe("success");
+  });
+
+  test("resume includes --resume flag with session ID", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter({ permissionMode: "bypass" });
+    adapter.resume("sess-prev", "continue working");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      expect.arrayContaining([
+        "--resume",
+        "sess-prev",
+        "--permission-mode",
+        "bypassPermissions",
+      ]),
+      expect.anything(),
+    );
+  });
+
+  test("invoke with cwd passes working directory", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter();
+    adapter.invoke("prompt", { cwd: "/worktree/path" });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      expect.any(Array),
+      expect.objectContaining({ cwd: "/worktree/path" }),
+    );
+  });
+
+  test("handles non-JSON output gracefully", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter();
+    const stream = adapter.invoke("prompt");
+
+    emitStdout(child, "not valid json at all");
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("unknown");
+    expect(result.responseText).toBe("not valid json at all");
+  });
+
+  test("handles empty output with non-zero exit", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter();
+    const stream = adapter.invoke("prompt");
+
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.responseText).toContain("claude exited with code 1");
+  });
+
+  test("captures stderr in result on error", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter();
+    const stream = adapter.invoke("prompt");
+
+    emitStderr(child, "Error: invalid session");
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.stderrText).toBe("Error: invalid session");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2E: Codex adapter full flow
+// ---------------------------------------------------------------------------
+describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
+  test("invoke sends correct args and returns parsed JSONL result", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ model: "gpt-5.4" });
+    const stream = adapter.invoke("fix the bug");
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining([
+        "exec",
+        "-s",
+        "danger-full-access",
+        "--json",
+        "-m",
+        "gpt-5.4",
+        "-c",
+        "model_reasoning_effort=high",
+      ]),
+      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
+    );
+
+    const jsonl = [
+      JSON.stringify({
+        type: "thread.started",
+        thread_id: "codex-sess-1",
+      }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "Fixed!" },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+    ].join("\n");
+
+    emitStdout(child, jsonl);
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.sessionId).toBe("codex-sess-1");
+    expect(result.responseText).toBe("Fixed!");
+    expect(result.status).toBe("success");
+  });
+
+  test("invoke does not include -a flag", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    adapter.invoke("prompt");
+
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).not.toContain("-a");
+    expect(spawnArgs).not.toContain("never");
+  });
+
+  test("defaults reasoning effort to high when not specified", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    adapter.invoke("prompt");
+
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("model_reasoning_effort=high");
+  });
+
+  test("invoke passes reasoning effort via -c", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ reasoningEffort: "high" });
+    adapter.invoke("prompt");
+
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("-c");
+    expect(spawnArgs).toContain("model_reasoning_effort=high");
+  });
+
+  test("resume passes reasoning effort via -c", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ reasoningEffort: "medium" });
+    adapter.resume("sess-1", "continue");
+
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("model_reasoning_effort=medium");
+  });
+
+  test("resume uses plain text parsing with -c config overrides", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ model: "gpt-5.3-codex" });
+    const stream = adapter.resume("sess-prev", "keep going");
+
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("resume");
+    expect(spawnArgs).toContain("sess-prev");
+    expect(spawnArgs).toContain("-c");
+    expect(spawnArgs).toContain("sandbox_mode=danger-full-access");
+    expect(spawnArgs).toContain('model="gpt-5.3-codex"');
+    expect(spawnArgs).toContain("model_reasoning_effort=high");
+    expect(spawnArgs).not.toContain("--json");
+    expect(spawnArgs).not.toContain("-m");
+
+    const resumeOutput = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "workdir: /tmp",
+      "model: gpt-5.4",
+      "session id: sess-prev",
+      "--------",
+      "user",
+      "keep going",
+      "codex",
+      "Continued work done.",
+      "tokens used",
+      "150",
+    ].join("\n");
+
+    emitStdout(child, resumeOutput);
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.responseText).toBe("Continued work done.");
+    expect(result.status).toBe("success");
+    expect(result.sessionId).toBeUndefined();
+  });
+
+  test("resume detects error keywords in plain text", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-1", "continue");
+
+    emitStdout(child, "Error: max turns reached");
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("max_turns");
+  });
+
+  test("invoke with cwd passes working directory", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    adapter.invoke("prompt", { cwd: "/worktree/path" });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "codex",
+      expect.any(Array),
+      expect.objectContaining({ cwd: "/worktree/path" }),
+    );
+  });
+
+  test("invoke with non-zero exit marks result as error", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.invoke("prompt");
+
+    const jsonl = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-fail" }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "turn.failed",
+        error: { message: "API error" },
+      }),
+    ].join("\n");
+
+    emitStdout(child, jsonl);
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.sessionId).toBe("sess-fail");
+  });
+
+  test("invoke handles invalid JSONL output gracefully on success", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.invoke("prompt");
+
+    emitStdout(child, "not json");
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.status).toBe("success");
+    expect(result.responseText).toBe("not json");
+  });
+
+  test("invoke handles invalid JSONL output with non-zero exit", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.invoke("prompt");
+
+    emitStdout(child, "garbage output");
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("unknown");
+    expect(result.responseText).toBe("garbage output");
+  });
+
+  test("captures stderr in result for diagnostics", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-1", "continue");
+
+    emitStderr(child, "unexpected argument '--model'");
+    child.emit("close", 2);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.stderrText).toBe("unexpected argument '--model'");
+  });
+});

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -1,0 +1,69 @@
+import { spawn } from "node:child_process";
+import type { AgentResult, AgentStream } from "./agent.js";
+
+export interface SpawnAgentOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  parseResult: (
+    output: string,
+    exitCode: number | null,
+    stderrText: string,
+  ) => AgentResult;
+}
+
+export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
+  const child = spawn(opts.command, opts.args, {
+    cwd: opts.cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const { stdout, stderr } = child;
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  const result = new Promise<AgentResult>((resolve, reject) => {
+    stdout?.on("data", (data: Buffer) => {
+      stdoutChunks.push(data.toString());
+    });
+
+    stderr?.on("data", (data: Buffer) => {
+      stderrChunks.push(data.toString());
+    });
+
+    child.on("error", (err) => {
+      if ("code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
+        resolve({
+          sessionId: undefined,
+          responseText: `${opts.command} CLI not found`,
+          status: "error",
+          errorType: "cli_not_found",
+          stderrText: "",
+        });
+      } else {
+        reject(err);
+      }
+    });
+
+    child.on("close", (code) => {
+      const output = stdoutChunks.join("");
+      const stderrText = stderrChunks.join("");
+      resolve(opts.parseResult(output, code, stderrText));
+    });
+  });
+
+  const stream: AgentStream = {
+    async *[Symbol.asyncIterator]() {
+      if (!stdout) return;
+      for await (const chunk of stdout) {
+        const text =
+          typeof chunk === "string" ? chunk : (chunk as Buffer).toString();
+        yield text;
+      }
+    },
+    result,
+    child,
+  };
+
+  return stream;
+}


### PR DESCRIPTION
## Summary

- Introduce `AgentAdapter` interface with `invoke`/`resume` returning `AgentStream` (async iterator + `Promise<AgentResult>`)
- Add Claude adapter: `claude -p --output-format json`, `--permission-mode`, `--resume`, status detection via `subtype` field
- Add Codex adapter: `codex exec --json` for invoke, `codex exec resume` for continuation (plain text), `-c` config overrides for sandbox_mode, model, and model_reasoning_effort
- Extract shared `spawnAgent` helper to eliminate duplication between adapters
- Support working directory (`cwd`) for running CLI from worktree paths

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm check` (Biome lint/format) passes
- [x] `pnpm test` passes — 195 tests total, 90 new:
  - Unit: `parseClaudeResponse` (9), `parseCodexJsonl` (11), `extractCodexResumeResponse` (5), `parseCodexPlainText` (14)
  - Args: `buildClaudeArgs` (7), `buildCodexInvokeArgs` (6), `buildCodexResumeArgs` (9)
  - Infra: `spawnAgent` basics (8), streaming (3)
  - E2E (mock spawn): Claude invoke/resume (6), Codex invoke/resume (12)

Closes #4