### PR TITLE
Switch to streaming output and add inactivity timeout

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,6 +6,7 @@ export type AgentErrorType =
   | "max_turns"
   | "execution_error"
   | "cli_not_found"
+  | "inactivity_timeout"
   | "unknown";
 
 export interface AgentResult {
@@ -42,4 +43,62 @@ export interface AgentAdapter {
 
 export interface InvokeOptions {
   cwd?: string;
+}
+
+/**
+ * Transforms raw stdout chunks into display-friendly text for the UI.
+ *
+ * Adapters provide implementations that parse format-specific output
+ * (e.g. Claude stream-json JSONL, Codex JSONL) and extract human-readable
+ * text.  Raw chunks are still collected separately for `parseResult`.
+ */
+export interface ChunkTransformer {
+  /** Process a raw stdout chunk; return display-friendly text (may be ""). */
+  push(raw: string): string;
+  /** Flush any remaining buffered content at stream end. */
+  flush(): string;
+}
+
+/**
+ * Base class for JSONL-based chunk transformers.  Handles line buffering
+ * and JSON parsing; subclasses implement `extractTextFromEvent` to pick
+ * out the display text for their specific event format.
+ */
+export abstract class JsonlLineTransformer implements ChunkTransformer {
+  private buffer = "";
+
+  push(raw: string): string {
+    this.buffer += raw;
+    const parts = this.buffer.split("\n");
+    this.buffer = parts.pop() ?? "";
+
+    let text = "";
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      try {
+        text += this.extractTextFromEvent(JSON.parse(trimmed));
+      } catch {
+        // Non-JSON line — ignore.
+      }
+    }
+    return text;
+  }
+
+  flush(): string {
+    const trimmed = this.buffer.trim();
+    this.buffer = "";
+    if (!trimmed) return "";
+    try {
+      return this.extractTextFromEvent(JSON.parse(trimmed));
+    } catch {
+      return "";
+    }
+  }
+
+  /**
+   * Given a parsed JSONL event, return the display-friendly text to emit
+   * (or empty string to skip).
+   */
+  protected abstract extractTextFromEvent(event: unknown): string;
 }

--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -1,19 +1,36 @@
 import { describe, expect, test } from "vitest";
-import { buildClaudeArgs, parseClaudeResponse } from "./claude-adapter.js";
+import {
+  buildClaudeArgs,
+  ClaudeStreamTransformer,
+  parseClaudeStreamJson,
+} from "./claude-adapter.js";
 
 // ---------------------------------------------------------------------------
-// parseClaudeResponse
+// parseClaudeStreamJson
 // ---------------------------------------------------------------------------
-describe("parseClaudeResponse", () => {
-  test("parses successful response", () => {
-    const json = JSON.stringify({
-      session_id: "sess-abc-123",
-      result: "Hello, world!",
-      subtype: "success",
-      is_error: false,
-    });
+describe("parseClaudeStreamJson", () => {
+  function streamJsonl(events: object[]): string {
+    return events.map((e) => JSON.stringify(e)).join("\n");
+  }
 
-    expect(parseClaudeResponse(json)).toEqual({
+  test("parses successful stream-json output", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "sess-abc-123" },
+      {
+        type: "assistant",
+        session_id: "sess-abc-123",
+        message: { content: [{ type: "text", text: "Hello, world!" }] },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "sess-abc-123",
+        is_error: false,
+        result: "Hello, world!",
+      },
+    ]);
+
+    expect(parseClaudeStreamJson(jsonl)).toEqual({
       sessionId: "sess-abc-123",
       responseText: "Hello, world!",
       status: "success",
@@ -23,14 +40,18 @@ describe("parseClaudeResponse", () => {
   });
 
   test("parses error_max_turns response", () => {
-    const json = JSON.stringify({
-      session_id: "sess-xyz",
-      result: "Reached maximum number of turns",
-      subtype: "error_max_turns",
-      is_error: true,
-    });
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "sess-xyz" },
+      {
+        type: "result",
+        subtype: "error_max_turns",
+        session_id: "sess-xyz",
+        is_error: true,
+        result: "Reached maximum number of turns",
+      },
+    ]);
 
-    expect(parseClaudeResponse(json)).toEqual({
+    expect(parseClaudeStreamJson(jsonl)).toEqual({
       sessionId: "sess-xyz",
       responseText: "Reached maximum number of turns",
       status: "error",
@@ -40,14 +61,18 @@ describe("parseClaudeResponse", () => {
   });
 
   test("parses error_during_execution response", () => {
-    const json = JSON.stringify({
-      session_id: "sess-err",
-      result: "Command failed",
-      subtype: "error_during_execution",
-      is_error: true,
-    });
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "sess-err" },
+      {
+        type: "result",
+        subtype: "error_during_execution",
+        session_id: "sess-err",
+        is_error: true,
+        result: "Command failed",
+      },
+    ]);
 
-    expect(parseClaudeResponse(json)).toEqual({
+    expect(parseClaudeStreamJson(jsonl)).toEqual({
       sessionId: "sess-err",
       responseText: "Command failed",
       status: "error",
@@ -57,66 +82,366 @@ describe("parseClaudeResponse", () => {
   });
 
   test("maps unknown error subtype to 'unknown'", () => {
-    const json = JSON.stringify({
-      session_id: "sess-unk",
-      result: "Something went wrong",
-      subtype: "error_something_new",
-      is_error: true,
-    });
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "error_something_new",
+        session_id: "sess-unk",
+        is_error: true,
+        result: "Something went wrong",
+      },
+    ]);
 
-    const result = parseClaudeResponse(json);
+    const result = parseClaudeStreamJson(jsonl);
     expect(result.status).toBe("error");
     expect(result.errorType).toBe("unknown");
   });
 
   test("treats empty session_id as undefined", () => {
-    const json = JSON.stringify({
-      session_id: "",
-      result: "response",
-      subtype: "success",
-      is_error: false,
-    });
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "",
+        is_error: false,
+        result: "response",
+      },
+    ]);
 
-    expect(parseClaudeResponse(json).sessionId).toBeUndefined();
+    expect(parseClaudeStreamJson(jsonl).sessionId).toBeUndefined();
   });
 
-  test("treats null result as empty string", () => {
-    const json = JSON.stringify({
-      session_id: "sess-1",
-      result: null,
-      subtype: "success",
-      is_error: false,
-    });
+  test("handles result with error field instead of result field", () => {
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "error",
+        session_id: "sess-1",
+        is_error: true,
+        error: "something failed",
+      },
+    ]);
 
-    expect(parseClaudeResponse(json).responseText).toBe("");
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.responseText).toBe("something failed");
+    expect(result.status).toBe("error");
   });
 
-  test("throws on invalid JSON", () => {
-    expect(() => parseClaudeResponse("not json")).toThrow();
+  test("extracts session_id from system init event", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "from-init" },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "from-result",
+        is_error: false,
+        result: "ok",
+      },
+    ]);
+
+    // result event overrides the init session_id
+    expect(parseClaudeStreamJson(jsonl).sessionId).toBe("from-result");
+  });
+
+  test("uses init session_id when result has none", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "from-init" },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "",
+        is_error: false,
+        result: "ok",
+      },
+    ]);
+
+    expect(parseClaudeStreamJson(jsonl).sessionId).toBe("from-init");
+  });
+
+  test("skips malformed JSON lines gracefully", () => {
+    const jsonl = [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "sess-1",
+      }),
+      "not valid json",
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "sess-1",
+        is_error: false,
+        result: "ok",
+      }),
+    ].join("\n");
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.sessionId).toBe("sess-1");
+    expect(result.responseText).toBe("ok");
+    expect(result.status).toBe("success");
+  });
+
+  test("handles empty input", () => {
+    const result = parseClaudeStreamJson("");
+    expect(result.sessionId).toBeUndefined();
+    expect(result.responseText).toBe("");
+    expect(result.status).toBe("success");
+  });
+
+  test("returns empty responseText when no result event exists", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "sess-no-result" },
+      {
+        type: "assistant",
+        session_id: "sess-no-result",
+        message: { content: [{ type: "text", text: "partial" }] },
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.sessionId).toBe("sess-no-result");
+    expect(result.responseText).toBe("");
+    expect(result.status).toBe("success");
+  });
+
+  test("handles result event with neither result nor error field", () => {
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "sess-empty",
+        is_error: false,
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.responseText).toBe("");
+    expect(result.status).toBe("success");
+  });
+
+  test("ignores assistant and user events for result extraction", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [{ type: "text", text: "turn 1 text" }] },
+      },
+      {
+        type: "user",
+        session_id: "s1",
+        message: { content: [{ type: "tool_result" }] },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "final answer",
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.responseText).toBe("final answer");
   });
 
   test("preserves multiline result text", () => {
-    const json = JSON.stringify({
-      session_id: "sess-ml",
-      result: "line 1\nline 2\nline 3",
-      subtype: "success",
-      is_error: false,
-    });
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "sess-ml",
+        is_error: false,
+        result: "line 1\nline 2\nline 3",
+      },
+    ]);
 
