### PR TITLE
Add split-pane terminal UI for agent output

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,15 @@
   "devDependencies": {
     "@biomejs/biome": "^2.4.7",
     "@types/node": "^24",
+    "@types/react": "^19.2.14",
+    "ink-testing-library": "^4.0.0",
     "typescript": "^5",
     "vitest": "^4.1.2"
   },
   "dependencies": {
-    "@inquirer/prompts": "^8.3.2"
+    "@inquirer/prompts": "^8.3.2",
+    "ink": "^6.8.0",
+    "ink-text-input": "^6.0.0",
+    "react": "^19.2.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@inquirer/prompts':
         specifier: ^8.3.2
         version: 8.3.2(@types/node@24.12.0)
+      ink:
+        specifier: ^6.8.0
+        version: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+      ink-text-input:
+        specifier: ^6.0.0
+        version: 6.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.7
@@ -18,6 +27,12 @@ importers:
       '@types/node':
         specifier: ^24
         version: 24.12.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      ink-testing-library:
+        specifier: ^4.0.0
+        version: 4.0.0(@types/react@19.2.14)
       typescript:
         specifier: ^5
         version: 5.9.3
@@ -26,6 +41,10 @@ importers:
         version: 4.1.2(@types/node@24.12.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@24.12.0))
 
 packages:
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    resolution: {integrity: sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw==}
+    engines: {node: '>=18'}
 
   '@biomejs/biome@2.4.10':
     resolution: {integrity: sha512-xxA3AphFQ1geij4JTHXv4EeSTda1IFn22ye9LdyVPoJU19fNVl0uzfEuhsfQ4Yue/0FaLs2/ccVi4UDiE7R30w==}
@@ -345,6 +364,9 @@ packages:
   '@types/node@24.12.0':
     resolution: {integrity: sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==}
 
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
@@ -374,30 +396,87 @@ packages:
   '@vitest/utils@4.1.2':
     resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  auto-bind@5.0.1:
+    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
   chardet@2.1.1:
     resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  cli-boxes@3.0.0:
