### PR TITLE
Add pipeline engine and loop control

### DIFF
--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -1,0 +1,311 @@
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const {
+  evaluateCiRuns,
+  normaliseCiConclusion,
+  fetchCiRuns,
+  getCiStatus,
+  collectFailureLogs,
+} = await import("./ci.js");
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+afterEach(() => {
+  mockExecFileSync.mockReset();
+});
+
+// ---- helpers -------------------------------------------------------------
+
+function run(
+  overrides: Partial<{
+    databaseId: number;
+    name: string;
+    status: string;
+    conclusion: string;
+    headBranch: string;
+  }> = {},
+) {
+  return {
+    databaseId: 1,
+    name: "CI",
+    status: "completed",
+    conclusion: "success",
+    headBranch: "main",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// normaliseCiConclusion
+// ---------------------------------------------------------------------------
+describe("normaliseCiConclusion", () => {
+  test("in_progress → pending", () => {
+    expect(normaliseCiConclusion(run({ status: "in_progress" }))).toBe(
+      "pending",
+    );
+  });
+
+  test("queued → pending", () => {
+    expect(normaliseCiConclusion(run({ status: "queued" }))).toBe("pending");
+  });
+
+  test("waiting → pending", () => {
+    expect(normaliseCiConclusion(run({ status: "waiting" }))).toBe("pending");
+  });
+
+  test("requested → pending", () => {
+    expect(normaliseCiConclusion(run({ status: "requested" }))).toBe("pending");
+  });
+
+  test("pending status → pending", () => {
+    expect(normaliseCiConclusion(run({ status: "pending" }))).toBe("pending");
+  });
+
+  test("completed + success → success", () => {
+    expect(normaliseCiConclusion(run())).toBe("success");
+  });
+
+  test("completed + neutral → success", () => {
+    expect(normaliseCiConclusion(run({ conclusion: "neutral" }))).toBe(
+      "success",
+    );
+  });
+
+  test("completed + skipped → skipped", () => {
+    expect(normaliseCiConclusion(run({ conclusion: "skipped" }))).toBe(
+      "skipped",
+    );
+  });
+
+  test("completed + cancelled → cancelled", () => {
+    expect(normaliseCiConclusion(run({ conclusion: "cancelled" }))).toBe(
+      "cancelled",
+    );
+  });
+
+  test("completed + failure → failure", () => {
+    expect(normaliseCiConclusion(run({ conclusion: "failure" }))).toBe(
+      "failure",
+    );
+  });
+
+  test("completed + unknown conclusion → failure", () => {
+    expect(normaliseCiConclusion(run({ conclusion: "timed_out" }))).toBe(
+      "failure",
+    );
+  });
+
+  test("handles mixed case", () => {
+    expect(normaliseCiConclusion(run({ status: "In_Progress" }))).toBe(
+      "pending",
+    );
+    expect(normaliseCiConclusion(run({ conclusion: "SUCCESS" }))).toBe(
+      "success",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateCiRuns
+// ---------------------------------------------------------------------------
+describe("evaluateCiRuns", () => {
+  test("all success → pass", () => {
+    expect(evaluateCiRuns([run(), run()])).toBe("pass");
+  });
+
+  test("empty array → pass", () => {
+    expect(evaluateCiRuns([])).toBe("pass");
+  });
+
+  test("all skipped → pass", () => {
+    expect(
+      evaluateCiRuns([
+        run({ conclusion: "skipped" }),
+        run({ conclusion: "skipped" }),
+      ]),
+    ).toBe("pass");
+  });
+
+  test("any failure → fail", () => {
+    expect(evaluateCiRuns([run(), run({ conclusion: "failure" })])).toBe(
+      "fail",
+    );
+  });
+
+  test("any cancelled → fail", () => {
+    expect(evaluateCiRuns([run(), run({ conclusion: "cancelled" })])).toBe(
+      "fail",
+    );
+  });
+
+  test("pending without failure → pending", () => {
+    expect(evaluateCiRuns([run(), run({ status: "in_progress" })])).toBe(
+      "pending",
+    );
+  });
+
+  test("failure takes precedence over pending", () => {
+    expect(
+      evaluateCiRuns([
+        run({ status: "in_progress" }),
+        run({ conclusion: "failure" }),
+      ]),
+    ).toBe("fail");
+  });
+
+  test("mix of success and skipped → pass", () => {
+    expect(evaluateCiRuns([run(), run({ conclusion: "skipped" })])).toBe(
+      "pass",
+    );
+  });
+
+  test("neutral conclusion → pass", () => {
+    expect(evaluateCiRuns([run({ conclusion: "neutral" })])).toBe("pass");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCiRuns
+// ---------------------------------------------------------------------------
+describe("fetchCiRuns", () => {
+  test("calls gh with correct arguments", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    fetchCiRuns("org", "repo", "issue-5");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "run",
+        "list",
+        "--repo",
+        "org/repo",
+        "--branch",
+        "issue-5",
+        "--json",
+        "databaseId,name,status,conclusion,headBranch",
+        "--limit",
+        "20",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("parses JSON output", () => {
+    const runs = [run({ databaseId: 100, name: "build" })];
+    mockExecFileSync.mockReturnValue(JSON.stringify(runs));
+    expect(fetchCiRuns("org", "repo", "main")).toEqual(runs);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCiStatus
+// ---------------------------------------------------------------------------
+describe("getCiStatus", () => {
+  test("returns pass verdict for successful runs", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify([run()]));
+    const status = getCiStatus("org", "repo", "main");
+    expect(status.verdict).toBe("pass");
+    expect(status.runs).toHaveLength(1);
+  });
+
+  test("returns fail verdict for failed runs", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify([run({ conclusion: "failure" })]),
+    );
+    expect(getCiStatus("org", "repo", "main").verdict).toBe("fail");
+  });
+
+  test("returns pending verdict for in-progress runs", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify([run({ status: "in_progress" })]),
+    );
+    expect(getCiStatus("org", "repo", "main").verdict).toBe("pending");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// collectFailureLogs
+// ---------------------------------------------------------------------------
+describe("collectFailureLogs", () => {
+  test("calls gh run view with --log-failed", () => {
+    mockExecFileSync.mockReturnValue("error log output");
+    const logs = collectFailureLogs("org", "repo", 12345);
+    expect(logs).toBe("error log output");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      ["run", "view", "12345", "--repo", "org/repo", "--log-failed"],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("propagates error when gh command fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("run not found");
+    });
+    expect(() => collectFailureLogs("org", "repo", 999)).toThrow(
+      "run not found",
+    );
+  });
+
+  test("returns empty string when logs are empty", () => {
+    mockExecFileSync.mockReturnValue("");
+    expect(collectFailureLogs("org", "repo", 1)).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// edge cases
+// ---------------------------------------------------------------------------
+describe("edge cases", () => {
+  test("evaluateCiRuns with only pending runs → pending", () => {
+    expect(
+      evaluateCiRuns([
+        run({ status: "queued" }),
+        run({ status: "in_progress" }),
+      ]),
+    ).toBe("pending");
+  });
+
+  test("cancelled takes precedence over pending", () => {
+    expect(
+      evaluateCiRuns([
+        run({ status: "in_progress" }),
+        run({ conclusion: "cancelled" }),
+      ]),
+    ).toBe("fail");
+  });
+
+  test("getCiStatus with empty runs returns pass", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    const status = getCiStatus("org", "repo", "main");
+    expect(status.verdict).toBe("pass");
+    expect(status.runs).toEqual([]);
+  });
+
+  test("normaliseCiConclusion handles null status", () => {
+    const r = run({ status: undefined as unknown as string });
+    expect(normaliseCiConclusion(r)).toBe("success");
+  });
+
+  test("normaliseCiConclusion handles null conclusion", () => {
+    const r = run({ conclusion: undefined as unknown as string });
+    expect(normaliseCiConclusion(r)).toBe("failure");
+  });
+
+  test("normaliseCiConclusion handles null status and conclusion", () => {
+    const r = run({
+      status: undefined as unknown as string,
+      conclusion: undefined as unknown as string,
+    });
+    expect(normaliseCiConclusion(r)).toBe("failure");
+  });
+
+  test("fetchCiRuns returns empty array on malformed JSON", () => {
+    mockExecFileSync.mockReturnValue("not json");
+    expect(fetchCiRuns("org", "repo", "main")).toEqual([]);
+  });
+});

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -1,0 +1,159 @@
+/**
+ * CI status polling and failure log collection.
+ *
+ * Wraps `gh run list` and `gh run view` to determine whether CI checks
+ * pass for a given branch/commit.  Reusable by stages 5, 7, and 8.
+ */
+
+import { execFileSync } from "node:child_process";
+
+// ---- public types --------------------------------------------------------
+
+export type CheckConclusion =
+  | "success"
+  | "failure"
+  | "cancelled"
+  | "skipped"
+  | "pending"
+  | "neutral";
+
+export interface CiRun {
+  databaseId: number;
+  name: string;
+  status: string;
+  conclusion: string;
+  headBranch: string;
+}
+
+export type CiVerdict = "pass" | "fail" | "pending";
+
+export interface CiStatus {
+  verdict: CiVerdict;
+  /** Individual check runs used to compute the verdict. */
+  runs: CiRun[];
+}
+
+// ---- CI pass criteria ----------------------------------------------------
+
+/**
+ * Evaluate a set of CI runs against the pass criteria:
+ *
+ * - `success` / `neutral` / `skipped` → pass
+ * - `pending` (status = "in_progress" | "queued" | "waiting") → pending
+ * - `cancelled` → failure
+ * - `failure` → failure
+ *
+ * Overall verdict:
+ * - If **any** run is `failure` or `cancelled` → `"fail"`
+ * - Else if **any** run is `pending` → `"pending"`
+ * - Otherwise → `"pass"`
+ */
+export function evaluateCiRuns(runs: CiRun[]): CiVerdict {
+  let hasPending = false;
+
+  for (const run of runs) {
+    const conclusion = normaliseCiConclusion(run);
+
+    if (conclusion === "failure" || conclusion === "cancelled") {
+      return "fail";
+    }
+    if (conclusion === "pending") {
+      hasPending = true;
+    }
+  }
+
+  return hasPending ? "pending" : "pass";
+}
+
+/**
+ * Derive a normalised conclusion from a run's status and conclusion
+ * fields.  GitHub's API uses `status` for in-flight runs and
+ * `conclusion` once finished.
+ */
+export function normaliseCiConclusion(run: CiRun): CheckConclusion {
+  const status = (run.status ?? "").toLowerCase();
+  if (
+    status === "in_progress" ||
+    status === "queued" ||
+    status === "waiting" ||
+    status === "pending" ||
+    status === "requested"
+  ) {
+    return "pending";
+  }
+
+  const conclusion = (run.conclusion ?? "").toLowerCase();
+  if (conclusion === "success" || conclusion === "neutral") return "success";
+  if (conclusion === "skipped") return "skipped";
+  if (conclusion === "cancelled") return "cancelled";
+  // Empty conclusion with a completed status means something went wrong.
+  return "failure";
+}
+
+// ---- gh CLI wrappers -----------------------------------------------------
+
+/**
+ * Fetch the latest CI runs for `branch` in `owner/repo`.
+ */
+export function fetchCiRuns(
+  owner: string,
+  repo: string,
+  branch: string,
+): CiRun[] {
+  const output = execFileSync(
+    "gh",
+    [
+      "run",
+      "list",
+      "--repo",
+      `${owner}/${repo}`,
+      "--branch",
+      branch,
+      "--json",
+      "databaseId,name,status,conclusion,headBranch",
+      "--limit",
+      "20",
+    ],
+    { encoding: "utf-8" },
+  );
+  try {
+    return JSON.parse(output);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Fetch CI status for a branch, returning the overall verdict.
+ */
+export function getCiStatus(
+  owner: string,
+  repo: string,
+  branch: string,
+): CiStatus {
+  const runs = fetchCiRuns(owner, repo, branch);
+  return { verdict: evaluateCiRuns(runs), runs };
+}
+
+/**
+ * Collect failure logs for a specific run ID.
+ */
+export function collectFailureLogs(
+  owner: string,
+  repo: string,
+  runId: number,
+): string {
+  const output = execFileSync(
+    "gh",
+    [
+      "run",
+      "view",
+      String(runId),
+      "--repo",
+      `${owner}/${repo}`,
+      "--log-failed",
+    ],
+    { encoding: "utf-8" },
+  );
+  return typeof output === "string" ? output : "";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
+import type { PipelineOptions } from "./pipeline.js";
+import { createDoneStageHandler, runPipeline } from "./pipeline.js";
 import { runStartup } from "./startup.js";
+import {
+  bootstrapRepo,
+  createWorktree,
+  detectDefaultBranch,
+  removeWorktree,
+} from "./worktree.js";
 
 if (!process.stdin.isTTY) {
   console.error("agentcoop requires an interactive terminal.");
@@ -19,6 +27,60 @@ try {
   console.log(`  Mode: ${result.executionMode}`);
   console.log(`  Permission: ${result.claudePermissionMode}`);
   console.log(`  Language: ${result.language}`);
+
+  // Bootstrap the repository and create a worktree.
+  console.log();
+  console.log("Bootstrapping repository...");
+  bootstrapRepo(result.owner, result.repo);
+
+  const defaultBranch = detectDefaultBranch(result.owner, result.repo);
+  const wt = createWorktree({
+    owner: result.owner,
+    repo: result.repo,
+    issueNumber: result.issue.number,
+    baseBranch: defaultBranch,
+    conflictChoice: "reuse",
+  });
+  console.log(`Worktree ready at ${wt.path} (branch: ${wt.branch})`);
+
+  if (wt.hadUncommittedChanges) {
+    console.warn(
+      "⚠ The existing worktree had uncommitted changes that were preserved.",
+    );
+  }
+
+  // Stage 9 (Done) is always present.  Stages 1–8 come from handler
+  // modules that are not yet implemented (see issues #6, #7, #8).
+  const doneStage = createDoneStageHandler({
+    reportCompletion: async (msg) => console.log(msg),
+    confirmMerge: async () => true, // placeholder until real prompts
+    cleanup: () =>
+      removeWorktree(result.owner, result.repo, result.issue.number, wt.branch),
+  });
+
+  const pipelineOpts: PipelineOptions = {
+    mode: result.executionMode,
+    stages: [doneStage],
+    prompt: {
+      confirmContinueLoop: async () => false,
+      confirmNextStage: async () => true,
+      handleBlocked: async () => ({ action: "halt" }),
+      handleError: async () => ({ action: "abort" }),
+      handleAmbiguous: async () => ({ action: "halt" }),
+      confirmMerge: async () => true,
+      reportCompletion: async () => {},
+    },
+    context: {
+      owner: result.owner,
+      repo: result.repo,
+      issueNumber: result.issue.number,
+      branch: wt.branch,
+      worktreePath: wt.path,
+    },
+  };
+  const pipelineResult = await runPipeline(pipelineOpts);
+  console.log();
+  console.log(pipelineResult.message);
 } catch (error) {
   if (
     error instanceof Error &&

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1,0 +1,849 @@
+import { describe, expect, test, vi } from "vitest";
+import type {
+  PipelineOptions,
+  StageContext,
+  StageDefinition,
+  StageResult,
+  UserAction,
+  UserPrompt,
+} from "./pipeline.js";
+import {
+  advanceLoop,
+  createDoneStageHandler,
+  createLoopControl,
+  grantLoopBudget,
+  isTerminalSuccess,
+  runPipeline,
+} from "./pipeline.js";
+import { buildClarificationPrompt } from "./step-parser.js";
+
+// ---- helpers -------------------------------------------------------------
+
+function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
+  return {
+    confirmContinueLoop: vi.fn().mockResolvedValue(true),
+    confirmNextStage: vi.fn().mockResolvedValue(true),
+    handleBlocked: vi
+      .fn()
+      .mockResolvedValue({ action: "halt" satisfies UserAction }),
+    handleError: vi
+      .fn()
+      .mockResolvedValue({ action: "abort" satisfies UserAction }),
+    handleAmbiguous: vi
+      .fn()
+      .mockResolvedValue({ action: "halt" satisfies UserAction }),
+    confirmMerge: vi.fn().mockResolvedValue(true),
+    reportCompletion: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function makeStage(
+  number: number,
+  handler: (ctx: StageContext) => Promise<StageResult>,
+  opts: Partial<StageDefinition> = {},
+): StageDefinition {
+  return {
+    name: `Stage ${number}`,
+    number,
+    handler,
+    ...opts,
+  };
+}
+
+const BASE_CTX: Omit<StageContext, "iteration" | "userInstruction"> = {
+  owner: "org",
+  repo: "repo",
+  issueNumber: 5,
+  branch: "issue-5",
+  worktreePath: "/tmp/wt",
+};
+
+function makePipelineOpts(
+  overrides: Partial<PipelineOptions> = {},
+): PipelineOptions {
+  return {
+    mode: "auto",
+    stages: [],
+    prompt: makePrompt(),
+    context: BASE_CTX,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Loop control
+// ---------------------------------------------------------------------------
+describe("createLoopControl", () => {
+  test("starts at iteration 0 with budget 3", () => {
+    const lc = createLoopControl();
+    expect(lc.iteration).toBe(0);
+    expect(lc.autoRemaining).toBe(3);
+  });
+});
+
+describe("advanceLoop", () => {
+  test("decrements remaining and increments iteration", () => {
+    const lc = createLoopControl();
+    const canContinue = advanceLoop(lc);
+    expect(lc.iteration).toBe(1);
+    expect(lc.autoRemaining).toBe(2);
+    expect(canContinue).toBe(true);
+  });
+
+  test("returns false when budget exhausted", () => {
+    const lc = createLoopControl();
+    advanceLoop(lc); // remaining: 2
+    advanceLoop(lc); // remaining: 1
+    const canContinue = advanceLoop(lc); // remaining: 0
+    expect(canContinue).toBe(false);
+    expect(lc.iteration).toBe(3);
+  });
+
+  test("returns true while budget remains", () => {
+    const lc = createLoopControl();
+    expect(advanceLoop(lc)).toBe(true); // 2 left
+    expect(advanceLoop(lc)).toBe(true); // 1 left
+    expect(advanceLoop(lc)).toBe(false); // 0 left
+  });
+});
+
+describe("grantLoopBudget", () => {
+  test("resets autoRemaining to 3", () => {
+    const lc = createLoopControl();
+    advanceLoop(lc);
+    advanceLoop(lc);
+    advanceLoop(lc);
+    expect(lc.autoRemaining).toBe(0);
+    grantLoopBudget(lc);
+    expect(lc.autoRemaining).toBe(3);
+  });
+
+  test("preserves iteration count", () => {
+    const lc = createLoopControl();
+    advanceLoop(lc);
+    advanceLoop(lc);
+    advanceLoop(lc);
+    grantLoopBudget(lc);
+    expect(lc.iteration).toBe(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isTerminalSuccess
+// ---------------------------------------------------------------------------
+describe("isTerminalSuccess", () => {
+  test("completed is terminal", () => {
+    expect(isTerminalSuccess("completed")).toBe(true);
+  });
+
+  test("fixed is terminal", () => {
+    expect(isTerminalSuccess("fixed")).toBe(true);
+  });
+
+  test("approved is terminal", () => {
+    expect(isTerminalSuccess("approved")).toBe(true);
+  });
+
+  test("not_approved is not terminal", () => {
+    expect(isTerminalSuccess("not_approved")).toBe(false);
+  });
+
+  test("blocked is not terminal", () => {
+    expect(isTerminalSuccess("blocked")).toBe(false);
+  });
+
+  test("error is not terminal", () => {
+    expect(isTerminalSuccess("error")).toBe(false);
+  });
+
+  test("needs_clarification is not terminal", () => {
+    expect(isTerminalSuccess("needs_clarification")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — basic flow
+// ---------------------------------------------------------------------------
+describe("runPipeline — basic flow", () => {
+  test("runs stages in order and succeeds", async () => {
+    const order: number[] = [];
+    const stages = [
+      makeStage(2, async () => {
+        order.push(2);
+        return { outcome: "completed", message: "done" };
+      }),
+      makeStage(1, async () => {
+        order.push(1);
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages }));
+    expect(result.success).toBe(true);
+    expect(order).toEqual([1, 2]); // sorted by stage number
+  });
+
+  test("returns success with no stages", async () => {
+    const result = await runPipeline(makePipelineOpts());
+    expect(result.success).toBe(true);
+  });
+
+  test("passes context to handler", async () => {
+    let captured: StageContext | undefined;
+    const stages = [
+      makeStage(1, async (ctx) => {
+        captured = ctx;
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages }));
+    expect(captured?.owner).toBe("org");
+    expect(captured?.repo).toBe("repo");
+    expect(captured?.issueNumber).toBe(5);
+    expect(captured?.branch).toBe("issue-5");
+    expect(captured?.iteration).toBe(0);
+    expect(captured?.userInstruction).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — step mode
+// ---------------------------------------------------------------------------
+describe("runPipeline — step mode", () => {
+  test("asks user before each stage", async () => {
+    const prompt = makePrompt();
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+    await runPipeline(makePipelineOpts({ mode: "step", stages, prompt }));
+    expect(prompt.confirmNextStage).toHaveBeenCalledTimes(2);
+  });
+
+  test("stops when user declines a stage", async () => {
+    const prompt = makePrompt({
+      confirmNextStage: vi
+        .fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ mode: "step", stages, prompt }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(2);
+  });
+
+  test("does not ask in auto mode", async () => {
+    const prompt = makePrompt();
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+    ];
+    await runPipeline(makePipelineOpts({ mode: "auto", stages, prompt }));
+    expect(prompt.confirmNextStage).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — loop control
+// ---------------------------------------------------------------------------
+describe("runPipeline — loop control", () => {
+  test("loops up to 3 times automatically then asks user", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        calls++;
+        return { outcome: "not_approved", message: "try again" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    // 3 auto iterations (budget used up), then user asked, declines.
+    expect(calls).toBe(3);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+  });
+
+  test("grants 3 more iterations when user approves", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi
+        .fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        calls++;
+        return { outcome: "not_approved", message: "try again" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    // 3 auto + user approves + 3 more auto + user declines = 6
+    expect(calls).toBe(6);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(2);
+  });
+
+  test("exits loop early on terminal success", async () => {
+    let calls = 0;
+    const stages = [
+      makeStage(1, async () => {
+        calls++;
+        if (calls === 2) {
+          return { outcome: "completed", message: "done" };
+        }
+        return { outcome: "not_approved", message: "nope" };
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages }));
+    expect(result.success).toBe(true);
+    expect(calls).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — blocked handling
+// ---------------------------------------------------------------------------
+describe("runPipeline — blocked handling", () => {
+  test("halts when user chooses halt on blocked", async () => {
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({
+        outcome: "blocked",
+        message: "stuck",
+      })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(1);
+  });
+
+  test("proceeds when user chooses proceed (non-artifact stage)", async () => {
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({ action: "proceed" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({
+        outcome: "blocked",
+        message: "stuck",
+      })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+    expect(prompt.handleBlocked).toHaveBeenCalledWith("stuck", true);
+  });
+
+  test("passes allowProceed=false for requiresArtifact stages", async () => {
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "blocked", message: "no PR" }), {
+        requiresArtifact: true,
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(prompt.handleBlocked).toHaveBeenCalledWith("no PR", false);
+  });
+
+  test("continues with instruction when user chooses instruct", async () => {
+    let receivedInstruction: string | undefined;
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValueOnce({
+        action: "instruct",
+        instruction: "try X instead",
+      }),
+    });
+    let callCount = 0;
+    const stages = [
+      makeStage(1, async (ctx) => {
+        callCount++;
+        if (callCount === 1) {
+          return { outcome: "blocked", message: "stuck" };
+        }
+        receivedInstruction = ctx.userInstruction;
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(receivedInstruction).toBe("try X instead");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — error handling
+// ---------------------------------------------------------------------------
+describe("runPipeline — error handling", () => {
+  test("aborts on error when user chooses abort", async () => {
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({
+        outcome: "error",
+        message: "crash",
+      })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+  });
+
+  test("skips stage on error when user chooses skip", async () => {
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "skip" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({
+        outcome: "error",
+        message: "crash",
+      })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+  });
+
+  test("retries on error when user chooses retry", async () => {
+    let callCount = 0;
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "retry" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        callCount++;
+        if (callCount < 3) {
+          return { outcome: "error", message: "crash" };
+        }
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+    expect(callCount).toBe(3);
+  });
+
+  test("handles thrown exceptions like error outcomes", async () => {
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        throw new Error("unexpected crash");
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(prompt.handleError).toHaveBeenCalledWith("unexpected crash");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — ambiguous / needs_clarification handling
+// ---------------------------------------------------------------------------
+describe("runPipeline — needs_clarification handling", () => {
+  test("halts on ambiguous when user chooses halt", async () => {
+    const prompt = makePrompt({
+      handleAmbiguous: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({
+        outcome: "needs_clarification",
+        message: "unclear",
+      })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+  });
+
+  test("proceeds on ambiguous when user chooses proceed", async () => {
+    const prompt = makePrompt({
+      handleAmbiguous: vi.fn().mockResolvedValue({ action: "proceed" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({
+        outcome: "needs_clarification",
+        message: "unclear",
+      })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+  });
+
+  test("continues with instruction on ambiguous after auto-clarification", async () => {
+    let receivedInstruction: string | undefined;
+    const prompt = makePrompt({
+      handleAmbiguous: vi.fn().mockResolvedValue({
+        action: "instruct",
+        instruction: "be clearer",
+      }),
+    });
+    let callCount = 0;
+    const stages = [
+      makeStage(1, async (ctx) => {
+        callCount++;
+        if (callCount <= 2) {
+          // Call 1: ambiguous → engine auto-retries with clarification prompt.
+          // Call 2: still ambiguous → engine falls back to user.
+          return { outcome: "needs_clarification", message: "unclear" };
+        }
+        // Call 3: user instruction arrives.
+        receivedInstruction = ctx.userInstruction;
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(callCount).toBe(3);
+    expect(receivedInstruction).toBe("be clearer");
+  });
+
+  test("auto-clarification sends buildClarificationPrompt on first ambiguous", async () => {
+    let receivedInstruction: string | undefined;
+    const stages = [
+      makeStage(1, async (ctx) => {
+        if (ctx.iteration === 0) {
+          return { outcome: "needs_clarification", message: "vague" };
+        }
+        // Iteration 1 receives auto-clarification prompt.
+        receivedInstruction = ctx.userInstruction;
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages }));
+    expect(receivedInstruction).toBe(buildClarificationPrompt("vague"));
+  });
+
+  test("handleAmbiguous not called on first ambiguous (auto-retry first)", async () => {
+    const prompt = makePrompt();
+    let callCount = 0;
+    const stages = [
+      makeStage(1, async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { outcome: "needs_clarification", message: "vague" };
+        }
+        // Second call succeeds.
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(prompt.handleAmbiguous).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runPipeline — edge cases
+// ---------------------------------------------------------------------------
+describe("runPipeline — edge cases", () => {
+  test("handles non-Error thrown exceptions", async () => {
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        throw "string error"; // eslint-disable-line no-throw-literal
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(prompt.handleError).toHaveBeenCalledWith("string error");
+  });
+
+  test("user instruction is cleared after one use", async () => {
+    const instructions: (string | undefined)[] = [];
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValueOnce({
+        action: "instruct",
+        instruction: "do X",
+      }),
+    });
+    let callCount = 0;
+    const stages = [
+      makeStage(1, async (ctx) => {
+        callCount++;
+        instructions.push(ctx.userInstruction);
+        if (callCount === 1) {
+          return { outcome: "blocked", message: "stuck" };
+        }
+        if (callCount === 2) {
+          return { outcome: "not_approved", message: "nope" };
+        }
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    // Call 1: no instruction, call 2: "do X" (from instruct),
+    // call 3: "nope" (from not_approved — message is forwarded as feedback).
+    expect(instructions).toEqual([undefined, "do X", "nope"]);
+  });
+
+  test("empty message in blocked outcome is forwarded", async () => {
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "blocked", message: "" })),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(prompt.handleBlocked).toHaveBeenCalledWith("", true);
+  });
+
+  test("step mode loops within a stage run as auto", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        calls++;
+        return { outcome: "not_approved", message: "again" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ mode: "step", stages, prompt }));
+    // 3 auto iterations within the stage, then user asked about loop.
+    expect(calls).toBe(3);
+    expect(prompt.confirmNextStage).toHaveBeenCalledTimes(1);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+  });
+
+  test("multiple user approvals grant 3 iterations each", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi
+        .fn()
+        .mockResolvedValueOnce(true) // 4th–6th
+        .mockResolvedValueOnce(true) // 7th–9th
+        .mockResolvedValue(false), // 10th declined
+    });
+    const stages = [
+      makeStage(1, async () => {
+        calls++;
+        return { outcome: "not_approved", message: "more" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    // 3 + 3 + 3 = 9 iterations.
+    expect(calls).toBe(9);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(3);
+  });
+
+  test("error retry does not consume loop budget", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      handleError: vi
+        .fn()
+        .mockResolvedValueOnce({ action: "retry" })
+        .mockResolvedValue({ action: "abort" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        calls++;
+        if (calls === 1) {
+          return { outcome: "error", message: "transient" };
+        }
+        // After retry, still an error to test budget.
+        return { outcome: "error", message: "persistent" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    // Retry doesn't advance loop, so no loop-budget prompt.
+    expect(calls).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createDoneStageHandler
+// ---------------------------------------------------------------------------
+function makeDoneOpts(
+  overrides: Partial<Parameters<typeof createDoneStageHandler>[0]> = {},
+) {
+  return {
+    reportCompletion: vi.fn().mockResolvedValue(undefined),
+    confirmMerge: vi.fn().mockResolvedValue(true),
+    cleanup: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("createDoneStageHandler", () => {
+  test("returns stage definition with number 9", () => {
+    const stage = createDoneStageHandler(makeDoneOpts());
+    expect(stage.number).toBe(9);
+    expect(stage.name).toBe("Done");
+  });
+
+  test("reports completion, confirms merge, then cleans up", async () => {
+    const opts = makeDoneOpts();
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.reportCompletion).toHaveBeenCalledOnce();
+    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("org/repo#5");
+    expect(result.message).toContain("cleaned up");
+  });
+
+  test("preserves worktree when merge not confirmed", async () => {
+    const opts = makeDoneOpts({
+      confirmMerge: vi.fn().mockResolvedValue(false),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.reportCompletion).toHaveBeenCalledOnce();
+    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.cleanup).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("preserved");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2E: multi-stage pipeline with mixed outcomes
+// ---------------------------------------------------------------------------
+describe("E2E — multi-stage pipeline", () => {
+  test("3 stages: complete → blocked+instruct → complete", async () => {
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({
+        action: "instruct",
+        instruction: "fix the test",
+      }),
+    });
+    let stage2calls = 0;
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "s1" })),
+      makeStage(2, async () => {
+        stage2calls++;
+        if (stage2calls === 1) {
+          return { outcome: "blocked", message: "need help" };
+        }
+        return { outcome: "fixed", message: "s2" };
+      }),
+      makeStage(3, async () => ({ outcome: "approved", message: "s3" })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+    expect(stage2calls).toBe(2);
+  });
+
+  test("step mode: approve all stages with loop in middle stage", async () => {
+    const prompt = makePrompt({
+      confirmNextStage: vi.fn().mockResolvedValue(true),
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    let s2calls = 0;
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(2, async () => {
+        s2calls++;
+        if (s2calls <= 3) {
+          return { outcome: "not_approved", message: "retry" };
+        }
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(3, async () => ({ outcome: "completed", message: "" })),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ mode: "step", stages, prompt }),
+    );
+    // Stage 2 loops 3 times, then user declines loop → pipeline aborts.
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(2);
+    expect(prompt.confirmNextStage).toHaveBeenCalledTimes(2);
+  });
+
+  test("error in stage 1 skip → stage 2 completes → success", async () => {
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "skip" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "error", message: "boom" })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+  });
+
+  test("thrown exception in stage 2, retry succeeds", async () => {
+    let s2calls = 0;
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "retry" }),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(2, async () => {
+        s2calls++;
+        if (s2calls === 1) {
+          throw new Error("transient failure");
+        }
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+    expect(s2calls).toBe(2);
+  });
+
+  test("clarification flow across stages does not leak state", async () => {
+    // Stage 1 triggers ambiguous → auto-clarification → succeeds.
+    // Stage 2 triggers ambiguous → auto-clarification should fire again
+    // (not carry over the "already attempted" flag from stage 1).
+    let s1calls = 0;
+    let s2calls = 0;
+    const stages = [
+      makeStage(1, async () => {
+        s1calls++;
+        if (s1calls === 1) {
+          return { outcome: "needs_clarification", message: "vague1" };
+        }
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(2, async () => {
+        s2calls++;
+        if (s2calls === 1) {
+          return { outcome: "needs_clarification", message: "vague2" };
+        }
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const prompt = makePrompt();
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+    // Each stage should get auto-clarification → succeed on 2nd call.
+    expect(s1calls).toBe(2);
+    expect(s2calls).toBe(2);
+    // handleAmbiguous should NOT have been called (auto-clarification succeeded).
+    expect(prompt.handleAmbiguous).not.toHaveBeenCalled();
+  });
+
+  test("full pipeline with Done stage (stage 9) runs cleanup", async () => {
+    const opts = makeDoneOpts();
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      createDoneStageHandler(opts),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages }));
+    expect(result.success).toBe(true);
+    expect(opts.reportCompletion).toHaveBeenCalledOnce();
+    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+  });
+});

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1,0 +1,416 @@
+/**
+ * Pipeline engine — stage registration, dispatch, loop control, and
+ * execution modes.
+ *
+ * The engine drives a 9-stage pipeline.  Each stage is implemented by a
+ * `StageHandler` registered at construction time.  This module owns the
+ * control flow (looping, user prompts, blocked/error handling) but does
+ * **not** contain stage-specific prompts — those live in separate handler
+ * modules (issues #6, #7, #8).
+ */
+
+import { buildClarificationPrompt } from "./step-parser.js";
+
+// ---- public types --------------------------------------------------------
+
+export type ExecutionMode = "auto" | "step";
+
+/**
+ * Outcome of a single handler invocation inside a loop iteration.
+ */
+export type StageOutcome =
+  | "completed"
+  | "fixed"
+  | "approved"
+  | "not_approved"
+  | "blocked"
+  | "needs_clarification"
+  | "error";
+
+/**
+ * What the user chose when an agent is blocked or an error occurs.
+ */
+export type UserAction =
+  | "proceed"
+  | "instruct"
+  | "halt"
+  | "retry"
+  | "skip"
+  | "abort";
+
+export interface StageResult {
+  outcome: StageOutcome;
+  /** Free-form message shown to the user or forwarded to the next stage. */
+  message: string;
+}
+
+/**
+ * A stage handler is an async function that performs the work for a
+ * single pipeline stage.  It receives context about the current run and
+ * returns a `StageResult`.
+ */
+export type StageHandler = (ctx: StageContext) => Promise<StageResult>;
+
+export interface StageDefinition {
+  /** Human-readable name, e.g. "Implementation". */
+  name: string;
+  /** 1-based stage number (1–9). */
+  number: number;
+  handler: StageHandler;
+  /**
+   * When true the "Proceed" option is **not** offered when the agent
+   * reports BLOCKED — the artifact is mandatory (e.g. PR creation).
+   */
+  requiresArtifact?: boolean;
+}
+
+/**
+ * Context passed into every stage handler.
+ */
+export interface StageContext {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  branch: string;
+  worktreePath: string;
+  /** Current loop iteration (0-based). */
+  iteration: number;
+  /** Instruction injected by the user after a "instruct" action. */
+  userInstruction: string | undefined;
+}
+
+// ---- user interaction interface ------------------------------------------
+
+/**
+ * Abstraction for user-facing prompts so the engine can be tested
+ * without a real TTY.
+ */
+export interface UserPrompt {
+  /**
+   * Ask the user to approve continuing after the automatic loop budget
+   * is exhausted.
+   */
+  confirmContinueLoop(stageName: string, iteration: number): Promise<boolean>;
+
+  /**
+   * Ask the user to approve advancing to the next stage (step mode).
+   */
+  confirmNextStage(stageName: string): Promise<boolean>;
+
+  /**
+   * Present a blocked agent's response and let the user choose.
+   * `allowProceed` is false for required-artifact stages.
+   */
+  handleBlocked(
+    message: string,
+    allowProceed: boolean,
+  ): Promise<{ action: UserAction; instruction?: string }>;
+
+  /**
+   * Present an error to the user and let them choose Retry / Skip / Abort.
+   */
+  handleError(
+    message: string,
+  ): Promise<{ action: Extract<UserAction, "retry" | "skip" | "abort"> }>;
+
+  /**
+   * Show the agent's response to the user when clarification has failed
+   * after a retry, and let the user decide.
+   */
+  handleAmbiguous(
+    message: string,
+  ): Promise<{ action: UserAction; instruction?: string }>;
+
+  /**
+   * Ask user to confirm merge and final cleanup (stage 9).
+   */
+  confirmMerge(message: string): Promise<boolean>;
+
+  /**
+   * Report completion to the user (stage 9).
+   */
+  reportCompletion(message: string): Promise<void>;
+}
+
+// ---- loop control --------------------------------------------------------
+
+/** Number of automatic iterations before asking the user. */
+const AUTO_BUDGET = 3;
+
+export interface LoopControl {
+  /** Current iteration (0-based). */
+  iteration: number;
+  /** Number of auto-iterations remaining before the next user prompt. */
+  autoRemaining: number;
+}
+
+/**
+ * Create a fresh loop-control state.
+ */
+export function createLoopControl(): LoopControl {
+  return { iteration: 0, autoRemaining: AUTO_BUDGET };
+}
+
+/**
+ * Advance the loop counter by one.  Returns `true` if the loop may
+ * continue automatically, `false` if user approval is needed.
+ */
+export function advanceLoop(lc: LoopControl): boolean {
+  lc.iteration += 1;
+  lc.autoRemaining -= 1;
+  return lc.autoRemaining > 0;
+}
+
+/**
+ * Grant a new budget of automatic iterations (called after user
+ * approves continuing).
+ */
+export function grantLoopBudget(lc: LoopControl): void {
+  lc.autoRemaining = AUTO_BUDGET;
+}
+
+// ---- terminal outcomes ---------------------------------------------------
+
+const TERMINAL_OUTCOMES = new Set<StageOutcome>([
+  "completed",
+  "fixed",
+  "approved",
+]);
+
+/**
+ * Whether the outcome means the stage is finished successfully and the
+ * pipeline should move on to the next stage.
+ */
+export function isTerminalSuccess(outcome: StageOutcome): boolean {
+  return TERMINAL_OUTCOMES.has(outcome);
+}
+
+// ---- pipeline engine -----------------------------------------------------
+
+export interface PipelineOptions {
+  mode: ExecutionMode;
+  stages: StageDefinition[];
+  prompt: UserPrompt;
+  /** Shared context fields injected into every `StageContext`. */
+  context: Omit<StageContext, "iteration" | "userInstruction">;
+}
+
+export interface PipelineResult {
+  /** Whether the entire pipeline completed successfully. */
+  success: boolean;
+  /** The stage number where the pipeline stopped (on abort/halt). */
+  stoppedAt: number | undefined;
+  message: string;
+}
+
+/**
+ * Run the full pipeline from stage 1 through stage 9.
+ */
+export async function runPipeline(
+  options: PipelineOptions,
+): Promise<PipelineResult> {
+  const { mode, stages, prompt, context } = options;
+
+  // Sort stages by number to guarantee order.
+  const sorted = [...stages].sort((a, b) => a.number - b.number);
+
+  for (const stage of sorted) {
+    // In step mode, ask the user before entering each stage.
+    if (mode === "step") {
+      const ok = await prompt.confirmNextStage(stage.name);
+      if (!ok) {
+        return {
+          success: false,
+          stoppedAt: stage.number,
+          message: `User skipped stage ${stage.number} (${stage.name}).`,
+        };
+      }
+    }
+
+    const result = await runStage(stage, context, prompt);
+
+    if (result.action === "abort") {
+      return {
+        success: false,
+        stoppedAt: stage.number,
+        message: result.message,
+      };
+    }
+
+    // "skip" and "done" both advance to the next stage.
+  }
+
+  return {
+    success: true,
+    stoppedAt: undefined,
+    message: "Pipeline completed successfully.",
+  };
+}
+
+// ---- single-stage runner -------------------------------------------------
+
+interface StageRunResult {
+  action: "done" | "skip" | "abort";
+  message: string;
+}
+
+/**
+ * Dispatch a user-facing error and return the appropriate run result,
+ * or `undefined` to signal a retry.
+ */
+async function dispatchError(
+  prompt: UserPrompt,
+  message: string,
+): Promise<StageRunResult | undefined> {
+  const decision = await prompt.handleError(message);
+  if (decision.action === "retry") return undefined;
+  if (decision.action === "skip") return { action: "skip", message };
+  return { action: "abort", message };
+}
+
+async function runStage(
+  stage: StageDefinition,
+  baseCtx: Omit<StageContext, "iteration" | "userInstruction">,
+  prompt: UserPrompt,
+): Promise<StageRunResult> {
+  const lc = createLoopControl();
+  let userInstruction: string | undefined;
+  /** Tracks whether the last iteration was an auto-clarification retry. */
+  let clarificationAttempted = false;
+
+  while (true) {
+    const ctx: StageContext = {
+      ...baseCtx,
+      iteration: lc.iteration,
+      userInstruction,
+    };
+
+    // Clear the one-shot instruction after use.
+    userInstruction = undefined;
+
+    let result: StageResult;
+    try {
+      result = await stage.handler(ctx);
+    } catch (err) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      const dispatched = await dispatchError(prompt, errMsg);
+      if (dispatched === undefined) continue; // retry
+      return dispatched;
+    }
+
+    // ---- evaluate outcome ------------------------------------------------
+
+    if (isTerminalSuccess(result.outcome)) {
+      return { action: "done", message: result.message };
+    }
+
+    if (result.outcome === "not_approved") {
+      // Treat as needing another loop iteration with feedback.
+      userInstruction = result.message;
+      clarificationAttempted = false;
+    } else if (result.outcome === "blocked") {
+      clarificationAttempted = false;
+      const decision = await prompt.handleBlocked(
+        result.message,
+        !stage.requiresArtifact,
+      );
+      if (decision.action === "halt") {
+        return { action: "abort", message: "User halted on blocked agent." };
+      }
+      if (decision.action === "proceed") {
+        return { action: "done", message: result.message };
+      }
+      if (decision.action === "instruct") {
+        userInstruction = decision.instruction;
+      }
+    } else if (result.outcome === "needs_clarification") {
+      if (!clarificationAttempted) {
+        // First ambiguous response: auto-retry with a clarification prompt.
+        clarificationAttempted = true;
+        userInstruction = buildClarificationPrompt(result.message);
+      } else {
+        // Clarification already tried once — fall back to user.
+        clarificationAttempted = false;
+        const decision = await prompt.handleAmbiguous(result.message);
+        if (decision.action === "halt") {
+          return {
+            action: "abort",
+            message: "User halted on ambiguous response.",
+          };
+        }
+        if (decision.action === "proceed") {
+          return { action: "done", message: result.message };
+        }
+        if (decision.action === "instruct") {
+          userInstruction = decision.instruction;
+        }
+      }
+    } else if (result.outcome === "error") {
+      clarificationAttempted = false;
+      const dispatched = await dispatchError(prompt, result.message);
+      if (dispatched === undefined) continue; // retry
+      return dispatched;
+    }
+
+    // ---- loop control ----------------------------------------------------
+
+    const canContinue = advanceLoop(lc);
+    if (!canContinue) {
+      const approved = await prompt.confirmContinueLoop(
+        stage.name,
+        lc.iteration,
+      );
+      if (!approved) {
+        return {
+          action: "abort",
+          message: `User declined to continue loop at iteration ${lc.iteration}.`,
+        };
+      }
+      grantLoopBudget(lc);
+    }
+  }
+}
+
+// ---- Stage 9: Done -------------------------------------------------------
+
+/**
+ * Built-in stage-9 handler.  Reports completion, waits for the user to
+ * confirm merge, then cleans up the worktree.
+ *
+ * Callbacks are injected so the handler stays independent of the
+ * worktree module, keeping the engine testable.
+ */
+export function createDoneStageHandler(options: {
+  /** Called to report completion before asking about merge. */
+  reportCompletion: (message: string) => Promise<void>;
+  /** Called to ask the user whether the PR has been merged. */
+  confirmMerge: (message: string) => Promise<boolean>;
+  /** Called to remove the worktree after merge is confirmed. */
+  cleanup: () => void;
+}): StageDefinition {
+  return {
+    name: "Done",
+    number: 9,
+    handler: async (ctx) => {
+      const summary = `Pipeline for ${ctx.owner}/${ctx.repo}#${ctx.issueNumber} completed.`;
+      await options.reportCompletion(summary);
+
+      const merged = await options.confirmMerge(
+        "Has the PR been merged? Confirm to clean up the worktree.",
+      );
+
+      if (merged) {
+        options.cleanup();
+        return {
+          outcome: "completed",
+          message: `${summary} Worktree cleaned up.`,
+        };
+      }
+
+      return {
+        outcome: "completed",
+        message: `${summary} Worktree preserved (merge not confirmed).`,
+      };
+    },
+  };
+}

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -1,0 +1,71 @@
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const { findPrNumber } = await import("./pr.js");
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+afterEach(() => {
+  mockExecFileSync.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// findPrNumber
+// ---------------------------------------------------------------------------
+describe("findPrNumber", () => {
+  test("returns PR number when a PR exists", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify([{ number: 42 }]));
+    expect(findPrNumber("org", "repo", "issue-5")).toBe(42);
+  });
+
+  test("calls gh with correct arguments", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    findPrNumber("aicers", "agentcoop", "issue-10");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "pr",
+        "list",
+        "--repo",
+        "aicers/agentcoop",
+        "--head",
+        "issue-10",
+        "--json",
+        "number",
+        "--limit",
+        "1",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("returns undefined when no PR exists", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    expect(findPrNumber("org", "repo", "issue-5")).toBeUndefined();
+  });
+
+  test("returns the first PR when multiple exist", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify([{ number: 10 }, { number: 20 }]),
+    );
+    expect(findPrNumber("org", "repo", "issue-5")).toBe(10);
+  });
+
+  test("propagates error when gh command fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("gh: auth required");
+    });
+    expect(() => findPrNumber("org", "repo", "issue-5")).toThrow(
+      "gh: auth required",
+    );
+  });
+
+  test("returns undefined on malformed JSON output", () => {
+    mockExecFileSync.mockReturnValue("not json at all");
+    expect(findPrNumber("org", "repo", "issue-5")).toBeUndefined();
+  });
+});

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,0 +1,43 @@
+/**
+ * Pull request utilities.
+ *
+ * Wraps `gh pr list` to extract the PR number for a given branch.
+ */
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Find the PR number associated with `branch` in `owner/repo`.
+ *
+ * Returns `undefined` when no PR exists for the branch.
+ */
+export function findPrNumber(
+  owner: string,
+  repo: string,
+  branch: string,
+): number | undefined {
+  const output = execFileSync(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      `${owner}/${repo}`,
+      "--head",
+      branch,
+      "--json",
+      "number",
+      "--limit",
+      "1",
+    ],
+    { encoding: "utf-8" },
+  );
+
+  let prs: { number: number }[];
+  try {
+    prs = JSON.parse(output);
+  } catch {
+    return undefined;
+  }
+  return prs.length > 0 ? prs[0].number : undefined;
+}

--- a/src/step-parser.test.ts
+++ b/src/step-parser.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, test } from "vitest";
+import { buildClarificationPrompt, parseStepStatus } from "./step-parser.js";
+
+// ---------------------------------------------------------------------------
+// parseStepStatus
+// ---------------------------------------------------------------------------
+describe("parseStepStatus", () => {
+  // -- recognised keywords --------------------------------------------------
+  test("detects COMPLETED", () => {
+    const r = parseStepStatus("All tasks are done. COMPLETED");
+    expect(r).toEqual({ status: "completed", keyword: "COMPLETED" });
+  });
+
+  test("detects BLOCKED", () => {
+    const r = parseStepStatus("Cannot proceed — BLOCKED");
+    expect(r).toEqual({ status: "blocked", keyword: "BLOCKED" });
+  });
+
+  test("detects FIXED", () => {
+    const r = parseStepStatus("The issue has been FIXED");
+    expect(r).toEqual({ status: "fixed", keyword: "FIXED" });
+  });
+
+  test("detects DONE", () => {
+    const r = parseStepStatus("Everything is DONE");
+    expect(r).toEqual({ status: "fixed", keyword: "DONE" });
+  });
+
+  test("detects APPROVED", () => {
+    const r = parseStepStatus("Review passed. APPROVED");
+    expect(r).toEqual({ status: "approved", keyword: "APPROVED" });
+  });
+
+  test("detects NOT_APPROVED", () => {
+    const r = parseStepStatus("Changes required. NOT_APPROVED");
+    expect(r).toEqual({ status: "not_approved", keyword: "NOT_APPROVED" });
+  });
+
+  // -- case insensitivity ---------------------------------------------------
+  test("matches keywords case-insensitively", () => {
+    const r = parseStepStatus("completed");
+    expect(r.status).toBe("completed");
+  });
+
+  test("matches mixed case", () => {
+    const r = parseStepStatus("Completed");
+    expect(r.status).toBe("completed");
+  });
+
+  // -- last occurrence wins -------------------------------------------------
+  test("returns the last keyword when multiple are present", () => {
+    const r = parseStepStatus("BLOCKED at first, but then COMPLETED");
+    expect(r).toEqual({ status: "completed", keyword: "COMPLETED" });
+  });
+
+  test("BLOCKED after COMPLETED returns blocked", () => {
+    const r = parseStepStatus("COMPLETED initially, but now BLOCKED");
+    expect(r).toEqual({ status: "blocked", keyword: "BLOCKED" });
+  });
+
+  // -- word boundary --------------------------------------------------------
+  test("does not match keyword embedded in another word", () => {
+    const r = parseStepStatus("I am done with the uncompleted tasks");
+    // "DONE" should match as a word, but "COMPLETED" inside "uncompleted" should not.
+    expect(r.status).toBe("fixed");
+    expect(r.keyword).toBe("DONE");
+  });
+
+  test("does not match BLOCKED inside UNBLOCKED", () => {
+    const r = parseStepStatus("The issue is now UNBLOCKED");
+    expect(r.status).toBe("ambiguous");
+  });
+
+  // -- ambiguous (no keyword) -----------------------------------------------
+  test("returns ambiguous when no keyword is found", () => {
+    const r = parseStepStatus("I made some progress on the issue.");
+    expect(r).toEqual({ status: "ambiguous", keyword: undefined });
+  });
+
+  test("returns ambiguous for empty string", () => {
+    const r = parseStepStatus("");
+    expect(r).toEqual({ status: "ambiguous", keyword: undefined });
+  });
+
+  // -- NOT_APPROVED vs APPROVED precedence by position ----------------------
+  test("NOT_APPROVED takes precedence when it appears last", () => {
+    const r = parseStepStatus("APPROVED earlier, but NOT_APPROVED now");
+    expect(r.status).toBe("not_approved");
+  });
+
+  test("APPROVED wins when it appears after NOT_APPROVED", () => {
+    const r = parseStepStatus("NOT_APPROVED before, but APPROVED now");
+    expect(r.status).toBe("approved");
+  });
+
+  // -- keyword surrounded by various delimiters -----------------------------
+  test("matches keyword at start of string", () => {
+    const r = parseStepStatus("COMPLETED. All good.");
+    expect(r.status).toBe("completed");
+  });
+
+  test("matches keyword at end of string", () => {
+    const r = parseStepStatus("Result: BLOCKED");
+    expect(r.status).toBe("blocked");
+  });
+
+  test("matches keyword on its own line", () => {
+    const r = parseStepStatus("Some explanation.\nCOMPLETED\n");
+    expect(r.status).toBe("completed");
+  });
+
+  test("matches keyword after punctuation", () => {
+    const r = parseStepStatus("Done! FIXED.");
+    expect(r.status).toBe("fixed");
+  });
+
+  // -- multiline with multiple keywords -------------------------------------
+  test("handles multiline responses with last keyword winning", () => {
+    const text = [
+      "I tried to fix the issue.",
+      "Status: BLOCKED",
+      "After further investigation:",
+      "The tests pass now. FIXED",
+    ].join("\n");
+    expect(parseStepStatus(text).status).toBe("fixed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildClarificationPrompt
+// ---------------------------------------------------------------------------
+describe("buildClarificationPrompt", () => {
+  test("returns a non-empty string", () => {
+    const prompt = buildClarificationPrompt("Some ambiguous response");
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  test("mentions all recognised keywords", () => {
+    const prompt = buildClarificationPrompt("");
+    expect(prompt).toContain("COMPLETED");
+    expect(prompt).toContain("FIXED");
+    expect(prompt).toContain("DONE");
+    expect(prompt).toContain("APPROVED");
+    expect(prompt).toContain("NOT_APPROVED");
+    expect(prompt).toContain("BLOCKED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// edge cases
+// ---------------------------------------------------------------------------
+describe("parseStepStatus — edge cases", () => {
+  test("keyword surrounded by tabs and newlines", () => {
+    const r = parseStepStatus("\t\nCOMPLETED\t\n");
+    expect(r.status).toBe("completed");
+  });
+
+  test("keyword preceded by unicode characters", () => {
+    // Non-ASCII before keyword — \W matches non-word chars including unicode.
+    const r = parseStepStatus("결과: COMPLETED");
+    expect(r.status).toBe("completed");
+  });
+
+  test("very long text with keyword at the end", () => {
+    const filler = "a".repeat(10000);
+    const r = parseStepStatus(`${filler} DONE`);
+    expect(r.status).toBe("fixed");
+    expect(r.keyword).toBe("DONE");
+  });
+
+  test("multiple different keywords returns last by position", () => {
+    const r = parseStepStatus("BLOCKED then FIXED then APPROVED");
+    expect(r.status).toBe("approved");
+  });
+
+  test("keyword in all caps inside a sentence", () => {
+    const r = parseStepStatus("The task is now DONE and ready.");
+    expect(r.status).toBe("fixed");
+  });
+
+  test("only whitespace input returns ambiguous", () => {
+    const r = parseStepStatus("   \n\t  ");
+    expect(r).toEqual({ status: "ambiguous", keyword: undefined });
+  });
+
+  test("APPROVED inside NOT_APPROVED does not match separately", () => {
+    // "NOT_APPROVED" contains "APPROVED" as substring, but word boundary
+    // should prevent standalone APPROVED match.
+    const r = parseStepStatus("Status: NOT_APPROVED");
+    expect(r.status).toBe("not_approved");
+    expect(r.keyword).toBe("NOT_APPROVED");
+  });
+});

--- a/src/step-parser.ts
+++ b/src/step-parser.ts
@@ -1,0 +1,96 @@
+/**
+ * Parse agent responses for step completion status keywords.
+ *
+ * The orchestrator needs to understand whether an agent considers a step
+ * finished, blocked, or still in progress.  Agents are instructed to end
+ * their responses with one of the recognised keywords, but in practice
+ * the keyword may appear anywhere in the final paragraph.
+ */
+
+// ---- public types --------------------------------------------------------
+
+export type StepStatus =
+  | "completed"
+  | "fixed"
+  | "approved"
+  | "not_approved"
+  | "blocked"
+  | "ambiguous";
+
+export interface ParsedStep {
+  status: StepStatus;
+  /** The raw keyword that was matched, if any. */
+  keyword: string | undefined;
+}
+
+// ---- keyword map ---------------------------------------------------------
+
+const KEYWORD_MAP: ReadonlyMap<string, StepStatus> = new Map([
+  ["COMPLETED", "completed"],
+  ["DONE", "fixed"],
+  ["FIXED", "fixed"],
+  ["APPROVED", "approved"],
+  ["NOT_APPROVED", "not_approved"],
+  ["BLOCKED", "blocked"],
+]);
+
+// ---- public API ----------------------------------------------------------
+
+/**
+ * Scan `text` for the **last** occurrence of a recognised status keyword.
+ *
+ * Returns `{ status, keyword }` when a keyword is found, or
+ * `{ status: "ambiguous", keyword: undefined }` when no keyword is present.
+ */
+export function parseStepStatus(text: string): ParsedStep {
+  // We want the *last* match, so scan all occurrences.
+  const upper = text.toUpperCase();
+  let lastIndex = -1;
+  let lastKeyword: string | undefined;
+
+  for (const keyword of KEYWORD_MAP.keys()) {
+    // Use a simple search; we check word-boundary manually below.
+    let start = 0;
+    while (true) {
+      const idx = upper.indexOf(keyword, start);
+      if (idx === -1) break;
+
+      // Word-boundary check: character before and after must be non-word.
+      const before = idx > 0 ? upper[idx - 1] : " ";
+      const after =
+        idx + keyword.length < upper.length ? upper[idx + keyword.length] : " ";
+
+      if (/\W/.test(before) && /\W/.test(after)) {
+        if (idx > lastIndex) {
+          lastIndex = idx;
+          lastKeyword = keyword;
+        }
+      }
+      start = idx + 1;
+    }
+  }
+
+  if (lastKeyword === undefined) {
+    return { status: "ambiguous", keyword: undefined };
+  }
+
+  return {
+    status: KEYWORD_MAP.get(lastKeyword) as StepStatus,
+    keyword: lastKeyword,
+  };
+}
+
+/**
+ * Build a single-shot clarification prompt to send back to the agent when
+ * the previous response was ambiguous.
+ */
+export function buildClarificationPrompt(_originalResponse: string): string {
+  return [
+    "Your previous response did not end with a clear status keyword.",
+    "Please reply with exactly one of the following keywords to indicate",
+    "the current status: COMPLETED, FIXED, DONE, APPROVED, NOT_APPROVED,",
+    "or BLOCKED.",
+    "",
+    "Do not include any other commentary — just the keyword.",
+  ].join("\n");
+}

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -1,0 +1,367 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  rmSync: vi.fn(),
+}));
+
+const {
+  worktreePath,
+  repoPath,
+  detectDefaultBranch,
+  bootstrapRepo,
+  hasUncommittedChanges,
+  createWorktree,
+  removeWorktree,
+} = await import("./worktree.js");
+
+const mockExecFileSync = vi.mocked(execFileSync);
+const mockExistsSync = vi.mocked(existsSync);
+const mockRmSync = vi.mocked(rmSync);
+
+afterEach(() => {
+  vi.resetAllMocks();
+});
+
+const home = homedir();
+
+// ---------------------------------------------------------------------------
+// worktreePath
+// ---------------------------------------------------------------------------
+describe("worktreePath", () => {
+  test("returns deterministic path", () => {
+    expect(worktreePath("aicers", "agentcoop", 5)).toBe(
+      join(home, ".agentcoop", "worktrees", "aicers", "agentcoop", "issue-5"),
+    );
+  });
+
+  test("handles different issue numbers", () => {
+    expect(worktreePath("org", "repo", 42)).toBe(
+      join(home, ".agentcoop", "worktrees", "org", "repo", "issue-42"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repoPath
+// ---------------------------------------------------------------------------
+describe("repoPath", () => {
+  test("returns bare clone path", () => {
+    expect(repoPath("aicers", "agentcoop")).toBe(
+      join(home, ".agentcoop", "repos", "aicers", "agentcoop.git"),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectDefaultBranch
+// ---------------------------------------------------------------------------
+describe("detectDefaultBranch", () => {
+  test("parses default branch from gh output", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ defaultBranchRef: { name: "develop" } }),
+    );
+    expect(detectDefaultBranch("org", "repo")).toBe("develop");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      ["repo", "view", "org/repo", "--json", "defaultBranchRef"],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("falls back to main when defaultBranchRef is null", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ defaultBranchRef: null }),
+    );
+    expect(detectDefaultBranch("org", "repo")).toBe("main");
+  });
+
+  test("falls back to main when name is missing", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ defaultBranchRef: {} }));
+    expect(detectDefaultBranch("org", "repo")).toBe("main");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bootstrapRepo
+// ---------------------------------------------------------------------------
+describe("bootstrapRepo", () => {
+  test("clones when repo does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    const dest = bootstrapRepo("org", "repo");
+    expect(dest).toBe(repoPath("org", "repo"));
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["clone", "--bare", "https://github.com/org/repo.git", dest],
+      expect.objectContaining({ encoding: "utf-8" }),
+    );
+  });
+
+  test("fetches when repo already exists", () => {
+    const dest = repoPath("org", "repo");
+    mockExistsSync.mockReturnValue(true);
+    bootstrapRepo("org", "repo");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["fetch", "--all", "--prune"],
+      expect.objectContaining({ encoding: "utf-8", cwd: dest }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasUncommittedChanges
+// ---------------------------------------------------------------------------
+describe("hasUncommittedChanges", () => {
+  test("returns false when path does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(hasUncommittedChanges("/some/path")).toBe(false);
+  });
+
+  test("returns false when status is clean", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockReturnValue("");
+    expect(hasUncommittedChanges("/some/path")).toBe(false);
+  });
+
+  test("returns true when there are changes", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockReturnValue(" M src/index.ts\n");
+    expect(hasUncommittedChanges("/some/path")).toBe(true);
+  });
+
+  test("returns false when git status fails", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not a git repo");
+    });
+    expect(hasUncommittedChanges("/some/path")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWorktree
+// ---------------------------------------------------------------------------
+describe("createWorktree", () => {
+  const baseOpts = {
+    owner: "org",
+    repo: "repo",
+    issueNumber: 5,
+    baseBranch: "main",
+  };
+
+  test("creates worktree when path does not exist", () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = createWorktree(baseOpts);
+
+    expect(result.path).toBe(worktreePath("org", "repo", 5));
+    expect(result.branch).toBe("issue-5");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "add", "-b", "issue-5", result.path, "main"],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+  });
+
+  test("uses custom branch name when provided", () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = createWorktree({
+      ...baseOpts,
+      branch: "alice/issue-5",
+    });
+
+    expect(result.branch).toBe("alice/issue-5");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "add", "-b", "alice/issue-5", result.path, "main"],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+  });
+
+  test("throws when path exists and no conflictChoice given", () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(() => createWorktree(baseOpts)).toThrow("Worktree already exists");
+  });
+
+  test("reuses existing worktree", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockReturnValue(""); // git status --porcelain (clean)
+    const result = createWorktree({ ...baseOpts, conflictChoice: "reuse" });
+    expect(result.path).toBe(worktreePath("org", "repo", 5));
+    expect(result.hadUncommittedChanges).toBe(false);
+    // Only hasUncommittedChanges call, no git worktree add.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["status", "--porcelain"],
+      expect.objectContaining({ cwd: result.path }),
+    );
+  });
+
+  test("reuse reports hadUncommittedChanges when dirty", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockReturnValue(" M file.ts\n");
+    const result = createWorktree({ ...baseOpts, conflictChoice: "reuse" });
+    expect(result.hadUncommittedChanges).toBe(true);
+  });
+
+  test("halts when user chooses halt", () => {
+    mockExistsSync.mockReturnValue(true);
+    expect(() =>
+      createWorktree({ ...baseOpts, conflictChoice: "halt" }),
+    ).toThrow("User chose to halt");
+  });
+
+  test("cleans up and recreates when user chooses clean", () => {
+    // First call: existsSync for the worktree path → true (conflict)
+    // Second call: existsSync inside the new worktree add → false
+    mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
+    const result = createWorktree({ ...baseOpts, conflictChoice: "clean" });
+
+    expect(result.path).toBe(worktreePath("org", "repo", 5));
+    expect(mockRmSync).toHaveBeenCalledWith(result.path, {
+      recursive: true,
+      force: true,
+    });
+    // Should call git worktree remove, git branch -D, then git worktree add.
+    const calls = mockExecFileSync.mock.calls.map((c) => c[1]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["worktree", "remove"]),
+        expect.arrayContaining(["branch", "-D"]),
+        expect.arrayContaining(["worktree", "add"]),
+      ]),
+    );
+  });
+
+  test("clean continues even if worktree remove fails", () => {
+    mockExistsSync.mockReturnValueOnce(true).mockReturnValue(false);
+    mockExecFileSync
+      .mockImplementationOnce(() => {
+        throw new Error("worktree remove failed");
+      })
+      .mockImplementation(() => "" as never);
+
+    // Should not throw — the error is caught.
+    const result = createWorktree({ ...baseOpts, conflictChoice: "clean" });
+    expect(result.path).toBe(worktreePath("org", "repo", 5));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeWorktree
+// ---------------------------------------------------------------------------
+describe("removeWorktree", () => {
+  test("removes worktree, directory, and branch", () => {
+    removeWorktree("org", "repo", 5);
+
+    const wtPath = worktreePath("org", "repo", 5);
+    const bare = repoPath("org", "repo");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "remove", "--force", wtPath],
+      expect.objectContaining({ cwd: bare }),
+    );
+    expect(mockRmSync).toHaveBeenCalledWith(wtPath, {
+      recursive: true,
+      force: true,
+    });
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["branch", "-D", "issue-5"],
+      expect.objectContaining({ cwd: bare }),
+    );
+  });
+
+  test("does not throw if worktree remove fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("already removed");
+    });
+    expect(() => removeWorktree("org", "repo", 5)).not.toThrow();
+  });
+
+  test("uses custom branch name when provided", () => {
+    removeWorktree("org", "repo", 5, "alice/issue-5");
+
+    const bare = repoPath("org", "repo");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["branch", "-D", "alice/issue-5"],
+      expect.objectContaining({ cwd: bare }),
+    );
+  });
+
+  test("defaults to issue-N when branch not provided", () => {
+    removeWorktree("org", "repo", 5);
+
+    const bare = repoPath("org", "repo");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["branch", "-D", "issue-5"],
+      expect.objectContaining({ cwd: bare }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createWorktree — hadUncommittedChanges
+// ---------------------------------------------------------------------------
+describe("createWorktree — uncommitted changes detection", () => {
+  const baseOpts = {
+    owner: "org",
+    repo: "repo",
+    issueNumber: 5,
+    baseBranch: "main",
+  };
+
+  test("clean reports hadUncommittedChanges when dirty", () => {
+    // existsSync: true (worktree exists), true (hasUncommittedChanges path check)
+    mockExistsSync.mockReturnValue(true);
+    // First call: git status --porcelain (dirty)
+    // Subsequent calls: worktree remove, branch -D, worktree add
+    mockExecFileSync
+      .mockReturnValueOnce(" M dirty.ts\n" as never)
+      .mockImplementation(() => "" as never);
+    const result = createWorktree({ ...baseOpts, conflictChoice: "clean" });
+    expect(result.hadUncommittedChanges).toBe(true);
+  });
+
+  test("clean reports hadUncommittedChanges false when clean", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(() => "" as never);
+    const result = createWorktree({ ...baseOpts, conflictChoice: "clean" });
+    expect(result.hadUncommittedChanges).toBe(false);
+  });
+
+  test("new worktree always has hadUncommittedChanges false", () => {
+    mockExistsSync.mockReturnValue(false);
+    mockExecFileSync.mockImplementation(() => "" as never);
+    const result = createWorktree(baseOpts);
+    expect(result.hadUncommittedChanges).toBe(false);
+  });
+
+  test("halt still checks uncommitted changes before throwing", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockReturnValue(" M dirty.ts\n");
+    // halt throws, but hasUncommittedChanges was called before that.
+    expect(() =>
+      createWorktree({ ...baseOpts, conflictChoice: "halt" }),
+    ).toThrow("User chose to halt");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["status", "--porcelain"],
+      expect.objectContaining({ cwd: worktreePath("org", "repo", 5) }),
+    );
+  });
+});

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -1,0 +1,228 @@
+/**
+ * Local repository bootstrap and git worktree management.
+ *
+ * Provides utilities for:
+ * - Cloning a repository if missing, or fetching if it exists
+ * - Detecting the default branch via `gh repo view`
+ * - Creating / reusing / cleaning up worktrees at a deterministic path
+ */
+
+import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ---- public types --------------------------------------------------------
+
+export type WorktreeConflictChoice = "reuse" | "clean" | "halt";
+
+export interface WorktreeResult {
+  /** Absolute path to the worktree directory. */
+  path: string;
+  /** The branch name created for this worktree. */
+  branch: string;
+  /** True when the worktree had uncommitted changes (only for "reuse"/"clean"). */
+  hadUncommittedChanges: boolean;
+}
+
+// ---- path helpers --------------------------------------------------------
+
+/**
+ * Return the deterministic worktree path for a given owner/repo/issue
+ * combination:  `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`
+ */
+export function worktreePath(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): string {
+  return join(
+    homedir(),
+    ".agentcoop",
+    "worktrees",
+    owner,
+    repo,
+    `issue-${issueNumber}`,
+  );
+}
+
+/**
+ * Return the path to the bare clone used as the main repository:
+ * `~/.agentcoop/repos/{owner}/{repo}.git`
+ */
+export function repoPath(owner: string, repo: string): string {
+  return join(homedir(), ".agentcoop", "repos", owner, `${repo}.git`);
+}
+
+// ---- default branch detection --------------------------------------------
+
+/**
+ * Detect the default branch for `owner/repo` via `gh repo view`.
+ */
+export function detectDefaultBranch(owner: string, repo: string): string {
+  const output = execFileSync(
+    "gh",
+    ["repo", "view", `${owner}/${repo}`, "--json", "defaultBranchRef"],
+    { encoding: "utf-8" },
+  );
+  const data = JSON.parse(output);
+  return data.defaultBranchRef?.name ?? "main";
+}
+
+// ---- repo bootstrap ------------------------------------------------------
+
+const EXEC_OPTS: ExecFileSyncOptions = { encoding: "utf-8", stdio: "pipe" };
+
+/**
+ * Ensure a bare clone of `owner/repo` exists locally.
+ * - Missing → `git clone --bare`
+ * - Exists  → `git fetch --all --prune`
+ */
+export function bootstrapRepo(owner: string, repo: string): string {
+  const dest = repoPath(owner, repo);
+  if (existsSync(dest)) {
+    execFileSync("git", ["fetch", "--all", "--prune"], {
+      ...EXEC_OPTS,
+      cwd: dest,
+    });
+  } else {
+    execFileSync(
+      "git",
+      ["clone", "--bare", `https://github.com/${owner}/${repo}.git`, dest],
+      EXEC_OPTS,
+    );
+  }
+  return dest;
+}
+
+// ---- worktree management -------------------------------------------------
+
+/**
+ * Check whether a worktree directory already exists and contains
+ * uncommitted changes.
+ */
+export function hasUncommittedChanges(wtPath: string): boolean {
+  if (!existsSync(wtPath)) return false;
+  try {
+    const output = execFileSync("git", ["status", "--porcelain"], {
+      ...EXEC_OPTS,
+      cwd: wtPath,
+    }) as string;
+    return output.trim().length > 0;
+  } catch {
+    // If git status fails (e.g. not a git directory), treat as no changes.
+    return false;
+  }
+}
+
+/**
+ * Force-remove a worktree entry from the bare repo and delete the branch.
+ * Errors are silently ignored (the worktree/branch may not exist).
+ */
+function forceRemoveWorktreeAndBranch(
+  bare: string,
+  wtPath: string,
+  branch: string,
+): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", wtPath], {
+      ...EXEC_OPTS,
+      cwd: bare,
+    });
+  } catch {
+    // Already removed or never existed.
+  }
+
+  rmSync(wtPath, { recursive: true, force: true });
+
+  try {
+    execFileSync("git", ["branch", "-D", branch], { ...EXEC_OPTS, cwd: bare });
+  } catch {
+    // Branch may not exist.
+  }
+}
+
+/**
+ * Create a worktree for the given issue, branching from `baseBranch`.
+ *
+ * When the target path already exists the caller must provide a
+ * `conflictChoice` — otherwise the function throws.  If the existing
+ * worktree contains uncommitted changes, `hadUncommittedChanges` in
+ * the result will be `true` so the caller can warn the user.
+ *
+ * @returns The worktree path, branch name, and dirty flag.
+ */
+export function createWorktree(options: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  baseBranch: string;
+  /**
+   * Branch name for the worktree.  Defaults to `issue-{number}`.
+   * Stage handlers typically pass `{username}/issue-{number}`.
+   */
+  branch?: string;
+  conflictChoice?: WorktreeConflictChoice;
+}): WorktreeResult {
+  const { owner, repo, issueNumber, baseBranch, conflictChoice } = options;
+  const bare = repoPath(owner, repo);
+  const wtPath = worktreePath(owner, repo, issueNumber);
+  const branch = options.branch ?? `issue-${issueNumber}`;
+
+  if (existsSync(wtPath)) {
+    if (conflictChoice === undefined) {
+      throw new Error(
+        `Worktree already exists at ${wtPath}. ` +
+          "Provide a conflictChoice (reuse | clean | halt).",
+      );
+    }
+
+    const dirty = hasUncommittedChanges(wtPath);
+
+    if (conflictChoice === "halt") {
+      throw new Error("User chose to halt — worktree conflict unresolved.");
+    }
+
+    if (conflictChoice === "clean") {
+      forceRemoveWorktreeAndBranch(bare, wtPath, branch);
+
+      // Recreate.
+      execFileSync(
+        "git",
+        ["worktree", "add", "-b", branch, wtPath, baseBranch],
+        { ...EXEC_OPTS, cwd: bare },
+      );
+      return { path: wtPath, branch, hadUncommittedChanges: dirty };
+    }
+
+    // "reuse"
+    return { path: wtPath, branch, hadUncommittedChanges: dirty };
+  }
+
+  // Create the worktree with a new branch tracking the base branch.
+  execFileSync("git", ["worktree", "add", "-b", branch, wtPath, baseBranch], {
+    ...EXEC_OPTS,
+    cwd: bare,
+  });
+
+  return { path: wtPath, branch, hadUncommittedChanges: false };
+}
+
+/**
+ * Remove a worktree and its branch.  Used during final cleanup (stage 9).
+ *
+ * @param branch - The branch to delete.  Defaults to `issue-{issueNumber}`
+ *   but callers should pass the actual branch name when a custom name was
+ *   used during `createWorktree`.
+ */
+export function removeWorktree(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  branch?: string,
+): void {
+  const bare = repoPath(owner, repo);
+  const wtPath = worktreePath(owner, repo, issueNumber);
+  const resolvedBranch = branch ?? `issue-${issueNumber}`;
+  forceRemoveWorktreeAndBranch(bare, wtPath, resolvedBranch);
+}


### PR DESCRIPTION
## Summary

- Implement the orchestrator core pipeline engine with 9-stage sequencing, auto/step execution modes, and loop control (3 automatic iterations, then user approval for 3 more)
- Add step completion keyword parsing with auto-clarification retry, blocked/error/ambiguous handling, repo bootstrap, git worktree management, PR extraction, CI polling, and Stage 9 (Done with merge confirmation + cleanup)
- Include 345 tests covering all modules with unit, edge case, and E2E scenarios

## Test plan

- [x] `pnpm vitest run` — 345 tests passing
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check src` — no lint/format issues

Closes #5