### PR TITLE
Preserve session ID in Codex resume output

### DIFF
--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -3,6 +3,7 @@ import {
   buildCodexInvokeArgs,
   buildCodexResumeArgs,
   extractCodexResumeResponse,
+  extractSessionId,
   parseCodexJsonl,
   parseCodexPlainText,
 } from "./codex-adapter.js";
@@ -249,25 +250,32 @@ describe("extractCodexResumeResponse", () => {
 // parseCodexPlainText
 // ---------------------------------------------------------------------------
 describe("parseCodexPlainText", () => {
-  test("parses successful plain text response with banner stripping", () => {
-    const text = [
-      "OpenAI Codex v0.46.0 (research preview)",
-      "--------",
-      "workdir: /path",
-      "model: gpt-5.4",
-      "session id: sess-1",
-      "--------",
+  const BANNER = [
+    "OpenAI Codex v0.46.0 (research preview)",
+    "--------",
+    "workdir: /path",
+    "model: gpt-5.4",
+    "session id: sess-1",
+    "--------",
+  ].join("\n");
+
+  function buildResumeOutput(response: string): string {
+    return [
+      BANNER,
       "user",
       "Question",
       "codex",
-      "Answer",
+      response,
       "tokens used",
       "100",
     ].join("\n");
+  }
 
-    const result = parseCodexPlainText(text, 0, "");
+  test("parses successful plain text response with banner stripping", () => {
+    const result = parseCodexPlainText(buildResumeOutput("Answer"), 0, "");
     expect(result.responseText).toBe("Answer");
     expect(result.status).toBe("success");
+    expect(result.sessionId).toBe("sess-1");
   });
 
   test("returns raw text on failure (no banner stripping)", () => {
@@ -344,7 +352,21 @@ describe("parseCodexPlainText", () => {
     expect(result.errorType).toBe("unknown");
   });
 
-  test("sessionId is always undefined for plain text", () => {
+  test("extracts sessionId from banner when present", () => {
+    expect(
+      parseCodexPlainText(buildResumeOutput("Answer"), 0, "").sessionId,
+    ).toBe("sess-1");
+  });
+
+  test("extracts sessionId from banner even on error exit", () => {
+    // The CLI may print the banner before crashing.
+    const text = buildResumeOutput("partial output");
+    const result = parseCodexPlainText(text, 1, "");
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.status).toBe("error");
+  });
+
+  test("sessionId is undefined when output has no session id line", () => {
     expect(parseCodexPlainText("response", 0, "").sessionId).toBeUndefined();
     expect(parseCodexPlainText("error", 1, "").sessionId).toBeUndefined();
   });
@@ -352,6 +374,127 @@ describe("parseCodexPlainText", () => {
   test("includes stderrText in result", () => {
     const result = parseCodexPlainText("output", 0, "some warning");
     expect(result.stderrText).toBe("some warning");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSessionId
+// ---------------------------------------------------------------------------
+describe("extractSessionId", () => {
+  test("extracts session ID from banner", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "session id: 019d46a1-d07f-7bc3-b96d-d50d44001c82",
+      "--------",
+    ].join("\n");
+
+    expect(extractSessionId(text)).toBe("019d46a1-d07f-7bc3-b96d-d50d44001c82");
+  });
+
+  test("returns undefined when no separator lines", () => {
+    expect(extractSessionId("session id: fake-id")).toBeUndefined();
+  });
+
+  test("returns undefined when no Codex header before separators", () => {
+    const text = ["--------", "session id: fake-id", "--------"].join("\n");
+    expect(extractSessionId(text)).toBeUndefined();
+  });
+
+  test("returns undefined when only one separator line", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "session id: fake-id",
+    ].join("\n");
+    expect(extractSessionId(text)).toBeUndefined();
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(extractSessionId("")).toBeUndefined();
+  });
+
+  test("handles session id with extra whitespace", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "session id:   abc-123",
+      "--------",
+    ].join("\n");
+    expect(extractSessionId(text)).toBe("abc-123");
+  });
+
+  test("ignores session id in response body outside banner", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "session id: real-id",
+      "--------",
+      "user",
+      "prompt",
+      "codex",
+      "session id: fake-id-in-response",
+      "tokens used",
+      "100",
+    ].join("\n");
+
+    expect(extractSessionId(text)).toBe("real-id");
+  });
+
+  test("returns undefined when response body contains session id but banner does not", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "workdir: /path",
+      "--------",
+      "user",
+      "prompt",
+      "codex",
+      "session id: fake-id-in-response",
+      "tokens used",
+      "100",
+    ].join("\n");
+
+    expect(extractSessionId(text)).toBeUndefined();
+  });
+
+  test("ignores fake banner in response body with separators", () => {
+    const text = [
+      "codex",
+      "Here is the session info:",
+      "--------",
+      "session id: fake-id",
+      "--------",
+      "tokens used",
+      "100",
+    ].join("\n");
+
+    expect(extractSessionId(text)).toBeUndefined();
+  });
+
+  test("ignores Codex header echoed mid-output with fake banner", () => {
+    const text = [
+      "codex",
+      "The output looks like:",
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "session id: fake-id",
+      "--------",
+      "tokens used",
+      "100",
+    ].join("\n");
+
+    expect(extractSessionId(text)).toBeUndefined();
+  });
+
+  test("does not match indented session id in banner", () => {
+    const text = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "  session id: indented",
+      "--------",
+    ].join("\n");
+    expect(extractSessionId(text)).toBeUndefined();
   });
 });
 

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -151,6 +151,40 @@ export function extractCodexResumeResponse(text: string): string {
   return text.slice(start, end).trim();
 }
 
+/**
+ * Extract the session ID from `codex exec resume` plain text banner.
+ *
+ * The real Codex banner always looks like:
+ * ```
+ * OpenAI Codex v0.46.0 (research preview)
+ * --------
+ * ...key: value lines including session id...
+ * --------
+ * ```
+ *
+ * We verify the `OpenAI Codex` header precedes the first `--------`
+ * separator so that separator pairs appearing in the assistant's
+ * response body are never mistaken for the banner.  Returns
+ * `undefined` when the banner is absent or does not contain a
+ * `session id:` line.
+ */
+export function extractSessionId(text: string): string | undefined {
+  const sep = "--------";
+  const first = text.indexOf(sep);
+  if (first === -1) return undefined;
+
+  // The real Codex banner always starts the output.  Reject when the
+  // header is missing so that response body content is never mistaken
+  // for the banner.
+  if (!text.trimStart().startsWith("OpenAI Codex")) return undefined;
+
+  const second = text.indexOf(sep, first + sep.length);
+  if (second === -1) return undefined;
+  const banner = text.slice(first, second + sep.length);
+  const match = /^session id:\s*(\S+)/m.exec(banner);
+  return match?.[1];
+}
+
 export function parseCodexPlainText(
   text: string,
   exitCode: number | null,
@@ -163,7 +197,7 @@ export function parseCodexPlainText(
     errorType = detectCodexError(text + stderrText);
   }
   return {
-    sessionId: undefined,
+    sessionId: extractSessionId(text),
     responseText,
     status: failed ? "error" : "success",
     errorType,
@@ -285,7 +319,15 @@ export function createCodexAdapter(
           reasoningEffort,
         }),
         cwd: options?.cwd,
-        parseResult: parseCodexPlainText,
+        parseResult(output, exitCode, stderr) {
+          const result = parseCodexPlainText(output, exitCode, stderr);
+          // Preserve the input session ID when the plain text output
+          // does not contain one (e.g. older CLI versions).
+          if (result.sessionId === undefined) {
+            result.sessionId = sessionId;
+          }
+          return result;
+        },
       });
     },
   };

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -598,15 +598,31 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     const result = await stream.result;
     expect(result.responseText).toBe("Continued work done.");
     expect(result.status).toBe("success");
