### PR TITLE
Set fetch refspec after bare clone (#42)

### DIFF
--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -108,6 +108,12 @@ describe("bootstrapRepo", () => {
 
   test("sets fetch refspec after cloning", () => {
     mockExistsSync.mockReturnValue(false);
+    // git config read will throw (no refspec yet)
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        throw new Error("key missing");
+      return "" as never;
+    }) as typeof execFileSync);
     const dest = bootstrapRepo("org", "repo");
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "git",
@@ -119,12 +125,61 @@ describe("bootstrapRepo", () => {
   test("fetches when repo already exists", () => {
     const dest = repoPath("org", "repo");
     mockExistsSync.mockReturnValue(true);
+    // Return existing refspec so ensureFetchRefspec is a no-op
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        return "+refs/heads/*:refs/heads/*\n";
+      return "" as never;
+    }) as typeof execFileSync);
     bootstrapRepo("org", "repo");
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "git",
       ["fetch", "--all", "--prune"],
       expect.objectContaining({ encoding: "utf-8", cwd: dest }),
     );
+  });
+
+  test("repairs missing refspec on existing bare repo before fetching", () => {
+    const dest = repoPath("org", "repo");
+    mockExistsSync.mockReturnValue(true);
+    const calls: string[][] = [];
+    // Simulate a legacy bare repo with no refspec
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      calls.push([cmd, ...args]);
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        throw new Error("key missing");
+      return "" as never;
+    }) as typeof execFileSync);
+    bootstrapRepo("org", "repo");
+    // Should set the refspec before fetching
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
+      expect.objectContaining({ cwd: dest }),
+    );
+    const configSetIdx = calls.findIndex(
+      (c) => c[0] === "git" && c[1] === "config" && c.length === 4,
+    );
+    const fetchIdx = calls.findIndex((c) => c[0] === "git" && c[1] === "fetch");
+    expect(configSetIdx).toBeLessThan(fetchIdx);
+  });
+
+  test("skips setting refspec when it already exists", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        return "+refs/heads/*:refs/heads/*\n";
+      return "" as never;
+    }) as typeof execFileSync);
+    bootstrapRepo("org", "repo");
+    // Should NOT have called config with 3 args (the setter)
+    const configSetCalls = mockExecFileSync.mock.calls.filter(
+      (c) =>
+        c[0] === "git" &&
+        (c[1] as string[])[0] === "config" &&
+        (c[1] as string[]).length === 3,
+    );
+    expect(configSetCalls).toHaveLength(0);
   });
 });
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -82,6 +82,9 @@ const EXEC_OPTS: ExecFileSyncOptions = { encoding: "utf-8", stdio: "pipe" };
 export function bootstrapRepo(owner: string, repo: string): string {
   const dest = repoPath(owner, repo);
   if (existsSync(dest)) {
+    // Ensure the fetch refspec exists — bare clones (including those
+    // created before this fix) lack one, making `git fetch` a no-op.
+    ensureFetchRefspec(dest);
     execFileSync("git", ["fetch", "--all", "--prune"], {
       ...EXEC_OPTS,
       cwd: dest,
@@ -92,14 +95,35 @@ export function bootstrapRepo(owner: string, repo: string): string {
       ["clone", "--bare", `https://github.com/${owner}/${repo}.git`, dest],
       EXEC_OPTS,
     );
-    // bare clones lack a fetch refspec, so `git fetch` would be a no-op.
-    execFileSync(
-      "git",
-      ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
-      { ...EXEC_OPTS, cwd: dest },
-    );
+    ensureFetchRefspec(dest);
   }
   return dest;
+}
+
+const FETCH_REFSPEC = "+refs/heads/*:refs/heads/*";
+
+/**
+ * Set `remote.origin.fetch` if it is missing or empty.
+ *
+ * `git clone --bare` does not create this config entry, so without it
+ * `git fetch --all` has nothing to fetch and local refs stay stale.
+ */
+function ensureFetchRefspec(cwd: string): void {
+  try {
+    const current = (
+      execFileSync("git", ["config", "remote.origin.fetch"], {
+        ...EXEC_OPTS,
+        cwd,
+      }) as string
+    ).trim();
+    if (current) return;
+  } catch {
+    // Config key missing — fall through to set it.
+  }
+  execFileSync("git", ["config", "remote.origin.fetch", FETCH_REFSPEC], {
+    ...EXEC_OPTS,
+    cwd,
+  });
 }
 
 // ---- HEAD SHA capture ----------------------------------------------------


### PR DESCRIPTION
## Summary

- After `git clone --bare`, set `remote.origin.fetch` to `+refs/heads/*:refs/heads/*` so that `git fetch --all --prune` actually updates local refs on subsequent runs.
- Without this, bare clones have no fetch refspec and all fetches are no-ops, leaving worktrees pinned to the original clone's HEAD.

## Test plan

- [x] Verify `git config remote.origin.fetch` is set after cloning a new bare repo
- [x] Verify `git fetch --all --prune` updates local refs on subsequent `bootstrapRepo` calls
- [x] Verify worktrees are created from the latest remote commit, not a stale ref
- [x] Existing unit tests pass (`pnpm vitest run`)

Closes #42 