-    expect(parseClaudeResponse(json).responseText).toBe(
+    expect(parseClaudeStreamJson(jsonl).responseText).toBe(
       "line 1\nline 2\nline 3",
     );
   });
 
   test("preserves unicode in result text", () => {
-    const json = JSON.stringify({
-      session_id: "sess-u",
-      result: "한국어 테스트 🎉",
-      subtype: "success",
-      is_error: false,
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "sess-u",
+        is_error: false,
+        result: "한국어 테스트 🎉",
+      },
+    ]);
+
+    expect(parseClaudeStreamJson(jsonl).responseText).toBe("한국어 테스트 🎉");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClaudeStreamTransformer
+// ---------------------------------------------------------------------------
+describe("ClaudeStreamTransformer", () => {
+  test("extracts text from assistant event content blocks", () => {
+    const t = new ClaudeStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [{ type: "text", text: "Hello world" }] },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("Hello world");
+  });
+
+  test("concatenates multiple text blocks in one assistant event", () => {
+    const t = new ClaudeStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [
+            { type: "text", text: "Part 1. " },
+            { type: "tool_use", id: "tool_1", name: "Read" },
+            { type: "text", text: "Part 2." },
+          ],
+        },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("Part 1. Part 2.");
+  });
+
+  test("ignores non-assistant events", () => {
+    const t = new ClaudeStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "s1" }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "ok",
+      }),
+      JSON.stringify({ type: "rate_limit_event", rate_limit_info: {} }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("");
+  });
+
+  test("ignores tool_use content blocks (no text field)", () => {
+    const t = new ClaudeStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "tool_use", id: "t1", name: "Bash" }],
+        },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("");
+  });
+
+  test("buffers incomplete lines across pushes", () => {
+    const t = new ClaudeStreamTransformer();
+    const line = JSON.stringify({
+      type: "assistant",
+      session_id: "s1",
+      message: { content: [{ type: "text", text: "Hi" }] },
     });
 
-    expect(parseClaudeResponse(json).responseText).toBe("한국어 테스트 🎉");
+    // Send first half
+    const half = line.slice(0, 20);
+    expect(t.push(half)).toBe("");
+
+    // Send second half with newline
+    expect(t.push(`${line.slice(20)}\n`)).toBe("Hi");
+  });
+
+  test("flush emits buffered content", () => {
+    const t = new ClaudeStreamTransformer();
+    const line = JSON.stringify({
+      type: "assistant",
+      session_id: "s1",
+      message: { content: [{ type: "text", text: "end" }] },
+    });
+
+    t.push(line); // no trailing newline, stays in buffer
+    expect(t.flush()).toBe("end");
+  });
+
+  test("flush returns empty string when buffer is empty", () => {
+    const t = new ClaudeStreamTransformer();
+    expect(t.flush()).toBe("");
+  });
+
+  test("handles JSON split mid-character across multiple pushes", () => {
+    const t = new ClaudeStreamTransformer();
+    const line = JSON.stringify({
+      type: "assistant",
+      session_id: "s1",
+      message: { content: [{ type: "text", text: "split" }] },
+    });
+
+    const parts = [line.slice(0, 5), line.slice(5, 30), `${line.slice(30)}\n`];
+    expect(t.push(parts[0])).toBe("");
+    expect(t.push(parts[1])).toBe("");
+    expect(t.push(parts[2])).toBe("split");
+  });
+
+  test("handles multiple assistant events in a single push", () => {
+    const t = new ClaudeStreamTransformer();
+    const events = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [{ type: "text", text: "Turn 1" }] },
+      }),
+      JSON.stringify({
+        type: "user",
+        session_id: "s1",
+        message: { content: [] },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [{ type: "text", text: "Turn 2" }] },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(events)).toBe("Turn 1Turn 2");
+  });
+
+  test("handles assistant event with empty content array", () => {
+    const t = new ClaudeStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [] },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("");
+  });
+
+  test("flush handles non-JSON content in buffer", () => {
+    const t = new ClaudeStreamTransformer();
+    t.push("garbage without newline");
+    expect(t.flush()).toBe("");
   });
 });
 
