### PR TITLE
Add pipeline settings to startup flow

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -37,6 +37,12 @@ describe("loadConfig", () => {
       owners: [],
       cloneBaseDir: "~/projects",
       language: "en",
+      pipelineSettings: {
+        selfCheckAutoIterations: 3,
+        reviewAutoRounds: 3,
+        inactivityTimeoutMinutes: 15,
+        autoResumeAttempts: 3,
+      },
     });
     expect(existsSync(configPath())).toBe(true);
   });
@@ -48,6 +54,12 @@ describe("loadConfig", () => {
       owners: [],
       cloneBaseDir: "~/projects",
       language: "en",
+      pipelineSettings: {
+        selfCheckAutoIterations: 3,
+        reviewAutoRounds: 3,
+        inactivityTimeoutMinutes: 15,
+        autoResumeAttempts: 3,
+      },
     });
   });
 
@@ -72,6 +84,12 @@ describe("loadConfig", () => {
     expect(config.owners).toEqual(["foo"]);
     expect(config.cloneBaseDir).toBe("~/projects");
     expect(config.language).toBe("en");
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
   });
 
   test("ignores unknown extra fields", () => {
@@ -86,11 +104,9 @@ describe("loadConfig", () => {
       }),
     );
     const config = loadConfig();
-    expect(config).toEqual({
-      owners: ["bar"],
-      cloneBaseDir: "~/code",
-      language: "en",
-    });
+    expect(config.owners).toEqual(["bar"]);
+    expect(config.cloneBaseDir).toBe("~/code");
+    expect(config.language).toBe("en");
     expect("unknownField" in config).toBe(false);
     expect("nested" in config).toBe(false);
   });
