### PR TITLE
Filter CI polling by commit SHA

### DIFF
--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -34,6 +34,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     status: "completed",
     conclusion: "success",
     headBranch: "issue-42",
+    headSha: "abc123",
     ...overrides,
   };
 }
@@ -67,10 +68,12 @@ function makeOpts(overrides: Partial<CiPollOptions> = {}): CiPollOptions {
     issueBody: "The widget is broken.",
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
+    getHeadSha: vi.fn().mockReturnValue("abc123"),
     delay: vi.fn().mockResolvedValue(undefined),
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
     maxFixAttempts: 3,
+    emptyRunsGracePeriodMs: 0,
     ...overrides,
   };
 }
@@ -335,6 +338,118 @@ describe("pollCiAndFix", () => {
     expect(result.passed).toBe(false);
     expect(result.message).toContain("still failing after 0 fix attempt");
     expect(agent.invoke).not.toHaveBeenCalled();
+  });
+
+  // -- getHeadSha integration ---------------------------------------------------
+
+  test("reads HEAD SHA from worktree and forwards to getCiStatus", async () => {
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+    const getHeadSha = vi.fn().mockReturnValue("deadbeef");
+    const opts = makeOpts({ getCiStatus, getHeadSha });
+    await pollCiAndFix(opts);
+
+    expect(getHeadSha).toHaveBeenCalledWith("/tmp/wt");
+    expect(getCiStatus).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-42",
+      "deadbeef",
+    );
+  });
+
+  test("waits within grace period when SHA filter returns empty pass", async () => {
+    // No workflow yet → getCiStatus returns pass with empty runs.
+    // Grace period keeps polling; eventually runs appear and pass.
+    const getHeadSha = vi.fn().mockReturnValue("new-sha");
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pass")) // empty, within grace
+      .mockReturnValueOnce(makeCiStatus("pass")) // empty, within grace
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()])); // runs appeared
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 100;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        getCiStatus,
+        getHeadSha,
+        delay,
+        emptyRunsGracePeriodMs: 500,
+      }),
+    );
+
+    expect(result.passed).toBe(true);
+    expect(getCiStatus).toHaveBeenCalledTimes(3);
+
+    vi.restoreAllMocks();
+  });
+
+  test("accepts empty pass after grace period expires", async () => {
+    // No CI configured → empty runs persist beyond grace period.
+    const getHeadSha = vi.fn().mockReturnValue("new-sha");
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass")); // always empty
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 300;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        getCiStatus,
+        getHeadSha,
+        delay,
+        emptyRunsGracePeriodMs: 500,
+        pollIntervalMs: 100,
+      }),
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("CI checks passed");
+
+    vi.restoreAllMocks();
+  });
+
+  test("re-reads HEAD SHA after each fix push", async () => {
+    let shaCall = 0;
+    const shas = ["aaa111", "bbb222"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    const agent = makeAgent();
+    await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, collectFailureLogs, getHeadSha }),
+    );
+
+    expect(getHeadSha).toHaveBeenCalledTimes(2);
+    expect(getCiStatus).toHaveBeenNthCalledWith(
+      1,
+      "org",
+      "repo",
+      "issue-42",
+      "aaa111",
+    );
+    expect(getCiStatus).toHaveBeenNthCalledWith(
+      2,
+      "org",
+      "repo",
+      "issue-42",
+      "bbb222",
+    );
   });
 
   // -- timeout during fix loop (pending after agent pushes fix) ---------------

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiStatus } from "./ci.js";
+import type { CiStatus, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -16,12 +16,14 @@ import {
 } from "./ci.js";
 import type { StageContext } from "./pipeline.js";
 import { buildCiFixPrompt } from "./stage-cicheck.js";
+import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
 
 // ---- defaults ----------------------------------------------------------------
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_POLL_TIMEOUT_MS = 600_000; // 10 minutes
 const DEFAULT_MAX_FIX_ATTEMPTS = 3;
+const DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS = 60_000; // 1 minute
 
 function defaultDelay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -35,15 +37,28 @@ export interface CiPollOptions {
   issueTitle: string;
   issueBody: string;
   /** Injected for testability. Defaults to `ci.getCiStatus`. */
-  getCiStatus?: (owner: string, repo: string, branch: string) => CiStatus;
+  getCiStatus?: GetCiStatusFn;
   /** Injected for testability. Defaults to `ci.collectFailureLogs`. */
   collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  /**
+   * Read the current HEAD SHA from the worktree.  Called before each
+   * CI poll so that fix pushes automatically target the new commit.
+   * Injected for testability.  Defaults to `worktree.getHeadSha`.
+   */
+  getHeadSha?: (cwd: string) => string;
   /** Delay in ms between polls when CI is pending. Default 30 000. */
   pollIntervalMs?: number;
   /** Max time in ms to wait for pending CI. Default 600 000 (10 min). */
   pollTimeoutMs?: number;
   /** Maximum number of fix attempts before giving up. Default 3. */
   maxFixAttempts?: number;
+  /**
+   * How long to keep polling when SHA filtering returns zero runs
+   * (workflow not yet created).  After this period, an empty "pass"
+   * is accepted (covers repos with no CI or skipped workflows).
+   * Default 60 000 (1 min).
+   */
+  emptyRunsGracePeriodMs?: number;
   /** Injected for testability. Defaults to a real delay function. */
   delay?: (ms: number) => Promise<void>;
 }
@@ -65,21 +80,35 @@ async function waitForCi(
   owner: string,
   repo: string,
   branch: string,
-  getCiStatus: (owner: string, repo: string, branch: string) => CiStatus,
+  getCiStatus: GetCiStatusFn,
   pollInterval: number,
   pollTimeout: number,
   delay: (ms: number) => Promise<void>,
+  commitSha?: string,
+  emptyRunsGracePeriod?: number,
 ): Promise<{ timedOut: boolean; ciStatus: CiStatus }> {
   const startTime = Date.now();
 
   while (true) {
-    const ciStatus = getCiStatus(owner, repo, branch);
+    const ciStatus = getCiStatus(owner, repo, branch, commitSha);
+    const elapsed = Date.now() - startTime;
 
     if (ciStatus.verdict !== "pending") {
-      return { timedOut: false, ciStatus };
+      // When SHA-filtering, an empty "pass" may mean the workflow
+      // hasn't been created yet.  Keep polling until the grace period
+      // elapses; after that, accept the verdict (no CI / skipped).
+      const withinGrace =
+        commitSha &&
+        emptyRunsGracePeriod !== undefined &&
+        ciStatus.runs.length === 0 &&
+        elapsed < emptyRunsGracePeriod;
+
+      if (!withinGrace) {
+        return { timedOut: false, ciStatus };
+      }
     }
 
-    if (Date.now() - startTime >= pollTimeout) {
+    if (elapsed >= pollTimeout) {
       return { timedOut: true, ciStatus };
     }
 
@@ -106,8 +135,15 @@ export async function pollCiAndFix(
   const delay = options.delay ?? defaultDelay;
 
   const { ctx, agent, issueTitle, issueBody } = options;
+  const readHeadSha = options.getHeadSha ?? defaultGetHeadSha;
+  const emptyGrace =
+    options.emptyRunsGracePeriodMs ?? DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS;
 
   for (let attempt = 0; attempt <= maxFix; attempt++) {
+    // Read HEAD SHA from the worktree so we only consider CI runs
+    // triggered by the most recent push (initial or fix).
+    const commitSha = readHeadSha(ctx.worktreePath);
+
     const { timedOut, ciStatus } = await waitForCi(
       ctx.owner,
       ctx.repo,
@@ -116,6 +152,8 @@ export async function pollCiAndFix(
       pollInterval,
       pollTimeout,
       delay,
+      commitSha,
+      emptyGrace,
     );
 
     if (timedOut) {

--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -28,6 +28,7 @@ function run(
     status: string;
     conclusion: string;
     headBranch: string;
+    headSha: string;
   }> = {},
 ) {
   return {
@@ -36,6 +37,7 @@ function run(
     status: "completed",
     conclusion: "success",
     headBranch: "main",
+    headSha: "abc123",
     ...overrides,
   };
 }
@@ -173,7 +175,7 @@ describe("evaluateCiRuns", () => {
 // fetchCiRuns
 // ---------------------------------------------------------------------------
 describe("fetchCiRuns", () => {
-  test("calls gh with correct arguments", () => {
+  test("calls gh with correct arguments including headSha", () => {
     mockExecFileSync.mockReturnValue("[]");
     fetchCiRuns("org", "repo", "issue-5");
     expect(mockExecFileSync).toHaveBeenCalledWith(
@@ -186,9 +188,9 @@ describe("fetchCiRuns", () => {
         "--branch",
         "issue-5",
         "--json",
-        "databaseId,name,status,conclusion,headBranch",
+        "databaseId,name,status,conclusion,headBranch,headSha",
         "--limit",
-        "20",
+        "100",
       ],
       { encoding: "utf-8" },
     );
@@ -198,6 +200,36 @@ describe("fetchCiRuns", () => {
     const runs = [run({ databaseId: 100, name: "build" })];
     mockExecFileSync.mockReturnValue(JSON.stringify(runs));
     expect(fetchCiRuns("org", "repo", "main")).toEqual(runs);
+  });
+
+  test("passes --commit flag when commitSha is provided", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    fetchCiRuns("org", "repo", "main", "abc123");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "run",
+        "list",
+        "--repo",
+        "org/repo",
+        "--branch",
+        "main",
+        "--json",
+        "databaseId,name,status,conclusion,headBranch,headSha",
+        "--limit",
+        "100",
+        "--commit",
+        "abc123",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("omits --commit flag when commitSha is not provided", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    fetchCiRuns("org", "repo", "main");
+    const args = mockExecFileSync.mock.calls[0][1] as string[];
+    expect(args).not.toContain("--commit");
   });
 });
 
@@ -224,6 +256,27 @@ describe("getCiStatus", () => {
       JSON.stringify([run({ status: "in_progress" })]),
     );
     expect(getCiStatus("org", "repo", "main").verdict).toBe("pending");
+  });
+
+  test("passes commitSha to fetchCiRuns and evaluates filtered result", () => {
+    // Server returns only the matching run (via --commit flag).
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify([run({ headSha: "aaa", conclusion: "success" })]),
+    );
+    const status = getCiStatus("org", "repo", "main", "aaa");
+    expect(status.verdict).toBe("pass");
+    expect(status.runs).toHaveLength(1);
+    // Verify --commit was passed to gh.
+    const args = mockExecFileSync.mock.calls[0][1] as string[];
+    expect(args).toContain("--commit");
+    expect(args).toContain("aaa");
+  });
+
+  test("returns pass when server returns no runs for commitSha", () => {
+    mockExecFileSync.mockReturnValue("[]");
+    const status = getCiStatus("org", "repo", "main", "zzz");
+    expect(status.verdict).toBe("pass");
+    expect(status.runs).toEqual([]);
   });
 });
 

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -23,6 +23,7 @@ export interface CiRun {
   status: string;
   conclusion: string;
   headBranch: string;
+  headSha: string;
 }
 
 export type CiVerdict = "pass" | "fail" | "pending";
@@ -32,6 +33,18 @@ export interface CiStatus {
   /** Individual check runs used to compute the verdict. */
   runs: CiRun[];
 }
+
+/**
+ * Signature shared by `getCiStatus` and all injectable overrides.
+ * Extracted to avoid repeating the 4-param signature across every
+ * stage options interface.
+ */
+export type GetCiStatusFn = (
+  owner: string,
+  repo: string,
+  branch: string,
+  commitSha?: string,
+) => CiStatus;
 
 // ---- CI pass criteria ----------------------------------------------------
 
@@ -94,28 +107,33 @@ export function normaliseCiConclusion(run: CiRun): CheckConclusion {
 
 /**
  * Fetch the latest CI runs for `branch` in `owner/repo`.
+ *
+ * When `commitSha` is provided, uses `gh run list --commit` to let
+ * the server filter by SHA.  This avoids pagination issues where the
+ * target commit's runs could be paged out on high-activity branches.
  */
 export function fetchCiRuns(
   owner: string,
   repo: string,
   branch: string,
+  commitSha?: string,
 ): CiRun[] {
-  const output = execFileSync(
-    "gh",
-    [
-      "run",
-      "list",
-      "--repo",
-      `${owner}/${repo}`,
-      "--branch",
-      branch,
-      "--json",
-      "databaseId,name,status,conclusion,headBranch",
-      "--limit",
-      "20",
-    ],
-    { encoding: "utf-8" },
-  );
+  const args = [
+    "run",
+    "list",
+    "--repo",
+    `${owner}/${repo}`,
+    "--branch",
+    branch,
+    "--json",
+    "databaseId,name,status,conclusion,headBranch,headSha",
+    "--limit",
+    "100",
+  ];
+  if (commitSha) {
+    args.push("--commit", commitSha);
+  }
+  const output = execFileSync("gh", args, { encoding: "utf-8" });
   try {
     return JSON.parse(output);
   } catch {
@@ -125,13 +143,17 @@ export function fetchCiRuns(
 
 /**
  * Fetch CI status for a branch, returning the overall verdict.
+ *
+ * When `commitSha` is provided, only runs triggered by that commit
+ * are considered.
  */
 export function getCiStatus(
   owner: string,
   repo: string,
   branch: string,
+  commitSha?: string,
 ): CiStatus {
-  const runs = fetchCiRuns(owner, repo, branch);
+  const runs = fetchCiRuns(owner, repo, branch, commitSha);
   return { verdict: evaluateCiRuns(runs), runs };
 }
 

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -38,6 +38,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     status: "completed",
     conclusion: "success",
     headBranch: "issue-42",
+    headSha: "abc123",
     ...overrides,
   };
 }
@@ -68,9 +69,11 @@ function makeOpts(
     issueBody: "The widget is broken.",
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
+    getHeadSha: vi.fn().mockReturnValue("abc123"),
     delay: vi.fn().mockResolvedValue(undefined),
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
+    emptyRunsGracePeriodMs: 0,
     ...overrides,
   };
 }
@@ -427,6 +430,113 @@ describe("createCiCheckStageHandler", () => {
   });
 
   // -- message preservation --------------------------------------------------
+
+  test("reads HEAD SHA and forwards to getCiStatus", async () => {
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+    const getHeadSha = vi.fn().mockReturnValue("deadbeef");
+    const opts = makeOpts({ getCiStatus, getHeadSha });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(getHeadSha).toHaveBeenCalledWith("/tmp/wt");
+    expect(getCiStatus).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-42",
+      "deadbeef",
+    );
+  });
+
+  test("re-reads HEAD SHA on each poll cycle", async () => {
+    let shaCall = 0;
+    const shas = ["aaa111", "bbb222", "bbb222"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pending"))
+      .mockReturnValueOnce(makeCiStatus("pending"))
+      .mockReturnValueOnce(makeCiStatus("pass"));
+
+    const opts = makeOpts({
+      getCiStatus,
+      getHeadSha,
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(getHeadSha).toHaveBeenCalledTimes(3);
+    expect(getCiStatus).toHaveBeenNthCalledWith(
+      1,
+      "org",
+      "repo",
+      "issue-42",
+      "aaa111",
+    );
+    expect(getCiStatus).toHaveBeenNthCalledWith(
+      2,
+      "org",
+      "repo",
+      "issue-42",
+      "bbb222",
+    );
+  });
+
+  test("waits within grace period when SHA filter returns empty pass", async () => {
+    const getHeadSha = vi.fn().mockReturnValue("new-sha");
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pass")) // empty, within grace
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()])); // runs appeared
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 100;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const opts = makeOpts({
+      getCiStatus,
+      getHeadSha,
+      delay,
+      emptyRunsGracePeriodMs: 500,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(getCiStatus).toHaveBeenCalledTimes(2);
+
+    vi.restoreAllMocks();
+  });
+
+  test("accepts empty pass after grace period expires (no CI)", async () => {
+    const getHeadSha = vi.fn().mockReturnValue("new-sha");
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 300;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const opts = makeOpts({
+      getCiStatus,
+      getHeadSha,
+      delay,
+      emptyRunsGracePeriodMs: 500,
+      pollIntervalMs: 100,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("CI checks passed");
+
+    vi.restoreAllMocks();
+  });
 
   test("preserves agent fix response text in message", async () => {
     const getCiStatus = vi

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -12,7 +12,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiStatus } from "./ci.js";
+import type { CiStatus, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -20,11 +20,13 @@ import {
 } from "./ci.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import { mapAgentError } from "./stage-util.js";
+import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
 
 // ---- defaults --------------------------------------------------------------
 
 const DEFAULT_POLL_INTERVAL_MS = 30_000;
 const DEFAULT_POLL_TIMEOUT_MS = 600_000; // 10 minutes
+const DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS = 60_000; // 1 minute
 
 function defaultDelay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -37,13 +39,24 @@ export interface CiCheckStageOptions {
   issueTitle: string;
   issueBody: string;
   /** Injected for testability. Defaults to `ci.getCiStatus`. */
-  getCiStatus?: (owner: string, repo: string, branch: string) => CiStatus;
+  getCiStatus?: GetCiStatusFn;
   /** Injected for testability. Defaults to `ci.collectFailureLogs`. */
   collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  /**
+   * Read the current HEAD SHA from the worktree.  Called before each
+   * CI poll so that fix pushes automatically target the new commit.
+   * Injected for testability.  Defaults to `worktree.getHeadSha`.
+   */
+  getHeadSha?: (cwd: string) => string;
   /** Delay in ms between polls when CI is pending. Default 30 000. */
   pollIntervalMs?: number;
   /** Max time in ms to wait for pending CI. Default 600 000 (10 min). */
   pollTimeoutMs?: number;
+  /**
+   * How long to keep polling when SHA filtering returns zero runs.
+   * After this period, an empty "pass" is accepted.  Default 60 000.
+   */
+  emptyRunsGracePeriodMs?: number;
   /** Injected for testability. Defaults to a real delay function. */
   delay?: (ms: number) => Promise<void>;
 }
@@ -92,8 +105,11 @@ export function createCiCheckStageHandler(
 ): StageDefinition {
   const getCiStatus = opts.getCiStatus ?? defaultGetCiStatus;
   const collectLogs = opts.collectFailureLogs ?? defaultCollectFailureLogs;
+  const readHeadSha = opts.getHeadSha ?? defaultGetHeadSha;
   const pollInterval = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const pollTimeout = opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+  const emptyGrace =
+    opts.emptyRunsGracePeriodMs ?? DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS;
   const delay = opts.delay ?? defaultDelay;
 
   return {
@@ -106,11 +122,21 @@ export function createCiCheckStageHandler(
 
       let ciStatus: CiStatus;
       while (true) {
-        ciStatus = getCiStatus(ctx.owner, ctx.repo, ctx.branch);
+        const commitSha = readHeadSha(ctx.worktreePath);
+        ciStatus = getCiStatus(ctx.owner, ctx.repo, ctx.branch, commitSha);
 
-        if (ciStatus.verdict !== "pending") break;
+        const elapsed = Date.now() - startTime;
 
-        if (Date.now() - startTime >= pollTimeout) {
+        if (ciStatus.verdict !== "pending") {
+          // When SHA-filtering, an empty "pass" may mean the workflow
+          // hasn't been created yet.  Keep polling within the grace
+          // period; after that, accept it (no CI / skipped workflow).
+          const withinGrace =
+            ciStatus.runs.length === 0 && elapsed < emptyGrace;
+          if (!withinGrace) break;
+        }
+
+        if (elapsed >= pollTimeout) {
           return {
             outcome: "error",
             message:

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -500,9 +500,12 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     status: "completed",
     conclusion: "success",
     headBranch: "issue-5",
+    headSha: "abc123",
     ...overrides,
   };
 }
+
+const stubGetHeadSha = () => "abc123";
 
 function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
   return { verdict, runs };
@@ -657,6 +660,8 @@ describe("Stage 5 (CI check) through pipeline", () => {
       getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
       collectFailureLogs: vi.fn(),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
@@ -690,6 +695,8 @@ describe("Stage 5 (CI check) through pipeline", () => {
       getCiStatus,
       collectFailureLogs: vi.fn().mockReturnValue("test error"),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
@@ -725,6 +732,8 @@ describe("Stage 5 (CI check) through pipeline", () => {
       getCiStatus,
       collectFailureLogs: vi.fn().mockReturnValue("err"),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(
@@ -759,6 +768,8 @@ describe("Stage 5 (CI check) through pipeline", () => {
       getCiStatus,
       collectFailureLogs: vi.fn().mockReturnValue("err"),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(
@@ -767,6 +778,212 @@ describe("Stage 5 (CI check) through pipeline", () => {
 
     expect(result.success).toBe(false);
     expect(result.stoppedAt).toBe(5);
+  });
+});
+
+// ---- Stage 5 SHA filtering E2E ---------------------------------------------
+
+describe("Stage 5 (CI check) SHA filtering through pipeline", () => {
+  test("getHeadSha is called and SHA is forwarded to getCiStatus", async () => {
+    const getHeadSha = vi.fn().mockReturnValue("sha-after-push");
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      getHeadSha,
+      collectFailureLogs: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+      emptyRunsGracePeriodMs: 0,
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(getHeadSha).toHaveBeenCalledWith("/tmp/wt");
+    expect(getCiStatus).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-5",
+      "sha-after-push",
+    );
+  });
+
+  test("SHA changes after fix push: new SHA used for re-poll", async () => {
+    let shaCall = 0;
+    const shas = ["sha-v1", "sha-v2"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+
+    let pollCount = 0;
+    const getCiStatus = vi
+      .fn()
+      .mockImplementation(
+        (_o: string, _r: string, _b: string, sha?: string) => {
+          pollCount++;
+          if (pollCount === 1) {
+            expect(sha).toBe("sha-v1");
+            return makeCiStatus("fail", [
+              makeCiRun({ conclusion: "failure", databaseId: 200 }),
+            ]);
+          }
+          expect(sha).toBe("sha-v2");
+          return makeCiStatus("pass");
+        },
+      );
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "Fixed CI." }))),
+      resume: vi.fn(),
+    };
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      getHeadSha,
+      collectFailureLogs: vi.fn().mockReturnValue("test error"),
+      delay: vi.fn().mockResolvedValue(undefined),
+      emptyRunsGracePeriodMs: 0,
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(getHeadSha).toHaveBeenCalledTimes(2);
+    expect(getCiStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("no runs for new SHA yet: grace period prevents false-pass", async () => {
+    // Key false-pass scenario from issue #24:
+    // After a push, the workflow hasn't been created yet.  getCiStatus
+    // returns pass with empty runs.  The grace period keeps polling
+    // until the run appears.
+    const getHeadSha = vi.fn().mockReturnValue("brand-new-sha");
+    let pollCount = 0;
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      pollCount++;
+      if (pollCount <= 2) {
+        // No runs match the new SHA yet → empty pass (within grace)
+        return makeCiStatus("pass");
+      }
+      return makeCiStatus("pass", [
+        makeCiRun({ conclusion: "success", headSha: "brand-new-sha" }),
+      ]);
+    });
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 100;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      getHeadSha,
+      collectFailureLogs: vi.fn(),
+      delay,
+      emptyRunsGracePeriodMs: 500,
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(pollCount).toBe(3);
+    expect(agent.invoke).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  test("no CI configured: accepts empty pass after grace period", async () => {
+    const getHeadSha = vi.fn().mockReturnValue("some-sha");
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 300;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      getHeadSha,
+      collectFailureLogs: vi.fn(),
+      delay,
+      emptyRunsGracePeriodMs: 500,
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(agent.invoke).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+  });
+
+  test("stale run with old SHA is ignored, new SHA run is pending then passes", async () => {
+    // Simulates the stale-failure scenario from issue #24:
+    // getHeadSha returns the new SHA, getCiStatus only sees runs
+    // matching that SHA (pending initially, then pass).
+    const getHeadSha = vi.fn().mockReturnValue("new-sha");
+    let pollCount = 0;
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      pollCount++;
+      if (pollCount === 1) {
+        // Only the new-sha run is returned (pending), old success is filtered out
+        return makeCiStatus("pending", [
+          makeCiRun({
+            status: "in_progress",
+            conclusion: "",
+            headSha: "new-sha",
+          }),
+        ]);
+      }
+      return makeCiStatus("pass", [
+        makeCiRun({ conclusion: "success", headSha: "new-sha" }),
+      ]);
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+
+    const stage = createCiCheckStageHandler({
+      agent,
+      ...ISSUE_CTX,
+      getCiStatus,
+      getHeadSha,
+      collectFailureLogs: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    expect(pollCount).toBe(2);
+    expect(agent.invoke).not.toHaveBeenCalled();
   });
 });
 
@@ -1047,6 +1264,8 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
       getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
       collectFailureLogs: vi.fn(),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
     const tpStage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
 
@@ -1097,6 +1316,8 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
       getCiStatus,
       collectFailureLogs: vi.fn(),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
     const tpStage = {
       ...createTestPlanStageHandler({ agent, ...ISSUE_CTX }),
@@ -1146,6 +1367,8 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
       getCiStatus,
       collectFailureLogs: vi.fn(),
       delay: vi.fn().mockResolvedValue(undefined),
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
     const tpStage = {
       ...createTestPlanStageHandler({ agent, ...ISSUE_CTX }),
@@ -1368,6 +1591,8 @@ describe("Stage 7 (Squash) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
@@ -1399,6 +1624,8 @@ describe("Stage 7 (Squash) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(
@@ -1441,6 +1668,8 @@ describe("Stage 8 (Review) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
@@ -1496,6 +1725,8 @@ describe("Stage 8 (Review) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
@@ -1544,6 +1775,8 @@ describe("Stage 8 (Review) through pipeline", () => {
         delay: vi.fn().mockResolvedValue(undefined),
         pollIntervalMs: 100,
         pollTimeoutMs: 1000,
+        getHeadSha: stubGetHeadSha,
+        emptyRunsGracePeriodMs: 0,
       }),
       autoBudget: 3,
     };
@@ -1608,6 +1841,8 @@ describe("Stage 8 (Review) through pipeline", () => {
         delay: vi.fn().mockResolvedValue(undefined),
         pollIntervalMs: 100,
         pollTimeoutMs: 1000,
+        getHeadSha: stubGetHeadSha,
+        emptyRunsGracePeriodMs: 0,
       }),
       autoBudget: 3,
     };
@@ -1668,6 +1903,8 @@ describe("Stage 8 (Review) through pipeline", () => {
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
       maxFixAttempts: 3,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(
@@ -1723,6 +1960,8 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const reviewStage = createReviewStageHandler({
@@ -1734,6 +1973,8 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(
@@ -1774,6 +2015,8 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const reviewStage = createReviewStageHandler({
@@ -1785,6 +2028,8 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
       delay: vi.fn().mockResolvedValue(undefined),
       pollIntervalMs: 100,
       pollTimeoutMs: 1000,
+      getHeadSha: stubGetHeadSha,
+      emptyRunsGracePeriodMs: 0,
     });
 
     const result = await runPipeline(

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -41,6 +41,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     status: "completed",
     conclusion: "success",
     headBranch: "issue-42",
+    headSha: "abc123",
     ...overrides,
   };
 }
@@ -97,9 +98,11 @@ function makeOpts(
     issueBody: "The widget is broken.",
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
+    getHeadSha: vi.fn().mockReturnValue("abc123"),
     delay: vi.fn().mockResolvedValue(undefined),
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
+    emptyRunsGracePeriodMs: 0,
     ...overrides,
   };
 }
@@ -819,6 +822,36 @@ describe("createReviewStageHandler", () => {
     await stage.handler(BASE_CTX);
 
     expect(opts.agentA.invoke).not.toHaveBeenCalled();
+  });
+
+  // -- getHeadSha forwarding ----------------------------------------------------
+
+  test("forwards getHeadSha to pollCiAndFix and uses SHA in getCiStatus", async () => {
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "NOT_APPROVED",
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+    const getHeadSha = vi.fn().mockReturnValue("deadbeef");
+    const opts = makeOpts({ agentB, getCiStatus, getHeadSha });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(getHeadSha).toHaveBeenCalledWith("/tmp/wt");
+    expect(getCiStatus).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-42",
+      "deadbeef",
+    );
   });
 
   // -- CI timeout during NOT_APPROVED fix flow --------------------------------

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -20,7 +20,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiStatus } from "./ci.js";
+import type { GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -34,15 +34,6 @@ import {
 } from "./stage-util.js";
 import { parseStepStatus } from "./step-parser.js";
 
-// ---- defaults ----------------------------------------------------------------
-
-const DEFAULT_POLL_INTERVAL_MS = 30_000;
-const DEFAULT_POLL_TIMEOUT_MS = 600_000;
-
-function defaultDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // ---- public types ------------------------------------------------------------
 
 export interface ReviewStageOptions {
@@ -51,11 +42,15 @@ export interface ReviewStageOptions {
   issueTitle: string;
   issueBody: string;
   /** Injected for testability. */
-  getCiStatus?: (owner: string, repo: string, branch: string) => CiStatus;
+  getCiStatus?: GetCiStatusFn;
   /** Injected for testability. */
   collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  /** Injected for testability. Defaults to `worktree.getHeadSha`. */
+  getHeadSha?: (cwd: string) => string;
   pollIntervalMs?: number;
   pollTimeoutMs?: number;
+  /** Grace period for empty SHA-filtered runs. Default 60 000. */
+  emptyRunsGracePeriodMs?: number;
   maxFixAttempts?: number;
   /** Injected for testability. */
   delay?: (ms: number) => Promise<void>;
@@ -294,10 +289,12 @@ export function createReviewStageHandler(
         getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
         collectFailureLogs:
           opts.collectFailureLogs ?? defaultCollectFailureLogs,
-        pollIntervalMs: opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
-        pollTimeoutMs: opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
+        getHeadSha: opts.getHeadSha,
+        emptyRunsGracePeriodMs: opts.emptyRunsGracePeriodMs,
+        pollIntervalMs: opts.pollIntervalMs,
+        pollTimeoutMs: opts.pollTimeoutMs,
         maxFixAttempts: opts.maxFixAttempts,
-        delay: opts.delay ?? defaultDelay,
+        delay: opts.delay,
       });
 
       if (!ciResult.passed) {

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -39,6 +39,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     status: "completed",
     conclusion: "success",
     headBranch: "issue-42",
+    headSha: "abc123",
     ...overrides,
   };
 }
@@ -79,9 +80,11 @@ function makeOpts(
     issueBody: "The widget is broken.",
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
+    getHeadSha: vi.fn().mockReturnValue("abc123"),
     delay: vi.fn().mockResolvedValue(undefined),
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
+    emptyRunsGracePeriodMs: 0,
     ...overrides,
   };
 }
@@ -518,6 +521,24 @@ describe("createSquashStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("needs_clarification");
+  });
+
+  // -- getHeadSha forwarding ----------------------------------------------------
+
+  test("forwards getHeadSha to pollCiAndFix and uses SHA in getCiStatus", async () => {
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+    const getHeadSha = vi.fn().mockReturnValue("deadbeef");
+    const opts = makeOpts({ getCiStatus, getHeadSha });
+    const stage = createSquashStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(getHeadSha).toHaveBeenCalledWith("/tmp/wt");
+    expect(getCiStatus).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-42",
+      "deadbeef",
+    );
   });
 
   // -- agent error during CI fix attempt --------------------------------------

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -13,7 +13,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiStatus } from "./ci.js";
+import type { GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -27,15 +27,6 @@ import {
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
-// ---- defaults ----------------------------------------------------------------
-
-const DEFAULT_POLL_INTERVAL_MS = 30_000;
-const DEFAULT_POLL_TIMEOUT_MS = 600_000;
-
-function defaultDelay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 // ---- public types ------------------------------------------------------------
 
 export interface SquashStageOptions {
@@ -43,11 +34,15 @@ export interface SquashStageOptions {
   issueTitle: string;
   issueBody: string;
   /** Injected for testability. */
-  getCiStatus?: (owner: string, repo: string, branch: string) => CiStatus;
+  getCiStatus?: GetCiStatusFn;
   /** Injected for testability. */
   collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  /** Injected for testability. Defaults to `worktree.getHeadSha`. */
+  getHeadSha?: (cwd: string) => string;
   pollIntervalMs?: number;
   pollTimeoutMs?: number;
+  /** Grace period for empty SHA-filtered runs. Default 60 000. */
+  emptyRunsGracePeriodMs?: number;
   /** Max CI fix attempts. Default 3. */
   maxFixAttempts?: number;
   /** Injected for testability. */
@@ -176,10 +171,12 @@ export function createSquashStageHandler(
         getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
         collectFailureLogs:
           opts.collectFailureLogs ?? defaultCollectFailureLogs,
-        pollIntervalMs: opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS,
-        pollTimeoutMs: opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS,
+        getHeadSha: opts.getHeadSha,
+        emptyRunsGracePeriodMs: opts.emptyRunsGracePeriodMs,
+        pollIntervalMs: opts.pollIntervalMs,
+        pollTimeoutMs: opts.pollTimeoutMs,
         maxFixAttempts: opts.maxFixAttempts,
-        delay: opts.delay ?? defaultDelay,
+        delay: opts.delay,
       });
 
       if (!ciResult.passed) {

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -19,6 +19,7 @@ const {
   detectDefaultBranch,
   bootstrapRepo,
   hasUncommittedChanges,
+  getHeadSha,
   createWorktree,
   removeWorktree,
 } = await import("./worktree.js");
@@ -144,6 +145,28 @@ describe("hasUncommittedChanges", () => {
       throw new Error("not a git repo");
     });
     expect(hasUncommittedChanges("/some/path")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHeadSha
+// ---------------------------------------------------------------------------
+describe("getHeadSha", () => {
+  test("returns trimmed HEAD SHA", () => {
+    mockExecFileSync.mockReturnValue("abc123def456\n");
+    expect(getHeadSha("/tmp/wt")).toBe("abc123def456");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["rev-parse", "HEAD"],
+      expect.objectContaining({ cwd: "/tmp/wt" }),
+    );
+  });
+
+  test("propagates error when git fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not a git repo");
+    });
+    expect(() => getHeadSha("/tmp/bad")).toThrow("not a git repo");
   });
 });
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -95,6 +95,23 @@ export function bootstrapRepo(owner: string, repo: string): string {
   return dest;
 }
 
+// ---- HEAD SHA capture ----------------------------------------------------
+
+/**
+ * Return the full commit SHA at HEAD in `cwd`.
+ *
+ * Used by CI-polling stages to target only workflow runs triggered by
+ * the most recent push, avoiding false-pass and stale-failure problems.
+ */
+export function getHeadSha(cwd: string): string {
+  return (
+    execFileSync("git", ["rev-parse", "HEAD"], {
+      ...EXEC_OPTS,
+      cwd,
+    }) as string
+  ).trim();
+}
+
 // ---- worktree management -------------------------------------------------
 
 /**


### PR DESCRIPTION
## Summary

- Use `gh run list --commit <sha>` for server-side SHA filtering, preventing false-pass (stale success) and stale-failure (old failure triggers unnecessary fix) after force-push or fix push.
- Add `getHeadSha(cwd)` utility called dynamically before each CI poll in `pollCiAndFix` and stage-5 handler, so fix pushes automatically target the new commit.
- Add configurable grace period (default 60 s) for empty SHA-filtered runs: keeps polling within the grace window to wait for the workflow to appear, then accepts empty pass (covers repos with no CI or skipped workflows).
- Extract `GetCiStatusFn` type alias to deduplicate the 4-param signature across option interfaces.
- Remove redundant poll-interval constants from `stage-squash` and `stage-review` (`pollCiAndFix` owns the defaults).

## Test plan

- [x] `pnpm exec tsc --noEmit` passes
- [x] `pnpm exec biome ci --error-on-warnings .` passes
- [x] `pnpm exec vitest run` — all CI-related tests pass (647 tests), including:
  - `--commit` flag passed to `gh run list` when commitSha provided (unit)
  - `getHeadSha` called before each poll and re-read after fix push (unit)
  - Grace period: empty pass within grace keeps polling, accepts after expiry (unit)
  - SHA forwarding through stages 5, 7, 8 (unit)
  - Grace period prevents false-pass in pipeline (E2E)
  - No CI configured: accepts empty pass after grace period (E2E)
  - Stale run filtered out, new SHA pending→pass (E2E)
  - SHA changes after fix push in pipeline (E2E)

Closes #24