@@ -124,7 +449,7 @@ describe("parseClaudeResponse", () => {
 // buildClaudeArgs
 // ---------------------------------------------------------------------------
 describe("buildClaudeArgs", () => {
-  test("builds basic args with auto permission mode", () => {
+  test("builds basic args with auto permission mode and --verbose", () => {
     const args = buildClaudeArgs("do something", {
       permissionMode: "auto",
     });
@@ -133,10 +458,16 @@ describe("buildClaudeArgs", () => {
       "-p",
       "do something",
       "--output-format",
-      "json",
+      "stream-json",
+      "--verbose",
       "--permission-mode",
       "auto",
     ]);
+  });
+
+  test("always includes --verbose (required by stream-json)", () => {
+    const args = buildClaudeArgs("prompt", { permissionMode: "auto" });
+    expect(args).toContain("--verbose");
   });
 
   test("builds args with bypass permission mode", () => {
@@ -196,7 +527,8 @@ describe("buildClaudeArgs", () => {
       "-p",
       "full prompt",
       "--output-format",
-      "json",
+      "stream-json",
+      "--verbose",
       "--model",
       "sonnet",
       "--permission-mode",

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -4,25 +4,89 @@ import type {
   AgentResult,
   InvokeOptions,
 } from "./agent.js";
+import { JsonlLineTransformer } from "./agent.js";
 import { spawnAgent } from "./spawn-agent.js";
 
-/**
- * Shape of the final JSON object emitted by `claude -p --output-format json`.
- */
-export interface ClaudeJsonResponse {
-  session_id: string;
-  result: string;
-  subtype: string;
-  is_error: boolean;
-}
+// ---------------------------------------------------------------------------
+// stream-json event types
+// ---------------------------------------------------------------------------
 
-export function parseClaudeResponse(json: string): AgentResult {
-  const parsed: ClaudeJsonResponse = JSON.parse(json);
+/**
+ * Subset of JSONL events emitted by
+ * `claude -p --output-format stream-json --verbose` that we consume.
+ *
+ * With `--verbose`, each completed assistant turn emits an `assistant`
+ * event containing the full message content.  The final `result` event
+ * carries the aggregate response text and session metadata.
+ */
+export type ClaudeStreamEvent =
+  | { type: "system"; subtype: "init"; session_id: string }
+  | {
+      type: "assistant";
+      message: {
+        content: { type: string; text?: string }[];
+      };
+      session_id: string;
+    }
+  | {
+      type: "result";
+      subtype: string;
+      session_id: string;
+      is_error: boolean;
+      result?: string;
+      error?: string;
+    }
+  | { type: string };
+
+// ---------------------------------------------------------------------------
+// JSONL parser (full output → AgentResult)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse the full JSONL output from `--output-format stream-json --verbose`.
+ *
+ * We iterate through all lines looking for the `result` event (always
+ * the last meaningful event).  Earlier events may also carry the
+ * session ID (the `system/init` event).
+ */
+export function parseClaudeStreamJson(jsonl: string): AgentResult {
+  const lines = jsonl
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+
+  let sessionId: string | undefined;
+  let resultText = "";
+  let isError = false;
+  let subtype = "";
+
+  for (const line of lines) {
+    let event: ClaudeStreamEvent;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (event.type === "system" && "session_id" in event) {
+      const e = event as Extract<ClaudeStreamEvent, { type: "system" }>;
+      sessionId ??= e.session_id;
+    }
+
+    if (event.type === "result") {
+      const e = event as Extract<ClaudeStreamEvent, { type: "result" }>;
+      sessionId = e.session_id || sessionId;
+      resultText = e.result ?? e.error ?? "";
+      isError = e.is_error;
+      subtype = e.subtype;
+    }
+  }
+
   return {
-    sessionId: parsed.session_id || undefined,
-    responseText: parsed.result ?? "",
-    status: parsed.is_error ? "error" : "success",
-    errorType: parsed.is_error ? claudeErrorType(parsed.subtype) : undefined,
+    sessionId: sessionId || undefined,
+    responseText: resultText,
+    status: isError ? "error" : "success",
+    errorType: isError ? claudeErrorType(subtype) : undefined,
     stderrText: "",
   };
 }
@@ -38,11 +102,45 @@ function claudeErrorType(subtype: string): AgentErrorType {
   }
 }
 
+// ---------------------------------------------------------------------------
+// ChunkTransformer — extract display text from streaming events
+// ---------------------------------------------------------------------------
+
+/**
+ * Transforms raw JSONL chunks into human-readable text for the terminal
+ * UI.  Extracts text from `assistant` events (each completed model turn)
+ * so the UI updates after every turn rather than waiting for the final
+ * `result` event.
+ */
+export class ClaudeStreamTransformer extends JsonlLineTransformer {
+  protected extractTextFromEvent(event: unknown): string {
+    const e = event as Record<string, unknown>;
+    if (e.type !== "assistant") return "";
+    const msg = e.message as Record<string, unknown> | undefined;
+    const content = msg?.content as
+      | { type: string; text?: string }[]
+      | undefined;
+    if (!Array.isArray(content)) return "";
+    let text = "";
+    for (const block of content) {
+      if (block.type === "text" && block.text) {
+        text += block.text;
+      }
+    }
+    return text;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Adapter options + args builder
+// ---------------------------------------------------------------------------
+
 export type ClaudePermissionMode = "auto" | "bypass";
 
 export interface ClaudeAdapterOptions {
   model?: string;
   permissionMode?: ClaudePermissionMode;
+  inactivityTimeoutMs?: number;
 }
 
 export function buildClaudeArgs(
@@ -50,7 +148,8 @@ export function buildClaudeArgs(
   opts: { model?: string; permissionMode: ClaudePermissionMode },
   sessionId?: string,
 ): string[] {
-  const args = ["-p", prompt, "--output-format", "json"];
+  // --verbose is required for --output-format stream-json.
+  const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
   if (opts.model) {
     args.push("--model", opts.model);
   }
@@ -64,6 +163,10 @@ export function buildClaudeArgs(
   }
   return args;
 }
+
+// ---------------------------------------------------------------------------
+// parseResult callback
+// ---------------------------------------------------------------------------
 
 function parseClaudeOutput(
   output: string,
@@ -80,7 +183,18 @@ function parseClaudeOutput(
     };
   }
   try {
-    const result = parseClaudeResponse(output);
+    const result = parseClaudeStreamJson(output);
+    // Non-zero exit overrides a parsed success — partial stream-json
+    // output (e.g. no `result` event) can look successful to the JSONL
+    // parser even though the process actually failed.
+    if (code !== 0 && result.status === "success") {
+      return {
+        ...result,
+        stderrText,
+        status: "error",
+        errorType: "unknown",
+      };
+    }
     return { ...result, stderrText };
   } catch {
     return {
@@ -93,11 +207,16 @@ function parseClaudeOutput(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Adapter factory
+// ---------------------------------------------------------------------------
+
 export function createClaudeAdapter(
   opts: ClaudeAdapterOptions = {},
 ): AgentAdapter {
   const model = opts.model;
   const permissionMode = opts.permissionMode ?? "auto";
+  const inactivityTimeoutMs = opts.inactivityTimeoutMs;
 
   return {
     invoke(prompt, options?: InvokeOptions) {
@@ -106,6 +225,8 @@ export function createClaudeAdapter(
         args: buildClaudeArgs(prompt, { model, permissionMode }),
         cwd: options?.cwd,
         parseResult: parseClaudeOutput,
+        chunkTransformer: new ClaudeStreamTransformer(),
+        inactivityTimeoutMs,
       });
     },
     resume(sessionId, prompt, options?: InvokeOptions) {
@@ -114,6 +235,8 @@ export function createClaudeAdapter(
         args: buildClaudeArgs(prompt, { model, permissionMode }, sessionId),
         cwd: options?.cwd,
         parseResult: parseClaudeOutput,
+        chunkTransformer: new ClaudeStreamTransformer(),
+        inactivityTimeoutMs,
       });
     },
   };

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   buildCodexInvokeArgs,
   buildCodexResumeArgs,
+  CodexStreamTransformer,
   extractCodexResumeResponse,
   extractSessionId,
   parseCodexJsonl,
@@ -114,8 +115,19 @@ describe("parseCodexJsonl", () => {
     expect(result.responseText).toBe("ok");
   });
 
-  test("throws on invalid JSON line", () => {
-    expect(() => parseCodexJsonl("not json")).toThrow();
+  test("skips malformed JSON lines gracefully", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-7" }),
+      "not json",
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "ok" },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.sessionId).toBe("sess-7");
+    expect(result.responseText).toBe("ok");
   });
 
   test("handles missing thread.started (sessionId is undefined)", () => {
@@ -359,7 +371,6 @@ describe("parseCodexPlainText", () => {
   });
 
   test("extracts sessionId from banner even on error exit", () => {
-    // The CLI may print the banner before crashing.
     const text = buildResumeOutput("partial output");
     const result = parseCodexPlainText(text, 1, "");
     expect(result.sessionId).toBe("sess-1");
@@ -499,6 +510,85 @@ describe("extractSessionId", () => {
 });
 
 // ---------------------------------------------------------------------------
+// CodexStreamTransformer
+// ---------------------------------------------------------------------------
+describe("CodexStreamTransformer", () => {
+  test("extracts agent_message text from item.completed events", () => {
+    const t = new CodexStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "Hello" },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("Hello");
+  });
+
+  test("ignores reasoning items", () => {
+    const t = new CodexStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "reasoning", text: "Thinking..." },
+      }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("");
+  });
+
+  test("ignores non-item events", () => {
+    const t = new CodexStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({ type: "thread.started", thread_id: "s1" }),
+      JSON.stringify({ type: "turn.started" }),
+      "",
+    ].join("\n");
+
+    expect(t.push(chunk)).toBe("");
+  });
+
+  test("buffers incomplete lines across pushes", () => {
+    const t = new CodexStreamTransformer();
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: { id: "item_0", type: "agent_message", text: "Buffered" },
+    });
+
+    const half = line.slice(0, 20);
+    expect(t.push(half)).toBe("");
+    expect(t.push(`${line.slice(20)}\n`)).toBe("Buffered");
+  });
+
+  test("flush emits buffered content", () => {
+    const t = new CodexStreamTransformer();
+    const line = JSON.stringify({
+      type: "item.completed",
+      item: { id: "item_0", type: "agent_message", text: "end" },
+    });
+
+    t.push(line); // no trailing newline
+    expect(t.flush()).toBe("end");
+  });
+
+  test("flush returns empty string when buffer is empty", () => {
+    const t = new CodexStreamTransformer();
+    expect(t.flush()).toBe("");
+  });
+
+  test("flush handles non-JSON content in buffer", () => {
+    const t = new CodexStreamTransformer();
+    t.push("garbage without newline");
+    expect(t.flush()).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildCodexInvokeArgs
 // ---------------------------------------------------------------------------
 describe("buildCodexInvokeArgs", () => {
@@ -566,6 +656,11 @@ describe("buildCodexResumeArgs", () => {
     expect(args).toContain("sandbox_mode=danger-full-access");
   });
 
+  test("does not include --json (resume outputs plain text)", () => {
+    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+    expect(args).not.toContain("--json");
+  });
+
   test("includes -c model override when model is specified", () => {
     const args = buildCodexResumeArgs("sess-abc", "continue", {
       model: "gpt-5.3-codex",
@@ -594,11 +689,6 @@ describe("buildCodexResumeArgs", () => {
     // Both should come after all -c flags
     const lastCIdx = args.lastIndexOf("-c");
     expect(sessIdx).toBeGreaterThan(lastCIdx + 1);
-  });
-
-  test("does not include --json (resume outputs plain text)", () => {
-    const args = buildCodexResumeArgs("sess-abc", "continue", {});
-    expect(args).not.toContain("--json");
   });
 
   test("does not include -s flag (uses -c for sandbox instead)", () => {

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -4,6 +4,7 @@ import type {
   AgentResult,
   InvokeOptions,
 } from "./agent.js";
+import { JsonlLineTransformer } from "./agent.js";
 import { spawnAgent } from "./spawn-agent.js";
 
 // ---------------------------------------------------------------------------
@@ -65,7 +66,12 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
   let failMessage = "";
 
   for (const line of lines) {
-    const event: CodexJsonEvent = JSON.parse(line);
+    let event: CodexJsonEvent;
+    try {
+      event = JSON.parse(line);
+    } catch {
+      continue;
+    }
 
     if (event.type === "thread.started") {
       const e = event as ThreadStartedEvent;
@@ -108,7 +114,7 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
 }
 
 // ---------------------------------------------------------------------------
-// Plain text parser (codex exec resume)
+// Plain text parser (codex exec resume — does not support --json)
 // ---------------------------------------------------------------------------
 
 /**
@@ -205,6 +211,29 @@ export function parseCodexPlainText(
   };
 }
 
+// ---------------------------------------------------------------------------
+// ChunkTransformer — extract display text from Codex JSONL events
+// ---------------------------------------------------------------------------
+
+/**
+ * Transforms raw Codex JSONL chunks into human-readable text for the
+ * terminal UI.  Extracts `agent_message` text from `item.completed`
+ * events.
+ */
+export class CodexStreamTransformer extends JsonlLineTransformer {
+  protected extractTextFromEvent(event: unknown): string {
+    const e = event as Record<string, unknown>;
+    if (e.type !== "item.completed") return "";
+    const item = e.item as Record<string, unknown> | undefined;
+    if (item?.type !== "agent_message") return "";
+    return (item.text as string) ?? "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Error detection
+// ---------------------------------------------------------------------------
+
 function detectCodexError(text: string): AgentErrorType {
   const lower = text.toLowerCase();
   if (lower.includes("max turns") || lower.includes("turn limit")) {
@@ -228,6 +257,7 @@ export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high";
 export interface CodexAdapterOptions {
   model?: string;
   reasoningEffort?: CodexReasoningEffort;
+  inactivityTimeoutMs?: number;
 }
 
 export function buildCodexInvokeArgs(
@@ -250,6 +280,7 @@ export function buildCodexResumeArgs(
   prompt: string,
   opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
 ): string[] {
+  // Note: `codex exec resume` does not support --json; output is plain text.
   const args = ["exec", "resume", "-c", "sandbox_mode=danger-full-access"];
   if (opts.model) {
     args.push("-c", `model="${opts.model}"`);
@@ -301,6 +332,7 @@ export function createCodexAdapter(
 ): AgentAdapter {
   const model = opts.model;
   const reasoningEffort = opts.reasoningEffort ?? "high";
+  const inactivityTimeoutMs = opts.inactivityTimeoutMs;
 
   return {
     invoke(prompt, options?: InvokeOptions) {
@@ -309,9 +341,12 @@ export function createCodexAdapter(
         args: buildCodexInvokeArgs(prompt, { model, reasoningEffort }),
         cwd: options?.cwd,
         parseResult: parseCodexInvokeOutput,
+        chunkTransformer: new CodexStreamTransformer(),
+        inactivityTimeoutMs,
       });
     },
     resume(sessionId, prompt, options?: InvokeOptions) {
+      // codex exec resume outputs plain text, not JSONL.
       return spawnAgent({
         command: "codex",
         args: buildCodexResumeArgs(sessionId, prompt, {
@@ -328,6 +363,9 @@ export function createCodexAdapter(
           }
           return result;
         },
+        // No chunkTransformer for resume — plain text is already
+        // human-readable and can go directly to the UI.
+        inactivityTimeoutMs,
       });
     },
   };

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -40,7 +40,7 @@ describe("loadConfig", () => {
       pipelineSettings: {
         selfCheckAutoIterations: 3,
         reviewAutoRounds: 3,
-        inactivityTimeoutMinutes: 15,
+        inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
     });
@@ -57,7 +57,7 @@ describe("loadConfig", () => {
       pipelineSettings: {
         selfCheckAutoIterations: 3,
         reviewAutoRounds: 3,
-        inactivityTimeoutMinutes: 15,
+        inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
     });
@@ -87,7 +87,7 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
-      inactivityTimeoutMinutes: 15,
+      inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
   });
@@ -265,7 +265,7 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
-      inactivityTimeoutMinutes: 15,
+      inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
   });
@@ -279,7 +279,7 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
-      inactivityTimeoutMinutes: 15,
+      inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
   });
@@ -310,8 +310,115 @@ describe("loadConfig", () => {
     const config = loadConfig();
     expect(config.pipelineSettings.selfCheckAutoIterations).toBe(10);
     expect(config.pipelineSettings.reviewAutoRounds).toBe(3);
-    expect(config.pipelineSettings.inactivityTimeoutMinutes).toBe(15);
+    expect(config.pipelineSettings.inactivityTimeoutMinutes).toBe(20);
     expect(config.pipelineSettings.autoResumeAttempts).toBe(5);
+  });
+
+  test("zero values fall back to defaults (must be positive)", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: 0,
+          reviewAutoRounds: 0,
+          inactivityTimeoutMinutes: 0,
+          autoResumeAttempts: 0,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 20,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("very large values are accepted", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: 999999,
+          reviewAutoRounds: 100,
+          inactivityTimeoutMinutes: 1440,
+          autoResumeAttempts: 50,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings.selfCheckAutoIterations).toBe(999999);
+    expect(config.pipelineSettings.inactivityTimeoutMinutes).toBe(1440);
+  });
+
+  test("float values fall back to defaults (must be integer)", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: 3.5,
+          reviewAutoRounds: 2.1,
+          inactivityTimeoutMinutes: 20.5,
+          autoResumeAttempts: 1.9,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 20,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("string number values fall back to defaults (type check)", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: "3",
+          reviewAutoRounds: "3",
+          inactivityTimeoutMinutes: "20",
+          autoResumeAttempts: "3",
+        },
+      }),
+    );
+    const config = loadConfig();
+    // Strings are not valid — all should fall back.
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 20,
+      autoResumeAttempts: 3,
+    });
+  });
+
+  test("boolean values fall back to defaults", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        pipelineSettings: {
+          selfCheckAutoIterations: true,
+          reviewAutoRounds: false,
+          inactivityTimeoutMinutes: true,
+          autoResumeAttempts: false,
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.pipelineSettings).toEqual({
+      selfCheckAutoIterations: 3,
+      reviewAutoRounds: 3,
+      inactivityTimeoutMinutes: 20,
+      autoResumeAttempts: 3,
+    });
   });
 
   test("pipelineSettings null falls back to defaults", () => {
@@ -323,7 +430,7 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
-      inactivityTimeoutMinutes: 15,
+      inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
   });
@@ -337,7 +444,7 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
-      inactivityTimeoutMinutes: 15,
+      inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
   });
@@ -351,7 +458,7 @@ describe("saveConfig", () => {
   const defaultPS = {
     selfCheckAutoIterations: 3,
     reviewAutoRounds: 3,
-    inactivityTimeoutMinutes: 15,
+    inactivityTimeoutMinutes: 20,
     autoResumeAttempts: 3,
   };
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export interface PipelineSettings {
 export const DEFAULT_PIPELINE_SETTINGS: PipelineSettings = {
   selfCheckAutoIterations: 3,
   reviewAutoRounds: 3,
-  inactivityTimeoutMinutes: 15,
+  inactivityTimeoutMinutes: 20,
   autoResumeAttempts: 3,
 };
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -181,7 +181,7 @@ describe("module exports", () => {
     expect(config.DEFAULT_PIPELINE_SETTINGS).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
-      inactivityTimeoutMinutes: 15,
+      inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,11 +65,19 @@ const CLAUDE_MODELS = new Set(["opus", "sonnet"]);
 function createAdapter(
   agentConfig: AgentConfig,
   permissionMode: "auto" | "bypass",
+  inactivityTimeoutMs?: number,
 ): AgentAdapter {
   if (CLAUDE_MODELS.has(agentConfig.model)) {
-    return createClaudeAdapter({ model: agentConfig.model, permissionMode });
+    return createClaudeAdapter({
+      model: agentConfig.model,
+      permissionMode,
+      inactivityTimeoutMs,
+    });
   }
-  return createCodexAdapter({ model: agentConfig.model });
+  return createCodexAdapter({
+    model: agentConfig.model,
+    inactivityTimeoutMs,
+  });
 }
 
 function cliForModel(model: string): string {
@@ -250,8 +258,18 @@ try {
   }
 
   // Create agent adapters.
-  const agentA = createAdapter(agentAConfig, claudePermissionMode);
-  const agentB = createAdapter(agentBConfig, claudePermissionMode);
+  const inactivityTimeoutMs =
+    pipelineSettings.inactivityTimeoutMinutes * 60_000;
+  const agentA = createAdapter(
+    agentAConfig,
+    claudePermissionMode,
+    inactivityTimeoutMs,
+  );
+  const agentB = createAdapter(
+    agentBConfig,
+    claudePermissionMode,
+    inactivityTimeoutMs,
+  );
 
   const issueCtx = { issueTitle, issueBody };
 

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -387,9 +387,277 @@ describe("streaming", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ChunkTransformer
+// ---------------------------------------------------------------------------
+describe("chunkTransformer", () => {
+  test("iterator yields transformed chunks instead of raw", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => ({
+        sessionId: undefined,
+        responseText: output,
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      chunkTransformer: {
+        push: (raw) => raw.toUpperCase(),
+        flush: () => "",
+      },
+    });
+
+    const chunks: string[] = [];
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    })();
+
+    emitStdout(child, "hello");
+    emitStdout(child, "world");
+    child.emit("close", 0);
+    await iteratorDone;
+
+    expect(chunks.join("")).toBe("HELLOWORLD");
+  });
+
+  test("raw chunks still collected for parseResult", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    let capturedOutput = "";
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => {
+        capturedOutput = output;
+        return {
+          sessionId: undefined,
+          responseText: output,
+          status: "success",
+          errorType: undefined,
+          stderrText: "",
+        };
+      },
+      chunkTransformer: {
+        push: (raw) => `[${raw}]`,
+        flush: () => "",
+      },
+    });
+
+    emitStdout(child, "raw data");
+    child.emit("close", 0);
+    await stream.result;
+
+    // parseResult receives unmodified raw output
+    expect(capturedOutput).toBe("raw data");
+  });
+
+  test("empty transformer output is not yielded", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      chunkTransformer: {
+        push: () => "",
+        flush: () => "",
+      },
+    });
+
+    const chunks: string[] = [];
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    })();
+
+    emitStdout(child, "data");
+    child.emit("close", 0);
+    await iteratorDone;
+
+    expect(chunks).toEqual([]);
+  });
+
+  test("flush output is yielded at stream end", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      chunkTransformer: {
+        push: () => "",
+        flush: () => "flushed!",
+      },
+    });
+
+    const chunks: string[] = [];
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    })();
+
+    emitStdout(child, "data");
+    child.emit("close", 0);
+    await iteratorDone;
+
+    expect(chunks).toEqual(["flushed!"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Inactivity timeout
+// ---------------------------------------------------------------------------
+describe("inactivityTimeoutMs", () => {
+  test("kills process after silence exceeds timeout", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => ({
+        sessionId: "sess-1",
+        responseText: output,
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      inactivityTimeoutMs: 5000,
+    });
+
+    // No output for 5 seconds — should kill.
+    vi.advanceTimersByTime(5000);
+    expect(child.kill).toHaveBeenCalled();
+
+    // Simulate process exit after kill.
+    child.emit("close", null);
+    const result = await stream.result;
+
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("inactivity_timeout");
+    vi.useRealTimers();
+  });
+
+  test("resets timer on stdout data", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      inactivityTimeoutMs: 5000,
+    });
+
+    // Emit data at 4 seconds — resets the timer.
+    vi.advanceTimersByTime(4000);
+    emitStdout(child, "still alive");
+
+    // Another 4 seconds — still within timeout from last data.
+    vi.advanceTimersByTime(4000);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    // 1 more second — now 5s since last data, should kill.
+    vi.advanceTimersByTime(1000);
+    expect(child.kill).toHaveBeenCalled();
+
+    child.emit("close", null);
+    vi.useRealTimers();
+  });
+
+  test("does not kill when timeout is disabled (0)", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      inactivityTimeoutMs: 0,
+    });
+
+    vi.advanceTimersByTime(60_000);
+    expect(child.kill).not.toHaveBeenCalled();
+
+    child.emit("close", 0);
+    vi.useRealTimers();
+  });
+
+  test("preserves parsed sessionId on timeout", async () => {
+    vi.useFakeTimers();
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: "sess-timeout",
+        responseText: "partial",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      inactivityTimeoutMs: 1000,
+    });
+
+    emitStdout(child, "some output");
+    vi.advanceTimersByTime(1000);
+    child.emit("close", null);
+
+    const result = await stream.result;
+    expect(result.sessionId).toBe("sess-timeout");
+    expect(result.errorType).toBe("inactivity_timeout");
+
+    vi.useRealTimers();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // E2E: Claude adapter full flow
 // ---------------------------------------------------------------------------
 describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
+  function streamJsonl(events: object[]): string {
+    return events.map((e) => JSON.stringify(e)).join("\n");
+  }
+
   test("invoke sends correct args and returns parsed result", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
@@ -403,17 +671,29 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
 
     expect(mockSpawn).toHaveBeenCalledWith(
       "claude",
-      expect.arrayContaining(["-p", "write tests", "--model", "opus"]),
+      expect.arrayContaining([
+        "-p",
+        "write tests",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+        "--model",
+        "opus",
+      ]),
       expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
     );
 
-    const responseJson = JSON.stringify({
-      session_id: "sess-new",
-      result: "Done!",
-      subtype: "success",
-      is_error: false,
-    });
-    emitStdout(child, responseJson);
+    const output = streamJsonl([
+      { type: "system", subtype: "init", session_id: "sess-new" },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "sess-new",
+        is_error: false,
+        result: "Done!",
+      },
+    ]);
+    emitStdout(child, output);
     child.emit("close", 0);
 
     const result = await stream.result;
@@ -455,22 +735,6 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
     );
   });
 
-  test("handles non-JSON output gracefully", async () => {
-    const child = createMockChild();
-    mockSpawn.mockReturnValue(child);
-
-    const adapter = createClaudeAdapter();
-    const stream = adapter.invoke("prompt");
-
-    emitStdout(child, "not valid json at all");
-    child.emit("close", 0);
-
-    const result = await stream.result;
-    expect(result.status).toBe("error");
-    expect(result.errorType).toBe("unknown");
-    expect(result.responseText).toBe("not valid json at all");
-  });
-
   test("handles empty output with non-zero exit", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
@@ -497,6 +761,79 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
 
     const result = await stream.result;
     expect(result.stderrText).toBe("Error: invalid session");
+  });
+
+  test("streams assistant event text through transformer", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter();
+    const stream = adapter.invoke("prompt");
+
+    const chunks: string[] = [];
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+    })();
+
+    // Emit events as a single blob (simulating real CLI output).
+    const events = [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "s1",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [{ type: "text", text: "Hello world" }] },
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "Hello world",
+      }),
+    ];
+
+    emitStdout(child, `${events.join("\n")}\n`);
+    child.emit("close", 0);
+    await iteratorDone;
+
+    // Transformer should extract text from assistant events.
+    const text = chunks.join("");
+    expect(text).toBe("Hello world");
+  });
+
+  test("non-zero exit with partial stream-json is classified as error", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter();
+    const stream = adapter.invoke("prompt");
+
+    // Emit partial JSONL without a result event, then crash.
+    const partial = [
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: "sess-partial",
+      }),
+      JSON.stringify({
+        type: "assistant",
+        session_id: "sess-partial",
+        message: { content: [{ type: "text", text: "partial" }] },
+      }),
+    ].join("\n");
+    emitStdout(child, partial);
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    // Must be error despite partial output parsing as "success" in JSONL.
+    expect(result.status).toBe("error");
+    expect(result.sessionId).toBe("sess-partial");
   });
 });
 
