### PR TITLE
Show loop iteration status in status bar (#50)

### DIFF
--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -281,7 +281,33 @@ describe("StatusBar", () => {
 
     const frame = lastFrame();
     expect(frame).toContain("Stage 3: Self-check");
+    expect(frame).toContain("Round: 2 (done)");
     expect(frame).toContain("Last: not approved");
+  });
+
+  test("shows in-progress then done on successive events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<StatusBar emitter={emitter} />);
+
+    emitter.emit("stage:enter", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("Round: 1 (in progress)");
+
+    emitter.emit("stage:exit", { stageNumber: 3, outcome: "not_approved" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("Round: 1 (done)");
+
+    emitter.emit("stage:enter", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      iteration: 1,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("Round: 2 (in progress)");
   });
 
   test("clears outcome on new stage:enter", async () => {


### PR DESCRIPTION
## Summary

- Add `Round: N (done)` assertion to the existing `stage:exit` test to verify the done status is displayed.
- Add a new test (`shows in-progress then done on successive events`) that verifies the full lifecycle: `Round: 1 (in progress)` on enter, `Round: 1 (done)` on exit, then `Round: 2 (in progress)` on the next iteration.

## Test plan

- [x] `Round: 1 (in progress)` is shown on `stage:enter` with `iteration: 0`
- [x] `Round: 1 (done)` is shown after `stage:exit`
- [x] `Round: 2 (in progress)` is shown on the next `stage:enter` with `iteration: 1`
- [x] Outcome text is cleared when a new stage begins
- [x] `pnpm vitest run`, `pnpm tsc --noEmit`, and `pnpm biome check` all pass

Closes #50