### PR TITLE
Add pipeline stages 4-6: PR creation, CI loop, test plan

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,11 @@ import { createClaudeAdapter } from "./claude-adapter.js";
 import { createCodexAdapter } from "./codex-adapter.js";
 import type { PipelineOptions } from "./pipeline.js";
 import { createDoneStageHandler, runPipeline } from "./pipeline.js";
+import { createCiCheckStageHandler } from "./stage-cicheck.js";
+import { createCreatePrStageHandler } from "./stage-createpr.js";
 import { createImplementStageHandler } from "./stage-implement.js";
 import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
+import { createTestPlanStageHandler } from "./stage-testplan.js";
 import type { AgentConfig } from "./startup.js";
 import { runStartup } from "./startup.js";
 import {
@@ -98,6 +101,24 @@ try {
     autoBudget: result.pipelineSettings.selfCheckAutoIterations,
   };
 
+  const createPrStage = createCreatePrStageHandler({
+    agent: agentA,
+    ...issueCtx,
+  });
+
+  const ciCheckStage = createCiCheckStageHandler({
+    agent: agentA,
+    ...issueCtx,
+  });
+
+  const testPlanStage = {
+    ...createTestPlanStageHandler({
+      agent: agentA,
+      ...issueCtx,
+    }),
+    restartFromStage: 5,
+  };
+
   const doneStage = createDoneStageHandler({
     reportCompletion: async (msg) => console.log(msg),
     confirmMerge: async () => true, // placeholder until real prompts
@@ -107,7 +128,14 @@ try {
 
   const pipelineOpts: PipelineOptions = {
     mode: result.executionMode,
-    stages: [implementStage, selfCheckStage, doneStage],
+    stages: [
+      implementStage,
+      selfCheckStage,
+      createPrStage,
+      ciCheckStage,
+      testPlanStage,
+      doneStage,
+    ],
     prompt: {
       confirmContinueLoop: async () => false,
       confirmNextStage: async () => true,

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -720,6 +720,271 @@ describe("runPipeline — edge cases", () => {
 });
 
 // ---------------------------------------------------------------------------
+// runPipeline — backward stage transition (restartFromStage)
+// ---------------------------------------------------------------------------
+describe("runPipeline — backward stage transition", () => {
+  test("restartFromStage causes pipeline to jump back to earlier stage", async () => {
+    const order: number[] = [];
+    let s2calls = 0;
+    const stages = [
+      makeStage(1, async () => {
+        order.push(1);
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(
+        2,
+        async () => {
+          order.push(2);
+          s2calls++;
+          if (s2calls === 1) {
+            return { outcome: "not_approved", message: "need restart" };
+          }
+          return { outcome: "completed", message: "" };
+        },
+        { restartFromStage: 1 },
+      ),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages }));
+    expect(result.success).toBe(true);
+    // Stage 1 → Stage 2 (not_approved → restart from 1) → Stage 1 → Stage 2 (completed)
+    expect(order).toEqual([1, 2, 1, 2]);
+  });
+
+  test("restart budget: 3 auto restarts then asks user", async () => {
+    let s2calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        2,
+        async () => {
+          s2calls++;
+          return { outcome: "not_approved", message: "restart" };
+        },
+        { restartFromStage: 1 },
+      ),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(2);
+    // 3 auto restarts, then user asked and declines
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+    // Stage 1 runs 3 times (once initial + re-entered on each restart),
+    // Stage 2 runs 3 times (initial + 2 re-entries before budget check)
+    // Actually: initial run = stage1 + stage2(restart). Then stage1 + stage2(restart).
+    // Then stage1 + stage2(restart, budget=0, ask user, decline).
+    // So s2calls = 3.
+    expect(s2calls).toBe(3);
+  });
+
+  test("restart budget: user approves then 3 more auto restarts", async () => {
+    let s2calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi
+        .fn()
+        .mockResolvedValueOnce(true)
+        .mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        2,
+        async () => {
+          s2calls++;
+          return { outcome: "not_approved", message: "restart" };
+        },
+        { restartFromStage: 1 },
+      ),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    // 3 auto + user approves + 3 more + user declines = 6
+    expect(s2calls).toBe(6);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(2);
+  });
+
+  test("restart budget uses stage autoBudget override", async () => {
+    let s2calls = 0;
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        2,
+        async () => {
+          s2calls++;
+          return { outcome: "not_approved", message: "restart" };
+        },
+        { restartFromStage: 1, autoBudget: 2 },
+      ),
+    ];
+    await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(s2calls).toBe(2);
+  });
+
+  test("restart budget clears when stage completes normally", async () => {
+    // Run pipeline twice (two stages that restart).
+    // Second restart stage should get a fresh budget.
+    let s2calls = 0;
+    let s3calls = 0;
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        2,
+        async () => {
+          s2calls++;
+          if (s2calls <= 2) {
+            return { outcome: "not_approved", message: "restart" };
+          }
+          return { outcome: "completed", message: "" };
+        },
+        { restartFromStage: 1 },
+      ),
+      makeStage(
+        3,
+        async () => {
+          s3calls++;
+          if (s3calls === 1) {
+            return { outcome: "not_approved", message: "restart" };
+          }
+          return { outcome: "completed", message: "" };
+        },
+        { restartFromStage: 2 },
+      ),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages }));
+    expect(result.success).toBe(true);
+    expect(s2calls).toBe(4); // 3 from own restarts + 1 from stage 3's restart
+    expect(s3calls).toBe(2);
+  });
+
+  test("invalid restart target (forward jump) throws at startup", async () => {
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        2,
+        async () => ({ outcome: "not_approved", message: "bad" }),
+        { restartFromStage: 3 }, // forward jump — invalid
+      ),
+      makeStage(3, async () => ({ outcome: "completed", message: "" })),
+    ];
+    await expect(runPipeline(makePipelineOpts({ stages }))).rejects.toThrow(
+      "not an earlier stage",
+    );
+  });
+
+  test("invalid restart target (nonexistent stage) throws at startup", async () => {
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(2, async () => ({ outcome: "not_approved", message: "bad" }), {
+        restartFromStage: 99,
+      }),
+    ];
+    await expect(runPipeline(makePipelineOpts({ stages }))).rejects.toThrow(
+      "does not exist",
+    );
+  });
+
+  test("self-jump (restartFromStage = own number) throws at startup", async () => {
+    const stages = [
+      makeStage(1, async () => ({ outcome: "not_approved", message: "loop" }), {
+        restartFromStage: 1,
+      }),
+    ];
+    await expect(runPipeline(makePipelineOpts({ stages }))).rejects.toThrow(
+      "not an earlier stage",
+    );
+  });
+
+  test("blocked in stage with restartFromStage does NOT restart", async () => {
+    let s1calls = 0;
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        s1calls++;
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(2, async () => ({ outcome: "blocked", message: "stuck" }), {
+        restartFromStage: 1,
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(s1calls).toBe(1); // stage 1 NOT re-entered
+    expect(prompt.handleBlocked).toHaveBeenCalledOnce();
+  });
+
+  test("error in stage with restartFromStage does NOT restart", async () => {
+    let s1calls = 0;
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        s1calls++;
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(2, async () => ({ outcome: "error", message: "crash" }), {
+        restartFromStage: 1,
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(s1calls).toBe(1);
+    expect(prompt.handleError).toHaveBeenCalledOnce();
+  });
+
+  test("needs_clarification in stage with restartFromStage does NOT restart", async () => {
+    let s1calls = 0;
+    const prompt = makePrompt({
+      handleAmbiguous: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+    const stages = [
+      makeStage(1, async () => {
+        s1calls++;
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(
+        2,
+        async () => ({ outcome: "needs_clarification", message: "unclear" }),
+        { restartFromStage: 1 },
+      ),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(false);
+    expect(s1calls).toBe(1);
+  });
+
+  test("step mode asks confirmNextStage on every entry including restart re-entry", async () => {
+    let s2calls = 0;
+    const prompt = makePrompt();
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        2,
+        async () => {
+          s2calls++;
+          if (s2calls === 1) {
+            return { outcome: "not_approved", message: "restart" };
+          }
+          return { outcome: "completed", message: "" };
+        },
+        { restartFromStage: 1 },
+      ),
+    ];
+    await runPipeline(makePipelineOpts({ mode: "step", stages, prompt }));
+    // Initial: confirm stage 1, confirm stage 2.
+    // After restart: confirm stage 1 again, confirm stage 2 again.
+    expect(prompt.confirmNextStage).toHaveBeenCalledTimes(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // createDoneStageHandler
 // ---------------------------------------------------------------------------
 function makeDoneOpts(

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -67,6 +67,16 @@ export interface StageDefinition {
    * When omitted the engine uses its built-in default (3).
    */
   autoBudget?: number;
+  /**
+   * When set, a `"not_approved"` outcome causes the pipeline to jump
+   * back to the given stage number instead of looping within this
+   * stage.  The target must be an earlier stage (backward jump only).
+   *
+   * Example: stage 6 (test plan verification) sets
+   * `restartFromStage: 5` so that code changes are re-validated by
+   * the CI check before re-entering verification.
+   */
+  restartFromStage?: number;
 }
 
 /**
@@ -221,7 +231,34 @@ export async function runPipeline(
   // Sort stages by number to guarantee order.
   const sorted = [...stages].sort((a, b) => a.number - b.number);
 
+  // Validate restartFromStage references at startup.
+  const stageNumbers = new Set(sorted.map((s) => s.number));
   for (const stage of sorted) {
+    if (stage.restartFromStage !== undefined) {
+      if (!stageNumbers.has(stage.restartFromStage)) {
+        throw new Error(
+          `Stage ${stage.number} (${stage.name}) has invalid ` +
+            `restartFromStage: stage ${stage.restartFromStage} does not exist.`,
+        );
+      }
+      if (stage.restartFromStage >= stage.number) {
+        throw new Error(
+          `Stage ${stage.number} (${stage.name}) has invalid ` +
+            `restartFromStage: ${stage.restartFromStage} is not an earlier stage.`,
+        );
+      }
+    }
+  }
+
+  // Pipeline-level restart budget: tracks consecutive restarts per
+  // originating stage so the "3 auto / 4th asks user" contract holds
+  // across backward jumps.
+  const restartCounts = new Map<number, LoopControl>();
+
+  let i = 0;
+  while (i < sorted.length) {
+    const stage = sorted[i];
+
     // In step mode, ask the user before entering each stage.
     if (mode === "step") {
       const ok = await prompt.confirmNextStage(stage.name);
@@ -244,7 +281,50 @@ export async function runPipeline(
       };
     }
 
-    // "skip" and "done" both advance to the next stage.
+    if (result.action === "restart_from") {
+      const targetIdx = sorted.findIndex(
+        (s) => s.number === result.restartFromStage,
+      );
+
+      if (targetIdx === -1 || targetIdx >= i) {
+        return {
+          success: false,
+          stoppedAt: stage.number,
+          message: `Invalid restart target: stage ${result.restartFromStage}.`,
+        };
+      }
+
+      // Pipeline-level budget for restarts originating from this stage.
+      let lc = restartCounts.get(stage.number);
+      if (!lc) {
+        lc = createLoopControl(stage.autoBudget);
+        restartCounts.set(stage.number, lc);
+      }
+
+      const canContinue = advanceLoop(lc);
+      if (!canContinue) {
+        const approved = await prompt.confirmContinueLoop(
+          stage.name,
+          lc.iteration,
+        );
+        if (!approved) {
+          return {
+            success: false,
+            stoppedAt: stage.number,
+            message: `User declined to continue restart loop at iteration ${lc.iteration}.`,
+          };
+        }
+        grantLoopBudget(lc);
+      }
+
+      i = targetIdx;
+      continue;
+    }
+
+    // "done" and "skip" advance to the next stage.
+    // Clear restart budget when a stage completes normally.
+    restartCounts.delete(stage.number);
+    i++;
   }
 
   return {
@@ -257,8 +337,10 @@ export async function runPipeline(
 // ---- single-stage runner -------------------------------------------------
 
 interface StageRunResult {
-  action: "done" | "skip" | "abort";
+  action: "done" | "skip" | "abort" | "restart_from";
   message: string;
+  /** Target stage number — only set when action is `"restart_from"`. */
+  restartFromStage?: number;
 }
 
 /**
@@ -312,6 +394,14 @@ async function runStage(
     }
 
     if (result.outcome === "not_approved") {
+      if (stage.restartFromStage !== undefined) {
+        // Bubble up to the pipeline for a backward stage transition.
+        return {
+          action: "restart_from",
+          message: result.message,
+          restartFromStage: stage.restartFromStage,
+        };
+      }
       // Treat as needing another loop iteration with feedback.
       userInstruction = result.message;
       clarificationAttempted = false;

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -1,0 +1,453 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import type { CiRun, CiStatus, CiVerdict } from "./ci.js";
+import type { StageContext } from "./pipeline.js";
+import {
+  buildCiFixPrompt,
+  type CiCheckStageOptions,
+  createCiCheckStageHandler,
+} from "./stage-cicheck.js";
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    sessionId: "sess-1",
+    responseText: "Fixed the CI failures.",
+    status: "success",
+    errorType: undefined,
+    stderrText: "",
+    ...overrides,
+  };
+}
+
+function makeStream(result: AgentResult): AgentStream {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: async () => ({ done: true, value: "" }) };
+    },
+    result: Promise.resolve(result),
+    child: {} as AgentStream["child"],
+  };
+}
+
+function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
+  return {
+    databaseId: 100,
+    name: "build",
+    status: "completed",
+    conclusion: "success",
+    headBranch: "issue-42",
+    ...overrides,
+  };
+}
+
+function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
+  return { verdict, runs };
+}
+
+const BASE_CTX: StageContext = {
+  owner: "org",
+  repo: "repo",
+  issueNumber: 42,
+  branch: "issue-42",
+  worktreePath: "/tmp/wt",
+  iteration: 0,
+  userInstruction: undefined,
+};
+
+function makeOpts(
+  overrides: Partial<CiCheckStageOptions> = {},
+): CiCheckStageOptions {
+  return {
+    agent: {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    },
+    issueTitle: "Fix the widget",
+    issueBody: "The widget is broken.",
+    getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
+    collectFailureLogs: vi.fn().mockReturnValue(""),
+    delay: vi.fn().mockResolvedValue(undefined),
+    pollIntervalMs: 100,
+    pollTimeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+// ---- buildCiFixPrompt ------------------------------------------------------
+
+describe("buildCiFixPrompt", () => {
+  test("includes repo context", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "error log");
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).toContain("Worktree: /tmp/wt");
+  });
+
+  test("includes issue details", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "error log");
+    expect(prompt).toContain("Issue #42: Fix the widget");
+    expect(prompt).toContain("The widget is broken.");
+  });
+
+  test("includes failure logs", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "npm test failed");
+    expect(prompt).toContain("CI Failure Logs");
+    expect(prompt).toContain("npm test failed");
+  });
+
+  test("handles empty failure logs", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "");
+    expect(prompt).toContain("No detailed failure logs available");
+  });
+
+  test("instructs to commit and push", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "error");
+    expect(prompt).toContain("commit and push");
+  });
+
+  test("includes user instruction when present", () => {
+    const ctx = { ...BASE_CTX, userInstruction: "Ignore lint warnings" };
+    const prompt = buildCiFixPrompt(ctx, makeOpts(), "error");
+    expect(prompt).toContain("Additional feedback");
+    expect(prompt).toContain("Ignore lint warnings");
+  });
+
+  test("omits feedback section when no instruction", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "error");
+    expect(prompt).not.toContain("Additional feedback");
+  });
+});
+
+// ---- createCiCheckStageHandler ---------------------------------------------
+
+describe("createCiCheckStageHandler", () => {
+  test("returns stage definition with number 5 and name CI check", () => {
+    const stage = createCiCheckStageHandler(makeOpts());
+    expect(stage.number).toBe(5);
+    expect(stage.name).toBe("CI check");
+  });
+
+  test("does not set requiresArtifact", () => {
+    const stage = createCiCheckStageHandler(makeOpts());
+    expect(stage.requiresArtifact).toBeUndefined();
+  });
+
+  // -- CI passes immediately -------------------------------------------------
+
+  test("returns completed when CI passes on first poll", async () => {
+    const opts = makeOpts({
+      getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
+    });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("CI checks passed");
+    expect(opts.agent.invoke).not.toHaveBeenCalled();
+  });
+
+  // -- CI pending then passes ------------------------------------------------
+
+  test("polls when pending then returns completed on pass", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pending"))
+      .mockReturnValueOnce(makeCiStatus("pending"))
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const delay = vi.fn().mockResolvedValue(undefined);
+
+    const opts = makeOpts({ getCiStatus, delay });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(getCiStatus).toHaveBeenCalledTimes(3);
+    expect(delay).toHaveBeenCalledTimes(2);
+    expect(opts.agent.invoke).not.toHaveBeenCalled();
+  });
+
+  // -- CI pending timeout ----------------------------------------------------
+
+  test("returns error when pending exceeds timeout", async () => {
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pending"));
+    // Simulate time passing by advancing Date.now on each delay call.
+    let elapsed = 0;
+    const originalNow = Date.now;
+    const startTime = originalNow();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const opts = makeOpts({
+      getCiStatus,
+      delay,
+      pollIntervalMs: 100,
+      pollTimeoutMs: 1000,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("still pending");
+
+    vi.restoreAllMocks();
+  });
+
+  // -- CI fails — agent fix flow ---------------------------------------------
+
+  test("collects failure logs and invokes agent on CI failure", async () => {
+    const failedRun = makeCiRun({
+      databaseId: 200,
+      name: "test-suite",
+      conclusion: "failure",
+    });
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("fail", [failedRun]));
+    const collectFailureLogs = vi
+      .fn()
+      .mockReturnValue("Error: test failed at line 42");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
+    expect(agent.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("CI Failure Logs"),
+      { cwd: "/tmp/wt" },
+    );
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("fix prompt includes failure log content", async () => {
+    const failedRun = makeCiRun({
+      databaseId: 300,
+      name: "lint",
+      conclusion: "failure",
+    });
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("fail", [failedRun]));
+    const collectFailureLogs = vi
+      .fn()
+      .mockReturnValue("lint error: unused variable");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("lint error: unused variable");
+  });
+
+  test("returns not_approved after agent fix to trigger engine loop", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("error log");
+
+    const opts = makeOpts({ getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("includes user instruction in fix prompt when present", async () => {
+    const failedRun = makeCiRun({ conclusion: "failure" });
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("fail", [failedRun]));
+    const collectFailureLogs = vi.fn().mockReturnValue("error");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const ctx = { ...BASE_CTX, userInstruction: "Skip the flaky e2e test" };
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(ctx);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("Skip the flaky e2e test");
+  });
+
+  // -- error handling --------------------------------------------------------
+
+  test("returns error when agent fix call fails", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("error");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            stderrText: "crash",
+            responseText: "",
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("crash");
+    expect(result.message).toContain("CI fix");
+  });
+
+  test("handles no detailed logs gracefully", async () => {
+    const failedRun = makeCiRun({ conclusion: "failure" });
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("fail", [failedRun]));
+    const collectFailureLogs = vi.fn().mockReturnValue("");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("No detailed failure logs available");
+  });
+
+  test("collects logs from multiple failed runs", async () => {
+    const runs = [
+      makeCiRun({ databaseId: 200, name: "lint", conclusion: "failure" }),
+      makeCiRun({ databaseId: 201, name: "test", conclusion: "failure" }),
+      makeCiRun({ databaseId: 202, name: "build", conclusion: "success" }),
+    ];
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("fail", runs));
+    const collectFailureLogs = vi
+      .fn()
+      .mockReturnValueOnce("lint: unused var")
+      .mockReturnValueOnce("test: assertion failed");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    // Should collect from the two failed runs only
+    expect(collectFailureLogs).toHaveBeenCalledTimes(2);
+    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
+    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 201);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("lint: unused var");
+    expect(invokedPrompt).toContain("test: assertion failed");
+  });
+
+  test("handles fail verdict with no matching failed runs gracefully", async () => {
+    // Cancelled runs: verdict is "fail" but conclusion is "cancelled"
+    const runs = [makeCiRun({ conclusion: "cancelled" })];
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("fail", runs));
+    const collectFailureLogs = vi.fn().mockReturnValue("");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("No detailed failure logs available");
+  });
+
+  test("propagates getCiStatus exception as thrown error", async () => {
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      throw new Error("network timeout");
+    });
+
+    const opts = makeOpts({ getCiStatus });
+    const stage = createCiCheckStageHandler(opts);
+
+    await expect(stage.handler(BASE_CTX)).rejects.toThrow("network timeout");
+  });
+
+  test("propagates collectFailureLogs exception as thrown error", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockImplementation(() => {
+      throw new Error("gh CLI failed");
+    });
+
+    const opts = makeOpts({ getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+
+    await expect(stage.handler(BASE_CTX)).rejects.toThrow("gh CLI failed");
+  });
+
+  // -- message preservation --------------------------------------------------
+
+  test("preserves agent fix response text in message", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+    const fixResponse = "Fixed the linting issue and pushed.";
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: fixResponse }))),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.message).toBe(fixResponse);
+  });
+});

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -1,0 +1,165 @@
+/**
+ * Stage 5 — CI check loop.
+ *
+ * Polls CI status for the branch.  When CI is pending the handler waits
+ * internally (without consuming the engine's auto-budget).  When CI
+ * passes the stage completes.  When CI fails the handler collects
+ * failure logs, sends them to the agent for a fix, and returns
+ * `"not_approved"` so the engine loops back for another CI poll.
+ *
+ * The engine's default auto-budget (3) handles the "3 automatic /
+ * 4th asks user" requirement for fix iterations.
+ */
+
+import type { AgentAdapter } from "./agent.js";
+import type { CiStatus } from "./ci.js";
+import {
+  collectFailureLogs as defaultCollectFailureLogs,
+  getCiStatus as defaultGetCiStatus,
+  normaliseCiConclusion,
+} from "./ci.js";
+import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
+import { mapAgentError } from "./stage-util.js";
+
+// ---- defaults --------------------------------------------------------------
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+const DEFAULT_POLL_TIMEOUT_MS = 600_000; // 10 minutes
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// ---- public types ----------------------------------------------------------
+
+export interface CiCheckStageOptions {
+  agent: AgentAdapter;
+  issueTitle: string;
+  issueBody: string;
+  /** Injected for testability. Defaults to `ci.getCiStatus`. */
+  getCiStatus?: (owner: string, repo: string, branch: string) => CiStatus;
+  /** Injected for testability. Defaults to `ci.collectFailureLogs`. */
+  collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  /** Delay in ms between polls when CI is pending. Default 30 000. */
+  pollIntervalMs?: number;
+  /** Max time in ms to wait for pending CI. Default 600 000 (10 min). */
+  pollTimeoutMs?: number;
+  /** Injected for testability. Defaults to a real delay function. */
+  delay?: (ms: number) => Promise<void>;
+}
+
+// ---- prompt builders -------------------------------------------------------
+
+export function buildCiFixPrompt(
+  ctx: StageContext,
+  opts: CiCheckStageOptions,
+  failureLogs: string,
+): string {
+  const lines = [
+    `You are fixing CI failures for the following GitHub issue.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    `- Worktree: ${ctx.worktreePath}`,
+    ``,
+    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
+    ``,
+    opts.issueBody,
+    ``,
+    `## CI Failure Logs`,
+    ``,
+    failureLogs || "No detailed failure logs available.",
+    ``,
+    `## Instructions`,
+    ``,
+    `Diagnose and fix the CI failures shown above.  After making your`,
+    `changes, commit and push the branch so a new CI run is triggered.`,
+  ];
+
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+
+  return lines.join("\n");
+}
+
+// ---- handler ---------------------------------------------------------------
+
+export function createCiCheckStageHandler(
+  opts: CiCheckStageOptions,
+): StageDefinition {
+  const getCiStatus = opts.getCiStatus ?? defaultGetCiStatus;
+  const collectLogs = opts.collectFailureLogs ?? defaultCollectFailureLogs;
+  const pollInterval = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const pollTimeout = opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+  const delay = opts.delay ?? defaultDelay;
+
+  return {
+    name: "CI check",
+    number: 5,
+    handler: async (ctx: StageContext): Promise<StageResult> => {
+      // ---- poll for CI completion ------------------------------------------
+
+      const startTime = Date.now();
+
+      let ciStatus: CiStatus;
+      while (true) {
+        ciStatus = getCiStatus(ctx.owner, ctx.repo, ctx.branch);
+
+        if (ciStatus.verdict !== "pending") break;
+
+        if (Date.now() - startTime >= pollTimeout) {
+          return {
+            outcome: "error",
+            message:
+              `CI checks still pending after ${Math.round(pollTimeout / 1000)}s. ` +
+              `The pipeline cannot proceed until CI completes.`,
+          };
+        }
+
+        await delay(pollInterval);
+      }
+
+      // ---- CI passed -------------------------------------------------------
+
+      if (ciStatus.verdict === "pass") {
+        return { outcome: "completed", message: "CI checks passed." };
+      }
+
+      // ---- CI failed — collect logs and send to agent ----------------------
+
+      const failedRuns = ciStatus.runs.filter((r) => {
+        const conclusion = normaliseCiConclusion(r);
+        return conclusion === "failure" || conclusion === "cancelled";
+      });
+
+      const logSections: string[] = [];
+      for (const run of failedRuns) {
+        const logs = collectLogs(ctx.owner, ctx.repo, run.databaseId);
+        if (logs) {
+          logSections.push(
+            `### ${run.name} (run ${run.databaseId})\n\n${logs}`,
+          );
+        }
+      }
+
+      const failureLogs =
+        logSections.length > 0
+          ? logSections.join("\n\n")
+          : "No detailed failure logs available.";
+
+      const prompt = buildCiFixPrompt(ctx, opts, failureLogs);
+      const fixStream = opts.agent.invoke(prompt, { cwd: ctx.worktreePath });
+      const fixResult = await fixStream.result;
+
+      if (fixResult.status === "error") {
+        return mapAgentError(fixResult, "during CI fix");
+      }
+
+      // Return not_approved so the engine loops back to poll CI again.
+      return { outcome: "not_approved", message: fixResult.responseText };
+    },
+  };
+}

--- a/src/stage-createpr.test.ts
+++ b/src/stage-createpr.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import type { StageContext } from "./pipeline.js";
+import {
+  buildCreatePrPrompt,
+  buildPrCompletionCheckPrompt,
+  type CreatePrStageOptions,
+  createCreatePrStageHandler,
+} from "./stage-createpr.js";
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    sessionId: "sess-1",
+    responseText: "COMPLETED",
+    status: "success",
+    errorType: undefined,
+    stderrText: "",
+    ...overrides,
+  };
+}
+
+function makeStream(result: AgentResult): AgentStream {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: async () => ({ done: true, value: "" }) };
+    },
+    result: Promise.resolve(result),
+    child: {} as AgentStream["child"],
+  };
+}
+
+function makeAgent(
+  prResult: AgentResult,
+  checkResult?: AgentResult,
+): AgentAdapter {
+  const invoke = vi.fn().mockReturnValue(makeStream(prResult));
+  const resume = vi
+    .fn()
+    .mockReturnValue(makeStream(checkResult ?? makeResult()));
+  return { invoke, resume };
+}
+
+const BASE_CTX: StageContext = {
+  owner: "org",
+  repo: "repo",
+  issueNumber: 42,
+  branch: "issue-42",
+  worktreePath: "/tmp/wt",
+  iteration: 0,
+  userInstruction: undefined,
+};
+
+function makeOpts(
+  overrides: Partial<CreatePrStageOptions> = {},
+): CreatePrStageOptions {
+  return {
+    agent: makeAgent(makeResult()),
+    issueTitle: "Fix the widget",
+    issueBody: "The widget is broken.\n\nPlease fix it.",
+    ...overrides,
+  };
+}
+
+// ---- buildCreatePrPrompt ---------------------------------------------------
+
+describe("buildCreatePrPrompt", () => {
+  test("includes repo context", () => {
+    const prompt = buildCreatePrPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).toContain("Worktree: /tmp/wt");
+  });
+
+  test("includes issue details", () => {
+    const prompt = buildCreatePrPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("Issue #42: Fix the widget");
+    expect(prompt).toContain("The widget is broken.");
+  });
+
+  test("instructs to create PR with test plan", () => {
+    const prompt = buildCreatePrPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("gh pr create");
+    expect(prompt).toContain("Test plan");
+  });
+
+  test("includes user instruction when present", () => {
+    const ctx = { ...BASE_CTX, userInstruction: "Use a draft PR" };
+    const prompt = buildCreatePrPrompt(ctx, makeOpts());
+    expect(prompt).toContain("Additional feedback");
+    expect(prompt).toContain("Use a draft PR");
+  });
+
+  test("omits feedback section when no instruction", () => {
+    const prompt = buildCreatePrPrompt(BASE_CTX, makeOpts());
+    expect(prompt).not.toContain("Additional feedback");
+  });
+});
+
+// ---- buildPrCompletionCheckPrompt ------------------------------------------
+
+describe("buildPrCompletionCheckPrompt", () => {
+  test("mentions COMPLETED and BLOCKED", () => {
+    const prompt = buildPrCompletionCheckPrompt();
+    expect(prompt).toContain("COMPLETED");
+    expect(prompt).toContain("BLOCKED");
+  });
+
+  test("asks for exactly one keyword", () => {
+    const prompt = buildPrCompletionCheckPrompt();
+    expect(prompt).toContain("exactly one");
+  });
+
+  test("asks for a brief reason when BLOCKED", () => {
+    const prompt = buildPrCompletionCheckPrompt();
+    expect(prompt).toContain("BLOCKED");
+    expect(prompt).toContain("brief reason");
+  });
+});
+
+// ---- createCreatePrStageHandler --------------------------------------------
+
+describe("createCreatePrStageHandler", () => {
+  test("returns stage definition with number 4 and name Create PR", () => {
+    const stage = createCreatePrStageHandler(makeOpts());
+    expect(stage.number).toBe(4);
+    expect(stage.name).toBe("Create PR");
+  });
+
+  test("sets requiresArtifact to true", () => {
+    const stage = createCreatePrStageHandler(makeOpts());
+    expect(stage.requiresArtifact).toBe(true);
+  });
+
+  // -- two-step flow ---------------------------------------------------------
+
+  test("invokes agent for PR creation then resumes for check", async () => {
+    const prResult = makeResult({
+      sessionId: "sess-pr",
+      responseText: "PR created.",
+    });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent = makeAgent(prResult, checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+
+    await stage.handler(BASE_CTX);
+
+    expect(agent.invoke).toHaveBeenCalledWith(expect.any(String), {
+      cwd: "/tmp/wt",
+    });
+    expect(agent.resume).toHaveBeenCalledWith("sess-pr", expect.any(String), {
+      cwd: "/tmp/wt",
+    });
+  });
+
+  test("throws when PR creation returns no sessionId", async () => {
+    const prResult = makeResult({
+      sessionId: undefined,
+      responseText: "PR created.",
+    });
+    const agent = makeAgent(prResult);
+
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    await expect(stage.handler(BASE_CTX)).rejects.toThrow("no session ID");
+  });
+
+  // -- outcome mapping -------------------------------------------------------
+
+  test("returns completed on COMPLETED", async () => {
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent = makeAgent(makeResult(), checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("returns completed on DONE", async () => {
+    const checkResult = makeResult({ responseText: "DONE" });
+    const agent = makeAgent(makeResult(), checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("returns blocked on BLOCKED", async () => {
+    const checkResult = makeResult({ responseText: "BLOCKED" });
+    const agent = makeAgent(makeResult(), checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("blocked message includes step 1 diagnostic text", async () => {
+    const prResult = makeResult({
+      sessionId: "sess-pr",
+      responseText: "Push failed: permission denied to push to main.",
+    });
+    const checkResult = makeResult({
+      responseText: "BLOCKED\nCannot push to the remote.",
+    });
+    const agent = makeAgent(prResult, checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("permission denied");
+    expect(result.message).toContain("Cannot push to the remote");
+  });
+
+  test("returns not_approved on NOT_APPROVED", async () => {
+    const checkResult = makeResult({ responseText: "NOT_APPROVED" });
+    const agent = makeAgent(makeResult(), checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("ambiguous check → internal clarification → completed", async () => {
+    const prResult = makeResult({ sessionId: "sess-pr" });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "I think it worked.",
+    });
+    const clarifiedCheck = makeResult({ responseText: "COMPLETED" });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(prResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(clarifiedCheck)),
+    };
+
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // invoke called once (PR creation), resume called twice
+    // (completion check + clarification)
+    expect(agent.invoke).toHaveBeenCalledTimes(1);
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("ambiguous check → internal clarification also ambiguous → needs_clarification", async () => {
+    const prResult = makeResult({ sessionId: "sess-pr" });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "I think it worked.",
+    });
+    const stillAmbiguous = makeResult({
+      responseText: "I think so maybe.",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(prResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(stillAmbiguous)),
+    };
+
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("ambiguous check without sessionId skips internal clarification", async () => {
+    const prResult = makeResult({ sessionId: "sess-pr" });
+    const ambiguousCheck = makeResult({
+      sessionId: undefined,
+      responseText: "I think it worked.",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(prResult)),
+      resume: vi.fn().mockReturnValueOnce(makeStream(ambiguousCheck)),
+    };
+
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("needs_clarification");
+    // Only one resume call (completion check), no clarification attempt
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+  });
+
+  // -- error handling --------------------------------------------------------
+
+  test("returns error when PR creation call fails", async () => {
+    const prResult = makeResult({
+      status: "error",
+      errorType: "max_turns",
+      responseText: "",
+    });
+    const agent = makeAgent(prResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("maximum turn limit");
+    expect(agent.resume).not.toHaveBeenCalled();
+  });
+
+  test("returns error when completion check call fails", async () => {
+    const prResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "crash",
+      responseText: "",
+    });
+    const agent = makeAgent(prResult, checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("crash");
+    expect(result.message).toContain("PR completion check");
+  });
+
+  // -- message preservation --------------------------------------------------
+
+  test("preserves check response text in message", async () => {
+    const checkResult = makeResult({
+      responseText: "PR #99 created successfully.\n\nCOMPLETED",
+    });
+    const agent = makeAgent(makeResult(), checkResult);
+    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.message).toBe("PR #99 created successfully.\n\nCOMPLETED");
+  });
+});

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -1,0 +1,149 @@
+/**
+ * Stage 4 — Create PR.
+ *
+ * Two-step flow:
+ *   1. Send a PR creation prompt to Agent A with repo, issue, and
+ *      worktree context.
+ *   2. Resume the session and explicitly ask for a completion status
+ *      (COMPLETED or BLOCKED).
+ *
+ * If the completion check response is ambiguous, the handler retries
+ * by resuming the same session with a clarification prompt.  This
+ * avoids re-entering the handler (which would re-run the side-effectful
+ * PR creation step).  If clarification also fails, the ambiguous
+ * result is returned to the engine for user intervention.
+ *
+ * `requiresArtifact` is set to `true` so the engine suppresses the
+ * "Proceed" option when the agent reports BLOCKED — only Instruct and
+ * Halt are available.
+ */
+
+import type { AgentAdapter } from "./agent.js";
+import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
+import {
+  mapAgentError,
+  mapResponseToResult,
+  sendFollowUp,
+} from "./stage-util.js";
+import { buildClarificationPrompt } from "./step-parser.js";
+
+export interface CreatePrStageOptions {
+  agent: AgentAdapter;
+  issueTitle: string;
+  issueBody: string;
+}
+
+export function buildCreatePrPrompt(
+  ctx: StageContext,
+  opts: CreatePrStageOptions,
+): string {
+  const lines = [
+    `You are creating a pull request for the following GitHub issue.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    `- Worktree: ${ctx.worktreePath}`,
+    ``,
+    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
+    ``,
+    opts.issueBody,
+    ``,
+    `## Instructions`,
+    ``,
+    `1. Commit any remaining uncommitted changes on the branch.`,
+    `2. Push the branch to the remote.`,
+    `3. Create a pull request using \`gh pr create\` targeting the default`,
+    `   branch.  The PR title should reference the issue number`,
+    `   (e.g. "Fix widget rendering (#42)").`,
+    `4. In the PR body, include:`,
+    `   - A brief summary of the changes`,
+    `   - A "## Test plan" section with a checkbox checklist of items to`,
+    `     verify (derived from the issue requirements)`,
+    `5. Do NOT merge the PR — just create it.`,
+  ];
+
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildPrCompletionCheckPrompt(): string {
+  return [
+    `You have finished your PR creation attempt.  Please evaluate the`,
+    `result and respond with exactly one of the following keywords:`,
+    ``,
+    `- COMPLETED — if the pull request was created successfully`,
+    `- BLOCKED — if you could not create the PR and need user intervention`,
+    ``,
+    `If BLOCKED, add a brief reason on the next line explaining what`,
+    `went wrong (e.g. auth failure, push rejected, PR already exists).`,
+  ].join("\n");
+}
+
+export function createCreatePrStageHandler(
+  opts: CreatePrStageOptions,
+): StageDefinition {
+  return {
+    name: "Create PR",
+    number: 4,
+    requiresArtifact: true,
+    handler: async (ctx: StageContext): Promise<StageResult> => {
+      // Step 1: Send the PR creation prompt.
+      const prompt = buildCreatePrPrompt(ctx, opts);
+      const prStream = opts.agent.invoke(prompt, { cwd: ctx.worktreePath });
+      const prResult = await prStream.result;
+
+      if (prResult.status === "error") {
+        return mapAgentError(prResult);
+      }
+
+      // Step 2: Resume the session and ask for completion status.
+      // Clarification is handled internally by resuming the same
+      // session, because re-entering the handler would re-run the
+      // side-effectful PR creation step.
+      let checkResult = await sendFollowUp(
+        opts.agent,
+        prResult.sessionId,
+        buildPrCompletionCheckPrompt(),
+        ctx.worktreePath,
+      );
+
+      if (checkResult.status === "error") {
+        return mapAgentError(checkResult, "during PR completion check");
+      }
+
+      let result = mapResponseToResult(checkResult.responseText);
+
+      if (result.outcome === "needs_clarification" && checkResult.sessionId) {
+        const retryResult = await sendFollowUp(
+          opts.agent,
+          checkResult.sessionId,
+          buildClarificationPrompt(checkResult.responseText),
+          ctx.worktreePath,
+        );
+
+        if (retryResult.status === "error") {
+          return mapAgentError(
+            retryResult,
+            "during PR completion clarification",
+          );
+        }
+
+        checkResult = retryResult;
+        result = mapResponseToResult(retryResult.responseText);
+      }
+
+      // When blocked, combine the step 1 diagnostic text with the
+      // completion check response so the user can see what went wrong.
+      if (result.outcome === "blocked") {
+        result.message = `${prResult.responseText}\n\n---\n\n${checkResult.responseText}`;
+      }
+
+      return result;
+    },
+  };
+}

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -7,6 +7,7 @@
 
 import { describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import type { CiRun, CiStatus, CiVerdict } from "./ci.js";
 import type {
   PipelineOptions,
   StageContext,
@@ -14,8 +15,11 @@ import type {
   UserPrompt,
 } from "./pipeline.js";
 import { runPipeline } from "./pipeline.js";
+import { createCiCheckStageHandler } from "./stage-cicheck.js";
+import { createCreatePrStageHandler } from "./stage-createpr.js";
 import { createImplementStageHandler } from "./stage-implement.js";
 import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
+import { createTestPlanStageHandler } from "./stage-testplan.js";
 
 // ---- helpers ---------------------------------------------------------------
 
@@ -485,7 +489,678 @@ describe("Stage 3 (Self-check) through pipeline", () => {
   });
 });
 
-// ---- Multi-stage E2E -------------------------------------------------------
+// ---- CI helpers for stage 5 ------------------------------------------------
+
+function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
+  return {
+    databaseId: 100,
+    name: "build",
+    status: "completed",
+    conclusion: "success",
+    headBranch: "issue-5",
+    ...overrides,
+  };
+}
+
+function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
+  return { verdict, runs };
+}
+
+// ---- Stage 4 through pipeline ----------------------------------------------
+
+describe("Stage 4 (Create PR) through pipeline", () => {
+  test("completes pipeline when agent says COMPLETED", async () => {
+    const prResult = makeResult({
+      sessionId: "s1",
+      responseText: "PR created.",
+    });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(prResult)),
+      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+    };
+
+    const stage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+  });
+
+  test("blocked with requiresArtifact: handleBlocked called with allowProceed=false", async () => {
+    const prResult = makeResult({ sessionId: "s1" });
+    const checkResult = makeResult({ responseText: "BLOCKED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(prResult)),
+      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+    };
+    const handleBlocked = vi.fn().mockResolvedValue({ action: "halt" });
+    const prompt = makePrompt({ handleBlocked });
+
+    const stage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(4);
+    // allowProceed should be false because requiresArtifact is true
+    expect(handleBlocked).toHaveBeenCalledWith(expect.any(String), false);
+  });
+
+  test("blocked → user instructs → agent retries and completes", async () => {
+    let callCount = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        callCount++;
+        return makeStream(
+          makeResult({ sessionId: `s${callCount}`, responseText: "pr" }),
+        );
+      }),
+      resume: vi.fn().mockImplementation(() => {
+        if (callCount === 1) {
+          return makeStream(makeResult({ responseText: "BLOCKED" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
+    };
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValueOnce({
+        action: "instruct",
+        instruction: "try draft PR",
+      }),
+    });
+
+    const stage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(callCount).toBe(2);
+  });
+
+  test("ambiguous check → auto-clarification → completed", async () => {
+    let callCount = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        callCount++;
+        return makeStream(
+          makeResult({ sessionId: `s${callCount}`, responseText: "pr" }),
+        );
+      }),
+      resume: vi.fn().mockImplementation(() => {
+        if (callCount === 1) {
+          return makeStream(makeResult({ responseText: "I think it worked?" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
+    };
+    const prompt = makePrompt();
+
+    const stage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(prompt.handleAmbiguous).not.toHaveBeenCalled();
+  });
+
+  test("agent error → user retries → succeeds", async () => {
+    let callCount = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "timeout",
+              responseText: "",
+            }),
+          );
+        }
+        return makeStream(makeResult({ sessionId: "s2", responseText: "ok" }));
+      }),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValueOnce({ action: "retry" }),
+    });
+
+    const stage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(callCount).toBe(2);
+  });
+});
+
+// ---- Stage 5 through pipeline ----------------------------------------------
+
+describe("Stage 5 (CI check) through pipeline", () => {
+  test("CI passes on first poll: pipeline advances", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
+      collectFailureLogs: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(agent.invoke).not.toHaveBeenCalled();
+  });
+
+  test("CI fails, agent fixes, CI passes next poll: pipeline advances", async () => {
+    let pollCount = 0;
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      pollCount++;
+      if (pollCount === 1) {
+        return makeCiStatus("fail", [
+          makeCiRun({ conclusion: "failure", databaseId: 200 }),
+        ]);
+      }
+      return makeCiStatus("pass");
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "Fixed CI." }))),
+      resume: vi.fn(),
+    };
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      collectFailureLogs: vi.fn().mockReturnValue("test error"),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(pollCount).toBe(2);
+    expect(agent.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  test("CI fails 3x → budget exhausted → user approves → CI passes", async () => {
+    let pollCount = 0;
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      pollCount++;
+      if (pollCount <= 3) {
+        return makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]);
+      }
+      return makeCiStatus("pass");
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "Fixed." }))),
+      resume: vi.fn(),
+    };
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValueOnce(true),
+    });
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      collectFailureLogs: vi.fn().mockReturnValue("err"),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+    expect(pollCount).toBe(4);
+  });
+
+  test("CI fails 3x → budget exhausted → user declines → pipeline aborts", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "Fixed." }))),
+      resume: vi.fn(),
+    };
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      collectFailureLogs: vi.fn().mockReturnValue("err"),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(5);
+  });
+});
+
+// ---- Stage 6 through pipeline ----------------------------------------------
+
+describe("Stage 6 (Test plan verification) through pipeline", () => {
+  test("DONE on first check → pipeline completes", async () => {
+    const verifyResult = makeResult({
+      sessionId: "s1",
+      responseText: "Verified.",
+    });
+    const checkResult = makeResult({ responseText: "All good.\n\nDONE" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(verifyResult)),
+      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+    };
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+  });
+
+  test("FIXED → loops → DONE: pipeline completes", async () => {
+    let invokeCalls = 0;
+    let resumeCalls = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCalls++;
+        return makeStream(
+          makeResult({
+            sessionId: `s${invokeCalls}`,
+            responseText: "Verified.",
+          }),
+        );
+      }),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCalls++;
+        if (resumeCalls < 3) {
+          return makeStream(makeResult({ responseText: "FIXED" }));
+        }
+        return makeStream(makeResult({ responseText: "DONE" }));
+      }),
+    };
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(invokeCalls).toBe(3);
+    expect(resumeCalls).toBe(3);
+  });
+
+  test("FIXED 3x → budget exhausted → user approves → DONE", async () => {
+    let invokeCalls = 0;
+    let resumeCalls = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCalls++;
+        return makeStream(
+          makeResult({ sessionId: `s${invokeCalls}`, responseText: "ver" }),
+        );
+      }),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCalls++;
+        if (resumeCalls <= 3) {
+          return makeStream(makeResult({ responseText: "FIXED" }));
+        }
+        return makeStream(makeResult({ responseText: "DONE" }));
+      }),
+    };
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValueOnce(true),
+    });
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+    expect(invokeCalls).toBe(4);
+  });
+
+  test("FIXED 3x → budget exhausted → user declines → pipeline aborts", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockImplementation(() =>
+          makeStream(makeResult({ sessionId: "s1", responseText: "verify" })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "FIXED" }))),
+    };
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(6);
+  });
+
+  test("verify error → user retries → DONE", async () => {
+    let invokeCalls = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCalls++;
+        if (invokeCalls === 1) {
+          return makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "timeout",
+              responseText: "",
+            }),
+          );
+        }
+        return makeStream(
+          makeResult({
+            sessionId: `s${invokeCalls}`,
+            responseText: "verified",
+          }),
+        );
+      }),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "DONE" }))),
+    };
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValueOnce({ action: "retry" }),
+    });
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(invokeCalls).toBe(2);
+  });
+
+  test("ambiguous self-check → auto-clarification → DONE", async () => {
+    let invokeCalls = 0;
+    let resumeCalls = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCalls++;
+        return makeStream(
+          makeResult({
+            sessionId: `s${invokeCalls}`,
+            responseText: "verified",
+          }),
+        );
+      }),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCalls++;
+        if (resumeCalls === 1) {
+          return makeStream(makeResult({ responseText: "looks ok maybe?" }));
+        }
+        return makeStream(makeResult({ responseText: "DONE" }));
+      }),
+    };
+    const prompt = makePrompt();
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(prompt.handleAmbiguous).not.toHaveBeenCalled();
+  });
+
+  test("blocked during self-check → user instructs → completes next round", async () => {
+    let invokeCalls = 0;
+    let resumeCalls = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCalls++;
+        return makeStream(
+          makeResult({
+            sessionId: `s${invokeCalls}`,
+            responseText: "verified",
+          }),
+        );
+      }),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCalls++;
+        if (resumeCalls === 1) {
+          return makeStream(makeResult({ responseText: "BLOCKED" }));
+        }
+        return makeStream(makeResult({ responseText: "DONE" }));
+      }),
+    };
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValueOnce({
+        action: "instruct",
+        instruction: "skip the flaky check",
+      }),
+    });
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(invokeCalls).toBe(2);
+  });
+
+  test("self-check error → user aborts → pipeline fails", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ sessionId: "s1", responseText: "verified" })),
+        ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            status: "error",
+            errorType: "max_turns",
+            responseText: "",
+          }),
+        ),
+      ),
+    };
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+
+    const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(prompt.handleError).toHaveBeenCalled();
+  });
+});
+
+// ---- Multi-stage E2E: Stage 4 → Stage 5 → Stage 6 -------------------------
+
+describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
+  test("PR created, CI passes, test plan verified: full flow success", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation((prompt: string) => {
+        if (prompt.includes("creating a pull request")) {
+          return makeStream(
+            makeResult({ sessionId: "pr-1", responseText: "PR created." }),
+          );
+        }
+        // Test plan verification
+        return makeStream(
+          makeResult({ sessionId: "tp-1", responseText: "Verified." }),
+        );
+      }),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        if (prompt.includes("PR creation attempt")) {
+          return makeStream(makeResult({ responseText: "COMPLETED" }));
+        }
+        // Test plan self-check
+        return makeStream(makeResult({ responseText: "DONE" }));
+      }),
+    };
+
+    const prStage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const ciStage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
+      collectFailureLogs: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+    const tpStage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
+
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [prStage, ciStage, tpStage] }),
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  test("test plan FIXED → restarts from CI check → CI passes → test plan DONE", async () => {
+    let ciPollCount = 0;
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      ciPollCount++;
+      return makeCiStatus("pass");
+    });
+
+    let tpResumeCalls = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation((prompt: string) => {
+        if (prompt.includes("creating a pull request")) {
+          return makeStream(
+            makeResult({ sessionId: "pr-1", responseText: "PR created." }),
+          );
+        }
+        // Test plan verification (called multiple times due to restart)
+        return makeStream(
+          makeResult({ sessionId: "tp-1", responseText: "Verified." }),
+        );
+      }),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        if (prompt.includes("PR creation attempt")) {
+          return makeStream(makeResult({ responseText: "COMPLETED" }));
+        }
+        // Test plan self-check
+        tpResumeCalls++;
+        if (tpResumeCalls === 1) {
+          return makeStream(makeResult({ responseText: "FIXED" }));
+        }
+        return makeStream(makeResult({ responseText: "DONE" }));
+      }),
+    };
+
+    const prStage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const ciStage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      collectFailureLogs: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+    const tpStage = {
+      ...createTestPlanStageHandler({ agent, ...ISSUE_CTX }),
+      restartFromStage: 5,
+    };
+
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [prStage, ciStage, tpStage] }),
+    );
+
+    expect(result.success).toBe(true);
+    // CI polled twice: once on initial pass-through, once on restart
+    expect(ciPollCount).toBe(2);
+    expect(tpResumeCalls).toBe(2);
+  });
+
+  test("test plan FIXED 3x → restart budget exhausted → user declines", async () => {
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation((prompt: string) => {
+        if (prompt.includes("creating a pull request")) {
+          return makeStream(
+            makeResult({ sessionId: "pr-1", responseText: "PR created." }),
+          );
+        }
+        return makeStream(
+          makeResult({ sessionId: "tp-1", responseText: "Verified." }),
+        );
+      }),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        if (prompt.includes("PR creation attempt")) {
+          return makeStream(makeResult({ responseText: "COMPLETED" }));
+        }
+        // Always FIXED — never done
+        return makeStream(makeResult({ responseText: "FIXED" }));
+      }),
+    };
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+
+    const prStage = createCreatePrStageHandler({ agent, ...ISSUE_CTX });
+    const ciStage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      collectFailureLogs: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+    const tpStage = {
+      ...createTestPlanStageHandler({ agent, ...ISSUE_CTX }),
+      restartFromStage: 5,
+    };
+
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [prStage, ciStage, tpStage], prompt }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(6);
+    expect(prompt.confirmContinueLoop).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---- Multi-stage E2E: Stage 2 → Stage 3 -----------------------------------
 
 describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
   test("implement completes → self-check DONE → pipeline succeeds", async () => {

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -15,10 +15,9 @@ import type { AgentAdapter } from "./agent.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   mapAgentError,
-  mapParsedStepToResult,
+  mapFixOrDoneResponse,
   sendFollowUp,
 } from "./stage-util.js";
-import { parseStepStatus } from "./step-parser.js";
 
 export interface SelfCheckStageOptions {
   agent: AgentAdapter;
@@ -108,27 +107,7 @@ export function createSelfCheckStageHandler(
         return mapAgentError(fixResult, "during fix");
       }
 
-      return mapFixResponse(fixResult.responseText);
+      return mapFixOrDoneResponse(fixResult.responseText);
     },
   };