-    expect(result.sessionId).toBeUndefined();
+    expect(result.sessionId).toBe("sess-prev");
   });
 
-  test("resume detects error keywords in plain text", async () => {
+  test("resume falls back to input sessionId when output has no session id line", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
     const adapter = createCodexAdapter();
-    const stream = adapter.resume("sess-1", "continue");
+    const stream = adapter.resume("sess-input", "keep going");
+
+    // Output without a "session id:" banner line (e.g. older CLI version).
+    emitStdout(child, "codex\nDone.\ntokens used\n50");
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.sessionId).toBe("sess-input");
+    expect(result.status).toBe("success");
+  });
+
+  test("resume preserves sessionId on error exit", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-err", "continue");
 
     emitStdout(child, "Error: max turns reached");
     child.emit("close", 1);
@@ -614,6 +630,35 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     const result = await stream.result;
     expect(result.status).toBe("error");
     expect(result.errorType).toBe("max_turns");
+    expect(result.sessionId).toBe("sess-err");
+  });
+
+  test("resume prefers parsed sessionId over input when banner has one", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    // Pass "old-sess" as input, but the CLI output contains "new-sess".
+    const stream = adapter.resume("old-sess", "keep going");
+
+    const resumeOutput = [
+      "OpenAI Codex v0.46.0 (research preview)",
+      "--------",
+      "session id: new-sess",
+      "--------",
+      "user",
+      "keep going",
+      "codex",
+      "Done.",
+      "tokens used",
+      "50",
+    ].join("\n");
+
+    emitStdout(child, resumeOutput);
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.sessionId).toBe("new-sess");
   });
 
   test("invoke with cwd passes working directory", () => {

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -536,6 +536,43 @@ describe("createReviewStageHandler", () => {
     expect(retryPrompt).not.toContain("NOT_APPROVED");
   });
 
+  test("ambiguous author check without sessionId skips internal clarification", async () => {
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "NOT_APPROVED",
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+
+    const ambiguousCheck = makeResult({
+      sessionId: undefined,
+      responseText: "I addressed the feedback.",
+    });
+
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi.fn().mockReturnValueOnce(makeStream(ambiguousCheck)),
+    };
+
+    const opts = makeOpts({ agentA, agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("needs_clarification");
+    expect(agentA.resume).toHaveBeenCalledTimes(1);
+  });
+
   test("returns needs_clarification when author check stays ambiguous after retry", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -377,6 +377,27 @@ describe("createSquashStageHandler", () => {
     expect(agent.resume).toHaveBeenCalledTimes(2);
   });
 
+  test("ambiguous check without sessionId skips internal clarification", async () => {
+    const ambiguousCheck = makeResult({
+      sessionId: undefined,
+      responseText: "I squashed the commits.",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ sessionId: "sess-squash" }))),
+      resume: vi.fn().mockReturnValueOnce(makeStream(ambiguousCheck)),
+    };
+
+    const opts = makeOpts({ agent });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("needs_clarification");
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+  });
+
   // -- CI pending then pass ---------------------------------------------------
 
   test("polls CI when pending then completes on pass", async () => {


### PR DESCRIPTION
## Summary

- Add `extractSessionId()` that parses session ID from the Codex CLI banner (the `session id: UUID` line between `--------` separators), only when the output starts with the `OpenAI Codex` header
- Fall back to the input session ID when the banner is absent or has no session ID (e.g. older CLI versions)
- Add guard tests to stages 5 and 6 for the "no sessionId → skip internal clarification" path (matching stage 4's existing coverage)

## Test plan

- [x] `extractSessionId()`: banner 있을 때 파싱, 없을 때 undefined, 빈 문자열, 공백, 중복 라인, 들여쓰기
- [x] `extractSessionId()`: 응답 본문의 `session id:` 라인 무시
- [x] `extractSessionId()`: 응답 본문의 가짜 배너 (`--------` 쌍) 무시
- [x] `extractSessionId()`: 출력 중간에 에코된 Codex 헤더 + 가짜 배너 무시
- [x] `parseCodexPlainText()`: 성공 시 배너에서 sessionId 추출
- [x] `parseCodexPlainText()`: 에러 exit에서도 배너의 sessionId 추출
- [x] `parseCodexPlainText()`: 배너 없으면 sessionId undefined
- [x] E2E: resume 출력에 배너 있을 때 sessionId 파싱
- [x] E2E: resume 출력에 배너 없을 때 input sessionId로 폴백
- [x] E2E: resume 에러 시에도 sessionId 보존
- [x] E2E: 출력 sessionId ≠ input일 때 출력 것 우선
- [x] Stage 4, 5, 6: sessionId 없으면 internal clarification 스킵

Closes #22