@@ -597,7 +934,7 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(spawnArgs).toContain("model_reasoning_effort=medium");
   });
 
-  test("resume uses plain text parsing with -c config overrides", async () => {
+  test("resume uses plain text parsing without --json flag", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
@@ -670,34 +1007,6 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(result.sessionId).toBe("sess-err");
   });
 
-  test("resume prefers parsed sessionId over input when banner has one", async () => {
-    const child = createMockChild();
-    mockSpawn.mockReturnValue(child);
-
-    const adapter = createCodexAdapter();
-    // Pass "old-sess" as input, but the CLI output contains "new-sess".
-    const stream = adapter.resume("old-sess", "keep going");
-
-    const resumeOutput = [
-      "OpenAI Codex v0.46.0 (research preview)",
-      "--------",
-      "session id: new-sess",
-      "--------",
-      "user",
-      "keep going",
-      "codex",
-      "Done.",
-      "tokens used",
-      "50",
-    ].join("\n");
-
-    emitStdout(child, resumeOutput);
-    child.emit("close", 0);
-
-    const result = await stream.result;
-    expect(result.sessionId).toBe("new-sess");
-  });
-
   test("invoke with cwd passes working directory", () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
@@ -747,8 +1056,9 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     child.emit("close", 0);
 
     const result = await stream.result;
+    // Invalid JSONL lines are skipped; result has empty responseText.
     expect(result.status).toBe("success");
-    expect(result.responseText).toBe("not json");
+    expect(result.responseText).toBe("");
   });
 
   test("invoke handles invalid JSONL output with non-zero exit", async () => {
@@ -762,9 +1072,9 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     child.emit("close", 1);
 
     const result = await stream.result;
+    // Invalid JSONL skipped; non-zero exit triggers error status.
     expect(result.status).toBe("error");
     expect(result.errorType).toBe("unknown");
-    expect(result.responseText).toBe("garbage output");
   });
 
   test("captures stderr in result for diagnostics", async () => {

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import type { AgentResult, AgentStream } from "./agent.js";
+import type { AgentResult, AgentStream, ChunkTransformer } from "./agent.js";
 
 export interface SpawnAgentOptions {
   command: string;
@@ -10,6 +10,17 @@ export interface SpawnAgentOptions {
     exitCode: number | null,
     stderrText: string,
   ) => AgentResult;
+  /**
+   * When provided, the async iterator yields transformed (display-friendly)
+   * text instead of raw stdout chunks.  Raw chunks are still collected for
+   * `parseResult`.
+   */
+  chunkTransformer?: ChunkTransformer;
+  /**
+   * Kill the child process if stdout is silent for this many milliseconds.
+   * Omit or pass 0 to disable.
+   */
+  inactivityTimeoutMs?: number;
 }
 
 export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
@@ -21,6 +32,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
   const { stdout, stderr } = child;
   const stdoutChunks: string[] = [];
   const stderrChunks: string[] = [];
+  const transformer = opts.chunkTransformer;
 
   // Async queue: data listener is the single consumer of the stdout
   // stream.  It pushes to stdoutChunks (for the result promise) and to
@@ -31,12 +43,41 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
   let chunkResolve: (() => void) | null = null;
   let streamDone = false;
 
+  // Inactivity timeout state.
+  let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+  let timedOut = false;
+
+  function resetInactivityTimer(): void {
+    if (!opts.inactivityTimeoutMs) return;
+    if (inactivityTimer) clearTimeout(inactivityTimer);
+    inactivityTimer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, opts.inactivityTimeoutMs);
+  }
+
+  // Start the timer immediately so silence from the very beginning is
+  // caught.
+  resetInactivityTimer();
+
   stdout?.on("data", (data: Buffer) => {
     const text = data.toString();
     stdoutChunks.push(text);
-    chunkQueue.push(text);
-    chunkResolve?.();
-    chunkResolve = null;
+
+    resetInactivityTimer();
+
+    if (transformer) {
+      const transformed = transformer.push(text);
+      if (transformed) {
+        chunkQueue.push(transformed);
+        chunkResolve?.();
+        chunkResolve = null;
+      }
+    } else {
+      chunkQueue.push(text);
+      chunkResolve?.();
+      chunkResolve = null;
+    }
   });
 
   stderr?.on("data", (data: Buffer) => {
@@ -45,6 +86,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
 
   const result = new Promise<AgentResult>((resolve, reject) => {
     child.on("error", (err) => {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
       if ("code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
         resolve({
           sessionId: undefined,
@@ -59,12 +101,30 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
     });
 
     child.on("close", (code) => {
+      if (inactivityTimer) clearTimeout(inactivityTimer);
+
+      // Flush transformer at stream end.
+      if (transformer) {
+        const flushed = transformer.flush();
+        if (flushed) chunkQueue.push(flushed);
+      }
+
       streamDone = true;
       chunkResolve?.();
       chunkResolve = null;
       const output = stdoutChunks.join("");
       const stderrText = stderrChunks.join("");
-      resolve(opts.parseResult(output, code, stderrText));
+      const parsed = opts.parseResult(output, code, stderrText);
+
+      if (timedOut) {
+        resolve({
+          ...parsed,
+          status: "error",
+          errorType: "inactivity_timeout",
+        });
+      } else {
+        resolve(parsed);
+      }
     });
   });
 

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -2467,3 +2467,212 @@ describe("Pipeline event emitter integration", () => {
     ]);
   });
 });
+
+// ---- Streaming: agent:chunk events during stage execution --------------------
+
+describe("agent:chunk events emitted during stage execution", () => {
+  test("implement stage emits agent:chunk events for both invoke and follow-up", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "impl" });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStreamWithChunks(implResult, ["impl-c1", "impl-c2"]),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStreamWithChunks(checkResult, ["check-c1", "check-c2"]),
+        ),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const agentChunks: AgentChunkEvent[] = [];
+    emitter.on("agent:chunk", (ev) => agentChunks.push({ ...ev }));
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    await runPipeline(makePipelineOpts({ stages: [stage], events: emitter }));
+
+    // Allow fire-and-forget drainToSink to flush.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // All chunks should be tagged as agent "a".
+    expect(agentChunks.length).toBeGreaterThanOrEqual(2);
+    for (const ev of agentChunks) {
+      expect(ev.agent).toBe("a");
+    }
+    // Verify content includes chunks from both invoke and resume.
+    const allText = agentChunks.map((e) => e.chunk).join("");
+    expect(allText).toContain("impl-c1");
+    expect(allText).toContain("check-c1");
+  });
+
+  test("review stage emits chunks for both agent A and agent B", async () => {
+    // Agent B reviews, Agent A fixes, Agent A self-checks.
+    const reviewResult = makeResult({
+      sessionId: "sb1",
+      responseText: "APPROVED",
+    });
+    const agentA: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStreamWithChunks(reviewResult, ["review-chunk"])),
+      resume: vi.fn(),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const seenAgents = new Set<string>();
+    emitter.on("agent:chunk", (ev) => seenAgents.add(ev.agent));
+
+    const stage = createReviewStageHandler({
+      agentA,
+      agentB,
+      ...ISSUE_CTX,
+    });
+    await runPipeline(makePipelineOpts({ stages: [stage], events: emitter }));
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    // At minimum, agent B chunks should appear (reviewer).
+    expect(seenAgents.has("b")).toBe(true);
+  });
+
+  test("stage:enter fires before agent:chunk, stage:exit fires after", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "ok" });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStreamWithChunks(implResult, ["c1"])),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStreamWithChunks(checkResult, ["c2"])),
+    };
+
+    const emitter = new PipelineEventEmitter();
+    const timeline: string[] = [];
+    emitter.on("stage:enter", (ev) => timeline.push(`enter:${ev.stageNumber}`));
+    emitter.on("agent:chunk", () => timeline.push("chunk"));
+    emitter.on("stage:exit", (ev) => timeline.push(`exit:${ev.stageNumber}`));
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    await runPipeline(makePipelineOpts({ stages: [stage], events: emitter }));
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Enter must come before any chunk, exit must come after handler returns.
+    const enterIdx = timeline.indexOf("enter:2");
+    const firstChunkIdx = timeline.indexOf("chunk");
+    const exitIdx = timeline.indexOf("exit:2");
+
+    expect(enterIdx).toBeLessThan(firstChunkIdx);
+    expect(firstChunkIdx).toBeLessThan(exitIdx);
+  });
+});
+
+// ---- Inactivity timeout → auto-resume through pipeline ----------------------
+
+describe("Inactivity timeout auto-resume through pipeline", () => {
+  test("implement stage auto-resumes on timeout and completes", async () => {
+    // First invoke: returns successfully (implementation phase).
+    // First resume (completion check): times out.
+    // Auto-resume: succeeds with COMPLETED.
+    const implResult = makeResult({ sessionId: "s1", responseText: "Done." });
+    const timeoutResult = makeResult({
+      sessionId: "s1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const completedResult = makeResult({ responseText: "COMPLETED" });
+
+    let resumeCount = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCount++;
+        if (resumeCount === 1) {
+          // First resume = completion check → timeout.
+          return makeStream(timeoutResult);
+        }
+        // Second resume = auto-resume after timeout → success.
+        return makeStream(completedResult);
+      }),
+    };
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+
+    expect(result.success).toBe(true);
+    // invoke(1) + resume for completion check(1) + auto-resume(1) = 2 resumes
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("timeout exhausts retries → pipeline error → user aborts", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "Done." });
+    const timeoutResult = makeResult({
+      sessionId: "s1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+    };
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValue({ action: "abort" }),
+    });
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.stoppedAt).toBe(2);
+    // Error handler should have been called once.
+    expect(prompt.handleError).toHaveBeenCalledOnce();
+    const errorMsg = (prompt.handleError as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(errorMsg).toContain("inactivity");
+  });
+
+  test("timeout exhausts retries → user retries → succeeds", async () => {
+    const implResult = makeResult({ sessionId: "s1", responseText: "Done." });
+    const timeoutResult = makeResult({
+      sessionId: "s1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const completedResult = makeResult({ responseText: "COMPLETED" });
+
+    let totalResumes = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi.fn().mockImplementation(() => {
+        totalResumes++;
+        // First 4 resumes time out (completion check + 3 auto-retries).
+        // After user retries the stage, the 5th resume succeeds.
+        if (totalResumes <= 4) {
+          return makeStream(timeoutResult);
+        }
+        return makeStream(completedResult);
+      }),
+    };
+    const prompt = makePrompt({
+      handleError: vi.fn().mockResolvedValueOnce({ action: "retry" }),
+    });
+
+    const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
+
+    expect(result.success).toBe(true);
+    // invoke was called twice (first attempt + retry after user approval).
+    expect(agent.invoke).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -533,3 +533,396 @@ describe("drainToSink", () => {
     expect(collected).toEqual(["first", "second", "third"]);
   });
 });
+
+// ---- inactivity auto-resume -------------------------------------------------
+
+describe("invokeOrResume inactivity auto-resume", () => {
+  test("auto-resumes on inactivity timeout up to max attempts", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-timeout",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const successResult = makeResult({
+      sessionId: "sess-timeout",
+      responseText: "finally done",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(timeoutResult))
+        .mockReturnValueOnce(makeStream(successResult)),
+    };
+
+    const out = await invokeOrResume(
+      agent,
+      undefined,
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    // invoke was called once, then 2 resumes (first timeout, second success).
+    expect(agent.invoke).toHaveBeenCalledOnce();
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(out.responseText).toBe("finally done");
+    expect(out.status).toBe("success");
+  });
+
+  test("returns timeout error when all auto-resume attempts exhausted", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-stuck",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+      resume: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+    };
+
+    const out = await invokeOrResume(
+      agent,
+      undefined,
+      "prompt",
+      "/cwd",
+      undefined,
+      2,
+    );
+
+    // invoke once + 2 resume retries = 2 resume calls.
+    expect(agent.invoke).toHaveBeenCalledOnce();
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(out.errorType).toBe("inactivity_timeout");
+  });
+
+  test("does not auto-resume when sessionId is missing", async () => {
+    const timeoutResult = makeResult({
+      sessionId: undefined,
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+      resume: vi.fn(),
+    };
+
+    const out = await invokeOrResume(
+      agent,
+      undefined,
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    expect(agent.resume).not.toHaveBeenCalled();
+    expect(out.errorType).toBe("inactivity_timeout");
+  });
+});
+
+describe("sendFollowUp inactivity auto-resume", () => {
+  test("auto-resumes on inactivity timeout", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const successResult = makeResult({
+      sessionId: "sess-1",
+      responseText: "resumed ok",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(timeoutResult))
+        .mockReturnValueOnce(makeStream(successResult)),
+    };
+
+    const out = await sendFollowUp(
+      agent,
+      "sess-1",
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    // First resume (original call) + 1 retry resume.
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(out.responseText).toBe("resumed ok");
+  });
+
+  test("returns timeout error after exhausting retries", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+    };
+
+    const out = await sendFollowUp(
+      agent,
+      "sess-1",
+      "prompt",
+      "/cwd",
+      undefined,
+      1,
+    );
+
+    // Original call + 1 retry = 2 total.
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(out.errorType).toBe("inactivity_timeout");
+  });
+});
+
+describe("invokeOrResume: timeout does not fall through to fresh invoke", () => {
+  test("returns timeout error without invoking fresh when resume times out", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-saved",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+    };
+
+    // With maxAutoResumes=0 to isolate the fallthrough behavior.
+    const out = await invokeOrResume(
+      agent,
+      "sess-saved",
+      "prompt",
+      "/cwd",
+      undefined,
+      0,
+    );
+
+    // Should NOT fall through to invoke — must return the timeout error.
+    expect(agent.invoke).not.toHaveBeenCalled();
+    expect(out.errorType).toBe("inactivity_timeout");
+    expect(out.sessionId).toBe("sess-saved");
+  });
+
+  test("auto-resumes timeout from resumed session without losing state", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-saved",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const successResult = makeResult({
+      sessionId: "sess-saved",
+      responseText: "recovered",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(timeoutResult))
+        .mockReturnValueOnce(makeStream(successResult)),
+    };
+
+    const out = await invokeOrResume(
+      agent,
+      "sess-saved",
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    // Should resume twice (original + retry), never invoke fresh.
+    expect(agent.invoke).not.toHaveBeenCalled();
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(out.responseText).toBe("recovered");
+  });
+});
+
+describe("invokeOrResume inactivity auto-resume edge cases", () => {
+  test("stops retrying when resume returns non-timeout error", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const execError = makeResult({
+      sessionId: "sess-1",
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "segfault",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(timeoutResult)),
+      resume: vi.fn().mockReturnValue(makeStream(execError)),
+    };
+
+    const out = await invokeOrResume(
+      agent,
+      undefined,
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    // Should stop after first resume returns execution_error.
+    expect(agent.resume).toHaveBeenCalledOnce();
+    expect(out.errorType).toBe("execution_error");
+  });
+
+  test("uses sessionId from retry result for next retry", async () => {
+    const timeout1 = makeResult({
+      sessionId: "sess-v1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const timeout2 = makeResult({
+      sessionId: "sess-v2",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const success = makeResult({
+      sessionId: "sess-v2",
+      responseText: "done",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(timeout1)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(timeout2))
+        .mockReturnValueOnce(makeStream(success)),
+    };
+
+    const out = await invokeOrResume(
+      agent,
+      undefined,
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    expect(out.responseText).toBe("done");
+    // Second resume should use "sess-v2" (from timeout2), not "sess-v1".
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    const secondResumeArgs = (agent.resume as ReturnType<typeof vi.fn>).mock
+      .calls[1];
+    expect(secondResumeArgs[0]).toBe("sess-v2");
+  });
+});
+
+describe("sendFollowUp inactivity auto-resume edge cases", () => {
+  test("uses fallback sessionId when retry result has no sessionId", async () => {
+    const timeoutResult = makeResult({
+      sessionId: undefined,
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const successResult = makeResult({
+      sessionId: "sess-orig",
+      responseText: "resumed",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(timeoutResult))
+        .mockReturnValueOnce(makeStream(successResult)),
+    };
+
+    const out = await sendFollowUp(
+      agent,
+      "sess-orig",
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    expect(out.responseText).toBe("resumed");
+    // Retry should use original sessionId "sess-orig" as fallback.
+    const retryCall = (agent.resume as ReturnType<typeof vi.fn>).mock.calls[1];
+    expect(retryCall[0]).toBe("sess-orig");
+  });
+
+  test("stops retrying on non-timeout error during retry", async () => {
+    const timeoutResult = makeResult({
+      sessionId: "sess-1",
+      status: "error",
+      errorType: "inactivity_timeout",
+    });
+    const cliNotFound = makeResult({
+      sessionId: undefined,
+      status: "error",
+      errorType: "cli_not_found",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(timeoutResult))
+        .mockReturnValueOnce(makeStream(cliNotFound)),
+    };
+
+    const out = await sendFollowUp(
+      agent,
+      "sess-1",
+      "prompt",
+      "/cwd",
+      undefined,
+      3,
+    );
+
+    // Should stop after cli_not_found, not retry further.
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(out.errorType).toBe("cli_not_found");
+  });
+});
+
+// ---- mapAgentError for inactivity_timeout -----------------------------------
+
+describe("mapAgentError inactivity_timeout", () => {
+  test("maps inactivity_timeout to descriptive message", () => {
+    const result = mapAgentError({
+      sessionId: undefined,
+      responseText: "",
+      status: "error",
+      errorType: "inactivity_timeout",
+      stderrText: "",
+    });
+    expect(result.outcome).toBe("error");
+    expect(result.message).toBe("Agent process timed out due to inactivity.");
+  });
+
+  test("includes context with inactivity_timeout", () => {
+    const result = mapAgentError(
+      {
+        sessionId: undefined,
+        responseText: "",
+        status: "error",
+        errorType: "inactivity_timeout",
+        stderrText: "",
+      },
+      "during implementation",
+    );
+    expect(result.message).toBe(
+      "Agent process timed out due to inactivity during implementation.",
+    );
+  });
+});

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -1,6 +1,6 @@
 /**
- * Shared utilities for stage handlers — agent error mapping and
- * step-status-to-outcome conversion.
+ * Shared utilities for stage handlers — agent error mapping,
+ * step-status-to-outcome conversion, and inactivity auto-resume.
  */
 
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
@@ -26,6 +26,12 @@ export function mapAgentError(
     return {
       outcome: "error",
       message: `Agent hit the maximum turn limit${during}.`,
+    };
+  }
+  if (result.errorType === "inactivity_timeout") {
+    return {
+      outcome: "error",
+      message: `Agent process timed out due to inactivity${during}.`,
     };
   }
   const detail = result.stderrText || result.errorType || "unknown";
@@ -81,40 +87,70 @@ export function drainToSink(stream: AgentStream, sink: StreamSink): void {
   })();
 }
 
+// ---------------------------------------------------------------------------
+// Inactivity auto-resume
+// ---------------------------------------------------------------------------
+
+const DEFAULT_RESUME_PROMPT = "Continue where you left off.";
+
 /**
- * Send a follow-up prompt to the agent by resuming the session.
- *
- * Throws if `sessionId` is undefined — a follow-up without session
- * context would produce an ungrounded response because the agent has
- * never seen the preceding conversation.
+ * Retry an agent call on inactivity timeout.  Resumes the session with
+ * a generic "continue" prompt up to `maxRetries` times, using
+ * `fallbackSessionId` when the result lacks one.
  */
-export async function sendFollowUp(
+async function retryOnTimeout(
   agent: AgentAdapter,
-  sessionId: string | undefined,
-  prompt: string,
+  initial: AgentResult,
   cwd: string,
-  sink?: StreamSink,
+  fallbackSessionId: string | undefined,
+  sink: StreamSink | undefined,
+  maxRetries: number,
 ): Promise<AgentResult> {
-  if (sessionId === undefined) {
-    throw new Error(
-      "Cannot send follow-up: no session ID from the previous turn. " +
-        "The agent CLI may have failed to return a session.",
-    );
+  let result = initial;
+  let left = maxRetries;
+
+  while (result.errorType === "inactivity_timeout" && left > 0) {
+    const sid = result.sessionId ?? fallbackSessionId;
+    if (!sid) break;
+    left--;
+    const stream = agent.resume(sid, DEFAULT_RESUME_PROMPT, { cwd });
+    if (sink) drainToSink(stream, sink);
+    result = await stream.result;
   }
-  const stream = agent.resume(sessionId, prompt, { cwd });
-  if (sink) drainToSink(stream, sink);
-  return stream.result;
+
+  return result;
 }
 
 /**
- * Invoke an agent, or resume an existing session if a saved session ID
- * is available.  Used on pipeline resume so stage handlers can continue
- * from a prior conversation.
+ * Invoke-or-resume with automatic retry on inactivity timeout.
  *
- * If `resume()` fails (e.g. expired session), falls back to a fresh
- * `invoke()` automatically.
+ * When the agent process is killed due to stdout inactivity, this
+ * function automatically resumes the session (up to `maxAutoResumes`
+ * times).  After that, the timeout error is returned to the caller so
+ * the pipeline can prompt the user.
  */
 export async function invokeOrResume(
+  agent: AgentAdapter,
+  savedSessionId: string | undefined,
+  prompt: string,
+  cwd: string,
+  sink?: StreamSink,
+  maxAutoResumes = 3,
+): Promise<AgentResult> {
+  const result = await invokeOrResumeOnce(
+    agent,
+    savedSessionId,
+    prompt,
+    cwd,
+    sink,
+  );
+  return retryOnTimeout(agent, result, cwd, undefined, sink, maxAutoResumes);
+}
+
+/**
+ * Single-shot invoke-or-resume (no auto-retry).
+ */
+async function invokeOrResumeOnce(
   agent: AgentAdapter,
   savedSessionId: string | undefined,
   prompt: string,
@@ -128,10 +164,13 @@ export async function invokeOrResume(
     if (result.status === "success") {
       return result;
     }
-    // Non-recoverable errors should be surfaced, not retried.
+    // Non-recoverable errors and inactivity timeouts should be surfaced
+    // immediately — the caller's retryOnTimeout handles timeout retries.
+    // Falling through to fresh invoke would lose the session state.
     if (
       result.errorType === "cli_not_found" ||
-      result.errorType === "execution_error"
+      result.errorType === "execution_error" ||
+      result.errorType === "inactivity_timeout"
     ) {
       return result;
     }
@@ -140,6 +179,34 @@ export async function invokeOrResume(
   const stream = agent.invoke(prompt, { cwd });
   if (sink) drainToSink(stream, sink);
   return stream.result;
+}
+
+/**
+ * Send a follow-up prompt to the agent by resuming the session, with
+ * automatic retry on inactivity timeout.
+ *
+ * Throws if `sessionId` is undefined — a follow-up without session
+ * context would produce an ungrounded response because the agent has
+ * never seen the preceding conversation.
+ */
+export async function sendFollowUp(
+  agent: AgentAdapter,
+  sessionId: string | undefined,
+  prompt: string,
+  cwd: string,
+  sink?: StreamSink,
+  maxAutoResumes = 3,
+): Promise<AgentResult> {
+  if (sessionId === undefined) {
+    throw new Error(
+      "Cannot send follow-up: no session ID from the previous turn. " +
+        "The agent CLI may have failed to return a session.",
+    );
+  }
+  const stream = agent.resume(sessionId, prompt, { cwd });
+  if (sink) drainToSink(stream, sink);
+  const result = await stream.result;
+  return retryOnTimeout(agent, result, cwd, sessionId, sink, maxAutoResumes);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Switch Claude adapter from `--output-format json` to `stream-json --verbose` for real-time JSONL streaming; extract text from `assistant` events per completed model turn
- Codex adapter: add `CodexStreamTransformer` for invoke (`--json`); keep plain text parsing for resume (`codex exec resume` does not support `--json`)
- Add stdout inactivity timeout to `spawnAgent` that kills hung agent processes after configurable silence period (default 20 minutes)
- Add auto-resume on inactivity timeout in `stage-util`: retries up to 3 times with "Continue where you left off" before surfacing the error to the user

## Test plan

- [x] All 861 tests pass (`pnpm test`)
- [x] TypeScript type check passes (`tsc`)
- [x] Biome lint/format passes (`pnpm run check`)
- [x] CI passes
- [x] Manual verification: `claude -p --output-format stream-json --verbose` outputs expected JSONL events (`system/init`, `assistant`, `result`)
- [x] Manual verification: `codex exec resume --help` confirms no `--json` flag — plain text parsing is correct
- [x] Manual verification: inactivity timeout kills hung process after configured silence period (tested with 2s timeout, process killed at 2043ms)

Closes #16