### PR TITLE
Add run state persistence and pipeline resume

### DIFF
--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -204,6 +204,10 @@ export async function pollCiAndFix(
     const fixStream = agent.invoke(fixPrompt, { cwd: ctx.worktreePath });
     const fixResult = await fixStream.result;
 
+    if (fixResult.sessionId) {
+      ctx.onSessionId?.("a", fixResult.sessionId);
+    }
+
     if (fixResult.status === "error") {
       const detail =
         fixResult.stderrText || fixResult.errorType || "unknown error";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,21 @@
 #!/usr/bin/env node
 
+import { confirm, select } from "@inquirer/prompts";
+
 import type { AgentAdapter } from "./agent.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
 import { createCodexAdapter } from "./codex-adapter.js";
+import type { PipelineSettings } from "./config.js";
+import { getIssue } from "./github.js";
 import type { PipelineOptions } from "./pipeline.js";
 import { createDoneStageHandler, runPipeline } from "./pipeline.js";
+import { findPrNumber } from "./pr.js";
+import {
+  deleteRunState,
+  loadRunState,
+  type RunState,
+  saveRunState,
+} from "./run-state.js";
 import { createCiCheckStageHandler } from "./stage-cicheck.js";
 import { createCreatePrStageHandler } from "./stage-createpr.js";
 import { createImplementStageHandler } from "./stage-implement.js";
@@ -13,13 +24,33 @@ import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
 import { createSquashStageHandler } from "./stage-squash.js";
 import { createTestPlanStageHandler } from "./stage-testplan.js";
 import type { AgentConfig } from "./startup.js";
-import { runStartup } from "./startup.js";
+import { runStartup, selectTarget } from "./startup.js";
 import {
   bootstrapRepo,
   createWorktree,
   detectDefaultBranch,
+  hasUncommittedChanges,
   removeWorktree,
+  worktreePath,
 } from "./worktree.js";
+
+// ---- types ---------------------------------------------------------------
+
+interface RunParams {
+  agentAConfig: AgentConfig;
+  agentBConfig: AgentConfig;
+  executionMode: "auto" | "step";
+  claudePermissionMode: "auto" | "bypass";
+  pipelineSettings: PipelineSettings;
+  issueTitle: string;
+  issueBody: string;
+  startFromStage: number | undefined;
+  resuming: boolean;
+  /** True when user chose "Start fresh" — worktree should be cleaned. */
+  startFresh: boolean;
+}
+
+// ---- helpers -------------------------------------------------------------
 
 const CLAUDE_MODELS = new Set(["opus", "sonnet"]);
 
@@ -33,46 +64,152 @@ function createAdapter(
   return createCodexAdapter({ model: agentConfig.model });
 }
 
+function cliForModel(model: string): string {
+  return CLAUDE_MODELS.has(model) ? "claude" : "codex";
+}
+
+// ---- stage name lookup (for display) -------------------------------------
+
+const STAGE_NAMES: Record<number, string> = {
+  2: "Implement",
+  3: "Self-check",
+  4: "Create PR",
+  5: "CI check",
+  6: "Test plan verification",
+  7: "Squash commits",
+  8: "Review",
+  9: "Done",
+};
+
+function formatStateSummary(state: RunState): string {
+  const stageName =
+    STAGE_NAMES[state.currentStage] ?? `Stage ${state.currentStage}`;
+  const lines = [
+    `  Saved run state found:`,
+    `    Stage: ${state.currentStage} (${stageName})`,
+    `    Loop count: ${state.stageLoopCount}`,
+    `    Branch: ${state.branch}`,
+  ];
+  if (state.prNumber !== undefined) {
+    lines.push(`    PR: #${state.prNumber}`);
+  }
+  if (state.reviewRound > 0) {
+    lines.push(`    Review round: ${state.reviewRound}`);
+  }
+  lines.push(
+    `    Mode: ${state.executionMode}`,
+    `    Agent A: ${state.agentA.model}`,
+    `    Agent B: ${state.agentB.model}`,
+  );
+  return lines.join("\n");
+}
+
 if (!process.stdin.isTTY) {
   console.error("agentcoop requires an interactive terminal.");
   process.exit(1);
 }
 
 try {
-  const result = await runStartup();
+  // Phase 1: select target (owner / repo / issue).
+  const target = await selectTarget();
+  const { owner, repo, issueNumber } = target;
 
-  console.log();
-  console.log(
-    `Starting pipeline for ${result.owner}/${result.repo}#${result.issue.number}`,
-  );
-  console.log(`  Agent A: ${result.agentA.model}`);
-  console.log(`  Agent B: ${result.agentB.model}`);
-  console.log(`  Mode: ${result.executionMode}`);
-  console.log(`  Permission: ${result.claudePermissionMode}`);
-  console.log(`  Language: ${result.language}`);
-  console.log(
-    `  Self-check iterations: ${result.pipelineSettings.selfCheckAutoIterations}`,
-  );
-  console.log(`  Review rounds: ${result.pipelineSettings.reviewAutoRounds}`);
-  console.log(
-    `  Inactivity timeout: ${result.pipelineSettings.inactivityTimeoutMinutes} min`,
-  );
-  console.log(
-    `  Auto-resume attempts: ${result.pipelineSettings.autoResumeAttempts}`,
-  );
+  // Phase 2: check for resumable state and collect run parameters.
+  const savedState = loadRunState(owner, repo, issueNumber);
+  let params: RunParams;
+  let userChoseFresh = false;
+
+  if (savedState) {
+    console.log();
+    console.log(formatStateSummary(savedState));
+    console.log();
+
+    const choice = await select({
+      message: "Resume or start fresh?",
+      choices: [
+        { name: "Resume", value: "resume" as const },
+        { name: "Start fresh", value: "fresh" as const },
+      ],
+    });
+
+    if (choice === "resume") {
+      const issue = getIssue(owner, repo, issueNumber);
+      params = {
+        agentAConfig: { model: savedState.agentA.model },
+        agentBConfig: { model: savedState.agentB.model },
+        executionMode: savedState.executionMode,
+        claudePermissionMode: savedState.claudePermissionMode,
+        pipelineSettings: target.config.pipelineSettings,
+        issueTitle: issue.title,
+        issueBody: issue.body,
+        startFromStage: savedState.currentStage,
+        resuming: true,
+        startFresh: false,
+      };
+    } else {
+      // Start fresh: warn about uncommitted changes.
+      const wtPath = worktreePath(owner, repo, issueNumber);
+      if (hasUncommittedChanges(wtPath)) {
+        const ok = await confirm({
+          message:
+            "The existing worktree has uncommitted changes. " +
+            "Starting fresh will discard them. Continue?",
+          default: false,
+        });
+        if (!ok) {
+          throw new Error(
+            "Aborted: user declined to discard uncommitted changes.",
+          );
+        }
+      }
+      deleteRunState(owner, repo, issueNumber);
+      userChoseFresh = true;
+    }
+  }
+
+  // When not resuming (either no saved state or user chose fresh), run
+  // full startup to collect remaining options.
+  params ??= await (async () => {
+    const result = await runStartup(target);
+    return {
+      agentAConfig: result.agentA,
+      agentBConfig: result.agentB,
+      executionMode: result.executionMode,
+      claudePermissionMode: result.claudePermissionMode,
+      pipelineSettings: result.pipelineSettings,
+      issueTitle: result.issue.title,
+      issueBody: result.issue.body,
+      startFromStage: undefined,
+      resuming: false,
+      startFresh: userChoseFresh,
+    };
+  })();
+
+  const {
+    agentAConfig,
+    agentBConfig,
+    executionMode,
+    claudePermissionMode,
+    pipelineSettings,
+    issueTitle,
+    issueBody,
+    startFromStage: rawStartFromStage,
+    resuming,
+    startFresh,
+  } = params;
 
   // Bootstrap the repository and create a worktree.
   console.log();
   console.log("Bootstrapping repository...");
-  bootstrapRepo(result.owner, result.repo);
+  bootstrapRepo(owner, repo);
 
-  const defaultBranch = detectDefaultBranch(result.owner, result.repo);
+  const defaultBranch = detectDefaultBranch(owner, repo);
   const wt = createWorktree({
-    owner: result.owner,
-    repo: result.repo,
-    issueNumber: result.issue.number,
+    owner,
+    repo,
+    issueNumber,
     baseBranch: defaultBranch,
-    conflictChoice: "reuse",
+    conflictChoice: startFresh ? "clean" : "reuse",
   });
   console.log(`Worktree ready at ${wt.path} (branch: ${wt.branch})`);
 
@@ -82,14 +219,33 @@ try {
     );
   }
 
-  // Create agent adapters.
-  const agentA = createAdapter(result.agentA, result.claudePermissionMode);
-  const agentB = createAdapter(result.agentB, result.claudePermissionMode);
+  // Skip stage 4 (PR creation) on resume when the PR already exists.
+  // This avoids replaying the side-effectful `gh pr create` if the
+  // process was interrupted after the PR was created but before the
+  // completion check finished.
+  let startFromStage = rawStartFromStage;
+  if (startFromStage === 4 && findPrNumber(owner, repo, wt.branch)) {
+    console.log("  PR already exists — skipping to stage 5 (CI check).");
+    startFromStage = 5;
+  }
 
-  const issueCtx = {
-    issueTitle: result.issue.title,
-    issueBody: result.issue.body,
-  };
+  console.log();
+  console.log(
+    `Starting pipeline for ${owner}/${repo}#${issueNumber}${resuming ? " (resuming)" : ""}`,
+  );
+  console.log(`  Agent A: ${agentAConfig.model}`);
+  console.log(`  Agent B: ${agentBConfig.model}`);
+  console.log(`  Mode: ${executionMode}`);
+  console.log(`  Permission: ${claudePermissionMode}`);
+  if (startFromStage !== undefined) {
+    console.log(`  Resuming from stage: ${startFromStage}`);
+  }
+
+  // Create agent adapters.
+  const agentA = createAdapter(agentAConfig, claudePermissionMode);
+  const agentB = createAdapter(agentBConfig, claudePermissionMode);
+
+  const issueCtx = { issueTitle, issueBody };
 
   const implementStage = createImplementStageHandler({
     agent: agentA,
@@ -101,7 +257,7 @@ try {
       agent: agentA,
       ...issueCtx,
     }),
-    autoBudget: result.pipelineSettings.selfCheckAutoIterations,
+    autoBudget: pipelineSettings.selfCheckAutoIterations,
   };
 
   const createPrStage = createCreatePrStageHandler({
@@ -133,18 +289,45 @@ try {
       agentB,
       ...issueCtx,
     }),
-    autoBudget: result.pipelineSettings.reviewAutoRounds,
+    autoBudget: pipelineSettings.reviewAutoRounds,
   };
+
+  // Mutable run state for persistence.
+  const runState: RunState = savedState ?? {
+    owner,
+    repo,
+    issueNumber,
+    branch: wt.branch,
+    worktreePath: wt.path,
+    prNumber: undefined,
+    currentStage: 2,
+    stageLoopCount: 0,
+    reviewRound: 0,
+    executionMode,
+    claudePermissionMode,
+    agentA: {
+      cli: cliForModel(agentAConfig.model),
+      model: agentAConfig.model,
+      sessionId: undefined,
+    },
+    agentB: {
+      cli: cliForModel(agentBConfig.model),
+      model: agentBConfig.model,
+      sessionId: undefined,
+    },
+  };
+
+  // Save initial state.
+  saveRunState(runState);
 
   const doneStage = createDoneStageHandler({
     reportCompletion: async (msg) => console.log(msg),
     confirmMerge: async () => true, // placeholder until real prompts
-    cleanup: () =>
-      removeWorktree(result.owner, result.repo, result.issue.number, wt.branch),
+    cleanup: () => removeWorktree(owner, repo, issueNumber, wt.branch),
   });
 
   const pipelineOpts: PipelineOptions = {
-    mode: result.executionMode,
+    mode: executionMode,
     stages: [
       implementStage,
       selfCheckStage,
@@ -165,16 +348,45 @@ try {
       reportCompletion: async () => {},
     },
     context: {
-      owner: result.owner,
-      repo: result.repo,
-      issueNumber: result.issue.number,
+      owner,
+      repo,
+      issueNumber,
       branch: wt.branch,
       worktreePath: wt.path,
+    },
+    startFromStage,
+    startFromStageLoopCount: savedState?.stageLoopCount,
+    savedAgentASessionId: savedState?.agentA.sessionId,
+    savedAgentBSessionId: savedState?.agentB.sessionId,
+    onSessionId: (agent, sessionId) => {
+      if (agent === "a") {
+        runState.agentA.sessionId = sessionId;
+      } else {
+        runState.agentB.sessionId = sessionId;
+      }
+      saveRunState(runState);
+    },
+    onStageTransition: (stageNumber, stageLoopCount) => {
+      runState.currentStage = stageNumber;
+      runState.stageLoopCount = stageLoopCount;
+      // Update PR number when entering stage 5+ (PR should exist by then).
+      if (stageNumber >= 5 && runState.prNumber === undefined) {
+        runState.prNumber = findPrNumber(owner, repo, wt.branch);
+      }
+      // Track review round.
+      if (stageNumber === 8) {
+        runState.reviewRound = stageLoopCount + 1;
+      }
+      saveRunState(runState);
     },
   };
   const pipelineResult = await runPipeline(pipelineOpts);
   console.log();
   console.log(pipelineResult.message);
+
+  if (pipelineResult.success) {
+    deleteRunState(owner, repo, issueNumber);
+  }
 } catch (error) {
   if (
     error instanceof Error &&

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1230,3 +1230,516 @@ describe("E2E — multi-stage pipeline", () => {
     expect(opts.cleanup).toHaveBeenCalledOnce();
   });
 });
+
+// ---------------------------------------------------------------------------
+// startFromStage
+// ---------------------------------------------------------------------------
+describe("startFromStage", () => {
+  test("skips stages before startFromStage", async () => {
+    const calls: number[] = [];
+    const stages = [
+      makeStage(2, async () => {
+        calls.push(2);
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(5, async () => {
+        calls.push(5);
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(8, async () => {
+        calls.push(8);
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, startFromStage: 5 }),
+    );
+    expect(result.success).toBe(true);
+    expect(calls).toEqual([5, 8]);
+  });
+
+  test("runs all stages when startFromStage matches first stage", async () => {
+    const calls: number[] = [];
+    const stages = [
+      makeStage(2, async () => {
+        calls.push(2);
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(3, async () => {
+        calls.push(3);
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, startFromStage: 2 }),
+    );
+    expect(result.success).toBe(true);
+    expect(calls).toEqual([2, 3]);
+  });
+
+  test("skips all stages when startFromStage exceeds all stage numbers", async () => {
+    const calls: number[] = [];
+    const stages = [
+      makeStage(2, async () => {
+        calls.push(2);
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, startFromStage: 99 }),
+    );
+    expect(result.success).toBe(true);
+    expect(calls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onStageTransition
+// ---------------------------------------------------------------------------
+describe("onStageTransition", () => {
+  test("called before each stage handler invocation", async () => {
+    const transitions: [number, number][] = [];
+    const stages = [
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+      makeStage(5, async () => ({ outcome: "completed", message: "" })),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        onStageTransition: (stage, loop) => transitions.push([stage, loop]),
+      }),
+    );
+    // Each stage: called once before handler (loop=0), and once after advanceLoop is NOT called
+    // because terminal success returns immediately before advanceLoop.
+    // So we expect exactly one call per stage at iteration 0.
+    expect(transitions).toEqual([
+      [2, 0],
+      [5, 0],
+    ]);
+  });
+
+  test("called after loop counter advances on non-terminal outcome", async () => {
+    const transitions: [number, number][] = [];
+    let callCount = 0;
+    const stages = [
+      makeStage(2, async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { outcome: "not_approved", message: "needs work" };
+        }
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        onStageTransition: (stage, loop) => transitions.push([stage, loop]),
+      }),
+    );
+    // Iteration 0: before handler → (2, 0)
+    // After not_approved: advanceLoop → iteration becomes 1 → (2, 1)
+    // Iteration 1: before handler → (2, 1)
+    // Terminal success → return (no advanceLoop)
+    expect(transitions).toEqual([
+      [2, 0],
+      [2, 1],
+      [2, 1],
+    ]);
+  });
+
+  test("stageLoopCount resets to 0 when transitioning between stages", async () => {
+    const transitions: [number, number][] = [];
+    let stage2Calls = 0;
+    const stages = [
+      makeStage(2, async () => {
+        stage2Calls++;
+        if (stage2Calls === 1) {
+          return { outcome: "not_approved", message: "loop" };
+        }
+        return { outcome: "completed", message: "done" };
+      }),
+      makeStage(3, async () => ({ outcome: "completed", message: "done" })),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        onStageTransition: (stage, loop) => transitions.push([stage, loop]),
+      }),
+    );
+    // Stage 2: (2,0), advance→(2,1), (2,1), terminal
+    // Stage 3: (3,0), terminal
+    expect(transitions).toEqual([
+      [2, 0],
+      [2, 1],
+      [2, 1],
+      [3, 0],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startFromStageLoopCount (intra-stage resume)
+// ---------------------------------------------------------------------------
+describe("startFromStageLoopCount", () => {
+  test("restores loop iteration when resuming same stage", async () => {
+    const transitions: [number, number][] = [];
+    const iterations: number[] = [];
+    const stages = [
+      makeStage(5, async (ctx) => {
+        iterations.push(ctx.iteration);
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        startFromStage: 5,
+        startFromStageLoopCount: 3,
+        onStageTransition: (stage, loop) => transitions.push([stage, loop]),
+      }),
+    );
+    // Handler should receive iteration=3 (restored).
+    expect(iterations).toEqual([3]);
+    // onStageTransition should fire with restored count.
+    expect(transitions).toEqual([[5, 3]]);
+  });
+
+  test("does not affect stages after the resume stage", async () => {
+    const iterations: [number, number][] = [];
+    const stages = [
+      makeStage(5, async (ctx) => {
+        iterations.push([5, ctx.iteration]);
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(8, async (ctx) => {
+        iterations.push([8, ctx.iteration]);
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        startFromStage: 5,
+        startFromStageLoopCount: 2,
+      }),
+    );
+    // Stage 5 resumes at iteration 2, stage 8 starts fresh at 0.
+    expect(iterations).toEqual([
+      [5, 2],
+      [8, 0],
+    ]);
+  });
+
+  test("auto-budget is reduced by restored loop count", async () => {
+    let callCount = 0;
+    const promptMock = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const stages = [
+      makeStage(
+        5,
+        async () => {
+          callCount++;
+          return { outcome: "not_approved", message: "loop" };
+        },
+        { autoBudget: 3 },
+      ),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        prompt: promptMock,
+        startFromStage: 5,
+        startFromStageLoopCount: 2,
+      }),
+    );
+    // Budget is 3. Restored iteration is 2. autoRemaining = max(1, 3-2) = 1.
+    // First call runs at iteration 2, then advanceLoop makes autoRemaining 0.
+    // User declines to continue → abort.
+    expect(callCount).toBe(1);
+    expect(promptMock.confirmContinueLoop).toHaveBeenCalledOnce();
+  });
+
+  test("ignored when startFromStage is not set", async () => {
+    const iterations: number[] = [];
+    const stages = [
+      makeStage(2, async (ctx) => {
+        iterations.push(ctx.iteration);
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        startFromStageLoopCount: 5,
+      }),
+    );
+    // Without startFromStage, loop count should start at 0.
+    expect(iterations).toEqual([0]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onSessionId
+// ---------------------------------------------------------------------------
+describe("onSessionId", () => {
+  test("passes onSessionId callback through to StageContext", async () => {
+    const sessionCalls: [string, string][] = [];
+    const stages = [
+      makeStage(2, async (ctx) => {
+        ctx.onSessionId?.("a", "sess-impl-1");
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        onSessionId: (agent, sid) => sessionCalls.push([agent, sid]),
+      }),
+    );
+    expect(sessionCalls).toEqual([["a", "sess-impl-1"]]);
+  });
+
+  test("captures session IDs from multiple stages and agents", async () => {
+    const sessionCalls: [string, string][] = [];
+    const stages = [
+      makeStage(2, async (ctx) => {
+        ctx.onSessionId?.("a", "sess-a-1");
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(8, async (ctx) => {
+        ctx.onSessionId?.("b", "sess-b-1");
+        ctx.onSessionId?.("a", "sess-a-2");
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        onSessionId: (agent, sid) => sessionCalls.push([agent, sid]),
+      }),
+    );
+    expect(sessionCalls).toEqual([
+      ["a", "sess-a-1"],
+      ["b", "sess-b-1"],
+      ["a", "sess-a-2"],
+    ]);
+  });
+
+  test("onSessionId is optional — stages work without it", async () => {
+    const stages = [
+      makeStage(2, async (ctx) => {
+        // Should not throw even without onSessionId.
+        ctx.onSessionId?.("a", "sess-1");
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const result = await runPipeline(makePipelineOpts({ stages }));
+    expect(result.success).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// E2E: full resume cycle
+// ---------------------------------------------------------------------------
+describe("full resume cycle (E2E)", () => {
+  test("pipeline halts, state captured, resumed from correct stage and loop", async () => {
+    const transitions: [number, number][] = [];
+    let stage5Calls = 0;
+
+    // First run: stage 2 completes, stage 5 loops once then user aborts.
+    const prompt1 = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    const makeStage5Handler = () =>
+      makeStage(
+        5,
+        async () => {
+          stage5Calls++;
+          return { outcome: "not_approved", message: "CI fail" };
+        },
+        { autoBudget: 1 },
+      );
+
+    const result1 = await runPipeline(
+      makePipelineOpts({
+        stages: [
+          makeStage(2, async () => ({ outcome: "completed", message: "" })),
+          makeStage5Handler(),
+        ],
+        prompt: prompt1,
+        onStageTransition: (s, l) => transitions.push([s, l]),
+      }),
+    );
+
+    expect(result1.success).toBe(false);
+    expect(result1.stoppedAt).toBe(5);
+
+    // Extract last transition to simulate saved state.
+    const lastTransition = transitions[transitions.length - 1];
+    expect(lastTransition[0]).toBe(5); // stage 5
+    expect(lastTransition[1]).toBe(1); // loop count 1
+
+    // Second run: resume from stage 5, loop count 1.
+    const transitions2: [number, number][] = [];
+    stage5Calls = 0;
+
+    const result2 = await runPipeline(
+      makePipelineOpts({
+        stages: [
+          makeStage(2, async () => ({ outcome: "completed", message: "" })),
+          makeStage(5, async () => {
+            stage5Calls++;
+            return { outcome: "completed", message: "CI pass now" };
+          }),
+          makeStage(8, async () => ({ outcome: "completed", message: "" })),
+        ],
+        startFromStage: 5,
+        startFromStageLoopCount: 1,
+        onStageTransition: (s, l) => transitions2.push([s, l]),
+      }),
+    );
+
+    expect(result2.success).toBe(true);
+    // Stage 2 was skipped (startFromStage: 5).
+    // Stage 5 resumed at iteration 1, completed immediately.
+    // Stage 8 started fresh at iteration 0.
+    expect(stage5Calls).toBe(1);
+    expect(transitions2).toEqual([
+      [5, 1], // stage 5 at restored iteration
+      [8, 0], // stage 8 fresh
+    ]);
+  });
+
+  test("pipeline saves review round via onStageTransition in stage 8", async () => {
+    const transitions: [number, number][] = [];
+    let reviewCalls = 0;
+
+    const stages = [
+      makeStage(8, async () => {
+        reviewCalls++;
+        if (reviewCalls <= 2) {
+          return { outcome: "not_approved", message: "needs work" };
+        }
+        return { outcome: "completed", message: "approved" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        onStageTransition: (s, l) => transitions.push([s, l]),
+      }),
+    );
+
+    // 3 iterations: calls at (8,0), advance→(8,1), (8,1), advance→(8,2), (8,2), terminal
+    expect(transitions).toEqual([
+      [8, 0],
+      [8, 1],
+      [8, 1],
+      [8, 2],
+      [8, 2],
+    ]);
+    // A caller can derive reviewRound = loopCount + 1.
+  });
+
+  test("saved session IDs are passed to resumed stage handler and cleared after", async () => {
+    const receivedSessions: {
+      a: string | undefined;
+      b: string | undefined;
+    }[] = [];
+    const stages = [
+      makeStage(5, async (ctx) => {
+        receivedSessions.push({
+          a: ctx.savedAgentASessionId,
+          b: ctx.savedAgentBSessionId,
+        });
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(8, async (ctx) => {
+        receivedSessions.push({
+          a: ctx.savedAgentASessionId,
+          b: ctx.savedAgentBSessionId,
+        });
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        startFromStage: 5,
+        savedAgentASessionId: "sess-a-saved",
+        savedAgentBSessionId: "sess-b-saved",
+      }),
+    );
+    // Stage 5 (resume stage) should receive saved session IDs.
+    expect(receivedSessions[0]).toEqual({
+      a: "sess-a-saved",
+      b: "sess-b-saved",
+    });
+    // Stage 8 (after resume) should NOT receive saved session IDs.
+    expect(receivedSessions[1]).toEqual({
+      a: undefined,
+      b: undefined,
+    });
+  });
+
+  test("saved session IDs are cleared after first invocation within same stage", async () => {
+    const receivedSessions: (string | undefined)[] = [];
+    let callCount = 0;
+    const stages = [
+      makeStage(5, async (ctx) => {
+        receivedSessions.push(ctx.savedAgentASessionId);
+        callCount++;
+        if (callCount === 1) {
+          return { outcome: "not_approved", message: "loop" };
+        }
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        startFromStage: 5,
+        savedAgentASessionId: "sess-a-saved",
+      }),
+    );
+    // First call has saved session, second call does not.
+    expect(receivedSessions).toEqual(["sess-a-saved", undefined]);
+  });
+
+  test("restart_from jump is checkpointed via onStageTransition", async () => {
+    const transitions: [number, number][] = [];
+    const stages = [
+      makeStage(5, async () => ({ outcome: "completed", message: "" })),
+      makeStage(
+        6,
+        async () => ({ outcome: "not_approved", message: "test fail" }),
+        { restartFromStage: 5 },
+      ),
+    ];
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockResolvedValue(false),
+    });
+    await runPipeline(
+      makePipelineOpts({
+        stages,
+        prompt,
+        onStageTransition: (s, l) => transitions.push([s, l]),
+      }),
+    );
+    // Stage 5 entry: (5,0)
+    // Stage 6 entry: (6,0)
+    // Stage 6 returns restart_from 5 → checkpoint: (5,0)
+    // Stage 5 re-entry: (5,0)
+    // Stage 6 re-entry: (6,0)
+    // Stage 6 returns restart_from again → checkpoint: (5,0)
+    // Budget exhausted → confirmContinueLoop → user declines
+    expect(transitions).toContainEqual([5, 0]);
+    // Verify the jump target is checkpointed (not just the source stage).
+    const jumpCheckpoints = transitions.filter(
+      ([s, l], idx) =>
+        s === 5 && l === 0 && idx > 0 && transitions[idx - 1][0] === 6,
+    );
+    expect(jumpCheckpoints.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -97,6 +97,17 @@ export interface StageContext {
   lastAutoIteration: boolean;
   /** Instruction injected by the user after a "instruct" action. */
   userInstruction: string | undefined;
+  /**
+   * Callback for stage handlers to report agent session IDs so they
+   * can be persisted for resume.  `agent` is `"a"` or `"b"`.
+   */
+  onSessionId?: (agent: "a" | "b", sessionId: string) => void;
+  /**
+   * Saved session IDs from a prior run, passed on resume so stage
+   * handlers can `resume()` instead of `invoke()` on first call.
+   */
+  savedAgentASessionId?: string;
+  savedAgentBSessionId?: string;
 }
 
 // ---- user interaction interface ------------------------------------------
@@ -221,8 +232,45 @@ export interface PipelineOptions {
   /** Shared context fields injected into every `StageContext`. */
   context: Omit<
     StageContext,
-    "iteration" | "lastAutoIteration" | "userInstruction"
+    | "iteration"
+    | "lastAutoIteration"
+    | "userInstruction"
+    | "onSessionId"
+    | "savedAgentASessionId"
+    | "savedAgentBSessionId"
   >;
+  /**
+   * When set, stages with a number strictly less than this value are
+   * skipped.  Used to resume a pipeline from a saved checkpoint.
+   */
+  startFromStage?: number;
+  /**
+   * When resuming mid-stage, set this to the saved `stageLoopCount` so
+   * the loop control picks up where it left off.  Only meaningful when
+   * `startFromStage` is also set.
+   */
+  startFromStageLoopCount?: number;
+  /**
+   * Called before each stage handler invocation and after every
+   * loop-counter change, so the caller can persist progress.
+   *
+   * @param stageNumber - The 1-based stage number about to run.
+   * @param stageLoopCount - The current loop iteration within the stage.
+   */
+  onStageTransition?: (stageNumber: number, stageLoopCount: number) => void;
+  /**
+   * Called by stage handlers when they receive an agent session ID.
+   * Wired into `StageContext.onSessionId` for each handler invocation.
+   */
+  onSessionId?: (agent: "a" | "b", sessionId: string) => void;
+  /**
+   * Saved session IDs from a prior run.  Passed into `StageContext` on
+   * the first handler invocation of the resumed stage so handlers can
+   * `resume()` an existing agent conversation.  Cleared after the first
+   * invocation to prevent stale sessions from leaking into later stages.
+   */
+  savedAgentASessionId?: string;
+  savedAgentBSessionId?: string;
 }
 
 export interface PipelineResult {
@@ -239,7 +287,18 @@ export interface PipelineResult {
 export async function runPipeline(
   options: PipelineOptions,
 ): Promise<PipelineResult> {
-  const { mode, stages, prompt, context } = options;
+  const {
+    mode,
+    stages,
+    prompt,
+    context,
+    startFromStage,
+    startFromStageLoopCount,
+    onStageTransition,
+    onSessionId,
+    savedAgentASessionId,
+    savedAgentBSessionId,
+  } = options;
 
   // Sort stages by number to guarantee order.
   const sorted = [...stages].sort((a, b) => a.number - b.number);
@@ -269,6 +328,14 @@ export async function runPipeline(
   const restartCounts = new Map<number, LoopControl>();
 
   let i = 0;
+
+  // Skip stages below startFromStage when resuming.
+  if (startFromStage !== undefined) {
+    while (i < sorted.length && sorted[i].number < startFromStage) {
+      i++;
+    }
+  }
+
   while (i < sorted.length) {
     const stage = sorted[i];
 
@@ -284,7 +351,27 @@ export async function runPipeline(
       }
     }
 
-    const result = await runStage(stage, context, prompt);
+    // On the first stage after resume, restore loop count and session IDs.
+    const isResumeStage =
+      startFromStage !== undefined && stage.number === startFromStage;
+
+    const resumeLoopCount =
+      isResumeStage &&
+      startFromStageLoopCount !== undefined &&
+      startFromStageLoopCount > 0
+        ? startFromStageLoopCount
+        : undefined;
+
+    const result = await runStage(
+      stage,
+      context,
+      prompt,
+      onStageTransition,
+      onSessionId,
+      resumeLoopCount,
+      isResumeStage ? savedAgentASessionId : undefined,
+      isResumeStage ? savedAgentBSessionId : undefined,
+    );
 
     if (result.action === "abort") {
       return {
@@ -332,6 +419,9 @@ export async function runPipeline(
       }
 
       i = targetIdx;
+      // Persist the jump target so a crash before the next handler
+      // invocation resumes at the correct stage.
+      onStageTransition?.(sorted[targetIdx].number, 0);
       continue;
     }
 
@@ -375,11 +465,27 @@ async function runStage(
   stage: StageDefinition,
   baseCtx: Omit<
     StageContext,
-    "iteration" | "lastAutoIteration" | "userInstruction"
+    | "iteration"
+    | "lastAutoIteration"
+    | "userInstruction"
+    | "onSessionId"
+    | "savedAgentASessionId"
+    | "savedAgentBSessionId"
   >,
   prompt: UserPrompt,
+  onStageTransition?: (stageNumber: number, stageLoopCount: number) => void,
+  onSessionId?: (agent: "a" | "b", sessionId: string) => void,
+  resumeLoopCount?: number,
+  savedAgentASessionId?: string,
+  savedAgentBSessionId?: string,
 ): Promise<StageRunResult> {
   const lc = createLoopControl(stage.autoBudget);
+
+  // Restore loop state when resuming mid-stage.
+  if (resumeLoopCount !== undefined) {
+    lc.iteration = resumeLoopCount;
+    lc.autoRemaining = Math.max(1, lc.budget - resumeLoopCount);
+  }
   let userInstruction: string | undefined;
   /** Last not_approved message, forwarded to confirmContinueLoop. */
   let loopMessage = "";
@@ -387,15 +493,23 @@ async function runStage(
   let clarificationAttempted = false;
 
   while (true) {
+    // Notify caller before each handler invocation for persistence.
+    onStageTransition?.(stage.number, lc.iteration);
+
     const ctx: StageContext = {
       ...baseCtx,
       iteration: lc.iteration,
       lastAutoIteration: lc.autoRemaining === 1,
       userInstruction,
+      onSessionId,
+      savedAgentASessionId,
+      savedAgentBSessionId,
     };
 
-    // Clear the one-shot instruction after use.
+    // Clear one-shot fields after use.
     userInstruction = undefined;
+    savedAgentASessionId = undefined;
+    savedAgentBSessionId = undefined;
 
     let result: StageResult;
     try {
@@ -473,6 +587,8 @@ async function runStage(
     // ---- loop control ----------------------------------------------------
 
     const canContinue = advanceLoop(lc);
+    // Notify caller after loop counter change for persistence.
+    onStageTransition?.(stage.number, lc.iteration);
     if (!canContinue) {
       const approved = await prompt.confirmContinueLoop(
         stage.name,

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -1,0 +1,181 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const tmpHome = join(import.meta.dirname, "..", ".tmp-test-home-run-state");
+
+vi.mock("node:os", () => ({
+  homedir: () => tmpHome,
+}));
+
+const { deleteRunState, loadRunState, runStatePath, saveRunState } =
+  await import("./run-state.js");
+
+import type { RunState } from "./run-state.js";
+
+// ---- helpers -------------------------------------------------------------
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    owner: "org",
+    repo: "repo",
+    issueNumber: 42,
+    branch: "issue-42",
+    worktreePath: "/tmp/wt/issue-42",
+    prNumber: undefined,
+    currentStage: 2,
+    stageLoopCount: 0,
+    reviewRound: 0,
+    executionMode: "auto",
+    claudePermissionMode: "auto",
+    agentA: { cli: "claude", model: "opus", sessionId: "sess-a" },
+    agentB: { cli: "claude", model: "sonnet", sessionId: undefined },
+    ...overrides,
+  };
+}
+
+// ---- setup / teardown ----------------------------------------------------
+
+beforeEach(() => {
+  mkdirSync(tmpHome, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(tmpHome, { recursive: true, force: true });
+});
+
+// ---- tests ---------------------------------------------------------------
+
+describe("runStatePath", () => {
+  test("returns expected path", () => {
+    const p = runStatePath("acme", "widget", 7);
+    expect(p).toBe(
+      join(tmpHome, ".agentcoop", "runs", "acme", "widget", "7.json"),
+    );
+  });
+});
+
+describe("saveRunState / loadRunState round-trip", () => {
+  test("round-trips a full state object", () => {
+    const state = makeRunState({ prNumber: 99, stageLoopCount: 5 });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded).toEqual(state);
+  });
+
+  test("preserves stageLoopCount across save/load", () => {
+    const state = makeRunState({ stageLoopCount: 5 });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.stageLoopCount).toBe(5);
+  });
+
+  test("preserves undefined prNumber", () => {
+    const state = makeRunState({ prNumber: undefined });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.prNumber).toBeUndefined();
+  });
+
+  test("preserves agent sessionIds", () => {
+    const state = makeRunState({
+      agentA: { cli: "claude", model: "opus", sessionId: "abc-123" },
+      agentB: { cli: "codex", model: "gpt-5.4", sessionId: undefined },
+    });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.agentA.sessionId).toBe("abc-123");
+    expect(loaded?.agentB.sessionId).toBeUndefined();
+  });
+
+  test("overwrites existing state file", () => {
+    saveRunState(makeRunState({ currentStage: 2 }));
+    saveRunState(makeRunState({ currentStage: 5 }));
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.currentStage).toBe(5);
+  });
+});
+
+describe("loadRunState — missing / malformed", () => {
+  test("returns undefined when file does not exist", () => {
+    expect(loadRunState("org", "repo", 99)).toBeUndefined();
+  });
+
+  test("returns undefined for malformed JSON", () => {
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, "not json{{{");
+    expect(loadRunState("org", "repo", 42)).toBeUndefined();
+  });
+
+  test("returns undefined when required fields are missing", () => {
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify({ owner: "org" }));
+    expect(loadRunState("org", "repo", 42)).toBeUndefined();
+  });
+
+  test("returns undefined for invalid executionMode", () => {
+    const state = { ...makeRunState(), executionMode: "turbo" };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(state));
+    expect(loadRunState("org", "repo", 42)).toBeUndefined();
+  });
+
+  test("returns undefined when agentA is missing cli field", () => {
+    const raw = { ...makeRunState(), agentA: { model: "opus" } };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    expect(loadRunState("org", "repo", 42)).toBeUndefined();
+  });
+
+  test("normalises null prNumber to undefined", () => {
+    const raw = { ...makeRunState(), prNumber: null };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded).toBeDefined();
+    expect(loaded?.prNumber).toBeUndefined();
+  });
+
+  test("normalises null sessionId to undefined", () => {
+    const raw = {
+      ...makeRunState(),
+      agentA: { cli: "claude", model: "opus", sessionId: null },
+    };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded).toBeDefined();
+    expect(loaded?.agentA.sessionId).toBeUndefined();
+  });
+});
+
+describe("deleteRunState", () => {
+  test("removes the state file", () => {
+    saveRunState(makeRunState());
+    expect(loadRunState("org", "repo", 42)).toBeDefined();
+    deleteRunState("org", "repo", 42);
+    expect(loadRunState("org", "repo", 42)).toBeUndefined();
+  });
+
+  test("does not throw when file does not exist", () => {
+    expect(() => deleteRunState("org", "repo", 999)).not.toThrow();
+  });
+});

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -1,0 +1,144 @@
+/**
+ * Run state persistence — save/load/delete pipeline state so the
+ * pipeline can be resumed after interruption.
+ *
+ * State files live at `~/.agentcoop/runs/{owner}/{repo}/{issue_number}.json`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+// ---- public types --------------------------------------------------------
+
+export interface AgentState {
+  cli: string;
+  model: string;
+  sessionId: string | undefined;
+}
+
+export interface RunState {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  branch: string;
+  worktreePath: string;
+  prNumber: number | undefined;
+  currentStage: number;
+  stageLoopCount: number;
+  reviewRound: number;
+  executionMode: "auto" | "step";
+  claudePermissionMode: "auto" | "bypass";
+  agentA: AgentState;
+  agentB: AgentState;
+}
+
+// ---- path helpers --------------------------------------------------------
+
+export function runStatePath(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): string {
+  return join(
+    homedir(),
+    ".agentcoop",
+    "runs",
+    owner,
+    repo,
+    `${issueNumber}.json`,
+  );
+}
+
+// ---- save / load / delete ------------------------------------------------
+
+export function saveRunState(state: RunState): void {
+  const path = runStatePath(state.owner, state.repo, state.issueNumber);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(state, null, 2)}\n`);
+  renameSync(tmp, path);
+}
+
+function isValidAgentState(v: unknown): v is AgentState {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.cli === "string" &&
+    typeof r.model === "string" &&
+    (r.sessionId === undefined ||
+      r.sessionId === null ||
+      typeof r.sessionId === "string")
+  );
+}
+
+function isValidRunState(v: unknown): v is RunState {
+  if (typeof v !== "object" || v === null || Array.isArray(v)) return false;
+  const r = v as Record<string, unknown>;
+  return (
+    typeof r.owner === "string" &&
+    typeof r.repo === "string" &&
+    typeof r.issueNumber === "number" &&
+    typeof r.branch === "string" &&
+    typeof r.worktreePath === "string" &&
+    (r.prNumber === undefined ||
+      r.prNumber === null ||
+      typeof r.prNumber === "number") &&
+    typeof r.currentStage === "number" &&
+    typeof r.stageLoopCount === "number" &&
+    typeof r.reviewRound === "number" &&
+    (r.executionMode === "auto" || r.executionMode === "step") &&
+    (r.claudePermissionMode === "auto" ||
+      r.claudePermissionMode === "bypass") &&
+    isValidAgentState(r.agentA) &&
+    isValidAgentState(r.agentB)
+  );
+}
+
+export function loadRunState(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): RunState | undefined {
+  const path = runStatePath(owner, repo, issueNumber);
+  if (!existsSync(path)) return undefined;
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf-8"));
+  } catch {
+    return undefined;
+  }
+
+  if (!isValidRunState(raw)) return undefined;
+
+  // Normalise null → undefined for optional fields.
+  return {
+    ...raw,
+    prNumber: raw.prNumber ?? undefined,
+    agentA: {
+      ...raw.agentA,
+      sessionId: raw.agentA.sessionId ?? undefined,
+    },
+    agentB: {
+      ...raw.agentB,
+      sessionId: raw.agentB.sessionId ?? undefined,
+    },
+  };
+}
+
+export function deleteRunState(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): void {
+  const path = runStatePath(owner, repo, issueNumber);
+  rmSync(path, { force: true });
+}

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -19,7 +19,7 @@ import {
   normaliseCiConclusion,
 } from "./ci.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
-import { mapAgentError } from "./stage-util.js";
+import { invokeOrResume, mapAgentError } from "./stage-util.js";
 import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
 
 // ---- defaults --------------------------------------------------------------
@@ -177,8 +177,16 @@ export function createCiCheckStageHandler(
           : "No detailed failure logs available.";
 
       const prompt = buildCiFixPrompt(ctx, opts, failureLogs);
-      const fixStream = opts.agent.invoke(prompt, { cwd: ctx.worktreePath });
-      const fixResult = await fixStream.result;
+      const fixResult = await invokeOrResume(
+        opts.agent,
+        ctx.savedAgentASessionId,
+        prompt,
+        ctx.worktreePath,
+      );
+
+      if (fixResult.sessionId) {
+        ctx.onSessionId?.("a", fixResult.sessionId);
+      }
 
       if (fixResult.status === "error") {
         return mapAgentError(fixResult, "during CI fix");

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -21,6 +21,7 @@
 import type { AgentAdapter } from "./agent.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
@@ -92,10 +93,18 @@ export function createCreatePrStageHandler(
     number: 4,
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
-      // Step 1: Send the PR creation prompt.
+      // Step 1: Send the PR creation prompt (resume if saved session).
       const prompt = buildCreatePrPrompt(ctx, opts);
-      const prStream = opts.agent.invoke(prompt, { cwd: ctx.worktreePath });
-      const prResult = await prStream.result;
+      const prResult = await invokeOrResume(
+        opts.agent,
+        ctx.savedAgentASessionId,
+        prompt,
+        ctx.worktreePath,
+      );
+
+      if (prResult.sessionId) {
+        ctx.onSessionId?.("a", prResult.sessionId);
+      }
 
       if (prResult.status === "error") {
         return mapAgentError(prResult);

--- a/src/stage-implement.test.ts
+++ b/src/stage-implement.test.ts
@@ -237,4 +237,75 @@ describe("createImplementStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
     expect(result.message).toBe("Everything looks good.\n\nCOMPLETED");
   });
+
+  // -- session ID reporting ---------------------------------------------------
+
+  test("reports agent session ID via onSessionId callback", async () => {
+    const sessionCalls: [string, string][] = [];
+    const implResult = makeResult({ sessionId: "sess-impl-42" });
+    const agent = makeAgent(implResult);
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      onSessionId: (agent, sid) => sessionCalls.push([agent, sid]),
+    };
+    await stage.handler(ctx);
+    expect(sessionCalls).toEqual([["a", "sess-impl-42"]]);
+  });
+
+  test("does not throw when onSessionId is not provided", async () => {
+    const agent = makeAgent(makeResult());
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("resumes saved session when savedAgentASessionId is present", async () => {
+    const resumeResult = makeResult({ sessionId: "resumed-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(resumeResult))
+        .mockReturnValueOnce(makeStream(makeResult())),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      savedAgentASessionId: "old-sess",
+    };
+    const result = await stage.handler(ctx);
+    expect(result.outcome).toBe("completed");
+    // Should have called resume (via invokeOrResume), not invoke.
+    expect(agent.resume).toHaveBeenCalled();
+    expect(agent.resume).toHaveBeenCalledWith("old-sess", expect.any(String), {
+      cwd: "/tmp/wt",
+    });
+  });
+
+  test("falls back to invoke when saved session fails", async () => {
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "unknown",
+      stderrText: "expired",
+    });
+    const freshResult = makeResult({ sessionId: "fresh-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(freshResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(errorResult))
+        .mockReturnValueOnce(makeStream(makeResult())),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      savedAgentASessionId: "expired-sess",
+    };
+    const result = await stage.handler(ctx);
+    expect(result.outcome).toBe("completed");
+    // Should have attempted resume, then fallen back to invoke.
+    expect(agent.resume).toHaveBeenCalled();
+    expect(agent.invoke).toHaveBeenCalled();
+  });
 });

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -11,6 +11,7 @@
 import type { AgentAdapter } from "./agent.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
@@ -72,10 +73,18 @@ export function createImplementStageHandler(
     name: "Implement",
     number: 2,
     handler: async (ctx: StageContext): Promise<StageResult> => {
-      // Step 1: Send the implementation prompt.
+      // Step 1: Send the implementation prompt (resume if saved session).
       const prompt = buildImplementPrompt(ctx, opts);
-      const implStream = opts.agent.invoke(prompt, { cwd: ctx.worktreePath });
-      const implResult = await implStream.result;
+      const implResult = await invokeOrResume(
+        opts.agent,
+        ctx.savedAgentASessionId,
+        prompt,
+        ctx.worktreePath,
+      );
+
+      if (implResult.sessionId) {
+        ctx.onSessionId?.("a", implResult.sessionId);
+      }
 
       if (implResult.status === "error") {
         return mapAgentError(implResult);

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -1086,3 +1086,80 @@ describe("createReviewStageHandler", () => {
     expect(result.message).toContain("Round 1 fixes applied");
   });
 });
+
+// ---------------------------------------------------------------------------
+// onSessionId callback
+// ---------------------------------------------------------------------------
+describe("onSessionId", () => {
+  test("reports agent B session ID after review", async () => {
+    const sessionCalls: [string, string][] = [];
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b-1", responseText: "APPROVED" }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+    const agentA: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+    const opts = makeOpts({ agentA, agentB });
+    const stage = createReviewStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      onSessionId: (agent, sid) => sessionCalls.push([agent, sid]),
+    };
+    await stage.handler(ctx);
+    expect(sessionCalls).toContainEqual(["b", "sess-b-1"]);
+  });
+
+  test("reports agent A session ID after fix", async () => {
+    const sessionCalls: [string, string][] = [];
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b-1",
+            responseText: "NOT_APPROVED",
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a-1", responseText: "COMPLETED" }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const ciPass = makeCiStatus("pass", [makeCiRun()]);
+    const opts = makeOpts({
+      agentA,
+      agentB,
+      getCiStatus: vi.fn().mockReturnValue(ciPass),
+      collectFailureLogs: vi.fn(),
+      getHeadSha: vi.fn().mockReturnValue("abc123"),
+      delay: vi.fn(),
+    });
+    const stage = createReviewStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      onSessionId: (agent, sid) => sessionCalls.push([agent, sid]),
+    };
+    await stage.handler(ctx);
+    expect(sessionCalls).toContainEqual(["b", "sess-b-1"]);
+    expect(sessionCalls).toContainEqual(["a", "sess-a-1"]);
+  });
+});

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -28,6 +28,7 @@ import {
 import { pollCiAndFix } from "./ci-poll.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
@@ -179,12 +180,18 @@ export function createReviewStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       const round = ctx.iteration + 1; // 1-based for display
 
-      // Step 1: Agent B reviews.
+      // Step 1: Agent B reviews (resume if saved session).
       const reviewPrompt = buildReviewPrompt(ctx, opts, round);
-      const reviewStream = opts.agentB.invoke(reviewPrompt, {
-        cwd: ctx.worktreePath,
-      });
-      const reviewResult = await reviewStream.result;
+      const reviewResult = await invokeOrResume(
+        opts.agentB,
+        ctx.savedAgentBSessionId,
+        reviewPrompt,
+        ctx.worktreePath,
+      );
+
+      if (reviewResult.sessionId) {
+        ctx.onSessionId?.("b", reviewResult.sessionId);
+      }
 
       if (reviewResult.status === "error") {
         return mapAgentError(reviewResult, "during review");
@@ -216,12 +223,18 @@ export function createReviewStageHandler(
         return mapResponseToResult(reviewResult.responseText);
       }
 
-      // Step 3: NOT_APPROVED — Agent A fixes.
+      // Step 3: NOT_APPROVED — Agent A fixes (resume if saved session).
       const fixPrompt = buildAuthorFixPrompt(ctx, opts, round);
-      const fixStream = opts.agentA.invoke(fixPrompt, {
-        cwd: ctx.worktreePath,
-      });
-      const fixResult = await fixStream.result;
+      const fixResult = await invokeOrResume(
+        opts.agentA,
+        ctx.savedAgentASessionId,
+        fixPrompt,
+        ctx.worktreePath,
+      );
+
+      if (fixResult.sessionId) {
+        ctx.onSessionId?.("a", fixResult.sessionId);
+      }
 
       if (fixResult.status === "error") {
         return mapAgentError(fixResult, "during author fix");

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -14,6 +14,7 @@
 import type { AgentAdapter } from "./agent.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
   sendFollowUp,
@@ -84,12 +85,18 @@ export function createSelfCheckStageHandler(
     name: "Self-check",
     number: 3,
     handler: async (ctx: StageContext): Promise<StageResult> => {
-      // Step 1: Send self-check prompt.
+      // Step 1: Send self-check prompt (resume if saved session).
       const checkPrompt = buildSelfCheckPrompt(ctx, opts);
-      const checkStream = opts.agent.invoke(checkPrompt, {
-        cwd: ctx.worktreePath,
-      });
-      const checkResult = await checkStream.result;
+      const checkResult = await invokeOrResume(
+        opts.agent,
+        ctx.savedAgentASessionId,
+        checkPrompt,
+        ctx.worktreePath,
+      );
+
+      if (checkResult.sessionId) {
+        ctx.onSessionId?.("a", checkResult.sessionId);
+      }
 
       if (checkResult.status === "error") {
         return mapAgentError(checkResult, "during self-check");

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -21,6 +21,7 @@ import {
 import { type CiPollResult, pollCiAndFix } from "./ci-poll.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
@@ -108,12 +109,18 @@ export function createSquashStageHandler(
     number: 7,
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
-      // Step 1: Send the squash prompt.
+      // Step 1: Send the squash prompt (resume if saved session).
       const prompt = buildSquashPrompt(ctx, opts);
-      const squashStream = opts.agent.invoke(prompt, {
-        cwd: ctx.worktreePath,
-      });
-      const squashResult = await squashStream.result;
+      const squashResult = await invokeOrResume(
+        opts.agent,
+        ctx.savedAgentASessionId,
+        prompt,
+        ctx.worktreePath,
+      );
+
+      if (squashResult.sessionId) {
+        ctx.onSessionId?.("a", squashResult.sessionId);
+      }
 
       if (squashResult.status === "error") {
         return mapAgentError(squashResult, "during squash");

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -15,6 +15,7 @@
 import type { AgentAdapter } from "./agent.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
   sendFollowUp,
@@ -86,12 +87,18 @@ export function createTestPlanStageHandler(
     name: "Test plan verification",
     number: 6,
     handler: async (ctx: StageContext): Promise<StageResult> => {
-      // Step 1: Send verification prompt.
+      // Step 1: Send verification prompt (resume if saved session).
       const verifyPrompt = buildTestPlanVerifyPrompt(ctx, opts);
-      const verifyStream = opts.agent.invoke(verifyPrompt, {
-        cwd: ctx.worktreePath,
-      });
-      const verifyResult = await verifyStream.result;
+      const verifyResult = await invokeOrResume(
+        opts.agent,
+        ctx.savedAgentASessionId,
+        verifyPrompt,
+        ctx.worktreePath,
+      );
+
+      if (verifyResult.sessionId) {
+        ctx.onSessionId?.("a", verifyResult.sessionId);
+      }
 
       if (verifyResult.status === "error") {
         return mapAgentError(verifyResult, "during test plan verification");

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import {
+  invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
   mapParsedStepToResult,
@@ -270,5 +271,104 @@ describe("sendFollowUp", () => {
     ).rejects.toThrow("no session ID");
     expect(agent.invoke).not.toHaveBeenCalled();
     expect(agent.resume).not.toHaveBeenCalled();
+  });
+});
+
+// ---- invokeOrResume --------------------------------------------------------
+
+describe("invokeOrResume", () => {
+  test("invokes fresh when no saved session ID", async () => {
+    const result = makeResult({ sessionId: "new-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(result)),
+      resume: vi.fn(),
+    };
+
+    const out = await invokeOrResume(agent, undefined, "prompt", "/cwd");
+    expect(out).toBe(result);
+    expect(agent.invoke).toHaveBeenCalledWith("prompt", { cwd: "/cwd" });
+    expect(agent.resume).not.toHaveBeenCalled();
+  });
+
+  test("resumes when saved session ID is available and succeeds", async () => {
+    const result = makeResult({ sessionId: "resumed-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(result)),
+    };
+
+    const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
+    expect(out).toBe(result);
+    expect(agent.resume).toHaveBeenCalledWith("saved-sess", "prompt", {
+      cwd: "/cwd",
+    });
+    expect(agent.invoke).not.toHaveBeenCalled();
+  });
+
+  test("falls back to invoke when resume returns error", async () => {
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "unknown",
+      stderrText: "session expired",
+    });
+    const freshResult = makeResult({ sessionId: "fresh-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(freshResult)),
+      resume: vi.fn().mockReturnValue(makeStream(errorResult)),
+    };
+
+    const out = await invokeOrResume(agent, "old-sess", "prompt", "/cwd");
+    expect(out).toBe(freshResult);
+    expect(agent.resume).toHaveBeenCalledOnce();
+    expect(agent.invoke).toHaveBeenCalledOnce();
+  });
+
+  test("falls back to invoke on max_turns (recoverable)", async () => {
+    const maxTurnsResult = makeResult({
+      status: "error",
+      errorType: "max_turns",
+    });
+    const freshResult = makeResult({ sessionId: "fresh" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(freshResult)),
+      resume: vi.fn().mockReturnValue(makeStream(maxTurnsResult)),
+    };
+
+    const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
+    expect(out).toBe(freshResult);
+    expect(agent.resume).toHaveBeenCalledOnce();
+    expect(agent.invoke).toHaveBeenCalledOnce();
+  });
+
+  test("returns error immediately on cli_not_found (non-recoverable)", async () => {
+    const cliNotFound = makeResult({
+      status: "error",
+      errorType: "cli_not_found",
+      stderrText: "claude: not found",
+    });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(cliNotFound)),
+    };
+
+    const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
+    expect(out).toBe(cliNotFound);
+    expect(agent.invoke).not.toHaveBeenCalled();
+  });
+
+  test("returns error immediately on execution_error (non-recoverable)", async () => {
+    const execError = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "segfault",
+    });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(execError)),
+    };
+
+    const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
+    expect(out).toBe(execError);
+    expect(agent.invoke).not.toHaveBeenCalled();
   });
 });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -83,6 +83,37 @@ export async function sendFollowUp(
 }
 
 /**
+ * Invoke an agent, or resume an existing session if a saved session ID
+ * is available.  Used on pipeline resume so stage handlers can continue
+ * from a prior conversation.
+ *
+ * If `resume()` fails (e.g. expired session), falls back to a fresh
+ * `invoke()` automatically.
+ */
+export async function invokeOrResume(
+  agent: AgentAdapter,
+  savedSessionId: string | undefined,
+  prompt: string,
+  cwd: string,
+): Promise<AgentResult> {
+  if (savedSessionId) {
+    const result = await agent.resume(savedSessionId, prompt, { cwd }).result;
+    if (result.status === "success") {
+      return result;
+    }
+    // Non-recoverable errors should be surfaced, not retried.
+    if (
+      result.errorType === "cli_not_found" ||
+      result.errorType === "execution_error"
+    ) {
+      return result;
+    }
+    // Session expired or unknown error — fall back to fresh invoke.
+  }
+  return agent.invoke(prompt, { cwd }).result;
+}
+
+/**
  * Convenience: parse response text and convert to a `StageResult` in one
  * call.
  */

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -35,7 +35,7 @@ vi.mock("./github.js", () => ({
   getIssue: (...args: unknown[]) => mockGetIssue(...args),
 }));
 
-const { runStartup } = await import("./startup.js");
+const { runStartup, selectTarget } = await import("./startup.js");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1093,5 +1093,103 @@ describe("runStartup — pipeline settings", () => {
     mockGetIssue.mockReturnValue(defaultIssue());
 
     await runStartup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectTarget
+// ---------------------------------------------------------------------------
+describe("selectTarget", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("returns owner, repo, issueNumber, config, and configDirty", async () => {
+    mockLoadConfig.mockReturnValue(defaultConfig());
+    mockSelect.mockResolvedValueOnce("aicers"); // owner
+    mockSearch.mockResolvedValueOnce("agentcoop"); // repo
+    mockInput.mockResolvedValueOnce("42"); // issue number
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "Multi-agent CLI" },
+    ]);
+
+    const result = await selectTarget();
+    expect(result.owner).toBe("aicers");
+    expect(result.repo).toBe("agentcoop");
+    expect(result.issueNumber).toBe(42);
+    expect(result.config).toBeDefined();
+    expect(result.configDirty).toBe(false);
+  });
+
+  test("does not prompt for agent models or execution mode", async () => {
+    mockLoadConfig.mockReturnValue(defaultConfig());
+    mockSelect.mockResolvedValueOnce("aicers"); // owner
+    mockSearch.mockResolvedValueOnce("agentcoop"); // repo
+    mockInput.mockResolvedValueOnce("7"); // issue number
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+
+    await selectTarget();
+    // select called only once for owner (not for models, mode, permission, language).
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    // getIssue NOT called (that happens in runStartup).
+    expect(mockGetIssue).not.toHaveBeenCalled();
+  });
+
+  test("marks configDirty when new owner is entered", async () => {
+    mockLoadConfig.mockReturnValue({
+      ...defaultConfig(),
+      owners: [],
+    });
+    mockInput
+      .mockResolvedValueOnce("new-org") // new owner
+      .mockResolvedValueOnce("1"); // issue number
+    mockSearch.mockResolvedValueOnce("some-repo");
+    mockListRepositories.mockReturnValue([
+      { name: "some-repo", description: "" },
+    ]);
+
+    const result = await selectTarget();
+    expect(result.owner).toBe("new-org");
+    expect(result.configDirty).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStartup with pre-selected target
+// ---------------------------------------------------------------------------
+describe("runStartup with target parameter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("skips owner/repo/issue prompts when target is provided", async () => {
+    const config = defaultConfig();
+    const target = {
+      owner: "aicers",
+      repo: "agentcoop",
+      issueNumber: 42,
+      config,
+      configDirty: false,
+    };
+    // Only prompts needed: agentA, agentB, executionMode, permissionMode, language, settings, confirm.
+    mockSelect
+      .mockResolvedValueOnce("opus") // agent A model
+      .mockResolvedValueOnce("sonnet") // agent B model
+      .mockResolvedValueOnce("auto") // execution mode
+      .mockResolvedValueOnce("auto") // permission mode
+      .mockResolvedValueOnce("en"); // language
+    mockCheckbox.mockResolvedValueOnce([]); // no settings adjusted
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+    mockGetIssue.mockReturnValue(defaultIssue());
+
+    const result = await runStartup(target);
+    expect(result.owner).toBe("aicers");
+    expect(result.repo).toBe("agentcoop");
+    expect(result.issue.number).toBe(42);
+    expect(result.agentA.model).toBe("opus");
+    // Should NOT have called search (repo) or input (issue number).
+    expect(mockSearch).not.toHaveBeenCalled();
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -4,6 +4,14 @@ import { loadConfig, saveConfig } from "./config.js";
 import type { Issue } from "./github.js";
 import { getIssue, listRepositories } from "./github.js";
 
+export interface TargetResult {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  config: Config;
+  configDirty: boolean;
+}
+
 export interface StartupResult {
   owner: string;
   repo: string;
@@ -32,7 +40,12 @@ const CODEX_MODELS = [
 
 const ALL_MODELS = [...CLAUDE_MODELS, ...CODEX_MODELS];
 
-export async function runStartup(): Promise<StartupResult> {
+/**
+ * First phase of startup: select owner, repo, and issue number.
+ * Returns early so the caller can check for a resumable run state
+ * before collecting the remaining options.
+ */
+export async function selectTarget(): Promise<TargetResult> {
   const config = loadConfig();
   let configDirty = false;
 
@@ -41,6 +54,26 @@ export async function runStartup(): Promise<StartupResult> {
 
   const repo = await selectRepository(owner);
   const issueNumber = await inputIssueNumber();
+
+  return { owner, repo, issueNumber, config, configDirty };
+}
+
+/**
+ * Second phase of startup: collect agent models, execution mode,
+ * language, and pipeline settings.  Confirm the issue before returning.
+ */
+export async function runStartup(
+  target?: TargetResult,
+): Promise<StartupResult> {
+  const {
+    owner,
+    repo,
+    issueNumber,
+    config,
+    configDirty: initialDirty,
+  } = target ?? (await selectTarget());
+  let configDirty = initialDirty;
+
   const agentA = await selectAgentModel("Agent A (implementer)");
   const agentB = await selectAgentModel("Agent B (reviewer)");
   const executionMode = await selectExecutionMode();


### PR DESCRIPTION
## Summary

- Add run state persistence so the pipeline can be resumed after interruption (crash, Ctrl-C, terminal close)
- State file saved at `~/.agentcoop/runs/{owner}/{repo}/{issue_number}.json` with full schema: stage, loop count, review round, session IDs, execution config
- Save points at every stage transition, loop iteration, and agent session ID capture
- On startup, detect saved state and offer Resume / Start fresh
- Resume restores stage position, loop count, and agent session IDs via `invokeOrResume` helper (with expired-session fallback to fresh invoke)
- Start fresh warns about uncommitted changes, deletes state file, and cleans worktree
- Skip stage 4 on resume when PR already exists (avoids replaying side-effectful `gh pr create`)
- Checkpoint `restart_from` jumps so a crash mid-restart saves the correct target stage

## Changes

- **New:** `src/run-state.ts` — `RunState` type, `saveRunState`/`loadRunState`/`deleteRunState` with JSON validation and atomic writes
- **New:** `src/run-state.test.ts` — 15 tests (round-trip, malformed input, null normalization, delete)
- **Modified:** `src/pipeline.ts` — `startFromStage`, `startFromStageLoopCount`, `onStageTransition`, `onSessionId`, `savedAgent*SessionId` in `PipelineOptions`/`StageContext`; checkpoint on `restart_from` jumps
- **Modified:** `src/stage-util.ts` — `invokeOrResume` helper with expired-session fallback (`cli_not_found`/`execution_error` surfaced immediately)
- **Modified:** `src/startup.ts` — Extracted `selectTarget()` for early resume check
- **Modified:** `src/index.ts` — Full resume flow wiring (state check → summary → Resume/Fresh → pipeline options); skip stage 4 when PR exists
- **Modified:** All stage handlers — Use `invokeOrResume` for first agent call, report session IDs via `onSessionId`
- **Tests:** 29 new tests (720 total) covering round-trip, resume logic, session ID restoration/clearing, E2E resume cycle, `selectTarget`, `runStartup(target)`, `invokeOrResume`, `restart_from` checkpoint

## Test plan

- [x] `pnpm test` — 720 tests pass
- [x] `pnpm biome check src/` — 0 errors
- [x] `tsc --noEmit` — no type errors

Closes #9