+    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
+    engines: {node: '>=10'}
+
+  cli-cursor@4.0.0:
+    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
 
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
+  code-excerpt@4.0.0:
+    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  convert-to-spaces@2.0.1:
+    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
+
+  escape-string-regexp@2.0.0:
+    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
+    engines: {node: '>=8'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -429,9 +508,55 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
+
+  indent-string@5.0.0:
+    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
+    engines: {node: '>=12'}
+
+  ink-testing-library@4.0.0:
+    resolution: {integrity: sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  ink-text-input@6.0.0:
+    resolution: {integrity: sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
+      react: '>=18'
+
+  ink@6.8.0:
+    resolution: {integrity: sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@types/react': '>=19.0.0'
+      react: '>=19.0.0'
+      react-devtools-core: '>=6.1.2'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react-devtools-core:
+        optional: true
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  is-in-ci@2.0.0:
+    resolution: {integrity: sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -506,6 +631,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -517,6 +646,14 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  patch-console@2.0.0:
+    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -532,6 +669,20 @@ packages:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  react-reconciler@0.33.0:
+    resolution: {integrity: sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.2.0
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  restore-cursor@4.0.0:
+    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   rolldown@1.0.0-rc.12:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -540,22 +691,56 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
+  terminal-size@4.0.1:
+    resolution: {integrity: sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -574,6 +759,14 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
+
+  type-fest@5.5.0:
+    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
+    engines: {node: '>=20'}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -666,7 +859,35 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  widest-line@6.0.0:
+    resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  yoga-layout@3.2.1:
+    resolution: {integrity: sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==}
+
 snapshots:
+
+  '@alcalzone/ansi-tokenize@0.2.5':
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
 
   '@biomejs/biome@2.4.10':
     optionalDependencies:
@@ -921,6 +1142,10 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@vitest/expect@4.1.2':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -962,19 +1187,58 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
   assertion-error@2.0.1: {}
+
+  auto-bind@5.0.1: {}
 
   chai@6.2.2: {}
 
+  chalk@5.6.2: {}
+
   chardet@2.1.1: {}
+
+  cli-boxes@3.0.0: {}
+
+  cli-cursor@4.0.0:
+    dependencies:
+      restore-cursor: 4.0.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
 
   cli-width@4.1.0: {}
 
+  code-excerpt@4.0.0:
+    dependencies:
+      convert-to-spaces: 2.0.1
+
   convert-source-map@2.0.0: {}
+
+  convert-to-spaces@2.0.1: {}
+
+  csstype@3.2.3: {}
 
   detect-libc@2.1.2: {}
 
+  emoji-regex@10.6.0: {}
+
+  environment@1.1.0: {}
+
   es-module-lexer@2.0.0: {}
+
+  es-toolkit@1.45.1: {}
+
+  escape-string-regexp@2.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -999,9 +1263,64 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-east-asian-width@1.5.0: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
+
+  indent-string@5.0.0: {}
+
+  ink-testing-library@4.0.0(@types/react@19.2.14):
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  ink-text-input@6.0.0(ink@6.8.0(@types/react@19.2.14)(react@19.2.4))(react@19.2.4):
+    dependencies:
+      chalk: 5.6.2
+      ink: 6.8.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      type-fest: 4.41.0
+
+  ink@6.8.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@alcalzone/ansi-tokenize': 0.2.5
+      ansi-escapes: 7.3.0
+      ansi-styles: 6.2.3
+      auto-bind: 5.0.1
+      chalk: 5.6.2
+      cli-boxes: 3.0.0
+      cli-cursor: 4.0.0
+      cli-truncate: 5.2.0
+      code-excerpt: 4.0.0
+      es-toolkit: 1.45.1
+      indent-string: 5.0.0
+      is-in-ci: 2.0.0
+      patch-console: 2.0.0
+      react: 19.2.4
+      react-reconciler: 0.33.0(react@19.2.4)
+      scheduler: 0.27.0
+      signal-exit: 3.0.7
+      slice-ansi: 8.0.0
+      stack-utils: 2.0.6
+      string-width: 8.2.0
+      terminal-size: 4.0.1
+      type-fest: 5.5.0
+      widest-line: 6.0.0
+      wrap-ansi: 9.0.2
+      ws: 8.20.0
+      yoga-layout: 3.2.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
+  is-in-ci@2.0.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1056,11 +1375,19 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mimic-fn@2.1.0: {}
+
   mute-stream@3.0.0: {}
 
   nanoid@3.3.11: {}
 
   obug@2.1.1: {}
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  patch-console@2.0.0: {}
 
   pathe@2.0.3: {}
 
@@ -1073,6 +1400,18 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  react-reconciler@0.33.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react@19.2.4: {}
+
+  restore-cursor@4.0.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
     dependencies:
@@ -1100,15 +1439,47 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  scheduler@0.27.0: {}
+
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   source-map-js@1.2.1: {}
+
+  stack-utils@2.0.6:
+    dependencies:
+      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
   std-env@4.0.0: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  tagged-tag@1.0.0: {}
+
+  terminal-size@4.0.1: {}
 
   tinybench@2.9.0: {}
 
@@ -1123,6 +1494,12 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  type-fest@4.41.0: {}
+
+  type-fest@5.5.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typescript@5.9.3: {}
 
@@ -1173,3 +1550,17 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  widest-line@6.0.0:
+    dependencies:
+      string-width: 8.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  ws@8.20.0: {}
+
+  yoga-layout@3.2.1: {}

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -16,6 +16,7 @@ import {
 } from "./ci.js";
 import type { StageContext } from "./pipeline.js";
 import { buildCiFixPrompt } from "./stage-cicheck.js";
+import { drainToSink } from "./stage-util.js";
 import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
 
 // ---- defaults ----------------------------------------------------------------
@@ -202,6 +203,9 @@ export async function pollCiAndFix(
       failureLogs,
     );
     const fixStream = agent.invoke(fixPrompt, { cwd: ctx.worktreePath });
+    if (ctx.streamSinks?.a) {
+      drainToSink(fixStream, ctx.streamSinks.a);
+    }
     const fixResult = await fixStream.result;
 
     if (fixResult.sessionId) {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -81,8 +81,8 @@ describe("tsconfig.json", () => {
     }
   });
 
-  test("does not include jsx setting", () => {
-    expect(tsconfig.compilerOptions.jsx).toBeUndefined();
+  test("includes jsx setting for ink TUI", () => {
+    expect(tsconfig.compilerOptions.jsx).toBe("react-jsx");
   });
 
   test("excludes test files from compilation", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 
 import { confirm, select } from "@inquirer/prompts";
+import { render } from "ink";
+import React from "react";
 
 import type { AgentAdapter } from "./agent.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
 import { createCodexAdapter } from "./codex-adapter.js";
 import type { PipelineSettings } from "./config.js";
 import { getIssue } from "./github.js";
-import type { PipelineOptions } from "./pipeline.js";
-import { createDoneStageHandler, runPipeline } from "./pipeline.js";
+import type {
+  PipelineOptions,
+  PipelineResult,
+  UserPrompt,
+} from "./pipeline.js";
+import { createDoneStageHandler } from "./pipeline.js";
+import { PipelineEventEmitter } from "./pipeline-events.js";
 import { findPrNumber } from "./pr.js";
 import {
   deleteRunState,
@@ -25,6 +32,7 @@ import { createSquashStageHandler } from "./stage-squash.js";
 import { createTestPlanStageHandler } from "./stage-testplan.js";
 import type { AgentConfig } from "./startup.js";
 import { runStartup, selectTarget } from "./startup.js";
+import { App } from "./ui/App.js";
 import {
   bootstrapRepo,
   createWorktree,
@@ -320,13 +328,31 @@ try {
   // Save initial state.
   saveRunState(runState);
 
+  // The TUI prompt is created inside <App> at mount time.  Done stage
+  // callbacks delegate to it via a late-binding ref so stage 9 shows
+  // a real user confirmation instead of auto-approving.
+  let tuiPrompt:
+    | {
+        confirmMerge: UserPrompt["confirmMerge"];
+        reportCompletion: UserPrompt["reportCompletion"];
+      }
+    | undefined;
+
   const doneStage = createDoneStageHandler({
-    reportCompletion: async (msg) => console.log(msg),
-    confirmMerge: async () => true, // placeholder until real prompts
+    reportCompletion: async (msg) => {
+      if (tuiPrompt) return tuiPrompt.reportCompletion(msg);
+      console.log(msg);
+    },
+    confirmMerge: async (msg) => {
+      if (tuiPrompt) return tuiPrompt.confirmMerge(msg);
+      return true;
+    },
     cleanup: () => removeWorktree(owner, repo, issueNumber, wt.branch),
   });
 
-  const pipelineOpts: PipelineOptions = {
+  // The `prompt` field is intentionally omitted here — it will be
+  // supplied by the ink <App> component via TuiUserPrompt.
+  const pipelineOpts: Omit<PipelineOptions, "prompt" | "events"> = {
     mode: executionMode,
     stages: [
       implementStage,
@@ -338,15 +364,6 @@ try {
       reviewStage,
       doneStage,
     ],
-    prompt: {
-      confirmContinueLoop: async (_stage, _iter, _msg) => false,
-      confirmNextStage: async () => true,
-      handleBlocked: async () => ({ action: "halt" }),
-      handleError: async () => ({ action: "abort" }),
-      handleAmbiguous: async () => ({ action: "halt" }),
-      confirmMerge: async () => true,
-      reportCompletion: async () => {},
-    },
     context: {
       owner,
       repo,
@@ -380,7 +397,26 @@ try {
       saveRunState(runState);
     },
   };
-  const pipelineResult = await runPipeline(pipelineOpts);
+
+  // Launch the ink TUI.
+  const emitter = new PipelineEventEmitter();
+
+  const pipelineResult = await new Promise<PipelineResult>((resolve) => {
+    const { unmount } = render(
+      React.createElement(App, {
+        emitter,
+        pipelineOptions: pipelineOpts,
+        onExit: (result: PipelineResult) => {
+          unmount();
+          resolve(result);
+        },
+        onPromptReady: (prompt) => {
+          tuiPrompt = prompt;
+        },
+      }),
+    );
+  });
+
   console.log();
   console.log(pipelineResult.message);
 

--- a/src/pipeline-events.test.ts
+++ b/src/pipeline-events.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  type AgentChunkEvent,
+  type AgentInvokeEvent,
+  PipelineEventEmitter,
+  type StageEnterEvent,
+  type StageExitEvent,
+} from "./pipeline-events.js";
+
+describe("PipelineEventEmitter", () => {
+  test("emits and receives agent:chunk events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("agent:chunk", handler);
+
+    const event: AgentChunkEvent = { agent: "a", chunk: "hello" };
+    emitter.emit("agent:chunk", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives stage:enter events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("stage:enter", handler);
+
+    const event: StageEnterEvent = {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    };
+    emitter.emit("stage:enter", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives stage:exit events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("stage:exit", handler);
+
+    const event: StageExitEvent = { stageNumber: 2, outcome: "completed" };
+    emitter.emit("stage:exit", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives agent:invoke events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("agent:invoke", handler);
+
+    const event: AgentInvokeEvent = { agent: "b", type: "resume" };
+    emitter.emit("agent:invoke", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("supports multiple listeners for the same event", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler1 = vi.fn();
+    const handler2 = vi.fn();
+    emitter.on("agent:chunk", handler1);
+    emitter.on("agent:chunk", handler2);
+
+    const event: AgentChunkEvent = { agent: "a", chunk: "data" };
+    emitter.emit("agent:chunk", event);
+
+    expect(handler1).toHaveBeenCalledWith(event);
+    expect(handler2).toHaveBeenCalledWith(event);
+  });
+
+  test("off removes listener", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("agent:chunk", handler);
+    emitter.off("agent:chunk", handler);
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "data" });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("different event types do not interfere", () => {
+    const emitter = new PipelineEventEmitter();
+    const chunkHandler = vi.fn();
+    const enterHandler = vi.fn();
+    emitter.on("agent:chunk", chunkHandler);
+    emitter.on("stage:enter", enterHandler);
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "x" });
+
+    expect(chunkHandler).toHaveBeenCalledTimes(1);
+    expect(enterHandler).not.toHaveBeenCalled();
+  });
+});

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -1,0 +1,31 @@
+import { EventEmitter } from "node:events";
+
+export interface AgentChunkEvent {
+  agent: "a" | "b";
+  chunk: string;
+}
+
+export interface StageEnterEvent {
+  stageNumber: number;
+  stageName: string;
+  iteration: number;
+}
+
+export interface StageExitEvent {
+  stageNumber: number;
+  outcome: string;
+}
+
+export interface AgentInvokeEvent {
+  agent: "a" | "b";
+  type: "invoke" | "resume";
+}
+
+interface PipelineEventMap {
+  "agent:chunk": [AgentChunkEvent];
+  "stage:enter": [StageEnterEvent];
+  "stage:exit": [StageExitEvent];
+  "agent:invoke": [AgentInvokeEvent];
+}
+
+export class PipelineEventEmitter extends EventEmitter<PipelineEventMap> {}

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -15,6 +15,11 @@ import {
   isTerminalSuccess,
   runPipeline,
 } from "./pipeline.js";
+import {
+  PipelineEventEmitter,
+  type StageEnterEvent,
+  type StageExitEvent,
+} from "./pipeline-events.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
 // ---- helpers -------------------------------------------------------------
@@ -1741,5 +1746,231 @@ describe("full resume cycle (E2E)", () => {
         s === 5 && l === 0 && idx > 0 && transitions[idx - 1][0] === 6,
     );
     expect(jumpCheckpoints.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline event emitter integration
+// ---------------------------------------------------------------------------
+
+describe("pipeline event emission", () => {
+  test("emits stage:enter before handler and stage:exit after handler", async () => {
+    const timeline: string[] = [];
+    const emitter = new PipelineEventEmitter();
+    emitter.on("stage:enter", () => timeline.push("enter"));
+    emitter.on("stage:exit", () => timeline.push("exit"));
+
+    const stages = [
+      makeStage(1, async () => {
+        timeline.push("handler");
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(timeline).toEqual(["enter", "handler", "exit"]);
+  });
+
+  test("stage:enter includes stageNumber, stageName, and iteration", async () => {
+    const emitter = new PipelineEventEmitter();
+    const enterEvents: StageEnterEvent[] = [];
+    emitter.on("stage:enter", (ev) => enterEvents.push(ev));
+
+    const stages = [
+      makeStage(5, async () => ({ outcome: "completed", message: "" })),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(enterEvents).toEqual([
+      { stageNumber: 5, stageName: "Stage 5", iteration: 0 },
+    ]);
+  });
+
+  test("stage:exit includes stageNumber and outcome", async () => {
+    const emitter = new PipelineEventEmitter();
+    const exitEvents: StageExitEvent[] = [];
+    emitter.on("stage:exit", (ev) => exitEvents.push(ev));
+
+    const stages = [
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(exitEvents).toEqual([{ stageNumber: 2, outcome: "completed" }]);
+  });
+
+  test("emits events for each stage in sequence", async () => {
+    const emitter = new PipelineEventEmitter();
+    const events: string[] = [];
+    emitter.on("stage:enter", (ev) => events.push(`enter:${ev.stageNumber}`));
+    emitter.on("stage:exit", (ev) => events.push(`exit:${ev.stageNumber}`));
+
+    const stages = [
+      makeStage(1, async () => ({ outcome: "completed", message: "" })),
+      makeStage(2, async () => ({ outcome: "completed", message: "" })),
+      makeStage(3, async () => ({ outcome: "completed", message: "" })),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(events).toEqual([
+      "enter:1",
+      "exit:1",
+      "enter:2",
+      "exit:2",
+      "enter:3",
+      "exit:3",
+    ]);
+  });
+
+  test("emits stage:enter on each loop iteration with incrementing iteration", async () => {
+    const emitter = new PipelineEventEmitter();
+    const enterEvents: StageEnterEvent[] = [];
+    emitter.on("stage:enter", (ev) => enterEvents.push(ev));
+
+    let call = 0;
+    const stages = [
+      makeStage(
+        4,
+        async () => {
+          call++;
+          // First two iterations return not_approved, third completes.
+          if (call < 3) return { outcome: "not_approved", message: "" };
+          return { outcome: "completed", message: "" };
+        },
+        { autoBudget: 5 },
+      ),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(enterEvents).toEqual([
+      { stageNumber: 4, stageName: "Stage 4", iteration: 0 },
+      { stageNumber: 4, stageName: "Stage 4", iteration: 1 },
+      { stageNumber: 4, stageName: "Stage 4", iteration: 2 },
+    ]);
+  });
+
+  test("emits stage:exit with not_approved on loop iterations", async () => {
+    const emitter = new PipelineEventEmitter();
+    const exitEvents: StageExitEvent[] = [];
+    emitter.on("stage:exit", (ev) => exitEvents.push(ev));
+
+    let call = 0;
+    const stages = [
+      makeStage(
+        3,
+        async () => {
+          call++;
+          if (call < 3) return { outcome: "not_approved", message: "" };
+          return { outcome: "completed", message: "" };
+        },
+        { autoBudget: 5 },
+      ),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(exitEvents).toEqual([
+      { stageNumber: 3, outcome: "not_approved" },
+      { stageNumber: 3, outcome: "not_approved" },
+      { stageNumber: 3, outcome: "completed" },
+    ]);
+  });
+
+  test("streamSinks are passed to stage context when events are provided", async () => {
+    const emitter = new PipelineEventEmitter();
+    let capturedSinks: StageContext["streamSinks"];
+
+    const stages = [
+      makeStage(1, async (ctx) => {
+        capturedSinks = ctx.streamSinks;
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(capturedSinks).toBeDefined();
+    expect(typeof capturedSinks?.a).toBe("function");
+    expect(typeof capturedSinks?.b).toBe("function");
+  });
+
+  test("streamSinks emit agent:chunk events on the emitter", async () => {
+    const emitter = new PipelineEventEmitter();
+    const chunks: { agent: string; chunk: string }[] = [];
+    emitter.on("agent:chunk", (ev) => chunks.push(ev));
+
+    const stages = [
+      makeStage(1, async (ctx) => {
+        ctx.streamSinks?.a("hello from A");
+        ctx.streamSinks?.b("hello from B");
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(chunks).toEqual([
+      { agent: "a", chunk: "hello from A" },
+      { agent: "b", chunk: "hello from B" },
+    ]);
+  });
+
+  test("streamSinks are undefined when events option is omitted", async () => {
+    let capturedSinks: StageContext["streamSinks"];
+
+    const stages = [
+      makeStage(1, async (ctx) => {
+        capturedSinks = ctx.streamSinks;
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages }));
+
+    expect(capturedSinks).toBeUndefined();
+  });
+
+  test("stage:exit emits blocked outcome when user halts", async () => {
+    const emitter = new PipelineEventEmitter();
+    const exitEvents: StageExitEvent[] = [];
+    emitter.on("stage:exit", (ev) => exitEvents.push(ev));
+
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockResolvedValue({ action: "halt" }),
+    });
+
+    const stages = [
+      makeStage(2, async () => ({
+        outcome: "blocked",
+        message: "stuck",
+      })),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter, prompt }));
+
+    expect(exitEvents).toEqual([{ stageNumber: 2, outcome: "blocked" }]);
+  });
+
+  test("stage:exit emits error outcome", async () => {
+    const emitter = new PipelineEventEmitter();
+    const exitEvents: StageExitEvent[] = [];
+    emitter.on("stage:exit", (ev) => exitEvents.push(ev));
+
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+
+    const stages = [
+      makeStage(1, async () => ({ outcome: "error", message: "boom" })),
+    ];
+
+    await runPipeline(makePipelineOpts({ stages, events: emitter, prompt }));
+
+    expect(exitEvents).toEqual([{ stageNumber: 1, outcome: "error" }]);
   });
 });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -9,6 +9,8 @@
  * modules (issues #6, #7, #8).
  */
 
+import type { PipelineEventEmitter } from "./pipeline-events.js";
+import type { StreamSink } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
 // ---- public types --------------------------------------------------------
@@ -108,6 +110,12 @@ export interface StageContext {
    */
   savedAgentASessionId?: string;
   savedAgentBSessionId?: string;
+  /**
+   * Optional sinks for real-time agent output streaming.  Stage handlers
+   * forward these to `invokeOrResume` / `sendFollowUp` so that output
+   * chunks are emitted as they arrive.
+   */
+  streamSinks?: { a?: StreamSink; b?: StreamSink };
 }
 
 // ---- user interaction interface ------------------------------------------
@@ -238,6 +246,7 @@ export interface PipelineOptions {
     | "onSessionId"
     | "savedAgentASessionId"
     | "savedAgentBSessionId"
+    | "streamSinks"
   >;
   /**
    * When set, stages with a number strictly less than this value are
@@ -271,6 +280,11 @@ export interface PipelineOptions {
    */
   savedAgentASessionId?: string;
   savedAgentBSessionId?: string;
+  /**
+   * Event emitter for the TUI.  When provided, stage lifecycle and
+   * agent-chunk events are emitted so the UI can render in real time.
+   */
+  events?: PipelineEventEmitter;
 }
 
 export interface PipelineResult {
@@ -298,6 +312,7 @@ export async function runPipeline(
     onSessionId,
     savedAgentASessionId,
     savedAgentBSessionId,
+    events,
   } = options;
 
   // Sort stages by number to guarantee order.
@@ -371,6 +386,7 @@ export async function runPipeline(
       resumeLoopCount,
       isResumeStage ? savedAgentASessionId : undefined,
       isResumeStage ? savedAgentBSessionId : undefined,
+      events,
     );
 
     if (result.action === "abort") {
@@ -471,6 +487,7 @@ async function runStage(
     | "onSessionId"
     | "savedAgentASessionId"
     | "savedAgentBSessionId"
+    | "streamSinks"
   >,
   prompt: UserPrompt,
   onStageTransition?: (stageNumber: number, stageLoopCount: number) => void,
@@ -478,6 +495,7 @@ async function runStage(
   resumeLoopCount?: number,
   savedAgentASessionId?: string,
   savedAgentBSessionId?: string,
+  events?: PipelineEventEmitter,
 ): Promise<StageRunResult> {
   const lc = createLoopControl(stage.autoBudget);
 
@@ -492,9 +510,23 @@ async function runStage(
   /** Tracks whether the last iteration was an auto-clarification retry. */
   let clarificationAttempted = false;
 
+  // Build per-agent stream sinks that delegate to the event emitter.
+  const streamSinks = events
+    ? {
+        a: (chunk: string) => events.emit("agent:chunk", { agent: "a", chunk }),
+        b: (chunk: string) => events.emit("agent:chunk", { agent: "b", chunk }),
+      }
+    : undefined;
+
   while (true) {
     // Notify caller before each handler invocation for persistence.
     onStageTransition?.(stage.number, lc.iteration);
+
+    events?.emit("stage:enter", {
+      stageNumber: stage.number,
+      stageName: stage.name,
+      iteration: lc.iteration,
+    });
 
     const ctx: StageContext = {
       ...baseCtx,
@@ -504,6 +536,7 @@ async function runStage(
       onSessionId,
       savedAgentASessionId,
       savedAgentBSessionId,
+      streamSinks,
     };
 
     // Clear one-shot fields after use.
@@ -520,6 +553,11 @@ async function runStage(
       if (dispatched === undefined) continue; // retry
       return dispatched;
     }
+
+    events?.emit("stage:exit", {
+      stageNumber: stage.number,
+      outcome: result.outcome,
+    });
 
     // ---- evaluate outcome ------------------------------------------------
 

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -328,6 +328,43 @@ describe("streaming", () => {
     expect(result.responseText).toBe("data");
   });
 
+  test("iterator and result both receive data simultaneously", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => ({
+        sessionId: undefined,
+        responseText: output,
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    // Consume iterator concurrently with result.
+    const chunks: string[] = [];
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    })();
+
+    emitStdout(child, "part1");
+    emitStdout(child, "part2");
+    endStdout(child);
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    await iteratorDone;
+
+    // Both paths should see all data.
+    expect(chunks.join("")).toBe("part1part2");
+    expect(result.responseText).toBe("part1part2");
+  });
+
   test("exposes child process for cancellation", () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -22,15 +22,28 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
 
+  // Async queue: data listener is the single consumer of the stdout
+  // stream.  It pushes to stdoutChunks (for the result promise) and to
+  // chunkQueue (for the async iterator).  This avoids the conflict
+  // between consuming a readable via both `data` events and
+  // `for await`.
+  const chunkQueue: string[] = [];
+  let chunkResolve: (() => void) | null = null;
+  let streamDone = false;
+
+  stdout?.on("data", (data: Buffer) => {
+    const text = data.toString();
+    stdoutChunks.push(text);
+    chunkQueue.push(text);
+    chunkResolve?.();
+    chunkResolve = null;
+  });
+
+  stderr?.on("data", (data: Buffer) => {
+    stderrChunks.push(data.toString());
+  });
+
   const result = new Promise<AgentResult>((resolve, reject) => {
-    stdout?.on("data", (data: Buffer) => {
-      stdoutChunks.push(data.toString());
-    });
-
-    stderr?.on("data", (data: Buffer) => {
-      stderrChunks.push(data.toString());
-    });
-
     child.on("error", (err) => {
       if ("code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
         resolve({
@@ -46,6 +59,9 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
     });
 
     child.on("close", (code) => {
+      streamDone = true;
+      chunkResolve?.();
+      chunkResolve = null;
       const output = stdoutChunks.join("");
       const stderrText = stderrChunks.join("");
       resolve(opts.parseResult(output, code, stderrText));
@@ -54,11 +70,15 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
 
   const stream: AgentStream = {
     async *[Symbol.asyncIterator]() {
-      if (!stdout) return;
-      for await (const chunk of stdout) {
-        const text =
-          typeof chunk === "string" ? chunk : (chunk as Buffer).toString();
-        yield text;
+      while (true) {
+        while (chunkQueue.length > 0) {
+          const chunk = chunkQueue.shift();
+          if (chunk !== undefined) yield chunk;
+        }
+        if (streamDone) return;
+        await new Promise<void>((r) => {
+          chunkResolve = r;
+        });
       }
     },
     result,

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -182,6 +182,7 @@ export function createCiCheckStageHandler(
         ctx.savedAgentASessionId,
         prompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (fixResult.sessionId) {

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -100,6 +100,7 @@ export function createCreatePrStageHandler(
         ctx.savedAgentASessionId,
         prompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (prResult.sessionId) {
@@ -119,6 +120,7 @@ export function createCreatePrStageHandler(
         prResult.sessionId,
         buildPrCompletionCheckPrompt(),
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (checkResult.status === "error") {
@@ -133,6 +135,7 @@ export function createCreatePrStageHandler(
           checkResult.sessionId,
           buildClarificationPrompt(checkResult.responseText),
           ctx.worktreePath,
+          ctx.streamSinks?.a,
         );
 
         if (retryResult.status === "error") {

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -15,6 +15,12 @@ import type {
   UserPrompt,
 } from "./pipeline.js";
 import { runPipeline } from "./pipeline.js";
+import {
+  type AgentChunkEvent,
+  PipelineEventEmitter,
+  type StageEnterEvent,
+  type StageExitEvent,
+} from "./pipeline-events.js";
 import { createCiCheckStageHandler } from "./stage-cicheck.js";
 import { createCreatePrStageHandler } from "./stage-createpr.js";
 import { createImplementStageHandler } from "./stage-implement.js";
@@ -40,6 +46,27 @@ function makeStream(result: AgentResult): AgentStream {
   return {
     [Symbol.asyncIterator]() {
       return { next: async () => ({ done: true, value: "" }) };
+    },
+    result: Promise.resolve(result),
+    child: {} as AgentStream["child"],
+  };
+}
+
+function makeStreamWithChunks(
+  result: AgentResult,
+  chunks: string[],
+): AgentStream {
+  let idx = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          if (idx < chunks.length) {
+            return { done: false, value: chunks[idx++] };
+          }
+          return { done: true, value: "" };
+        },
+      };
     },
     result: Promise.resolve(result),
     child: {} as AgentStream["child"],
@@ -2187,5 +2214,256 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
     expect(result.success).toBe(false);
     expect(result.stoppedAt).toBe(7);
     expect(agentB.invoke).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline event emitter integration
+// ---------------------------------------------------------------------------
+
+describe("Pipeline event emitter integration", () => {
+  test("emits stage:enter and stage:exit events during pipeline run", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "Done." });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const enterEvents: StageEnterEvent[] = [];
+    const exitEvents: StageExitEvent[] = [];
+    emitter.on("stage:enter", (ev) => enterEvents.push(ev));
+    emitter.on("stage:exit", (ev) => exitEvents.push(ev));
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], events: emitter }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(enterEvents).toEqual([
+      { stageNumber: 2, stageName: "Implement", iteration: 0 },
+    ]);
+    expect(exitEvents).toEqual([{ stageNumber: 2, outcome: "completed" }]);
+  });
+
+  test("emits agent:chunk events when sink is wired through stage handler", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "Done." });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStreamWithChunks(implResult, ["chunk-a1", "chunk-a2"]),
+        ),
+      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const chunkEvents: AgentChunkEvent[] = [];
+    emitter.on("agent:chunk", (ev) => chunkEvents.push(ev));
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], events: emitter }),
+    );
+    // Allow fire-and-forget drain to flush.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(result.success).toBe(true);
+    expect(chunkEvents.length).toBe(2);
+    expect(chunkEvents[0]).toEqual({ agent: "a", chunk: "chunk-a1" });
+    expect(chunkEvents[1]).toEqual({ agent: "a", chunk: "chunk-a2" });
+  });
+
+  test("emits stage events for multi-stage pipeline", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "ok" });
+    const implCheck = makeResult({ responseText: "COMPLETED" });
+    const selfResult = makeResult({ sessionId: "s2", responseText: "ok" });
+    const selfCheck = makeResult({ responseText: "DONE" });
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(implResult))
+        .mockReturnValueOnce(makeStream(selfResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(implCheck))
+        .mockReturnValueOnce(makeStream(selfCheck)),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const enterEvents: StageEnterEvent[] = [];
+    emitter.on("stage:enter", (ev) => enterEvents.push(ev));
+
+    const stages = [
+      createImplementStageHandler({ agent, ...ISSUE_CTX }),
+      createSelfCheckStageHandler({ agent, ...ISSUE_CTX }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, events: emitter }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(enterEvents).toEqual([
+      { stageNumber: 2, stageName: "Implement", iteration: 0 },
+      { stageNumber: 3, stageName: "Self-check", iteration: 0 },
+    ]);
+  });
+
+  test("no events emitted when events option is omitted", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "Done." });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+    };
+
+    // No emitter passed — should not throw.
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+  });
+
+  test("review stage emits chunks for agent B on sink b", async () => {
+    const reviewResult = makeResult({
+      sessionId: "sb1",
+      responseText: "APPROVED",
+    });
+    // Unresolved summary response.
+    const summaryResult = makeResult({ responseText: "NONE" });
+
+    const agentA: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStreamWithChunks(reviewResult, ["review-b1", "review-b2"]),
+        ),
+      resume: vi.fn().mockReturnValue(makeStream(summaryResult)),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const chunkEvents: AgentChunkEvent[] = [];
+    emitter.on("agent:chunk", (ev) => chunkEvents.push(ev));
+
+    const stage = createReviewStageHandler({
+      agentA,
+      agentB,
+      ...ISSUE_CTX,
+    });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], events: emitter }),
+    );
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(result.success).toBe(true);
+    const agentBChunks = chunkEvents.filter((e) => e.agent === "b");
+    expect(agentBChunks.length).toBe(2);
+    expect(agentBChunks[0].chunk).toBe("review-b1");
+  });
+
+  test("emits stage:enter on each iteration when self-check loops", async () => {
+    // Self-check returns FIXED twice (not_approved → loop), then DONE.
+    const implResult = makeResult({ sessionId: "s1", responseText: "ok" });
+    const implCheck = makeResult({ responseText: "COMPLETED" });
+
+    const selfResult1 = makeResult({ sessionId: "s2", responseText: "ok" });
+    const selfCheck1 = makeResult({ responseText: "FIXED" });
+    const selfResult2 = makeResult({ sessionId: "s3", responseText: "ok" });
+    const selfCheck2 = makeResult({ responseText: "FIXED" });
+    const selfResult3 = makeResult({ sessionId: "s4", responseText: "ok" });
+    const selfCheck3 = makeResult({ responseText: "DONE" });
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(implResult))
+        .mockReturnValueOnce(makeStream(selfResult1))
+        .mockReturnValueOnce(makeStream(selfResult2))
+        .mockReturnValueOnce(makeStream(selfResult3)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(implCheck))
+        .mockReturnValueOnce(makeStream(selfCheck1))
+        .mockReturnValueOnce(makeStream(selfCheck2))
+        .mockReturnValueOnce(makeStream(selfCheck3)),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const enterEvents: StageEnterEvent[] = [];
+    const exitEvents: StageExitEvent[] = [];
+    emitter.on("stage:enter", (ev) => enterEvents.push(ev));
+    emitter.on("stage:exit", (ev) => exitEvents.push(ev));
+
+    const stages = [
+      createImplementStageHandler({ agent, ...ISSUE_CTX }),
+      createSelfCheckStageHandler({ agent, ...ISSUE_CTX }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, events: emitter }),
+    );
+
+    expect(result.success).toBe(true);
+
+    // Implement: 1 enter + 1 exit.
+    // Self-check: 3 iterations (0,1,2) → 3 enter + 3 exit.
+    const selfEnterEvents = enterEvents.filter((e) => e.stageNumber === 3);
+    expect(selfEnterEvents).toEqual([
+      { stageNumber: 3, stageName: "Self-check", iteration: 0 },
+      { stageNumber: 3, stageName: "Self-check", iteration: 1 },
+      { stageNumber: 3, stageName: "Self-check", iteration: 2 },
+    ]);
+
+    const selfExitEvents = exitEvents.filter((e) => e.stageNumber === 3);
+    expect(selfExitEvents).toEqual([
+      { stageNumber: 3, outcome: "not_approved" },
+      { stageNumber: 3, outcome: "not_approved" },
+      { stageNumber: 3, outcome: "completed" },
+    ]);
+  });
+
+  test("event ordering: enter-exit pairs interleave correctly across stages", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "ok" });
+    const implCheck = makeResult({ responseText: "COMPLETED" });
+    const selfResult = makeResult({ sessionId: "s2", responseText: "ok" });
+    const selfCheck = makeResult({ responseText: "DONE" });
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(implResult))
+        .mockReturnValueOnce(makeStream(selfResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(implCheck))
+        .mockReturnValueOnce(makeStream(selfCheck)),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const timeline: string[] = [];
+    emitter.on("stage:enter", (ev) => timeline.push(`enter:${ev.stageNumber}`));
+    emitter.on("stage:exit", (ev) =>
+      timeline.push(`exit:${ev.stageNumber}:${ev.outcome}`),
+    );
+
+    const stages = [
+      createImplementStageHandler({ agent, ...ISSUE_CTX }),
+      createSelfCheckStageHandler({ agent, ...ISSUE_CTX }),
+    ];
+    await runPipeline(makePipelineOpts({ stages, events: emitter }));
+
+    expect(timeline).toEqual([
+      "enter:2",
+      "exit:2:completed",
+      "enter:3",
+      "exit:3:completed",
+    ]);
   });
 });

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -80,6 +80,7 @@ export function createImplementStageHandler(
         ctx.savedAgentASessionId,
         prompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (implResult.sessionId) {
@@ -96,6 +97,7 @@ export function createImplementStageHandler(
         implResult.sessionId,
         buildCompletionCheckPrompt(),
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (checkResult.status === "error") {

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -19,7 +19,7 @@
  * `reviewAutoRounds` config value in `index.ts`.
  */
 
-import type { AgentAdapter } from "./agent.js";
+import type { AgentAdapter, AgentResult } from "./agent.js";
 import type { GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
@@ -28,9 +28,11 @@ import {
 import { pollCiAndFix } from "./ci-poll.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  drainToSink,
   invokeOrResume,
   mapAgentError,
   mapResponseToResult,
+  type StreamSink,
   sendFollowUp,
 } from "./stage-util.js";
 import { parseStepStatus } from "./step-parser.js";
@@ -187,6 +189,7 @@ export function createReviewStageHandler(
         ctx.savedAgentBSessionId,
         reviewPrompt,
         ctx.worktreePath,
+        ctx.streamSinks?.b,
       );
 
       if (reviewResult.sessionId) {
@@ -207,6 +210,7 @@ export function createReviewStageHandler(
           reviewResult.sessionId,
           round,
           ctx.worktreePath,
+          ctx.streamSinks?.b,
         );
         if (error) return error;
 
@@ -230,6 +234,7 @@ export function createReviewStageHandler(
         ctx.savedAgentASessionId,
         fixPrompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (fixResult.sessionId) {
@@ -247,6 +252,7 @@ export function createReviewStageHandler(
         fixResult.sessionId,
         buildAuthorCompletionCheckPrompt(),
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (checkResult.status === "error") {
@@ -264,6 +270,7 @@ export function createReviewStageHandler(
           checkResult.sessionId,
           buildAuthorCompletionCheckPrompt(),
           ctx.worktreePath,
+          ctx.streamSinks?.a,
         );
 
         if (retryResult.status === "error") {
@@ -323,6 +330,7 @@ export function createReviewStageHandler(
           reviewResult.sessionId,
           round,
           ctx.worktreePath,
+          ctx.streamSinks?.b,
         );
         if (error) return error;
         if (summary) {
@@ -354,13 +362,25 @@ async function handleUnresolvedSummary(
   sessionId: string | undefined,
   round: number,
   cwd: string,
+  sink?: StreamSink,
 ): Promise<UnresolvedSummaryResult> {
   const summaryPrompt = buildUnresolvedSummaryPrompt(round);
 
   // If we have a session, resume; otherwise invoke fresh.
-  const result = sessionId
-    ? await sendFollowUp(opts.agentB, sessionId, summaryPrompt, cwd)
-    : await opts.agentB.invoke(summaryPrompt, { cwd }).result;
+  let result: AgentResult;
+  if (sessionId) {
+    result = await sendFollowUp(
+      opts.agentB,
+      sessionId,
+      summaryPrompt,
+      cwd,
+      sink,
+    );
+  } else {
+    const stream = opts.agentB.invoke(summaryPrompt, { cwd });
+    if (sink) drainToSink(stream, sink);
+    result = await stream.result;
+  }
 
   if (result.status === "error") {
     return {

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -92,6 +92,7 @@ export function createSelfCheckStageHandler(
         ctx.savedAgentASessionId,
         checkPrompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (checkResult.sessionId) {
@@ -108,6 +109,7 @@ export function createSelfCheckStageHandler(
         checkResult.sessionId,
         buildFixOrDonePrompt(),
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (fixResult.status === "error") {

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -116,6 +116,7 @@ export function createSquashStageHandler(
         ctx.savedAgentASessionId,
         prompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (squashResult.sessionId) {
@@ -133,6 +134,7 @@ export function createSquashStageHandler(
         squashResult.sessionId,
         buildSquashCompletionCheckPrompt(),
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (checkResult.status === "error") {
@@ -147,6 +149,7 @@ export function createSquashStageHandler(
           checkResult.sessionId,
           buildClarificationPrompt(checkResult.responseText),
           ctx.worktreePath,
+          ctx.streamSinks?.a,
         );
 
         if (retryResult.status === "error") {

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -94,6 +94,7 @@ export function createTestPlanStageHandler(
         ctx.savedAgentASessionId,
         verifyPrompt,
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (verifyResult.sessionId) {
@@ -110,6 +111,7 @@ export function createTestPlanStageHandler(
         verifyResult.sessionId,
         buildTestPlanSelfCheckPrompt(),
         ctx.worktreePath,
+        ctx.streamSinks?.a,
       );
 
       if (checkResult.status === "error") {

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -32,6 +32,30 @@ function makeStream(result: AgentResult): AgentStream {
   };
 }
 
+/**
+ * Create a stream that yields the given chunks before resolving.
+ */
+function makeStreamWithChunks(
+  result: AgentResult,
+  chunks: string[],
+): AgentStream {
+  let idx = 0;
+  return {
+    [Symbol.asyncIterator]() {
+      return {
+        next: async () => {
+          if (idx < chunks.length) {
+            return { done: false, value: chunks[idx++] };
+          }
+          return { done: true, value: "" };
+        },
+      };
+    },
+    result: Promise.resolve(result),
+    child: {} as AgentStream["child"],
+  };
+}
+
 // ---- mapAgentError ---------------------------------------------------------
 
 describe("mapAgentError", () => {
@@ -370,5 +394,142 @@ describe("invokeOrResume", () => {
     const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
     expect(out).toBe(execError);
     expect(agent.invoke).not.toHaveBeenCalled();
+  });
+});
+
+// ---- StreamSink integration --------------------------------------------------
+
+describe("invokeOrResume with StreamSink", () => {
+  test("sink receives chunks from invoke when no saved session", async () => {
+    const result = makeResult({ responseText: "chunk1chunk2" });
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStreamWithChunks(result, ["chunk1", "chunk2"])),
+      resume: vi.fn(),
+    };
+
+    const collected: string[] = [];
+    const sink = (chunk: string) => collected.push(chunk);
+
+    const out = await invokeOrResume(agent, undefined, "prompt", "/cwd", sink);
+    // Allow microtask queue to flush for the fire-and-forget drain.
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(out).toBe(result);
+    expect(collected).toEqual(["chunk1", "chunk2"]);
+  });
+
+  test("sink receives chunks from resume", async () => {
+    const result = makeResult({ responseText: "data" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStreamWithChunks(result, ["a", "b", "c"])),
+    };
+
+    const collected: string[] = [];
+    const out = await invokeOrResume(
+      agent,
+      "saved-id",
+      "prompt",
+      "/cwd",
+      (chunk) => collected.push(chunk),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(out).toBe(result);
+    expect(collected).toEqual(["a", "b", "c"]);
+  });
+
+  test("result is correct even without a sink", async () => {
+    const result = makeResult({ responseText: "hello" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStreamWithChunks(result, ["hello"])),
+      resume: vi.fn(),
+    };
+
+    const out = await invokeOrResume(agent, undefined, "prompt", "/cwd");
+    expect(out.responseText).toBe("hello");
+  });
+});
+
+describe("sendFollowUp with StreamSink", () => {
+  test("sink receives chunks during follow-up", async () => {
+    const result = makeResult({ responseText: "follow-up done" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStreamWithChunks(result, ["f1", "f2"])),
+    };
+
+    const collected: string[] = [];
+    const out = await sendFollowUp(agent, "sess-1", "prompt", "/cwd", (chunk) =>
+      collected.push(chunk),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(out.responseText).toBe("follow-up done");
+    expect(collected).toEqual(["f1", "f2"]);
+  });
+
+  test("works without sink (backward compatible)", async () => {
+    const result = makeResult({ responseText: "ok" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(result)),
+    };
+
+    const out = await sendFollowUp(agent, "sess-1", "prompt", "/cwd");
+    expect(out.responseText).toBe("ok");
+  });
+});
+
+// ---- drainToSink edge cases -------------------------------------------------
+
+describe("drainToSink", () => {
+  test("result resolves independently even when sink throws", async () => {
+    const result = makeResult({ responseText: "completed" });
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStreamWithChunks(result, ["c1", "c2"])),
+      resume: vi.fn(),
+    };
+
+    const sink = vi.fn().mockImplementation(() => {
+      throw new Error("sink exploded");
+    });
+
+    // drainToSink runs fire-and-forget, so the error is swallowed
+    // and .result should still resolve.
+    const out = await invokeOrResume(agent, undefined, "prompt", "/cwd", sink);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(out).toBe(result);
+    // sink was called at least once before the error stopped the drain.
+    expect(sink).toHaveBeenCalled();
+  });
+
+  test("sink receives all chunks in order", async () => {
+    const result = makeResult({ responseText: "done" });
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStreamWithChunks(result, ["first", "second", "third"]),
+        ),
+      resume: vi.fn(),
+    };
+
+    const collected: string[] = [];
+    await invokeOrResume(agent, undefined, "prompt", "/cwd", (chunk) =>
+      collected.push(chunk),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(collected).toEqual(["first", "second", "third"]);
   });
 });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -3,9 +3,14 @@
  * step-status-to-outcome conversion.
  */
 
-import type { AgentAdapter, AgentResult } from "./agent.js";
+import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import type { StageOutcome, StageResult } from "./pipeline.js";
 import { type ParsedStep, parseStepStatus } from "./step-parser.js";
+
+/**
+ * Callback that receives streaming output chunks from an agent process.
+ */
+export type StreamSink = (chunk: string) => void;
 
 /**
  * Map an `AgentResult` with `status === "error"` to a `StageResult`.
@@ -60,6 +65,23 @@ export function mapParsedStepToResult(
 }
 
 /**
+ * Drain the async iterator of a stream, forwarding chunks to a sink.
+ * The task runs detached — the returned promise is the stream's
+ * `.result` (which resolves independently of the iterator).
+ */
+export function drainToSink(stream: AgentStream, sink: StreamSink): void {
+  (async () => {
+    try {
+      for await (const chunk of stream) {
+        sink(chunk);
+      }
+    } catch {
+      // Fire-and-forget: sink errors must not become unhandled rejections.
+    }
+  })();
+}
+
+/**
  * Send a follow-up prompt to the agent by resuming the session.
  *
  * Throws if `sessionId` is undefined — a follow-up without session
@@ -71,6 +93,7 @@ export async function sendFollowUp(
   sessionId: string | undefined,
   prompt: string,
   cwd: string,
+  sink?: StreamSink,
 ): Promise<AgentResult> {
   if (sessionId === undefined) {
     throw new Error(
@@ -79,6 +102,7 @@ export async function sendFollowUp(
     );
   }
   const stream = agent.resume(sessionId, prompt, { cwd });
+  if (sink) drainToSink(stream, sink);
   return stream.result;
 }
 
@@ -95,9 +119,12 @@ export async function invokeOrResume(
   savedSessionId: string | undefined,
   prompt: string,
   cwd: string,
+  sink?: StreamSink,
 ): Promise<AgentResult> {
   if (savedSessionId) {
-    const result = await agent.resume(savedSessionId, prompt, { cwd }).result;
+    const stream = agent.resume(savedSessionId, prompt, { cwd });
+    if (sink) drainToSink(stream, sink);
+    const result = await stream.result;
     if (result.status === "success") {
       return result;
     }
@@ -110,7 +137,9 @@ export async function invokeOrResume(
     }
     // Session expired or unknown error — fall back to fresh invoke.
   }
-  return agent.invoke(prompt, { cwd }).result;
+  const stream = agent.invoke(prompt, { cwd });
+  if (sink) drainToSink(stream, sink);
+  return stream.result;
 }
 
 /**

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -1,0 +1,68 @@
+import { Box, type DOMElement, measureElement, Text } from "ink";
+import { useEffect, useRef, useState } from "react";
+import type { PipelineEventEmitter } from "../pipeline-events.js";
+import { useAgentLines } from "./useEventEmitter.js";
+
+interface AgentPaneProps {
+  label: string;
+  agent: "a" | "b";
+  emitter: PipelineEventEmitter;
+  color: string;
+}
+
+export function AgentPane({ label, agent, emitter, color }: AgentPaneProps) {
+  const { lines, pendingLine } = useAgentLines(emitter, agent);
+  const containerRef = useRef<DOMElement>(null);
+  const [visibleRows, setVisibleRows] = useState(20);
+
+  // Measure the content area after each render so we know
+  // exactly how many lines fit without relying on heuristics.
+  useEffect(() => {
+    if (containerRef.current) {
+      const { height } = measureElement(containerRef.current);
+      // Reserve 2 rows for the top/bottom border and 1 for the label.
+      setVisibleRows(height > 3 ? height - 3 : 0);
+    }
+  });
+
+  const allLines = pendingLine ? [...lines, pendingLine] : lines;
+  const visible =
+    visibleRows === 0
+      ? []
+      : allLines.length > visibleRows
+        ? allLines.slice(-visibleRows)
+        : allLines;
+
+  const hasOutput = allLines.length > 0;
+
+  let placeholder: string | undefined;
+  if (visible.length === 0) {
+    placeholder = hasOutput ? "(pane too small)" : "(waiting for output)";
+  }
+
+  return (
+    <Box
+      ref={containerRef}
+      flexDirection="column"
+      flexGrow={1}
+      borderStyle="single"
+      borderColor={color}
+      paddingX={1}
+      overflow="hidden"
+    >
+      <Text bold color={color}>
+        {label}
+      </Text>
+      {placeholder !== undefined ? (
+        <Text dimColor>{placeholder}</Text>
+      ) : (
+        visible.map((line, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: lines are plain strings without stable IDs
+          <Text key={i} wrap="truncate">
+            {line}
+          </Text>
+        ))
+      )}
+    </Box>
+  );
+}

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,0 +1,85 @@
+import { Box } from "ink";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  PipelineOptions,
+  PipelineResult,
+  UserPrompt,
+} from "../pipeline.js";
+import { runPipeline } from "../pipeline.js";
+import type { PipelineEventEmitter } from "../pipeline-events.js";
+import { AgentPane } from "./AgentPane.js";
+import { InputArea, type InputRequest } from "./InputArea.js";
+import { StatusBar } from "./StatusBar.js";
+import { createTuiUserPrompt } from "./TuiUserPrompt.js";
+
+export interface AppProps {
+  emitter: PipelineEventEmitter;
+  pipelineOptions: Omit<PipelineOptions, "prompt" | "events">;
+  onExit: (result: PipelineResult) => void;
+  /** Called once the TUI prompt is ready, so callers can late-bind to it. */
+  onPromptReady?: (prompt: UserPrompt) => void;
+}
+
+export function App({
+  emitter,
+  pipelineOptions,
+  onExit,
+  onPromptReady,
+}: AppProps) {
+  const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
+  const resolveRef = useRef<((value: string) => void) | null>(null);
+
+  // Store props in refs so the mount effect never re-runs.
+  const emitterRef = useRef(emitter);
+  const optsRef = useRef(pipelineOptions);
+  const onExitRef = useRef(onExit);
+  const onPromptReadyRef = useRef(onPromptReady);
+
+  const dispatch = useCallback((request: InputRequest): Promise<string> => {
+    return new Promise<string>((resolve) => {
+      resolveRef.current = resolve;
+      setInputRequest(request);
+    });
+  }, []);
+
+  const handleSubmit = useCallback((value: string) => {
+    resolveRef.current?.(value);
+    resolveRef.current = null;
+    setInputRequest(null);
+  }, []);
+
+  // Run the pipeline once on mount.
+  useEffect(() => {
+    const prompt = createTuiUserPrompt(dispatch);
+    onPromptReadyRef.current?.(prompt);
+
+    runPipeline({
+      ...optsRef.current,
+      prompt,
+      events: emitterRef.current,
+    }).then(
+      (result) => onExitRef.current(result),
+      (err) => {
+        onExitRef.current({
+          success: false,
+          stoppedAt: undefined,
+          message: err instanceof Error ? err.message : String(err),
+        });
+      },
+    );
+  }, [dispatch]);
+
+  return (
+    <Box flexDirection="column" width="100%" height="100%">
+      {/* Top row: two agent panes side by side */}
+      <Box flexDirection="row" flexGrow={1}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+        <AgentPane label="Agent B" agent="b" emitter={emitter} color="green" />
+      </Box>
+
+      {/* Bottom: status bar + input area */}
+      <StatusBar emitter={emitter} />
+      <InputArea request={inputRequest} onSubmit={handleSubmit} />
+    </Box>
+  );
+}

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -1,0 +1,82 @@
+import { Box, Text, useInput } from "ink";
+import TextInput from "ink-text-input";
+import { useState } from "react";
+
+// ---- types -------------------------------------------------------------------
+
+export interface InputRequest {
+  /** Message shown above the input. */
+  message: string;
+  /**
+   * When set, the input area shows selection options instead of a text
+   * field.  The user presses the number key to select.
+   */
+  choices?: { label: string; value: string }[];
+}
+
+export interface InputAreaProps {
+  request: InputRequest | null;
+  onSubmit: (value: string) => void;
+}
+
+// ---- component ---------------------------------------------------------------
+
+export function InputArea({ request, onSubmit }: InputAreaProps) {
+  const [text, setText] = useState("");
+
+  useInput(
+    (input) => {
+      if (!request?.choices) return;
+      const idx = Number.parseInt(input, 10) - 1;
+      if (idx >= 0 && idx < request.choices.length) {
+        onSubmit(request.choices[idx].value);
+      }
+    },
+    { isActive: !!request?.choices },
+  );
+
+  if (!request) {
+    return (
+      <Box paddingX={1}>
+        <Text dimColor>Pipeline running...</Text>
+      </Box>
+    );
+  }
+
+  if (request.choices) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text>{request.message}</Text>
+        {request.choices.map((c, i) => (
+          <Text key={c.value}>
+            {"  "}
+            <Text bold color="cyan">
+              {i + 1}
+            </Text>
+            {" — "}
+            {c.label}
+          </Text>
+        ))}
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text>{request.message}</Text>
+      <Box>
+        <Text bold color="cyan">
+          {">"}{" "}
+        </Text>
+        <TextInput
+          value={text}
+          onChange={setText}
+          onSubmit={(value) => {
+            onSubmit(value);
+            setText("");
+          }}
+        />
+      </Box>
+    </Box>
+  );
+}

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,0 +1,58 @@
+import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
+import type {
+  PipelineEventEmitter,
+  StageEnterEvent,
+  StageExitEvent,
+} from "../pipeline-events.js";
+
+interface StatusBarProps {
+  emitter: PipelineEventEmitter;
+}
+
+export function StatusBar({ emitter }: StatusBarProps) {
+  const [stage, setStage] = useState<StageEnterEvent | null>(null);
+  const [lastOutcome, setLastOutcome] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onEnter = (ev: StageEnterEvent) => {
+      setStage(ev);
+      setLastOutcome(null);
+    };
+    const onExit = (ev: StageExitEvent) => {
+      setLastOutcome(ev.outcome);
+    };
+    emitter.on("stage:enter", onEnter);
+    emitter.on("stage:exit", onExit);
+    return () => {
+      emitter.off("stage:enter", onEnter);
+      emitter.off("stage:exit", onExit);
+    };
+  }, [emitter]);
+
+  const stageText = stage
+    ? `Stage ${stage.stageNumber}: ${stage.stageName}`
+    : "Initialising...";
+
+  const iterText = stage ? `Loop: ${stage.iteration}` : "";
+
+  const outcomeText = lastOutcome ? `Last: ${lastOutcome}` : "";
+
+  return (
+    <Box borderStyle="single" borderColor="gray" paddingX={1}>
+      <Text bold>{stageText}</Text>
+      {iterText && (
+        <Text>
+          {"  |  "}
+          {iterText}
+        </Text>
+      )}
+      {outcomeText && (
+        <Text>
+          {"  |  "}
+          {outcomeText}
+        </Text>
+      )}
+    </Box>
+  );
+}

--- a/src/ui/TuiUserPrompt.test.ts
+++ b/src/ui/TuiUserPrompt.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test, vi } from "vitest";
+import { createTuiUserPrompt, type PromptDispatch } from "./TuiUserPrompt.js";
+
+// ---- helpers -----------------------------------------------------------------
+
+function makeDispatch(...responses: string[]): PromptDispatch {
+  let call = 0;
+  return vi.fn().mockImplementation(async () => {
+    const value = responses[call];
+    call++;
+    return value;
+  });
+}
+
+// ---- tests -------------------------------------------------------------------
+
+describe("TuiUserPrompt", () => {
+  describe("confirmContinueLoop", () => {
+    test("returns true when user selects yes", async () => {
+      const dispatch = makeDispatch("yes");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.confirmContinueLoop("Self-check", 3, "msg");
+      expect(result).toBe(true);
+    });
+
+    test("returns false when user selects no", async () => {
+      const dispatch = makeDispatch("no");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.confirmContinueLoop("Self-check", 3, "msg");
+      expect(result).toBe(false);
+    });
+
+    test("passes stage name and iteration in message", async () => {
+      const dispatch = makeDispatch("yes");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.confirmContinueLoop("Review", 5, "unresolved items");
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("Review"),
+          choices: expect.arrayContaining([
+            expect.objectContaining({ value: "yes" }),
+            expect.objectContaining({ value: "no" }),
+          ]),
+        }),
+      );
+    });
+
+    test("includes the stage message in the prompt", async () => {
+      const dispatch = makeDispatch("yes");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.confirmContinueLoop("Stage", 1, "3 items remain");
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("3 items remain"),
+        }),
+      );
+    });
+  });
+
+  describe("confirmNextStage", () => {
+    test("returns true for yes", async () => {
+      const dispatch = makeDispatch("yes");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmNextStage("CI check")).toBe(true);
+    });
+
+    test("returns false for no", async () => {
+      const dispatch = makeDispatch("no");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmNextStage("CI check")).toBe(false);
+    });
+  });
+
+  describe("handleBlocked", () => {
+    test("returns halt action", async () => {
+      const dispatch = makeDispatch("halt");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.handleBlocked("stuck", true);
+      expect(result).toEqual({ action: "halt" });
+    });
+
+    test("returns proceed action", async () => {
+      const dispatch = makeDispatch("proceed");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.handleBlocked("stuck", true);
+      expect(result).toEqual({ action: "proceed" });
+    });
+
+    test("returns instruct with follow-up instruction", async () => {
+      const dispatch = makeDispatch("instruct", "try another approach");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.handleBlocked("stuck", true);
+      expect(result).toEqual({
+        action: "instruct",
+        instruction: "try another approach",
+      });
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    });
+
+    test("omits proceed choice when allowProceed is false", async () => {
+      const dispatch = makeDispatch("halt");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.handleBlocked("stuck", false);
+      const call = vi.mocked(dispatch).mock.calls[0][0];
+      const values = call.choices?.map((c) => c.value) ?? [];
+      expect(values).not.toContain("proceed");
+      expect(values).toContain("instruct");
+      expect(values).toContain("halt");
+    });
+
+    test("includes proceed choice when allowProceed is true", async () => {
+      const dispatch = makeDispatch("halt");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.handleBlocked("stuck", true);
+      const call = vi.mocked(dispatch).mock.calls[0][0];
+      const values = call.choices?.map((c) => c.value) ?? [];
+      expect(values).toContain("proceed");
+    });
+
+    test("includes BLOCKED prefix in message", async () => {
+      const dispatch = makeDispatch("halt");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.handleBlocked("cannot access repo", true);
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("BLOCKED: cannot access repo"),
+        }),
+      );
+    });
+  });
+
+  describe("handleError", () => {
+    test("returns retry", async () => {
+      const dispatch = makeDispatch("retry");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.handleError("timeout")).toEqual({ action: "retry" });
+    });
+
+    test("returns skip", async () => {
+      const dispatch = makeDispatch("skip");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.handleError("timeout")).toEqual({ action: "skip" });
+    });
+
+    test("returns abort", async () => {
+      const dispatch = makeDispatch("abort");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.handleError("timeout")).toEqual({ action: "abort" });
+    });
+
+    test("includes ERROR prefix in message", async () => {
+      const dispatch = makeDispatch("abort");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.handleError("process crashed");
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining("ERROR: process crashed"),
+        }),
+      );
+    });
+  });
+
+  describe("handleAmbiguous", () => {
+    test("returns proceed", async () => {
+      const dispatch = makeDispatch("proceed");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.handleAmbiguous("unclear response");
+      expect(result).toEqual({ action: "proceed" });
+    });
+
+    test("returns instruct with follow-up", async () => {
+      const dispatch = makeDispatch("instruct", "clarify please");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.handleAmbiguous("unclear");
+      expect(result).toEqual({
+        action: "instruct",
+        instruction: "clarify please",
+      });
+      expect(dispatch).toHaveBeenCalledTimes(2);
+    });
+
+    test("returns halt", async () => {
+      const dispatch = makeDispatch("halt");
+      const prompt = createTuiUserPrompt(dispatch);
+      const result = await prompt.handleAmbiguous("unclear");
+      expect(result).toEqual({ action: "halt" });
+    });
+  });
+
+  describe("confirmMerge", () => {
+    test("returns true for yes", async () => {
+      const dispatch = makeDispatch("yes");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe(true);
+    });
+
+    test("returns false for no", async () => {
+      const dispatch = makeDispatch("no");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe(false);
+    });
+  });
+
+  describe("reportCompletion", () => {
+    test("dispatches message and waits for acknowledgement", async () => {
+      const dispatch = makeDispatch("ok");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.reportCompletion("Pipeline done.");
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Pipeline done.",
+          choices: expect.arrayContaining([
+            expect.objectContaining({ value: "ok" }),
+          ]),
+        }),
+      );
+    });
+  });
+});

--- a/src/ui/TuiUserPrompt.ts
+++ b/src/ui/TuiUserPrompt.ts
@@ -1,0 +1,129 @@
+import type { UserAction, UserPrompt } from "../pipeline.js";
+import type { InputRequest } from "./InputArea.js";
+
+/**
+ * Callback that the TUI uses to show a prompt and later resolve it.
+ * `setRequest` renders the prompt in the InputArea.  The returned
+ * promise resolves when the user submits a response.
+ */
+export type PromptDispatch = (request: InputRequest) => Promise<string>;
+
+/**
+ * `UserPrompt` implementation backed by the ink TUI InputArea.
+ *
+ * Each method builds an `InputRequest`, dispatches it to the UI, and
+ * awaits the user's response.
+ */
+export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
+  return {
+    async confirmContinueLoop(
+      stageName: string,
+      iteration: number,
+      message: string,
+    ): Promise<boolean> {
+      const response = await dispatch({
+        message:
+          `${message}\n\n` +
+          `Stage "${stageName}" has run ${iteration} iteration(s). Continue?`,
+        choices: [
+          { label: "Yes, continue", value: "yes" },
+          { label: "No, stop", value: "no" },
+        ],
+      });
+      return response === "yes";
+    },
+
+    async confirmNextStage(stageName: string): Promise<boolean> {
+      const response = await dispatch({
+        message: `Ready to enter stage "${stageName}". Proceed?`,
+        choices: [
+          { label: "Yes", value: "yes" },
+          { label: "Skip", value: "no" },
+        ],
+      });
+      return response === "yes";
+    },
+
+    async handleBlocked(
+      message: string,
+      allowProceed: boolean,
+    ): Promise<{ action: UserAction; instruction?: string }> {
+      const choices: { label: string; value: string }[] = [];
+      if (allowProceed) {
+        choices.push({ label: "Proceed anyway", value: "proceed" });
+      }
+      choices.push(
+        { label: "Give instruction", value: "instruct" },
+        { label: "Halt", value: "halt" },
+      );
+
+      const action = await dispatch({
+        message: `BLOCKED: ${message}`,
+        choices,
+      });
+
+      if (action === "instruct") {
+        const instruction = await dispatch({
+          message: "Enter your instruction:",
+        });
+        return { action: "instruct", instruction };
+      }
+
+      return { action: action as UserAction };
+    },
+
+    async handleError(
+      message: string,
+    ): Promise<{ action: Extract<UserAction, "retry" | "skip" | "abort"> }> {
+      const action = await dispatch({
+        message: `ERROR: ${message}`,
+        choices: [
+          { label: "Retry", value: "retry" },
+          { label: "Skip", value: "skip" },
+          { label: "Abort", value: "abort" },
+        ],
+      });
+      return { action: action as "retry" | "skip" | "abort" };
+    },
+
+    async handleAmbiguous(
+      message: string,
+    ): Promise<{ action: UserAction; instruction?: string }> {
+      const action = await dispatch({
+        message: `Ambiguous agent response:\n${message}`,
+        choices: [
+          { label: "Proceed", value: "proceed" },
+          { label: "Give instruction", value: "instruct" },
+          { label: "Halt", value: "halt" },
+        ],
+      });
+
+      if (action === "instruct") {
+        const instruction = await dispatch({
+          message: "Enter your instruction:",
+        });
+        return { action: "instruct", instruction };
+      }
+
+      return { action: action as UserAction };
+    },
+
+    async confirmMerge(message: string): Promise<boolean> {
+      const response = await dispatch({
+        message,
+        choices: [
+          { label: "Yes, merged", value: "yes" },
+          { label: "No, keep worktree", value: "no" },
+        ],
+      });
+      return response === "yes";
+    },
+
+    async reportCompletion(message: string): Promise<void> {
+      await dispatch({
+        message,
+        choices: [{ label: "OK", value: "ok" }],
+      });
+    },
+  };
+}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * Component rendering tests for the split-pane TUI.
+ *
+ * Uses ink-testing-library to render ink components in a test
+ * environment and assert on the terminal output frames.
+ */
+import { Box } from "ink";
+import { cleanup, render } from "ink-testing-library";
+import { afterEach, describe, expect, test } from "vitest";
+import { PipelineEventEmitter } from "../pipeline-events.js";
+import { AgentPane } from "./AgentPane.js";
+import { InputArea, type InputRequest } from "./InputArea.js";
+import { StatusBar } from "./StatusBar.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---- AgentPane ---------------------------------------------------------------
+
+describe("AgentPane", () => {
+  test("renders placeholder when no chunks have been emitted", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
+    );
+
+    const frame = lastFrame();
+    expect(frame).toContain("Agent A");
+    expect(frame).toContain("(waiting for output)");
+  });
+
+  test("renders streamed lines after agent:chunk events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
+    );
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "Hello world\n" });
+    // ink renders synchronously after state update.
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("Hello world");
+    expect(lastFrame()).not.toContain("(waiting for output)");
+  });
+
+  test("only shows chunks for the assigned agent", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
+    );
+
+    emitter.emit("agent:chunk", { agent: "b", chunk: "Agent B data\n" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("(waiting for output)");
+    expect(lastFrame()).not.toContain("Agent B data");
+  });
+
+  test("renders unterminated (pending) chunk without waiting for newline", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
+    );
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial token" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("partial token");
+    expect(lastFrame()).not.toContain("(waiting for output)");
+  });
+
+  test("accumulates multiple chunks into lines", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={10}>
+        <AgentPane label="Agent B" agent="b" emitter={emitter} color="green" />
+      </Box>,
+    );
+
+    emitter.emit("agent:chunk", { agent: "b", chunk: "line1\nline2\n" });
+    emitter.emit("agent:chunk", { agent: "b", chunk: "line3\n" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain("line1");
+    expect(frame).toContain("line2");
+    expect(frame).toContain("line3");
+  });
+
+  test("shows newest lines (tail) in a height-constrained container", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={10}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    // Emit 20 lines — only the last few should be visible.
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // The label must remain visible (not pushed off by too many rows).
+    expect(frame).toContain("Agent A");
+    // The newest lines must be visible as a contiguous tail.
+    expect(frame).toContain("line20");
+    expect(frame).toContain("line19");
+    expect(frame).toContain("line18");
+    // The oldest lines must be clipped away.
+    expect(frame).not.toContain("line1\n");
+    expect(frame).not.toContain("line2\n");
+  });
+
+  test("shows 'pane too small' instead of log lines in a tiny pane", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={3}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "line1\nline2\nline3\n" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // No log lines should leak through — there is no content space.
+    expect(frame).not.toContain("line1");
+    expect(frame).not.toContain("line2");
+    expect(frame).not.toContain("line3");
+    // Must not show the waiting placeholder — output exists.
+    expect(frame).not.toContain("waiting for output");
+    expect(frame).toContain("pane too small");
+  });
+});
+
+// ---- StatusBar ---------------------------------------------------------------
+
+describe("StatusBar", () => {
+  test("shows Initialising before any events", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<StatusBar emitter={emitter} />);
+
+    expect(lastFrame()).toContain("Initialising...");
+  });
+
+  test("updates stage display on stage:enter", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<StatusBar emitter={emitter} />);
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain("Stage 2: Implement");
+    expect(frame).toContain("Loop: 0");
+    expect(frame).not.toContain("Initialising");
+  });
+
+  test("shows last outcome after stage:exit", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<StatusBar emitter={emitter} />);
+
+    emitter.emit("stage:enter", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      iteration: 1,
+    });
+    emitter.emit("stage:exit", { stageNumber: 3, outcome: "not_approved" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain("Stage 3: Self-check");
+    expect(frame).toContain("Last: not_approved");
+  });
+
+  test("clears outcome on new stage:enter", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<StatusBar emitter={emitter} />);
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    emitter.emit("stage:exit", { stageNumber: 2, outcome: "completed" });
+    emitter.emit("stage:enter", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain("Stage 3: Self-check");
+    expect(frame).not.toContain("completed");
+  });
+});
+
+// ---- InputArea ---------------------------------------------------------------
+
+describe("InputArea", () => {
+  test("shows 'Pipeline running...' when no request", () => {
+    const { lastFrame } = render(
+      <InputArea request={null} onSubmit={() => {}} />,
+    );
+
+    expect(lastFrame()).toContain("Pipeline running...");
+  });
+
+  test("renders choice options when request has choices", () => {
+    const request: InputRequest = {
+      message: "What do you want to do?",
+      choices: [
+        { label: "Continue", value: "continue" },
+        { label: "Stop", value: "stop" },
+      ],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+
+    const frame = lastFrame();
+    expect(frame).toContain("What do you want to do?");
+    expect(frame).toContain("1");
+    expect(frame).toContain("Continue");
+    expect(frame).toContain("2");
+    expect(frame).toContain("Stop");
+  });
+
+  test("renders text input when request has no choices", () => {
+    const request: InputRequest = {
+      message: "Enter your instruction:",
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+
+    const frame = lastFrame();
+    expect(frame).toContain("Enter your instruction:");
+    expect(frame).toContain(">");
+  });
+
+  test("transitions from idle to active when request appears", async () => {
+    const { lastFrame, rerender } = render(
+      <InputArea request={null} onSubmit={() => {}} />,
+    );
+
+    expect(lastFrame()).toContain("Pipeline running...");
+
+    const request: InputRequest = {
+      message: "Blocked. Choose:",
+      choices: [{ label: "Halt", value: "halt" }],
+    };
+    rerender(<InputArea request={request} onSubmit={() => {}} />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("Blocked. Choose:");
+    expect(lastFrame()).not.toContain("Pipeline running...");
+  });
+});

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the useAgentLines hook logic.  Since React hooks cannot be
+ * invoked outside a component, we test the underlying event-driven
+ * accumulation pattern by simulating what the hook does: subscribe to
+ * PipelineEventEmitter events and accumulate chunks into lines.
+ */
+import { describe, expect, test } from "vitest";
+import { PipelineEventEmitter } from "../pipeline-events.js";
+
+// ---- line accumulation logic (mirrors useAgentLines) -------------------------
+
+/**
+ * Simplified version of the hook's accumulation logic, extracted for
+ * testability without React.
+ */
+function createLineAccumulator(
+  emitter: PipelineEventEmitter,
+  agent: "a" | "b",
+  maxLines = 500,
+) {
+  let buffer = "";
+  let lines: string[] = [];
+
+  const handler = (ev: { agent: "a" | "b"; chunk: string }) => {
+    if (ev.agent !== agent) return;
+    buffer += ev.chunk;
+    const parts = buffer.split("\n");
+    buffer = parts.pop() ?? "";
+    if (parts.length === 0) return;
+    const next = [...lines, ...parts];
+    lines = next.length > maxLines ? next.slice(-maxLines) : next;
+  };
+
+  emitter.on("agent:chunk", handler);
+
+  return {
+    getLines: () => lines,
+    getBuffer: () => buffer,
+    cleanup: () => emitter.off("agent:chunk", handler),
+  };
+}
+
+// ---- tests -------------------------------------------------------------------
+
+describe("line accumulation (useAgentLines logic)", () => {
+  test("splits chunks into lines on newline boundaries", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "line1\nline2\n" });
+
+    expect(acc.getLines()).toEqual(["line1", "line2"]);
+    expect(acc.getBuffer()).toBe("");
+  });
+
+  test("buffers incomplete lines until next newline", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial" });
+    expect(acc.getLines()).toEqual([]);
+    expect(acc.getBuffer()).toBe("partial");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: " data\n" });
+    expect(acc.getLines()).toEqual(["partial data"]);
+  });
+
+  test("accumulates across multiple chunks", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "a\nb\n" });
+    emitter.emit("agent:chunk", { agent: "a", chunk: "c\nd\n" });
+
+    expect(acc.getLines()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test("ignores chunks from other agent", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "b", chunk: "other\n" });
+    emitter.emit("agent:chunk", { agent: "a", chunk: "mine\n" });
+
+    expect(acc.getLines()).toEqual(["mine"]);
+  });
+
+  test("caps at maxLines", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a", 3);
+
+    emitter.emit("agent:chunk", {
+      agent: "a",
+      chunk: "1\n2\n3\n4\n5\n",
+    });
+
+    expect(acc.getLines()).toEqual(["3", "4", "5"]);
+  });
+
+  test("cleanup removes listener", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "before\n" });
+    acc.cleanup();
+    emitter.emit("agent:chunk", { agent: "a", chunk: "after\n" });
+
+    expect(acc.getLines()).toEqual(["before"]);
+  });
+
+  test("handles chunk with only newlines", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "\n\n\n" });
+
+    expect(acc.getLines()).toEqual(["", "", ""]);
+  });
+
+  test("handles empty chunk gracefully", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "" });
+
+    expect(acc.getLines()).toEqual([]);
+  });
+
+  test("pending buffer is available for display (unterminated chunks)", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial token" });
+
+    // No completed lines yet, but buffer holds the partial text.
+    expect(acc.getLines()).toEqual([]);
+    expect(acc.getBuffer()).toBe("partial token");
+  });
+
+  test("pending buffer clears when newline arrives", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "start" });
+    expect(acc.getBuffer()).toBe("start");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: " end\n" });
+    expect(acc.getBuffer()).toBe("");
+    expect(acc.getLines()).toEqual(["start end"]);
+  });
+
+  test("pending buffer survives across multiple partial chunks", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "one " });
+    emitter.emit("agent:chunk", { agent: "a", chunk: "two " });
+    emitter.emit("agent:chunk", { agent: "a", chunk: "three" });
+
+    expect(acc.getLines()).toEqual([]);
+    expect(acc.getBuffer()).toBe("one two three");
+  });
+});
+
+describe("event subscription patterns", () => {
+  test("receives stage:enter events", () => {
+    const emitter = new PipelineEventEmitter();
+    const received: unknown[] = [];
+
+    emitter.on("stage:enter", (ev) => received.push(ev));
+
+    emitter.emit("stage:enter", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      iteration: 1,
+    });
+
+    expect(received).toEqual([
+      { stageNumber: 3, stageName: "Self-check", iteration: 1 },
+    ]);
+  });
+
+  test("receives stage:exit events", () => {
+    const emitter = new PipelineEventEmitter();
+    const received: unknown[] = [];
+
+    emitter.on("stage:exit", (ev) => received.push(ev));
+
+    emitter.emit("stage:exit", { stageNumber: 3, outcome: "completed" });
+
+    expect(received).toEqual([{ stageNumber: 3, outcome: "completed" }]);
+  });
+
+  test("agent:chunk events for different agents are isolated", () => {
+    const emitter = new PipelineEventEmitter();
+    const accA = createLineAccumulator(emitter, "a");
+    const accB = createLineAccumulator(emitter, "b");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "from-a\n" });
+    emitter.emit("agent:chunk", { agent: "b", chunk: "from-b\n" });
+
+    expect(accA.getLines()).toEqual(["from-a"]);
+    expect(accB.getLines()).toEqual(["from-b"]);
+
+    accA.cleanup();
+    accB.cleanup();
+  });
+});

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from "react";
+import type { PipelineEventEmitter } from "../pipeline-events.js";
+
+export interface AgentLinesResult {
+  /** Completed (newline-terminated) lines. */
+  lines: string[];
+  /** Current unterminated fragment, or empty string if none. */
+  pendingLine: string;
+}
+
+/**
+ * Accumulate string chunks emitted on `agent:chunk` for a given agent
+ * into a line buffer.  Returns completed lines (capped at `maxLines`)
+ * and the current unterminated fragment so the UI can display partial
+ * output in real time.
+ */
+export function useAgentLines(
+  emitter: PipelineEventEmitter,
+  agent: "a" | "b",
+  maxLines = 500,
+): AgentLinesResult {
+  const [lines, setLines] = useState<string[]>([]);
+  const [pendingLine, setPendingLine] = useState("");
+  const bufferRef = useRef("");
+
+  useEffect(() => {
+    const handler = (ev: { agent: "a" | "b"; chunk: string }) => {
+      if (ev.agent !== agent) return;
+
+      bufferRef.current += ev.chunk;
+      const parts = bufferRef.current.split("\n");
+      // Last element is the incomplete line (may be empty string).
+      bufferRef.current = parts.pop() ?? "";
+
+      // Always update the pending line so partial output is visible.
+      setPendingLine(bufferRef.current);
+
+      if (parts.length === 0) return;
+
+      setLines((prev) => {
+        const next = [...prev, ...parts];
+        return next.length > maxLines ? next.slice(-maxLines) : next;
+      });
+    };
+
+    emitter.on("agent:chunk", handler);
+    return () => {
+      emitter.off("agent:chunk", handler);
+    };
+  }, [emitter, agent, maxLines]);
+
+  return { lines, pendingLine };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
+    "jsx": "react-jsx",
     "isolatedModules": true,
     "declaration": true,
     "declarationMap": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });


### PR DESCRIPTION
## Summary

- Implement three-pane ink-based terminal UI: Agent A (top-left), Agent B (top-right), Status/Input (bottom) with real-time streaming via `PipelineEventEmitter`
- Add `StreamSink` tee pattern to `invokeOrResume`/`sendFollowUp` so stage handlers forward agent output chunks to the UI without blocking `.result` resolution
- Add `TuiUserPrompt` implementing all 7 `UserPrompt` methods via a dispatch callback rendered in `InputArea`, supporting choice selection and text input modes

## Test plan

- [x] `pnpm vitest run` — 804 tests pass (27 files)
- [x] `pnpm biome ci --error-on-warnings .` — no warnings
- [x] `pnpm tsc --noEmit` — no type errors
- [x] Verify `pipeline.test.ts` event emission tests: stage:enter/exit ordering, streamSinks wiring, multi-iteration events, blocked/error outcomes
- [x] Verify `stage-e2e.test.ts` integration tests: exact event counts, multi-iteration self-check loop, cross-stage enter/exit ordering
- [x] Verify `ui/components.test.tsx` rendering tests: AgentPane chunk display, StatusBar state transitions, InputArea modes
- [x] Verify `stage-util.test.ts` drainToSink error resilience test

Closes #10