### PR TITLE
Skip squash stage for single-commit branches (#37)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -162,6 +162,7 @@ export const en: Messages = {
   "ci.fixLoopExhausted": "CI fix loop exhausted.",
   "ci.agentError": (detail) => `Agent error during CI fix: ${detail}`,
   "squash.completed": "Commits squashed and CI passed.",
+  "squash.singleCommitSkip": "Single commit — skipping squash.",
   "review.approved": (round) => `Review approved at round ${round}.`,
   "review.unresolvedItems": (base, summary) =>
     `${base}\n\nUnresolved items:\n${summary}`,

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -191,6 +191,7 @@ export const ko: Messages = {
   "ci.fixLoopExhausted": "CI 수정 반복이 소진되었습니다.",
   "ci.agentError": (detail) => `CI 수정 중 에이전트 오류: ${detail}`,
   "squash.completed": "커밋이 스쿼시되고 CI를 통과했습니다.",
+  "squash.singleCommitSkip": "커밋이 하나뿐이므로 스쿼시를 건너뜁니다.",
   "review.approved": (round) => `${round}라운드에서 리뷰가 승인되었습니다.`,
   "review.unresolvedItems": (base, summary) =>
     `${base}\n\n미해결 항목:\n${summary}`,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -156,6 +156,7 @@ export interface Messages {
   "ci.fixLoopExhausted": string;
   "ci.agentError": (detail: string) => string;
   "squash.completed": string;
+  "squash.singleCommitSkip": string;
   "review.approved": (round: number) => string;
   "review.unresolvedItems": (base: string, summary: string) => string;
   "review.fixesApplied": (round: number) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -316,6 +316,7 @@ try {
   const squashStage = createSquashStageHandler({
     agent: agentA,
     ...issueCtx,
+    defaultBranch,
   });
 
   const reviewStage = {

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -1613,6 +1613,8 @@ describe("Stage 7 (Squash) through pipeline", () => {
     const stage = createSquashStageHandler({
       agent,
       ...ISSUE_CTX,
+      defaultBranch: "main",
+      countBranchCommits: () => 2,
       getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
       collectFailureLogs: vi.fn().mockReturnValue(""),
       delay: vi.fn().mockResolvedValue(undefined),
@@ -1646,6 +1648,8 @@ describe("Stage 7 (Squash) through pipeline", () => {
     const stage = createSquashStageHandler({
       agent,
       ...ISSUE_CTX,
+      defaultBranch: "main",
+      countBranchCommits: () => 2,
       getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
       collectFailureLogs: vi.fn().mockReturnValue(""),
       delay: vi.fn().mockResolvedValue(undefined),
@@ -2131,6 +2135,8 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
     const squashStage = createSquashStageHandler({
       agent: squashAgent,
       ...ISSUE_CTX,
+      defaultBranch: "main",
+      countBranchCommits: () => 2,
       getCiStatus,
       collectFailureLogs: vi.fn().mockReturnValue(""),
       delay: vi.fn().mockResolvedValue(undefined),
@@ -2186,6 +2192,8 @@ describe("Stages 7+8 (Squash + Review) through pipeline", () => {
     const squashStage = createSquashStageHandler({
       agent: squashAgent,
       ...ISSUE_CTX,
+      defaultBranch: "main",
+      countBranchCommits: () => 2,
       getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
       collectFailureLogs: vi.fn().mockReturnValue(""),
       delay: vi.fn().mockResolvedValue(undefined),

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -79,6 +79,7 @@ function makeOpts(
     agent,
     issueTitle: "Fix the widget",
     issueBody: "The widget is broken.",
+    defaultBranch: "main",
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
     getHeadSha: vi.fn().mockReturnValue("abc123"),
@@ -86,6 +87,7 @@ function makeOpts(
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
     emptyRunsGracePeriodMs: 0,
+    countBranchCommits: vi.fn().mockReturnValue(2),
     ...overrides,
   };
 }
@@ -139,6 +141,31 @@ describe("createSquashStageHandler", () => {
     expect(stage.number).toBe(7);
     expect(stage.name).toBe("Squash commits");
     expect(stage.requiresArtifact).toBe(true);
+  });
+
+  // -- single commit skip ----------------------------------------------------
+
+  test("skips squash when branch has a single commit", async () => {
+    const countBranchCommits = vi.fn().mockReturnValue(1);
+    const opts = makeOpts({ countBranchCommits });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("Single commit");
+    expect(countBranchCommits).toHaveBeenCalledWith("/tmp/wt", "main");
+    expect(opts.agent.invoke).not.toHaveBeenCalled();
+    expect(opts.agent.resume).not.toHaveBeenCalled();
+  });
+
+  test("proceeds with squash when branch has multiple commits", async () => {
+    const countBranchCommits = vi.fn().mockReturnValue(3);
+    const opts = makeOpts({ countBranchCommits });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(opts.agent.invoke).toHaveBeenCalled();
   });
 
   // -- happy path: squash + CI pass ------------------------------------------

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -28,6 +28,7 @@ import {
   sendFollowUp,
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
+import { countBranchCommits as defaultCountBranchCommits } from "./worktree.js";
 
 // ---- public types ------------------------------------------------------------
 
@@ -35,6 +36,8 @@ export interface SquashStageOptions {
   agent: AgentAdapter;
   issueTitle: string;
   issueBody: string;
+  /** The default branch name (e.g. "main"). Used to count commits. */
+  defaultBranch: string;
   /** Injected for testability. */
   getCiStatus?: GetCiStatusFn;
   /** Injected for testability. */
@@ -49,6 +52,8 @@ export interface SquashStageOptions {
   maxFixAttempts?: number;
   /** Injected for testability. */
   delay?: (ms: number) => Promise<void>;
+  /** Injected for testability. Defaults to `worktree.countBranchCommits`. */
+  countBranchCommits?: (cwd: string, baseBranch: string) => number;
 }
 
 // ---- prompt builders ---------------------------------------------------------
@@ -110,6 +115,18 @@ export function createSquashStageHandler(
     number: 7,
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
+      // Skip squash when the branch has only one commit.
+      const count = (opts.countBranchCommits ?? defaultCountBranchCommits)(
+        ctx.worktreePath,
+        opts.defaultBranch,
+      );
+      if (count <= 1) {
+        return {
+          outcome: "completed",
+          message: t()["squash.singleCommitSkip"],
+        };
+      }
+
       // Step 1: Send the squash prompt (resume if saved session).
       const prompt = buildSquashPrompt(ctx, opts);
       const squashResult = await invokeOrResume(

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -143,6 +143,21 @@ export function getHeadSha(cwd: string): string {
   ).trim();
 }
 
+// ---- branch commit count -------------------------------------------------
+
+/**
+ * Return the number of commits on the current branch relative to
+ * `baseBranch`.  Used to decide whether squashing is necessary.
+ */
+export function countBranchCommits(cwd: string, baseBranch: string): number {
+  const output = execFileSync(
+    "git",
+    ["rev-list", "--count", `${baseBranch}..HEAD`],
+    { ...EXEC_OPTS, cwd },
+  ) as string;
+  return Number.parseInt(output.trim(), 10);
+}
+
 // ---- worktree management -------------------------------------------------
 
 /**


### PR DESCRIPTION
## Summary

- Add `countBranchCommits` helper in `worktree.ts` using `git rev-list --count`
- Check commit count at the start of Stage 7 handler; return early with a skip message when the branch has only one commit
- Pass `defaultBranch` through `SquashStageOptions` so the handler knows the base ref
- Add i18n message `squash.singleCommitSkip` (English + Korean)

## Test plan

- [x] `pnpm vitest run` — all 900 tests pass, including 2 new squash-skip tests
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check` — no lint issues
- [x] New test: single-commit branch returns `completed` without invoking the agent
- [x] New test: multi-commit branch proceeds with the normal squash flow
- [x] E2E tests updated to supply `defaultBranch` and `countBranchCommits`

Closes #37