@@ -131,41 +147,33 @@ describe("loadConfig", () => {
   test("falls back to default when root value is null", () => {
     writeFileSync(configPath(), "null");
     const config = loadConfig();
-    expect(config).toEqual({
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en",
-    });
+    expect(config.owners).toEqual([]);
+    expect(config.cloneBaseDir).toBe("~/projects");
+    expect(config.language).toBe("en");
   });
 
   test("falls back to default when root value is a number", () => {
     writeFileSync(configPath(), "42");
     const config = loadConfig();
-    expect(config).toEqual({
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en",
-    });
+    expect(config.owners).toEqual([]);
+    expect(config.cloneBaseDir).toBe("~/projects");
+    expect(config.language).toBe("en");
   });
 
   test("falls back to default when root value is a string", () => {
     writeFileSync(configPath(), JSON.stringify("hello"));
     const config = loadConfig();
-    expect(config).toEqual({
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en",
-    });
+    expect(config.owners).toEqual([]);
+    expect(config.cloneBaseDir).toBe("~/projects");
+    expect(config.language).toBe("en");
   });
 
   test("falls back to default when root value is an array", () => {
     writeFileSync(configPath(), JSON.stringify([1, 2, 3]));
     const config = loadConfig();
-    expect(config).toEqual({
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en",
-    });
+    expect(config.owners).toEqual([]);
+    expect(config.cloneBaseDir).toBe("~/projects");
+    expect(config.language).toBe("en");
   });
 
   test("filters out whitespace-only strings from owners array", () => {
@@ -217,6 +225,122 @@ describe("loadConfig", () => {
     a.owners.push("mutated");
     expect(b.owners).not.toContain("mutated");
   });
+
+  test("reads saved pipelineSettings from config", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: 5,
+          reviewAutoRounds: 2,
+          inactivityTimeoutMinutes: 30,
+          autoResumeAttempts: 1,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 2,
+      inactivityTimeoutMinutes: 30,
+      autoResumeAttempts: 1,
+    });
+  });
+
+  test("falls back to defaults for invalid pipelineSettings values", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: -1,
+          reviewAutoRounds: "abc",
+          inactivityTimeoutMinutes: 0,
+          autoResumeAttempts: 3.5,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("falls back to defaults when pipelineSettings is not an object", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], pipelineSettings: "invalid" }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("pipelineSettings defaults are isolated from mutations", () => {
+    const config1 = loadConfig();
+    config1.pipelineSettings.selfCheckAutoIterations = 99;
+
+    rmSync(configPath());
+
+    const config2 = loadConfig();
+    expect(config2.pipelineSettings.selfCheckAutoIterations).toBe(3);
+  });
+
+  test("partially valid pipelineSettings keeps valid values", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: 10,
+          reviewAutoRounds: -1,
+          inactivityTimeoutMinutes: "bad",
+          autoResumeAttempts: 5,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings.selfCheckAutoIterations).toBe(10);
+    expect(config.pipelineSettings.reviewAutoRounds).toBe(3);
+    expect(config.pipelineSettings.inactivityTimeoutMinutes).toBe(15);
+    expect(config.pipelineSettings.autoResumeAttempts).toBe(5);
+  });
+
+  test("pipelineSettings null falls back to defaults", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], pipelineSettings: null }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("pipelineSettings array falls back to defaults", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], pipelineSettings: [1, 2, 3] }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
+  });
 });
 
 describe("saveConfig", () => {
@@ -224,11 +348,19 @@ describe("saveConfig", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
+  const defaultPS = {
+    selfCheckAutoIterations: 3,
+    reviewAutoRounds: 3,
+    inactivityTimeoutMinutes: 15,
+    autoResumeAttempts: 3,
+  };
+
   test("creates directories and writes config", () => {
     const config = {
       owners: ["org1"],
       cloneBaseDir: "~/code",
       language: "ko" as const,
+      pipelineSettings: { ...defaultPS },
     };
     saveConfig(config);
     const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
@@ -236,18 +368,34 @@ describe("saveConfig", () => {
   });
 
   test("written file ends with newline", () => {
-    saveConfig({ owners: [], cloneBaseDir: "~/x", language: "en" });
+    saveConfig({
+      owners: [],
+      cloneBaseDir: "~/x",
+      language: "en",
+      pipelineSettings: { ...defaultPS },
+    });
     const content = readFileSync(configPath(), "utf-8");
     expect(content.endsWith("\n")).toBe(true);
   });
 
   test("overwrites existing config", () => {
-    saveConfig({ owners: ["a"], cloneBaseDir: "~/x", language: "en" });
-    saveConfig({ owners: ["b"], cloneBaseDir: "~/y", language: "ko" });
+    saveConfig({
+      owners: ["a"],
+      cloneBaseDir: "~/x",
+      language: "en",
+      pipelineSettings: { ...defaultPS },
+    });
+    saveConfig({
+      owners: ["b"],
+      cloneBaseDir: "~/y",
+      language: "ko",
+      pipelineSettings: { ...defaultPS, reviewAutoRounds: 5 },
+    });
     const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
     expect(raw.owners).toEqual(["b"]);
     expect(raw.cloneBaseDir).toBe("~/y");
     expect(raw.language).toBe("ko");
+    expect(raw.pipelineSettings.reviewAutoRounds).toBe(5);
   });
 
   test("roundtrips correctly with loadConfig", () => {
@@ -255,6 +403,7 @@ describe("saveConfig", () => {
       owners: ["aicers", "my-org"],
       cloneBaseDir: "~/dev",
       language: "ko" as const,
+      pipelineSettings: { ...defaultPS, inactivityTimeoutMinutes: 30 },
     };
     saveConfig(original);
     const loaded = loadConfig();

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,16 +2,32 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+export interface PipelineSettings {
+  selfCheckAutoIterations: number;
+  reviewAutoRounds: number;
+  inactivityTimeoutMinutes: number;
+  autoResumeAttempts: number;
+}
+
+export const DEFAULT_PIPELINE_SETTINGS: PipelineSettings = {
+  selfCheckAutoIterations: 3,
+  reviewAutoRounds: 3,
+  inactivityTimeoutMinutes: 15,
+  autoResumeAttempts: 3,
+};
+
 export interface Config {
   owners: string[];
   cloneBaseDir: string;
   language: "en" | "ko";
+  pipelineSettings: PipelineSettings;
 }
 
 const DEFAULT_CONFIG: Config = {
   owners: [],
   cloneBaseDir: "~/projects",
   language: "en",
+  pipelineSettings: { ...DEFAULT_PIPELINE_SETTINGS },
 };
 
 export function configPath(): string {
@@ -20,15 +36,49 @@ export function configPath(): string {
 
 const VALID_LANGUAGES = new Set<Config["language"]>(["en", "ko"]);
 
+function isPositiveInt(v: unknown): v is number {
+  return typeof v === "number" && Number.isInteger(v) && v > 0;
+}
+
+function loadPipelineSettings(raw: unknown): PipelineSettings {
+  const d = DEFAULT_PIPELINE_SETTINGS;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { ...d };
+  }
+  const r = raw as Record<string, unknown>;
+  return {
+    selfCheckAutoIterations: isPositiveInt(r.selfCheckAutoIterations)
+      ? r.selfCheckAutoIterations
+      : d.selfCheckAutoIterations,
+    reviewAutoRounds: isPositiveInt(r.reviewAutoRounds)
+      ? r.reviewAutoRounds
+      : d.reviewAutoRounds,
+    inactivityTimeoutMinutes: isPositiveInt(r.inactivityTimeoutMinutes)
+      ? r.inactivityTimeoutMinutes
+      : d.inactivityTimeoutMinutes,
+    autoResumeAttempts: isPositiveInt(r.autoResumeAttempts)
+      ? r.autoResumeAttempts
+      : d.autoResumeAttempts,
+  };
+}
+
 export function loadConfig(): Config {
   const path = configPath();
   if (!existsSync(path)) {
     saveConfig(DEFAULT_CONFIG);
-    return { ...DEFAULT_CONFIG, owners: [...DEFAULT_CONFIG.owners] };
+    return {
+      ...DEFAULT_CONFIG,
+      owners: [...DEFAULT_CONFIG.owners],
+      pipelineSettings: { ...DEFAULT_CONFIG.pipelineSettings },
+    };
   }
   const raw = JSON.parse(readFileSync(path, "utf-8"));
   if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
-    return { ...DEFAULT_CONFIG, owners: [...DEFAULT_CONFIG.owners] };
+    return {
+      ...DEFAULT_CONFIG,
+      owners: [...DEFAULT_CONFIG.owners],
+      pipelineSettings: { ...DEFAULT_CONFIG.pipelineSettings },
+    };
   }
   const language = VALID_LANGUAGES.has(raw.language)
     ? raw.language
@@ -44,6 +94,7 @@ export function loadConfig(): Config {
         ? raw.cloneBaseDir
         : DEFAULT_CONFIG.cloneBaseDir,
     language,
+    pipelineSettings: loadPipelineSettings(raw.pipelineSettings),
   };
 }
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -176,6 +176,16 @@ describe("module exports", () => {
     expect(typeof config.configPath).toBe("function");
   });
 
+  test("config module exports DEFAULT_PIPELINE_SETTINGS", async () => {
+    const config = await import("../dist/config.js");
+    expect(config.DEFAULT_PIPELINE_SETTINGS).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
+  });
+
   test("github module exports listRepositories and getIssue", async () => {
     const github = await import("../dist/github.js");
     expect(typeof github.listRepositories).toBe("function");

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,16 @@ try {
   console.log(`  Mode: ${result.executionMode}`);
   console.log(`  Permission: ${result.claudePermissionMode}`);
   console.log(`  Language: ${result.language}`);
+  console.log(
+    `  Self-check iterations: ${result.pipelineSettings.selfCheckAutoIterations}`,
+  );
+  console.log(`  Review rounds: ${result.pipelineSettings.reviewAutoRounds}`);
+  console.log(
+    `  Inactivity timeout: ${result.pipelineSettings.inactivityTimeoutMinutes} min`,
+  );
+  console.log(
+    `  Auto-resume attempts: ${result.pipelineSettings.autoResumeAttempts}`,
+  );
 
   // Bootstrap the repository and create a worktree.
   console.log();
@@ -80,10 +90,13 @@ try {
     ...issueCtx,
   });
 
-  const selfCheckStage = createSelfCheckStageHandler({
-    agent: agentA,
-    ...issueCtx,
-  });
+  const selfCheckStage = {
+    ...createSelfCheckStageHandler({
+      agent: agentA,
+      ...issueCtx,
+    }),
+    autoBudget: result.pipelineSettings.selfCheckAutoIterations,
+  };
 
   const doneStage = createDoneStageHandler({
     reportCompletion: async (msg) => console.log(msg),

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -79,6 +79,14 @@ describe("createLoopControl", () => {
     const lc = createLoopControl();
     expect(lc.iteration).toBe(0);
     expect(lc.autoRemaining).toBe(3);
+    expect(lc.budget).toBe(3);
+  });
+
+  test("accepts custom budget", () => {
+    const lc = createLoopControl(5);
+    expect(lc.iteration).toBe(0);
+    expect(lc.autoRemaining).toBe(5);
+    expect(lc.budget).toBe(5);
   });
 });
 
@@ -109,7 +117,7 @@ describe("advanceLoop", () => {
 });
 
 describe("grantLoopBudget", () => {
-  test("resets autoRemaining to 3", () => {
+  test("resets autoRemaining to budget", () => {
     const lc = createLoopControl();
     advanceLoop(lc);
     advanceLoop(lc);
@@ -117,6 +125,14 @@ describe("grantLoopBudget", () => {
     expect(lc.autoRemaining).toBe(0);
     grantLoopBudget(lc);
     expect(lc.autoRemaining).toBe(3);
+  });
+
+  test("resets autoRemaining to custom budget", () => {
+    const lc = createLoopControl(5);
+    for (let i = 0; i < 5; i++) advanceLoop(lc);
+    expect(lc.autoRemaining).toBe(0);
+    grantLoopBudget(lc);
+    expect(lc.autoRemaining).toBe(5);
   });
 
   test("preserves iteration count", () => {
@@ -252,6 +268,50 @@ describe("runPipeline — step mode", () => {
 // runPipeline — loop control
 // ---------------------------------------------------------------------------
 describe("runPipeline — loop control", () => {
+  test("uses custom per-stage autoBudget when provided", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(
+        1,
+        async () => {
+          calls++;
+          return { outcome: "not_approved", message: "try again" };
+        },
+        { autoBudget: 5 },
+      ),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(calls).toBe(5);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+  });
+
+  test("custom per-stage autoBudget is preserved after grant", async () => {
+    let calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi
+        .fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(
+        1,
+        async () => {
+          calls++;
+          return { outcome: "not_approved", message: "try again" };
+        },
+        { autoBudget: 2 },
+      ),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    // 2 auto + user approves + 2 more auto + user declines = 4
+    expect(calls).toBe(4);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(2);
+  });
+
   test("loops up to 3 times automatically then asks user", async () => {
     let calls = 0;
     const prompt = makePrompt({

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -62,6 +62,11 @@ export interface StageDefinition {
    * reports BLOCKED — the artifact is mandatory (e.g. PR creation).
    */
   requiresArtifact?: boolean;
+  /**
+   * Override the default auto-iteration budget for this stage's loop.
+   * When omitted the engine uses its built-in default (3).
+   */
+  autoBudget?: number;
 }
 
 /**
@@ -134,21 +139,23 @@ export interface UserPrompt {
 
 // ---- loop control --------------------------------------------------------
 
-/** Number of automatic iterations before asking the user. */
-const AUTO_BUDGET = 3;
+/** Default number of automatic iterations before asking the user. */
+const DEFAULT_AUTO_BUDGET = 3;
 
 export interface LoopControl {
   /** Current iteration (0-based). */
   iteration: number;
   /** Number of auto-iterations remaining before the next user prompt. */
   autoRemaining: number;
+  /** Budget granted on each reset. */
+  budget: number;
 }
 
 /**
  * Create a fresh loop-control state.
  */
-export function createLoopControl(): LoopControl {
-  return { iteration: 0, autoRemaining: AUTO_BUDGET };
+export function createLoopControl(budget = DEFAULT_AUTO_BUDGET): LoopControl {
+  return { iteration: 0, autoRemaining: budget, budget };
 }
 
 /**
@@ -166,7 +173,7 @@ export function advanceLoop(lc: LoopControl): boolean {
  * approves continuing).
  */
 export function grantLoopBudget(lc: LoopControl): void {
-  lc.autoRemaining = AUTO_BUDGET;
+  lc.autoRemaining = lc.budget;
 }
 
 // ---- terminal outcomes ---------------------------------------------------
@@ -273,7 +280,7 @@ async function runStage(
   baseCtx: Omit<StageContext, "iteration" | "userInstruction">,
   prompt: UserPrompt,
 ): Promise<StageRunResult> {
-  const lc = createLoopControl();
+  const lc = createLoopControl(stage.autoBudget);
   let userInstruction: string | undefined;
   /** Tracks whether the last iteration was an auto-clarification retry. */
   let clarificationAttempted = false;

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -9,12 +9,14 @@ const mockSelect = vi.fn();
 const mockSearch = vi.fn();
 const mockInput = vi.fn();
 const mockConfirm = vi.fn();
+const mockCheckbox = vi.fn();
 
 vi.mock("@inquirer/prompts", () => ({
   select: (...args: unknown[]) => mockSelect(...args),
   search: (...args: unknown[]) => mockSearch(...args),
   input: (...args: unknown[]) => mockInput(...args),
   confirm: (...args: unknown[]) => mockConfirm(...args),
+  checkbox: (...args: unknown[]) => mockCheckbox(...args),
 }));
 
 const mockLoadConfig = vi.fn();
@@ -43,6 +45,12 @@ function defaultConfig(): Config {
     owners: ["aicers", "my-org"],
     cloneBaseDir: "~/projects",
     language: "en",
+    pipelineSettings: {
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    },
   };
 }
 
@@ -67,6 +75,7 @@ function setupHappyPath() {
     .mockResolvedValueOnce("en"); // language
   mockSearch.mockResolvedValueOnce("agentcoop"); // repo
   mockInput.mockResolvedValueOnce("42"); // issue number
+  mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
   mockListRepositories.mockReturnValue([
     { name: "agentcoop", description: "Multi-agent CLI" },
   ]);
@@ -94,6 +103,12 @@ describe("runStartup — happy path", () => {
     expect(result.executionMode).toBe("auto");
     expect(result.claudePermissionMode).toBe("auto");
     expect(result.language).toBe("en");
+    expect(result.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
   });
 
   test("calls loadConfig exactly once", async () => {
@@ -126,10 +141,16 @@ describe("runStartup — happy path", () => {
 // ---------------------------------------------------------------------------
 describe("runStartup — owner selection", () => {
   test("prompts for input when owners list is empty", async () => {
-    const config = {
+    const config: Config = {
       owners: [],
       cloneBaseDir: "~/projects",
       language: "en" as const,
+      pipelineSettings: {
+        selfCheckAutoIterations: 3,
+        reviewAutoRounds: 3,
+        inactivityTimeoutMinutes: 15,
+        autoResumeAttempts: 3,
+      },
     };
     mockLoadConfig.mockReturnValue(config);
     mockInput
@@ -141,6 +162,7 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("step") // execution mode
       .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("ko"); // language
+    mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -160,11 +182,8 @@ describe("runStartup — owner selection", () => {
   });
 
   test("rejects empty owner input via validate", async () => {
-    const config = {
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en" as const,
-    };
+    const config = defaultConfig();
+    config.owners = [];
     mockLoadConfig.mockReturnValue(config);
 
     let ownerCallDone = false;
@@ -192,6 +211,7 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("auto")
       .mockResolvedValueOnce("auto")
       .mockResolvedValueOnce("en");
+    mockCheckbox.mockResolvedValueOnce([]);
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -201,11 +221,8 @@ describe("runStartup — owner selection", () => {
   });
 
   test("trims whitespace from manually entered owner", async () => {
-    const config = {
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en" as const,
-    };
+    const config = defaultConfig();
+    config.owners = [];
     mockLoadConfig.mockReturnValue(config);
     mockInput
       .mockResolvedValueOnce("  aicers  ") // owner with spaces
@@ -216,6 +233,7 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("auto")
       .mockResolvedValueOnce("auto")
       .mockResolvedValueOnce("en");
+    mockCheckbox.mockResolvedValueOnce([]);
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -498,6 +516,7 @@ describe("runStartup — language selection", () => {
       .mockResolvedValueOnce("ko"); // changed from "en" to "ko"
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce([]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -512,11 +531,8 @@ describe("runStartup — language selection", () => {
   });
 
   test("passes current config language as default to select", async () => {
-    const config = {
-      owners: ["aicers"],
-      cloneBaseDir: "~/projects",
-      language: "ko" as const,
-    };
+    const config = defaultConfig();
+    config.language = "ko";
     mockLoadConfig.mockReturnValue(config);
     mockSelect
       .mockResolvedValueOnce("aicers")
@@ -527,6 +543,7 @@ describe("runStartup — language selection", () => {
       .mockResolvedValueOnce("ko"); // same as config, no save
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce([]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -552,11 +569,8 @@ describe("runStartup — config dirty tracking", () => {
   });
 
   test("saves once when new owner entered and language unchanged", async () => {
-    const config = {
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en" as const,
-    };
+    const config = defaultConfig();
+    config.owners = [];
     mockLoadConfig.mockReturnValue(config);
     mockInput.mockResolvedValueOnce("new-org").mockResolvedValueOnce("1");
     mockSelect
@@ -565,6 +579,7 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("auto")
       .mockResolvedValueOnce("auto")
       .mockResolvedValueOnce("en"); // same language
+    mockCheckbox.mockResolvedValueOnce([]);
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -586,6 +601,7 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("ko"); // changed
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce([]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -624,11 +640,8 @@ describe("runStartup — error propagation", () => {
   });
 
   test("does not save config when listRepositories fails after owner input", async () => {
-    const config = {
-      owners: [],
-      cloneBaseDir: "~/projects",
-      language: "en" as const,
-    };
+    const config = defaultConfig();
+    config.owners = [];
     mockLoadConfig.mockReturnValue(config);
     mockInput.mockResolvedValueOnce("bad-org");
     mockListRepositories.mockImplementation(() => {
@@ -797,6 +810,7 @@ describe("runStartup — alternate selections", () => {
       .mockResolvedValueOnce("ko");
     mockSearch.mockResolvedValueOnce("my-repo");
     mockInput.mockResolvedValueOnce("99");
+    mockCheckbox.mockResolvedValueOnce([]);
     mockListRepositories.mockReturnValue([
       { name: "my-repo", description: "test" },
     ]);
@@ -818,5 +832,266 @@ describe("runStartup — alternate selections", () => {
     expect(result.executionMode).toBe("step");
     expect(result.claudePermissionMode).toBe("bypass");
     expect(result.language).toBe("ko");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline settings
+// ---------------------------------------------------------------------------
+describe("runStartup — pipeline settings", () => {
+  test("returns default settings when no adjustments selected", async () => {
+    setupHappyPath();
+    const result = await runStartup();
+    expect(result.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 15,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("returns adjusted settings and saves when user confirms", async () => {
+    setupHappyPath();
+    mockCheckbox
+      .mockReset()
+      .mockResolvedValueOnce(["selfCheckAutoIterations", "reviewAutoRounds"]);
+    // input for the two selected settings
+    mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
+    mockInput.mockResolvedValueOnce("5"); // selfCheckAutoIterations
+    mockInput.mockResolvedValueOnce("7"); // reviewAutoRounds
+    // confirm save = yes → config dirty
+    mockConfirm.mockReset().mockResolvedValueOnce(true); // save to config?
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+    expect(result.pipelineSettings.selfCheckAutoIterations).toBe(5);
+    expect(result.pipelineSettings.reviewAutoRounds).toBe(7);
+    expect(result.pipelineSettings.inactivityTimeoutMinutes).toBe(15);
+    expect(mockSaveConfig).toHaveBeenCalledOnce();
+  });
+
+  test("does not save config when user declines save", async () => {
+    setupHappyPath();
+    mockCheckbox.mockReset().mockResolvedValueOnce(["autoResumeAttempts"]);
+    mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
+    mockInput.mockResolvedValueOnce("10"); // autoResumeAttempts
+    mockConfirm.mockReset().mockResolvedValueOnce(false); // decline save
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+    expect(result.pipelineSettings.autoResumeAttempts).toBe(10);
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+  });
+
+  test("presents all four settings as checkbox choices", async () => {
+    setupHappyPath();
+    await runStartup();
+
+    expect(mockCheckbox).toHaveBeenCalledOnce();
+    const opts = mockCheckbox.mock.calls[0][0];
+    expect(opts.choices).toHaveLength(4);
+    const values = opts.choices.map((c: { value: string }) => c.value);
+    expect(values).toEqual([
+      "selfCheckAutoIterations",
+      "reviewAutoRounds",
+      "inactivityTimeoutMinutes",
+      "autoResumeAttempts",
+    ]);
+    // Verify labels include current values with unit suffix
+    const names = opts.choices.map((c: { name: string }) => c.name);
+    expect(names[0]).toBe("Self-check auto iterations: 3");
+    expect(names[1]).toBe("Review auto rounds: 3");
+    expect(names[2]).toBe("Inactivity timeout: 15 min");
+    expect(names[3]).toBe("Auto-resume attempts: 3");
+  });
+
+  test("displays current settings from config with unit suffix", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    setupHappyPath();
+    await runStartup();
+
+    const logs = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(logs).toContain("Pipeline settings");
+    expect(logs).toContain("Self-check auto iterations");
+    expect(logs).toContain("Review auto rounds");
+    expect(logs).toContain("Inactivity timeout");
+    expect(logs).toContain("15 min");
+    expect(logs).toContain("Auto-resume attempts");
+
+    consoleSpy.mockRestore();
+  });
+
+  test("displays custom settings from config", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const config = defaultConfig();
+    config.pipelineSettings.selfCheckAutoIterations = 10;
+    config.pipelineSettings.inactivityTimeoutMinutes = 30;
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers")
+      .mockResolvedValueOnce("opus")
+      .mockResolvedValueOnce("gpt-5.4")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("en");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce([]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+
+    const logs = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(logs).toContain("10");
+    expect(logs).toContain("30 min");
+    expect(result.pipelineSettings.selfCheckAutoIterations).toBe(10);
+    expect(result.pipelineSettings.inactivityTimeoutMinutes).toBe(30);
+
+    consoleSpy.mockRestore();
+  });
+
+  test("unchanged fields preserve original values after adjustment", async () => {
+    setupHappyPath();
+    mockCheckbox.mockReset().mockResolvedValueOnce(["selfCheckAutoIterations"]);
+    mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
+    mockInput.mockResolvedValueOnce("10"); // selfCheckAutoIterations only
+    mockConfirm.mockReset().mockResolvedValueOnce(false); // decline save
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+    expect(result.pipelineSettings.selfCheckAutoIterations).toBe(10);
+    expect(result.pipelineSettings.reviewAutoRounds).toBe(3);
+    expect(result.pipelineSettings.inactivityTimeoutMinutes).toBe(15);
+    expect(result.pipelineSettings.autoResumeAttempts).toBe(3);
+  });
+
+  test("validates input rejects negative, zero, decimal, and empty values", async () => {
+    setupHappyPath();
+    mockCheckbox.mockReset().mockResolvedValueOnce(["reviewAutoRounds"]);
+
+    mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
+    mockInput.mockImplementationOnce(
+      async (opts: {
+        message: string;
+        default: string;
+        validate: (v: string) => string | true;
+      }) => {
+        expect(opts.validate("")).toBe("Enter a positive integer");
+        expect(opts.validate("-1")).toBe("Enter a positive integer");
+        expect(opts.validate("0")).toBe("Enter a positive integer");
+        expect(opts.validate("3.5")).toBe("Enter a positive integer");
+        expect(opts.validate("abc")).toBe("Enter a positive integer");
+        expect(opts.validate("5")).toBe(true);
+        expect(opts.validate("1")).toBe(true);
+        return "5";
+      },
+    );
+    mockConfirm.mockReset().mockResolvedValueOnce(false); // decline save
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+    expect(result.pipelineSettings.reviewAutoRounds).toBe(5);
+  });
+
+  test("adjusting all four settings works correctly", async () => {
+    setupHappyPath();
+    mockCheckbox
+      .mockReset()
+      .mockResolvedValueOnce([
+        "selfCheckAutoIterations",
+        "reviewAutoRounds",
+        "inactivityTimeoutMinutes",
+        "autoResumeAttempts",
+      ]);
+    mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
+    mockInput
+      .mockResolvedValueOnce("5") // selfCheckAutoIterations
+      .mockResolvedValueOnce("7") // reviewAutoRounds
+      .mockResolvedValueOnce("30") // inactivityTimeoutMinutes
+      .mockResolvedValueOnce("2"); // autoResumeAttempts
+    mockConfirm.mockReset().mockResolvedValueOnce(true); // save
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+    expect(result.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 7,
+      inactivityTimeoutMinutes: 30,
+      autoResumeAttempts: 2,
+    });
+    expect(mockSaveConfig).toHaveBeenCalledOnce();
+    expect(mockSaveConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pipelineSettings: {
+          selfCheckAutoIterations: 5,
+          reviewAutoRounds: 7,
+          inactivityTimeoutMinutes: 30,
+          autoResumeAttempts: 2,
+        },
+      }),
+    );
+  });
+
+  test("session-only changes do not update config.pipelineSettings", async () => {
+    const config = defaultConfig();
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers")
+      .mockResolvedValueOnce("opus")
+      .mockResolvedValueOnce("gpt-5.4")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("en");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce(["selfCheckAutoIterations"]);
+    mockInput.mockResolvedValueOnce("99");
+    mockConfirm
+      .mockResolvedValueOnce(false) // decline save
+      .mockResolvedValueOnce(true); // confirm issue
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+
+    const result = await runStartup();
+    // Session gets the new value
+    expect(result.pipelineSettings.selfCheckAutoIterations).toBe(99);
+    // Config object was NOT mutated (save declined)
+    expect(config.pipelineSettings.selfCheckAutoIterations).toBe(3);
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+  });
+
+  test("input shows current value as default", async () => {
+    const config = defaultConfig();
+    config.pipelineSettings.autoResumeAttempts = 7;
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers")
+      .mockResolvedValueOnce("opus")
+      .mockResolvedValueOnce("gpt-5.4")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("en");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce(["autoResumeAttempts"]);
+    mockInput.mockImplementationOnce(
+      async (opts: { message: string; default: string }) => {
+        expect(opts.default).toBe("7");
+        return "7";
+      },
+    );
+    mockConfirm.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+
+    await runStartup();
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,5 +1,5 @@
-import { confirm, input, search, select } from "@inquirer/prompts";
-import type { Config } from "./config.js";
+import { checkbox, confirm, input, search, select } from "@inquirer/prompts";
+import type { Config, PipelineSettings } from "./config.js";
 import { loadConfig, saveConfig } from "./config.js";
 import type { Issue } from "./github.js";
 import { getIssue, listRepositories } from "./github.js";
@@ -13,6 +13,7 @@ export interface StartupResult {
   executionMode: "auto" | "step";
   claudePermissionMode: "auto" | "bypass";
   language: "en" | "ko";
+  pipelineSettings: PipelineSettings;
 }
 
 export interface AgentConfig {
@@ -48,6 +49,13 @@ export async function runStartup(): Promise<StartupResult> {
   const { language, dirty: langDirty } = await selectLanguage(config);
   configDirty ||= langDirty;
 
+  const { pipelineSettings, dirty: settingsDirty } =
+    await adjustPipelineSettings(config.pipelineSettings);
+  if (settingsDirty) {
+    config.pipelineSettings = pipelineSettings;
+  }
+  configDirty ||= settingsDirty;
+
   const issue = getIssue(owner, repo, issueNumber);
   const confirmed = await confirmIssue(owner, repo, issue);
   if (!confirmed) {
@@ -69,6 +77,7 @@ export async function runStartup(): Promise<StartupResult> {
     executionMode,
     claudePermissionMode,
     language,
+    pipelineSettings,
   };
 }
 
@@ -173,6 +182,80 @@ async function selectLanguage(
   const dirty = language !== config.language;
   config.language = language;
   return { language, dirty };
+}
+
+type SettingKey = keyof PipelineSettings;
+
+const SETTING_LABELS: Record<SettingKey, string> = {
+  selfCheckAutoIterations: "Self-check auto iterations",
+  reviewAutoRounds: "Review auto rounds",
+  inactivityTimeoutMinutes: "Inactivity timeout",
+  autoResumeAttempts: "Auto-resume attempts",
+};
+
+const SETTING_SUFFIXES: Partial<Record<SettingKey, string>> = {
+  inactivityTimeoutMinutes: "min",
+};
+
+const SETTING_KEYS: SettingKey[] = [
+  "selfCheckAutoIterations",
+  "reviewAutoRounds",
+  "inactivityTimeoutMinutes",
+  "autoResumeAttempts",
+];
+
+function formatSettingValue(key: SettingKey, value: number): string {
+  const suffix = SETTING_SUFFIXES[key];
+  return suffix ? `${value} ${suffix}` : String(value);
+}
+
+function displayPipelineSettings(settings: PipelineSettings): void {
+  console.log();
+  console.log("  Pipeline settings (press Enter to keep defaults):");
+  for (const key of SETTING_KEYS) {
+    const label = SETTING_LABELS[key].padEnd(30);
+    console.log(`    ${label} ${formatSettingValue(key, settings[key])}`);
+  }
+  console.log();
+}
+
+async function adjustPipelineSettings(
+  current: PipelineSettings,
+): Promise<{ pipelineSettings: PipelineSettings; dirty: boolean }> {
+  displayPipelineSettings(current);
+
+  const toAdjust = await checkbox<SettingKey>({
+    message: "Adjust any settings?",
+    choices: SETTING_KEYS.map((key) => ({
+      name: `${SETTING_LABELS[key]}: ${formatSettingValue(key, current[key])}`,
+      value: key,
+    })),
+  });
+
+  if (toAdjust.length === 0) {
+    return { pipelineSettings: { ...current }, dirty: false };
+  }
+
+  const updated = { ...current };
+  for (const key of toAdjust) {
+    const raw = await input({
+      message: `${SETTING_LABELS[key]}:`,
+      default: String(current[key]),
+      validate: (v) => {
+        const n = Number(v);
+        if (!Number.isInteger(n) || n <= 0) return "Enter a positive integer";
+        return true;
+      },
+    });
+    updated[key] = Number(raw);
+  }
+
+  const save = await confirm({
+    message: "Save changes to config?",
+    default: false,
+  });
+
+  return { pipelineSettings: updated, dirty: save };
 }
 
 async function confirmIssue(


### PR DESCRIPTION
## Summary

- Add `PipelineSettings` interface (`selfCheckAutoIterations`, `reviewAutoRounds`, `inactivityTimeoutMinutes`, `autoResumeAttempts`) to config with validation and fallback to defaults
- Show current pipeline settings at startup, let user adjust via multi-select checkbox, prompt for new values with validation, and optionally save to config (default: session only)
- Make pipeline loop budget configurable per-stage via `autoBudget` on `StageDefinition`, so `selfCheckAutoIterations` only affects the self-check stage

Closes #18

## Test plan

- [x] `pnpm test` passes (442 tests)
- [x] `pnpm run check` passes (biome lint + format)
- [x] Config: default creation, disk JSON, partial/invalid values fallback, null/array fallback, isolation, roundtrip
- [x] Startup: default settings, adjust+save, adjust+decline, all-four adjust, unchanged fields preserved, input validation, checkbox choices verification, display with unit suffix, custom config display, session-only non-mutation, input default display
- [x] Pipeline: custom per-stage budget creation, grant preserves custom budget, per-stage autoBudget E2E through pipeline