### PR TITLE
Detect config parsing errors in Codex adapter

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,6 +6,7 @@ export type AgentErrorType =
   | "max_turns"
   | "execution_error"
   | "cli_not_found"
+  | "config_parsing"
   | "inactivity_timeout"
   | "unknown";
 

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -3,10 +3,12 @@ import {
   buildCodexInvokeArgs,
   buildCodexResumeArgs,
   CodexStreamTransformer,
+  detectCodexError,
   extractCodexResumeResponse,
   extractSessionId,
   parseCodexJsonl,
   parseCodexPlainText,
+  validateCodexReasoningEffort,
 } from "./codex-adapter.js";
 
 // ---------------------------------------------------------------------------
@@ -85,6 +87,24 @@ describe("parseCodexJsonl", () => {
     expect(result.status).toBe("error");
     expect(result.responseText).toBe("unexpected status 400");
     expect(result.sessionId).toBe("sess-fail");
+  });
+
+  test("detects turn.failed with config parsing message as config_parsing error", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-cfg" }),
+      JSON.stringify({
+        type: "turn.failed",
+        error: {
+          message:
+            "unknown variant `xhigh`, expected one of `minimal`, `low`, `medium`, `high`",
+        },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("config_parsing");
+    expect(result.sessionId).toBe("sess-cfg");
   });
 
   test("handles JSONL with only thread.started (no items)", () => {
@@ -320,6 +340,24 @@ describe("parseCodexPlainText", () => {
   test("detects 'execution error' keyword", () => {
     const result = parseCodexPlainText("An execution error occurred", 1, "");
     expect(result.errorType).toBe("execution_error");
+  });
+
+  test("detects 'unknown variant' as config_parsing error", () => {
+    const result = parseCodexPlainText(
+      "",
+      1,
+      "Error: unknown variant `xhigh`, expected one of `minimal`, `low`, `medium`, `high`\nin `model_reasoning_effort`",
+    );
+    expect(result.errorType).toBe("config_parsing");
+  });
+
+  test("detects 'invalid value' as config_parsing error", () => {
+    const result = parseCodexPlainText(
+      "",
+      1,
+      "Error: invalid value for model_reasoning_effort",
+    );
+    expect(result.errorType).toBe("config_parsing");
   });
 
   test("keyword detection is case-insensitive", () => {
@@ -715,5 +753,87 @@ describe("buildCodexResumeArgs", () => {
     const args = buildCodexResumeArgs("sess-1", "prompt", {});
     const reArgs = args.filter((a) => a.includes("model_reasoning_effort"));
     expect(reArgs).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectCodexError — error classification
+// ---------------------------------------------------------------------------
+describe("detectCodexError", () => {
+  test("returns max_turns for 'max turns' text", () => {
+    expect(detectCodexError("Error: max turns reached")).toBe("max_turns");
+  });
+
+  test("returns max_turns for 'turn limit' text", () => {
+    expect(detectCodexError("Stopped: turn limit exceeded")).toBe("max_turns");
+  });
+
+  test("returns execution_error for 'error during execution'", () => {
+    expect(detectCodexError("error during execution of command")).toBe(
+      "execution_error",
+    );
+  });
+
+  test("returns execution_error for 'execution error'", () => {
+    expect(detectCodexError("An execution error occurred")).toBe(
+      "execution_error",
+    );
+  });
+
+  test("returns config_parsing for 'unknown variant'", () => {
+    expect(
+      detectCodexError(
+        "Error: unknown variant `xhigh`, expected one of `minimal`, `low`, `medium`, `high`",
+      ),
+    ).toBe("config_parsing");
+  });
+
+  test("returns config_parsing for 'invalid value'", () => {
+    expect(
+      detectCodexError("Error: invalid value for model_reasoning_effort"),
+    ).toBe("config_parsing");
+  });
+
+  test("is case-insensitive for config_parsing patterns", () => {
+    expect(detectCodexError("Unknown Variant `foo`")).toBe("config_parsing");
+    expect(detectCodexError("INVALID VALUE in config")).toBe("config_parsing");
+  });
+
+  test("returns unknown for unrecognized errors", () => {
+    expect(detectCodexError("something went wrong")).toBe("unknown");
+  });
+
+  test("is case-insensitive for all patterns", () => {
+    expect(detectCodexError("MAX TURNS reached")).toBe("max_turns");
+    expect(detectCodexError("Error During Execution")).toBe("execution_error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCodexReasoningEffort — runtime validation
+// ---------------------------------------------------------------------------
+describe("validateCodexReasoningEffort", () => {
+  test.each([
+    "minimal",
+    "low",
+    "medium",
+    "high",
+  ] as const)("accepts valid value: %s", (value) => {
+    expect(validateCodexReasoningEffort(value)).toBe(value);
+  });
+
+  test("rejects unsupported value with descriptive error", () => {
+    expect(() => validateCodexReasoningEffort("xhigh")).toThrow(
+      /Unsupported Codex reasoning effort "xhigh"/,
+    );
+  });
+
+  test("error message lists supported values", () => {
+    expect(() => validateCodexReasoningEffort("none")).toThrow(/minimal/);
+    expect(() => validateCodexReasoningEffort("none")).toThrow(/high/);
+  });
+
+  test("rejects empty string", () => {
+    expect(() => validateCodexReasoningEffort("")).toThrow(/Unsupported/);
   });
 });

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -234,7 +234,7 @@ export class CodexStreamTransformer extends JsonlLineTransformer {
 // Error detection
 // ---------------------------------------------------------------------------
 
-function detectCodexError(text: string): AgentErrorType {
+export function detectCodexError(text: string): AgentErrorType {
   const lower = text.toLowerCase();
   if (lower.includes("max turns") || lower.includes("turn limit")) {
     return "max_turns";
@@ -245,6 +245,9 @@ function detectCodexError(text: string): AgentErrorType {
   ) {
     return "execution_error";
   }
+  if (lower.includes("unknown variant") || lower.includes("invalid value")) {
+    return "config_parsing";
+  }
   return "unknown";
 }
 
@@ -252,7 +255,29 @@ function detectCodexError(text: string): AgentErrorType {
 // CLI args builders
 // ---------------------------------------------------------------------------
 
-export type CodexReasoningEffort = "minimal" | "low" | "medium" | "high";
+const CODEX_REASONING_EFFORTS = ["minimal", "low", "medium", "high"] as const;
+
+export type CodexReasoningEffort = (typeof CODEX_REASONING_EFFORTS)[number];
+
+const VALID_CODEX_REASONING_EFFORTS: ReadonlySet<string> = new Set(
+  CODEX_REASONING_EFFORTS,
+);
+
+/**
+ * Validate that `value` is a supported Codex reasoning effort level.
+ * Throws with a descriptive message when the value is unsupported.
+ */
+export function validateCodexReasoningEffort(
+  value: string,
+): CodexReasoningEffort {
+  if (VALID_CODEX_REASONING_EFFORTS.has(value)) {
+    return value as CodexReasoningEffort;
+  }
+  const supported = [...VALID_CODEX_REASONING_EFFORTS].join(", ");
+  throw new Error(
+    `Unsupported Codex reasoning effort "${value}". Supported values: ${supported}`,
+  );
+}
 
 export interface CodexAdapterOptions {
   model?: string;
@@ -331,7 +356,9 @@ export function createCodexAdapter(
   opts: CodexAdapterOptions = {},
 ): AgentAdapter {
   const model = opts.model;
-  const reasoningEffort = opts.reasoningEffort ?? "high";
+  const reasoningEffort = validateCodexReasoningEffort(
+    opts.reasoningEffort ?? "high",
+  );
   const inactivityTimeoutMs = opts.inactivityTimeoutMs;
 
   return {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -174,6 +174,9 @@ export const en: Messages = {
     `Agent hit the maximum turn limit${context}.`,
   "stageError.inactivityTimeout": (context) =>
     `Agent process timed out due to inactivity${context}.`,
+  "stageError.configParsing": (context, detail) =>
+    `Agent CLI rejected its configuration${context}. ` +
+    `Check ~/.codex/config.toml for unsupported values: ${detail}`,
   "stageError.agentError": (context, detail) =>
     `Agent error${context}: ${detail}`,
 

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -81,6 +81,7 @@ describe("catalogs are complete", () => {
       "statusBar.last": ["ok"],
       "stageError.maxTurns": [" (stage 1)"],
       "stageError.inactivityTimeout": [" (stage 2)"],
+      "stageError.configParsing": [" (stage 8)", "unknown variant"],
       "stageError.agentError": [" (stage 3)", "timeout"],
       "ci.pendingTimeout": [30],
       "ci.stillFailing": [3],

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -203,6 +203,9 @@ export const ko: Messages = {
     `\uC5D0\uC774\uC804\uD2B8\uAC00 \uCD5C\uB300 \uD134 \uC218\uC5D0 \uB3C4\uB2EC\uD588\uC2B5\uB2C8\uB2E4${context}.`,
   "stageError.inactivityTimeout": (context) =>
     `\uBE44\uD65C\uC131\uC73C\uB85C \uC778\uD574 \uC5D0\uC774\uC804\uD2B8 \uD504\uB85C\uC138\uC2A4\uAC00 \uC2DC\uAC04 \uCD08\uACFC\uB418\uC5C8\uC2B5\uB2C8\uB2E4${context}.`,
+  "stageError.configParsing": (context, detail) =>
+    `\uC5D0\uC774\uC804\uD2B8 CLI\uAC00 \uC124\uC815\uC744 \uAC70\uBD80\uD588\uC2B5\uB2C8\uB2E4${context}. ` +
+    `~/.codex/config.toml\uC5D0\uC11C \uC9C0\uC6D0\uB418\uC9C0 \uC54A\uB294 \uAC12\uC744 \uD655\uC778\uD558\uC138\uC694: ${detail}`,
   "stageError.agentError": (context, detail) =>
     `\uC5D0\uC774\uC804\uD2B8 \uC624\uB958${context}: ${detail}`,
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -164,6 +164,7 @@ export interface Messages {
 
   "stageError.maxTurns": (context: string) => string;
   "stageError.inactivityTimeout": (context: string) => string;
+  "stageError.configParsing": (context: string, detail: string) => string;
   "stageError.agentError": (context: string, detail: string) => string;
 
   // ---- worktree errors ---------------------------------------------------

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1091,4 +1091,48 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(result.status).toBe("error");
     expect(result.stderrText).toBe("unexpected argument '--model'");
   });
+
+  test("invoke: config parsing error from stderr produces config_parsing error type", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.invoke("prompt");
+
+    // Codex CLI rejects config at startup: no stdout, error on stderr.
+    emitStderr(
+      child,
+      "Error: unknown variant `xhigh`, expected one of `minimal`, `low`, `medium`, `high`\nin `model_reasoning_effort`",
+    );
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("config_parsing");
+    expect(result.stderrText).toContain("unknown variant");
+  });
+
+  test("resume: config parsing error from stderr produces config_parsing error type", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-1", "continue");
+
+    emitStderr(child, "Error: invalid value for model_reasoning_effort");
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("config_parsing");
+    expect(result.stderrText).toContain("invalid value");
+  });
+
+  test("createCodexAdapter rejects unsupported reasoning effort at construction", () => {
+    expect(() =>
+      createCodexAdapter({
+        reasoningEffort: "xhigh" as never,
+      }),
+    ).toThrow(/Unsupported Codex reasoning effort "xhigh"/);
+  });
 });

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -110,6 +110,54 @@ describe("mapAgentError", () => {
     const result = mapAgentError({ ...base, stderrText: "oops" }, "during fix");
     expect(result.message).toBe("Agent error during fix: oops");
   });
+
+  test("maps config_parsing to actionable message with stderr detail", () => {
+    const stderr =
+      "Error: unknown variant `xhigh`, expected one of `minimal`, `low`, `medium`, `high`";
+    const result = mapAgentError({
+      ...base,
+      errorType: "config_parsing",
+      stderrText: stderr,
+    });
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("~/.codex/config.toml");
+    expect(result.message).toContain(stderr);
+  });
+
+  test("config_parsing includes context when provided", () => {
+    const result = mapAgentError(
+      {
+        ...base,
+        errorType: "config_parsing",
+        stderrText: "invalid value",
+      },
+      " during review",
+    );
+    expect(result.message).toContain("during review");
+    expect(result.message).toContain("invalid value");
+  });
+
+  test("config_parsing falls back to responseText when stderrText is empty", () => {
+    const result = mapAgentError({
+      ...base,
+      errorType: "config_parsing",
+      stderrText: "",
+      responseText: "unknown variant `xhigh`",
+    });
+    expect(result.message).toContain("unknown variant `xhigh`");
+    expect(result.message).toContain("~/.codex/config.toml");
+  });
+
+  test("config_parsing falls back to 'unknown' when both stderr and response are empty", () => {
+    const result = mapAgentError({
+      ...base,
+      errorType: "config_parsing",
+      stderrText: "",
+      responseText: "",
+    });
+    expect(result.message).toContain("unknown");
+    expect(result.message).toContain("~/.codex/config.toml");
+  });
 });
 
 // ---- mapParsedStepToResult -------------------------------------------------
@@ -393,6 +441,23 @@ describe("invokeOrResume", () => {
 
     const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
     expect(out).toBe(execError);
+    expect(agent.invoke).not.toHaveBeenCalled();
+  });
+
+  test("returns error immediately on config_parsing (non-recoverable)", async () => {
+    const configError = makeResult({
+      status: "error",
+      errorType: "config_parsing",
+      stderrText:
+        "Error: unknown variant `xhigh`, expected one of `minimal`, `low`, `medium`, `high`",
+    });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(configError)),
+    };
+
+    const out = await invokeOrResume(agent, "saved-sess", "prompt", "/cwd");
+    expect(out).toBe(configError);
     expect(agent.invoke).not.toHaveBeenCalled();
   });
 });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -36,6 +36,13 @@ export function mapAgentError(
       message: m["stageError.inactivityTimeout"](during),
     };
   }
+  if (result.errorType === "config_parsing") {
+    const detail = result.stderrText || result.responseText || "unknown";
+    return {
+      outcome: "error",
+      message: m["stageError.configParsing"](during, detail),
+    };
+  }
   const detail = result.stderrText || result.errorType || "unknown";
   return {
     outcome: "error",
@@ -172,6 +179,7 @@ async function invokeOrResumeOnce(
     if (
       result.errorType === "cli_not_found" ||
       result.errorType === "execution_error" ||
+      result.errorType === "config_parsing" ||
       result.errorType === "inactivity_timeout"
     ) {
       return result;


### PR DESCRIPTION
## Summary

- Add `config_parsing` error type to detect when the Codex CLI rejects unsupported config values (e.g., `model_reasoning_effort = "xhigh"` in `~/.codex/config.toml`)
- Surface an actionable error message pointing the user to `~/.codex/config.toml` instead of the opaque "Agent error: unknown"
- Add `validateCodexReasoningEffort()` for runtime validation before spawning, and derive the `CodexReasoningEffort` type from a single source array to prevent drift
- Mark `config_parsing` as non-recoverable in `invokeOrResumeOnce` to prevent futile fresh-invoke fallback

## Test plan

- [x] `detectCodexError` directly tested for all error patterns including case-insensitivity (9 tests)
- [x] `validateCodexReasoningEffort` tested for all valid/invalid values (4 tests)
- [x] `mapAgentError` config_parsing tested with stderr, context, responseText fallback, and empty fallback (4 tests)
- [x] `invokeOrResume` verified to not retry on config_parsing (1 test)
- [x] Spawn-agent E2E: invoke and resume paths with config error stderr + non-zero exit (2 tests)
- [x] Spawn-agent E2E: `createCodexAdapter` rejects invalid reasoning effort at construction (1 test)
- [x] `parseCodexJsonl` turn.failed with config parsing message (1 test)
- [x] `parseCodexPlainText` with config error patterns (2 tests)
- [x] i18n coverage for new message key (1 test)
- [x] All 894 tests pass, tsc and biome clean

Closes #39