-}
-
-/**
- * Map the fix-or-done response to a StageResult.
- *
- * The parser maps both FIXED and DONE to `"fixed"` status.  We
- * distinguish by keyword:
- *   - DONE  → `"completed"` (stage done, pipeline advances)
- *   - FIXED → `"not_approved"` (pipeline loops back)
- */
-function mapFixResponse(responseText: string): StageResult {
-  const parsed = parseStepStatus(responseText);
-
-  if (parsed.status === "fixed" && parsed.keyword === "FIXED") {
-    return mapParsedStepToResult(parsed, responseText, {
-      fixed: "not_approved",
-    });
-  }
-
-  return mapParsedStepToResult(parsed, responseText);
 }

--- a/src/stage-testplan.test.ts
+++ b/src/stage-testplan.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import type { StageContext } from "./pipeline.js";
+import {
+  buildTestPlanSelfCheckPrompt,
+  buildTestPlanVerifyPrompt,
+  createTestPlanStageHandler,
+  type TestPlanStageOptions,
+} from "./stage-testplan.js";
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    sessionId: "sess-1",
+    responseText: "All items verified.\n\nDONE",
+    status: "success",
+    errorType: undefined,
+    stderrText: "",
+    ...overrides,
+  };
+}
+
+function makeStream(result: AgentResult): AgentStream {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: async () => ({ done: true, value: "" }) };
+    },
+    result: Promise.resolve(result),
+    child: {} as AgentStream["child"],
+  };
+}
+
+function makeAgent(
+  verifyResult: AgentResult,
+  checkResult?: AgentResult,
+): AgentAdapter {
+  const invoke = vi.fn().mockReturnValue(makeStream(verifyResult));
+  const resume = vi
+    .fn()
+    .mockReturnValue(makeStream(checkResult ?? verifyResult));
+  return { invoke, resume };
+}
+
+const BASE_CTX: StageContext = {
+  owner: "org",
+  repo: "repo",
+  issueNumber: 42,
+  branch: "issue-42",
+  worktreePath: "/tmp/wt",
+  iteration: 0,
+  userInstruction: undefined,
+};
+
+function makeOpts(
+  overrides: Partial<TestPlanStageOptions> = {},
+): TestPlanStageOptions {
+  return {
+    agent: makeAgent(makeResult()),
+    issueTitle: "Fix the widget",
+    issueBody: "The widget is broken.",
+    ...overrides,
+  };
+}
+
+// ---- buildTestPlanVerifyPrompt ---------------------------------------------
+
+describe("buildTestPlanVerifyPrompt", () => {
+  test("includes repo context", () => {
+    const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).toContain("Worktree: /tmp/wt");
+  });
+
+  test("includes issue details", () => {
+    const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("Issue #42: Fix the widget");
+    expect(prompt).toContain("The widget is broken.");
+  });
+
+  test("mentions PR test plan and issue task checklist", () => {
+    const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("Test plan");
+    expect(prompt).toContain("task checklist");
+  });
+
+  test("instructs to commit and push code changes", () => {
+    const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("commit and push");
+  });
+
+  test("includes user instruction when present", () => {
+    const ctx = { ...BASE_CTX, userInstruction: "Skip flaky tests" };
+    const prompt = buildTestPlanVerifyPrompt(ctx, makeOpts());
+    expect(prompt).toContain("Additional feedback");
+    expect(prompt).toContain("Skip flaky tests");
+  });
+
+  test("omits feedback section when no instruction", () => {
+    const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
+    expect(prompt).not.toContain("Additional feedback");
+  });
+});
+
+// ---- buildTestPlanSelfCheckPrompt ------------------------------------------
+
+describe("buildTestPlanSelfCheckPrompt", () => {
+  test("mentions FIXED and DONE keywords", () => {
+    const prompt = buildTestPlanSelfCheckPrompt();
+    expect(prompt).toContain("FIXED");
+    expect(prompt).toContain("DONE");
+  });
+
+  test("mentions CI status check", () => {
+    const prompt = buildTestPlanSelfCheckPrompt();
+    expect(prompt).toContain("CI still passing");
+  });
+});
+
+// ---- createTestPlanStageHandler --------------------------------------------
+
+describe("createTestPlanStageHandler", () => {
+  test("returns stage definition with number 6 and name", () => {
+    const stage = createTestPlanStageHandler(makeOpts());
+    expect(stage.number).toBe(6);
+    expect(stage.name).toBe("Test plan verification");
+  });
+
+  // -- two-step flow ---------------------------------------------------------
+
+  test("invokes agent for verification then resumes for self-check", async () => {
+    const verifyResult = makeResult({
+      sessionId: "sess-verify",
+      responseText: "Verified items.",
+    });
+    const checkResult = makeResult({ responseText: "All good.\n\nDONE" });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+
+    await stage.handler(BASE_CTX);
+
+    expect(agent.invoke).toHaveBeenCalledWith(expect.any(String), {
+      cwd: "/tmp/wt",
+    });
+    expect(agent.resume).toHaveBeenCalledWith(
+      "sess-verify",
+      expect.any(String),
+      { cwd: "/tmp/wt" },
+    );
+  });
+
+  test("throws when verification returns no sessionId", async () => {
+    const verifyResult = makeResult({ sessionId: undefined });
+    const agent = makeAgent(verifyResult);
+
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    await expect(stage.handler(BASE_CTX)).rejects.toThrow("no session ID");
+  });
+
+  // -- outcome mapping: DONE vs FIXED ----------------------------------------
+
+  test("returns completed when agent says DONE", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      responseText: "Everything is fine.\n\nDONE",
+    });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("returns not_approved when agent says FIXED (triggers loop)", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      responseText: "Fixed a checklist item.\n\nFIXED",
+    });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("returns completed when agent says COMPLETED", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({ responseText: "All set.\n\nCOMPLETED" });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("returns blocked when agent says BLOCKED", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      responseText: "Cannot verify.\n\nBLOCKED",
+    });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("returns not_approved on NOT_APPROVED", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      responseText: "Not right.\n\nNOT_APPROVED",
+    });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("returns needs_clarification on ambiguous response", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({ responseText: "I looked at things." });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  // -- error handling --------------------------------------------------------
+
+  test("returns error when verify agent call fails (max_turns)", async () => {
+    const verifyResult = makeResult({
+      status: "error",
+      errorType: "max_turns",
+      responseText: "",
+    });
+    const agent = makeAgent(verifyResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("maximum turn limit");
+    expect(result.message).toContain("test plan verification");
+    expect(agent.resume).not.toHaveBeenCalled();
+  });
+
+  test("returns error when verify fails with stderr", async () => {
+    const verifyResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "timeout",
+      responseText: "",
+    });
+    const agent = makeAgent(verifyResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("timeout");
+  });
+
+  test("returns error when self-check agent call fails", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "crash",
+      responseText: "",
+    });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("crash");
+    expect(result.message).toContain("test plan self-check");
+  });
+
+  // -- message preservation --------------------------------------------------
+
+  test("preserves self-check response text in message", async () => {
+    const text = "Fixed several checklist items.\n\nFIXED";
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({ responseText: text });
+    const agent = makeAgent(verifyResult, checkResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.message).toBe(text);
+  });
+});

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -1,0 +1,115 @@
+/**
+ * Stage 6 — Test plan verification loop.
+ *
+ * Two-step flow per iteration:
+ *   1. Send a verification prompt to Agent A instructing it to verify
+ *      PR test plan items and issue task checklist items.
+ *   2. Resume the session with a self-check prompt.
+ *
+ * The agent responds with FIXED (loop again) or DONE (proceed).  The
+ * pipeline engine's built-in loop control manages the 3-automatic /
+ * 4th-asks-user budget — the handler returns `"not_approved"` on FIXED
+ * so the engine loops.
+ */
+
+import type { AgentAdapter } from "./agent.js";
+import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
+import {
+  mapAgentError,
+  mapFixOrDoneResponse,
+  sendFollowUp,
+} from "./stage-util.js";
+
+export interface TestPlanStageOptions {
+  agent: AgentAdapter;
+  issueTitle: string;
+  issueBody: string;
+}
+
+export function buildTestPlanVerifyPrompt(
+  ctx: StageContext,
+  opts: TestPlanStageOptions,
+): string {
+  const lines = [
+    `You are verifying the test plan for the following GitHub issue.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    `- Worktree: ${ctx.worktreePath}`,
+    ``,
+    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
+    ``,
+    opts.issueBody,
+    ``,
+    `## Instructions`,
+    ``,
+    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `2. Go through each item in the PR's "Test plan" checklist.  For`,
+    `   each item, actually run or verify the described test or behavior.`,
+    `3. Check off each verified item in the PR using \`gh\` commands.`,
+    `4. Also go through the task checklist in the GitHub issue.  Check`,
+    `   off each completed task using \`gh\` commands.`,
+    `5. If you made any code changes, commit and push them so a new CI`,
+    `   run is triggered.`,
+    `6. Make sure CI is still passing after any changes.`,
+  ];
+
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+
+  return lines.join("\n");
+}
+
+export function buildTestPlanSelfCheckPrompt(): string {
+  return [
+    `Based on your verification above, evaluate the current state.`,
+    ``,
+    `- Are ALL test plan items in the PR checked off?`,
+    `- Are ALL task checklist items in the issue checked off?`,
+    `- Is CI still passing?`,
+    ``,
+    `If you found and fixed issues during verification, end your`,
+    `response with the keyword FIXED.`,
+    ``,
+    `If everything is verified and passing with no changes needed,`,
+    `end your response with the keyword DONE.`,
+  ].join("\n");
+}
+
+export function createTestPlanStageHandler(
+  opts: TestPlanStageOptions,
+): StageDefinition {
+  return {
+    name: "Test plan verification",
+    number: 6,
+    handler: async (ctx: StageContext): Promise<StageResult> => {
+      // Step 1: Send verification prompt.
+      const verifyPrompt = buildTestPlanVerifyPrompt(ctx, opts);
+      const verifyStream = opts.agent.invoke(verifyPrompt, {
+        cwd: ctx.worktreePath,
+      });
+      const verifyResult = await verifyStream.result;
+
+      if (verifyResult.status === "error") {
+        return mapAgentError(verifyResult, "during test plan verification");
+      }
+
+      // Step 2: Send self-check prompt (resume the same session).
+      const checkResult = await sendFollowUp(
+        opts.agent,
+        verifyResult.sessionId,
+        buildTestPlanSelfCheckPrompt(),
+        ctx.worktreePath,
+      );
+
+      if (checkResult.status === "error") {
+        return mapAgentError(checkResult, "during test plan self-check");
+      }
+
+      return mapFixOrDoneResponse(checkResult.responseText);
+    },
+  };
+}

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import {
   mapAgentError,
+  mapFixOrDoneResponse,
   mapParsedStepToResult,
   mapResponseToResult,
   sendFollowUp,
@@ -184,6 +185,57 @@ describe("mapResponseToResult", () => {
   test("preserves full response text in message", () => {
     const text = "Long response.\n\nCOMPLETED";
     const result = mapResponseToResult(text);
+    expect(result.message).toBe(text);
+  });
+});
+
+// ---- mapFixOrDoneResponse ---------------------------------------------------
+
+describe("mapFixOrDoneResponse", () => {
+  test("maps DONE to completed (pipeline advances)", () => {
+    // DONE and FIXED both parse to status "fixed" in the step parser,
+    // but the keyword-level check ensures only FIXED loops.
+    const result = mapFixOrDoneResponse("Everything looks good.\n\nDONE");
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("maps FIXED to not_approved (pipeline loops)", () => {
+    const result = mapFixOrDoneResponse("Patched the issue.\n\nFIXED");
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("distinguishes DONE from FIXED despite both having 'fixed' status", () => {
+    // Both DONE and FIXED map to StepStatus "fixed" in the parser.
+    // mapFixOrDoneResponse must check the keyword to differentiate.
+    const done = mapFixOrDoneResponse("All verified.\n\nDONE");
+    const fixed = mapFixOrDoneResponse("Patched one item.\n\nFIXED");
+    expect(done.outcome).toBe("completed");
+    expect(fixed.outcome).toBe("not_approved");
+  });
+
+  test("maps COMPLETED to completed", () => {
+    const result = mapFixOrDoneResponse("All set.\n\nCOMPLETED");
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("maps BLOCKED to blocked", () => {
+    const result = mapFixOrDoneResponse("Cannot fix.\n\nBLOCKED");
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("maps NOT_APPROVED to not_approved", () => {
+    const result = mapFixOrDoneResponse("Not right.\n\nNOT_APPROVED");
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("maps ambiguous to needs_clarification", () => {
+    const result = mapFixOrDoneResponse("I looked at things.");
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("preserves response text in message", () => {
+    const text = "Fixed several items.\n\nFIXED";
+    const result = mapFixOrDoneResponse(text);
     expect(result.message).toBe(text);
   });
 });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -96,3 +96,26 @@ export function mapResponseToResult(
     overrides,
   );
 }
+
+/**
+ * Map a fix-or-done / verify-or-done response to a `StageResult`.
+ *
+ * The step parser maps both FIXED and DONE to `"fixed"` status.  We
+ * distinguish by keyword:
+ *   - DONE  → `"completed"` (stage done, pipeline advances)
+ *   - FIXED → `"not_approved"` (pipeline loops back)
+ *
+ * Shared by the self-check (stage 3) and test-plan verification
+ * (stage 6) handlers.
+ */
+export function mapFixOrDoneResponse(responseText: string): StageResult {
+  const parsed = parseStepStatus(responseText);
+
+  if (parsed.status === "fixed" && parsed.keyword === "FIXED") {
+    return mapParsedStepToResult(parsed, responseText, {
+      fixed: "not_approved",
+    });
+  }
+
+  return mapParsedStepToResult(parsed, responseText);
+}


### PR DESCRIPTION
## Summary

- **Stage 4 (Create PR)**: two-step agent flow with `requiresArtifact: true` so BLOCKED only offers Instruct/Halt (no Proceed). Completion check handles ambiguity internally via session resume to avoid re-running the side-effectful PR creation step. On BLOCKED, step 1 diagnostic text is preserved in the message for user context.
- **Stage 5 (CI check loop)**: polls CI status internally (pending does not consume engine auto-budget), collects failure logs on CI failure, sends them to the agent for a fix, returns `not_approved` to re-poll. Engine auto-budget (3) handles the "3 auto / 4th asks user" requirement.
- **Stage 6 (Test plan verification)**: two-step verify + self-check loop. FIXED triggers a backward transition to stage 5 via `restartFromStage` so code changes are validated by CI before re-entering verification. The prompt instructs the agent to commit and push any fixes.
- **Pipeline engine**: adds `restartFromStage` on `StageDefinition` for backward stage transitions, with pipeline-level budget tracking and startup validation.
- Extracts `mapFixOrDoneResponse` to `stage-util.ts` to share the DONE-vs-FIXED keyword logic between stages 3 and 6.
- Registers all three stages in the pipeline between self-check and done.

Closes #7