### PR TITLE
Display prompts sent to agents in UI (#32)

### DIFF
--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -205,6 +205,7 @@ export async function pollCiAndFix(
       { agent, issueTitle, issueBody },
       failureLogs,
     );
+    ctx.promptSinks?.a?.(fixPrompt);
     const fixStream = agent.invoke(fixPrompt, { cwd: ctx.worktreePath });
     if (ctx.streamSinks?.a) {
       drainToSink(fixStream, ctx.streamSinks.a);

--- a/src/pipeline-events.test.ts
+++ b/src/pipeline-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, vi } from "vitest";
 import {
   type AgentChunkEvent,
   type AgentInvokeEvent,
+  type AgentPromptEvent,
   PipelineEventEmitter,
   type StageEnterEvent,
   type StageExitEvent,
@@ -52,6 +53,17 @@ describe("PipelineEventEmitter", () => {
 
     const event: AgentInvokeEvent = { agent: "b", type: "resume" };
     emitter.emit("agent:invoke", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives agent:prompt events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("agent:prompt", handler);
+
+    const event: AgentPromptEvent = { agent: "a", prompt: "Do the thing" };
+    emitter.emit("agent:prompt", event);
 
     expect(handler).toHaveBeenCalledWith(event);
   });

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -21,8 +21,14 @@ export interface AgentInvokeEvent {
   type: "invoke" | "resume";
 }
 
+export interface AgentPromptEvent {
+  agent: "a" | "b";
+  prompt: string;
+}
+
 interface PipelineEventMap {
   "agent:chunk": [AgentChunkEvent];
+  "agent:prompt": [AgentPromptEvent];
   "stage:enter": [StageEnterEvent];
   "stage:exit": [StageExitEvent];
   "agent:invoke": [AgentInvokeEvent];

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -11,7 +11,7 @@
 
 import { t } from "./i18n/index.js";
 import type { PipelineEventEmitter } from "./pipeline-events.js";
-import type { StreamSink } from "./stage-util.js";
+import type { PromptSink, StreamSink } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
 // ---- public types --------------------------------------------------------
@@ -117,6 +117,12 @@ export interface StageContext {
    * chunks are emitted as they arrive.
    */
   streamSinks?: { a?: StreamSink; b?: StreamSink };
+  /**
+   * Optional sinks for displaying outgoing prompts in the UI.  Stage
+   * handlers call these before sending a prompt to the agent so the
+   * user can see what the agent was asked to do.
+   */
+  promptSinks?: { a?: PromptSink; b?: PromptSink };
 }
 
 // ---- user interaction interface ------------------------------------------
@@ -248,6 +254,7 @@ export interface PipelineOptions {
     | "savedAgentASessionId"
     | "savedAgentBSessionId"
     | "streamSinks"
+    | "promptSinks"
   >;
   /**
    * When set, stages with a number strictly less than this value are
@@ -491,6 +498,7 @@ async function runStage(
     | "savedAgentASessionId"
     | "savedAgentBSessionId"
     | "streamSinks"
+    | "promptSinks"
   >,
   prompt: UserPrompt,
   onStageTransition?: (stageNumber: number, stageLoopCount: number) => void,
@@ -521,6 +529,16 @@ async function runStage(
       }
     : undefined;
 
+  // Build per-agent prompt sinks so the UI can display outgoing prompts.
+  const promptSinks = events
+    ? {
+        a: (prompt: string) =>
+          events.emit("agent:prompt", { agent: "a", prompt }),
+        b: (prompt: string) =>
+          events.emit("agent:prompt", { agent: "b", prompt }),
+      }
+    : undefined;
+
   while (true) {
     // Notify caller before each handler invocation for persistence.
     onStageTransition?.(stage.number, lc.iteration);
@@ -540,6 +558,7 @@ async function runStage(
       savedAgentASessionId,
       savedAgentBSessionId,
       streamSinks,
+      promptSinks,
     };
 
     // Clear one-shot fields after use.

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -176,6 +176,7 @@ export function createCiCheckStageHandler(
           : "No detailed failure logs available.";
 
       const prompt = buildCiFixPrompt(ctx, opts, failureLogs);
+      ctx.promptSinks?.a?.(prompt);
       const fixResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -99,6 +99,7 @@ export function createCreatePrStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the PR creation prompt (resume if saved session).
       const prompt = buildCreatePrPrompt(ctx, opts);
+      ctx.promptSinks?.a?.(prompt);
       const prResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -119,10 +120,12 @@ export function createCreatePrStageHandler(
       // Clarification is handled internally by resuming the same
       // session, because re-entering the handler would re-run the
       // side-effectful PR creation step.
+      const prCheckPrompt = buildPrCompletionCheckPrompt();
+      ctx.promptSinks?.a?.(prCheckPrompt);
       let checkResult = await sendFollowUp(
         opts.agent,
         prResult.sessionId,
-        buildPrCompletionCheckPrompt(),
+        prCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
       );
@@ -134,10 +137,14 @@ export function createCreatePrStageHandler(
       let result = mapResponseToResult(checkResult.responseText);
 
       if (result.outcome === "needs_clarification" && checkResult.sessionId) {
+        const clarifyPrompt = buildClarificationPrompt(
+          checkResult.responseText,
+        );
+        ctx.promptSinks?.a?.(clarifyPrompt);
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId,
-          buildClarificationPrompt(checkResult.responseText),
+          clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
         );

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -76,6 +76,7 @@ export function createImplementStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the implementation prompt (resume if saved session).
       const prompt = buildImplementPrompt(ctx, opts);
+      ctx.promptSinks?.a?.(prompt);
       const implResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -93,10 +94,12 @@ export function createImplementStageHandler(
       }
 
       // Step 2: Resume the session and ask for completion status.
+      const checkPrompt = buildCompletionCheckPrompt();
+      ctx.promptSinks?.a?.(checkPrompt);
       const checkResult = await sendFollowUp(
         opts.agent,
         implResult.sessionId,
-        buildCompletionCheckPrompt(),
+        checkPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
       );

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -33,6 +33,7 @@ import {
   invokeOrResume,
   mapAgentError,
   mapResponseToResult,
+  type PromptSink,
   type StreamSink,
   sendFollowUp,
 } from "./stage-util.js";
@@ -185,6 +186,7 @@ export function createReviewStageHandler(
 
       // Step 1: Agent B reviews (resume if saved session).
       const reviewPrompt = buildReviewPrompt(ctx, opts, round);
+      ctx.promptSinks?.b?.(reviewPrompt);
       const reviewResult = await invokeOrResume(
         opts.agentB,
         ctx.savedAgentBSessionId,
@@ -212,6 +214,7 @@ export function createReviewStageHandler(
           round,
           ctx.worktreePath,
           ctx.streamSinks?.b,
+          ctx.promptSinks?.b,
         );
         if (error) return error;
 
@@ -231,6 +234,7 @@ export function createReviewStageHandler(
 
       // Step 3: NOT_APPROVED — Agent A fixes (resume if saved session).
       const fixPrompt = buildAuthorFixPrompt(ctx, opts, round);
+      ctx.promptSinks?.a?.(fixPrompt);
       const fixResult = await invokeOrResume(
         opts.agentA,
         ctx.savedAgentASessionId,
@@ -249,10 +253,12 @@ export function createReviewStageHandler(
 
       // Completion check on Agent A (with clarification retry,
       // same pattern as stage 4 / stage 7).
+      const authorCheckPrompt = buildAuthorCompletionCheckPrompt();
+      ctx.promptSinks?.a?.(authorCheckPrompt);
       let checkResult = await sendFollowUp(
         opts.agentA,
         fixResult.sessionId,
-        buildAuthorCompletionCheckPrompt(),
+        authorCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
       );
@@ -267,10 +273,12 @@ export function createReviewStageHandler(
         checkMapped.outcome === "needs_clarification" &&
         checkResult.sessionId
       ) {
+        const retryPrompt = buildAuthorCompletionCheckPrompt();
+        ctx.promptSinks?.a?.(retryPrompt);
         const retryResult = await sendFollowUp(
           opts.agentA,
           checkResult.sessionId,
-          buildAuthorCompletionCheckPrompt(),
+          retryPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
         );
@@ -333,6 +341,7 @@ export function createReviewStageHandler(
           round,
           ctx.worktreePath,
           ctx.streamSinks?.b,
+          ctx.promptSinks?.b,
         );
         if (error) return error;
         if (summary) {
@@ -365,8 +374,10 @@ async function handleUnresolvedSummary(
   round: number,
   cwd: string,
   sink?: StreamSink,
+  promptSink?: PromptSink,
 ): Promise<UnresolvedSummaryResult> {
   const summaryPrompt = buildUnresolvedSummaryPrompt(round);
+  promptSink?.(summaryPrompt);
 
   // If we have a session, resume; otherwise invoke fresh.
   let result: AgentResult;

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -88,6 +88,7 @@ export function createSelfCheckStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send self-check prompt (resume if saved session).
       const checkPrompt = buildSelfCheckPrompt(ctx, opts);
+      ctx.promptSinks?.a?.(checkPrompt);
       const checkResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -105,10 +106,12 @@ export function createSelfCheckStageHandler(
       }
 
       // Step 2: Send fix-or-done prompt (resume the same session).
+      const fixPrompt = buildFixOrDonePrompt();
+      ctx.promptSinks?.a?.(fixPrompt);
       const fixResult = await sendFollowUp(
         opts.agent,
         checkResult.sessionId,
-        buildFixOrDonePrompt(),
+        fixPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
       );

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -129,6 +129,7 @@ export function createSquashStageHandler(
 
       // Step 1: Send the squash prompt (resume if saved session).
       const prompt = buildSquashPrompt(ctx, opts);
+      ctx.promptSinks?.a?.(prompt);
       const squashResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -147,10 +148,12 @@ export function createSquashStageHandler(
 
       // Step 2: Completion check (same internal-clarification pattern as
       // stage 4).
+      const squashCheckPrompt = buildSquashCompletionCheckPrompt();
+      ctx.promptSinks?.a?.(squashCheckPrompt);
       let checkResult = await sendFollowUp(
         opts.agent,
         squashResult.sessionId,
-        buildSquashCompletionCheckPrompt(),
+        squashCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
       );
@@ -162,10 +165,14 @@ export function createSquashStageHandler(
       let result = mapResponseToResult(checkResult.responseText);
 
       if (result.outcome === "needs_clarification" && checkResult.sessionId) {
+        const clarifyPrompt = buildClarificationPrompt(
+          checkResult.responseText,
+        );
+        ctx.promptSinks?.a?.(clarifyPrompt);
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId,
-          buildClarificationPrompt(checkResult.responseText),
+          clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
         );

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -90,6 +90,7 @@ export function createTestPlanStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send verification prompt (resume if saved session).
       const verifyPrompt = buildTestPlanVerifyPrompt(ctx, opts);
+      ctx.promptSinks?.a?.(verifyPrompt);
       const verifyResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -107,10 +108,12 @@ export function createTestPlanStageHandler(
       }
 
       // Step 2: Send self-check prompt (resume the same session).
+      const selfCheckPrompt = buildTestPlanSelfCheckPrompt();
+      ctx.promptSinks?.a?.(selfCheckPrompt);
       const checkResult = await sendFollowUp(
         opts.agent,
         verifyResult.sessionId,
-        buildTestPlanSelfCheckPrompt(),
+        selfCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
       );

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -14,6 +14,12 @@ import { type ParsedStep, parseStepStatus } from "./step-parser.js";
 export type StreamSink = (chunk: string) => void;
 
 /**
+ * Callback that receives the full prompt text before it is sent to the agent.
+ * Used by the UI to display outgoing prompts in the agent's pane.
+ */
+export type PromptSink = (prompt: string) => void;
+
+/**
  * Log full diagnostic details for an agent process failure so that
  * transient or hard-to-reproduce errors leave a durable trail.
  */

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -5,7 +5,11 @@ import type {
   PipelineEventEmitter,
   StageEnterEvent,
 } from "../pipeline-events.js";
-import { useAgentLines } from "./useEventEmitter.js";
+import {
+  PROMPT_LINE_PREFIX,
+  PROMPT_SEPARATOR_CHAR,
+  useAgentLines,
+} from "./useEventEmitter.js";
 
 /** Stage number at which Agent B becomes active. */
 const REVIEW_STAGE = 8;
@@ -106,12 +110,17 @@ export function AgentPane({ label, agent, emitter, color }: AgentPaneProps) {
       {placeholder !== undefined ? (
         <Text dimColor>{placeholder}</Text>
       ) : (
-        visible.map((line, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: lines are plain strings without stable IDs
-          <Text key={i} wrap="wrap">
-            {line}
-          </Text>
-        ))
+        visible.map((line, i) => {
+          const isPromptLine =
+            line.startsWith(PROMPT_LINE_PREFIX) ||
+            line.startsWith(PROMPT_SEPARATOR_CHAR);
+          return (
+            // biome-ignore lint/suspicious/noArrayIndexKey: lines are plain strings without stable IDs
+            <Text key={i} wrap="wrap" dimColor={isPromptLine}>
+              {line}
+            </Text>
+          );
+        })
       )}
     </Box>
   );

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -6,6 +6,11 @@
  */
 import { describe, expect, test } from "vitest";
 import { PipelineEventEmitter } from "../pipeline-events.js";
+import {
+  formatPromptForDisplay,
+  PROMPT_LINE_PREFIX,
+  PROMPT_SEPARATOR_CHAR,
+} from "./useEventEmitter.js";
 
 // ---- line accumulation logic (mirrors useAgentLines) -------------------------
 
@@ -159,6 +164,75 @@ describe("line accumulation (useAgentLines logic)", () => {
 
     expect(acc.getLines()).toEqual([]);
     expect(acc.getBuffer()).toBe("one two three");
+  });
+});
+
+describe("formatPromptForDisplay", () => {
+  test("formats a short prompt with separator and prefix", () => {
+    const lines = formatPromptForDisplay("Hello\nWorld");
+
+    // First line is separator with "Prompt" label
+    expect(lines[0]).toContain("Prompt");
+    expect(lines[0]).toContain(PROMPT_SEPARATOR_CHAR);
+    // Content lines are prefixed
+    expect(lines[1]).toBe(`${PROMPT_LINE_PREFIX}Hello`);
+    expect(lines[2]).toBe(`${PROMPT_LINE_PREFIX}World`);
+    // Last line is closing separator
+    expect(lines[lines.length - 1]).toContain(PROMPT_SEPARATOR_CHAR);
+  });
+
+  test("truncates long prompts to 8 lines with remainder count", () => {
+    const prompt = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+    const lines = formatPromptForDisplay(prompt);
+
+    // 1 header + 8 content + 1 truncation notice + 1 footer = 11
+    expect(lines).toHaveLength(11);
+    // First content line
+    expect(lines[1]).toBe(`${PROMPT_LINE_PREFIX}line 0`);
+    // Last content line shown
+    expect(lines[8]).toBe(`${PROMPT_LINE_PREFIX}line 7`);
+    // Truncation indicator
+    expect(lines[9]).toContain("12 more lines");
+  });
+
+  test("does not truncate prompt with exactly 8 lines", () => {
+    const prompt = Array.from({ length: 8 }, (_, i) => `line ${i}`).join("\n");
+    const lines = formatPromptForDisplay(prompt);
+
+    // 1 header + 8 content + 1 footer = 10, no truncation line
+    expect(lines).toHaveLength(10);
+    expect(lines.join("\n")).not.toContain("more lines");
+  });
+
+  test("handles single-line prompt", () => {
+    const lines = formatPromptForDisplay("Do the thing");
+
+    expect(lines[1]).toBe(`${PROMPT_LINE_PREFIX}Do the thing`);
+    expect(lines).toHaveLength(3); // header + 1 line + footer
+  });
+});
+
+describe("agent:prompt integration with line accumulator", () => {
+  test("prompt lines are injected into the accumulator", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    // Simulate agent:prompt by manually injecting formatted lines
+    // (mirrors what the hook does).
+    emitter.emit("agent:chunk", { agent: "a", chunk: "output\n" });
+
+    const formatted = formatPromptForDisplay("hello");
+    // Inject formatted lines as if the hook did it.
+    for (const line of formatted) {
+      emitter.emit("agent:chunk", { agent: "a", chunk: `${line}\n` });
+    }
+
+    const lines = acc.getLines();
+    expect(lines[0]).toBe("output");
+    expect(lines[1]).toContain("Prompt");
+    expect(lines[2]).toBe(`${PROMPT_LINE_PREFIX}hello`);
+
+    acc.cleanup();
   });
 });
 

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -8,11 +8,53 @@ export interface AgentLinesResult {
   pendingLine: string;
 }
 
+/** Maximum number of prompt lines shown before truncation. */
+const MAX_PROMPT_LINES = 8;
+
+/** Prefix applied to every displayed prompt line. */
+export const PROMPT_LINE_PREFIX = "\u25B6 ";
+
+/** Prefix for the prompt separator lines. */
+export const PROMPT_SEPARATOR_CHAR = "\u2504";
+
+/**
+ * Format a prompt string for display in the agent pane.
+ *
+ * The prompt is truncated to `MAX_PROMPT_LINES` lines with an
+ * indicator showing how many lines were omitted.  Each line is
+ * prefixed with `▶ ` so the renderer can apply distinct styling.
+ */
+export function formatPromptForDisplay(prompt: string): string[] {
+  const rawLines = prompt.split("\n");
+  const truncated = rawLines.length > MAX_PROMPT_LINES;
+  const shown = truncated ? rawLines.slice(0, MAX_PROMPT_LINES) : rawLines;
+
+  const separator = PROMPT_SEPARATOR_CHAR.repeat(36);
+  const result = [
+    `${separator} Prompt ${separator}`,
+    ...shown.map((l) => `${PROMPT_LINE_PREFIX}${l}`),
+  ];
+
+  if (truncated) {
+    result.push(
+      `${PROMPT_LINE_PREFIX}\u2026 (${rawLines.length - MAX_PROMPT_LINES} more lines)`,
+    );
+  }
+
+  result.push(separator.repeat(2));
+
+  return result;
+}
+
 /**
  * Accumulate string chunks emitted on `agent:chunk` for a given agent
  * into a line buffer.  Returns completed lines (capped at `maxLines`)
  * and the current unterminated fragment so the UI can display partial
  * output in real time.
+ *
+ * Also listens for `agent:prompt` events and injects formatted,
+ * truncated prompt lines into the buffer so the user can see what
+ * the agent was asked to do.
  */
 export function useAgentLines(
   emitter: PipelineEventEmitter,
@@ -46,6 +88,37 @@ export function useAgentLines(
     emitter.on("agent:chunk", handler);
     return () => {
       emitter.off("agent:chunk", handler);
+    };
+  }, [emitter, agent, maxLines]);
+
+  // Listen for outgoing prompt events and inject formatted lines.
+  useEffect(() => {
+    const handler = (ev: { agent: "a" | "b"; prompt: string }) => {
+      if (ev.agent !== agent) return;
+
+      const formatted = formatPromptForDisplay(ev.prompt);
+
+      // Flush any pending partial line before injecting prompt lines
+      // so the prompt appears on its own visual block.
+      if (bufferRef.current) {
+        const pending = bufferRef.current;
+        bufferRef.current = "";
+        setPendingLine("");
+        setLines((prev) => {
+          const next = [...prev, pending, ...formatted];
+          return next.length > maxLines ? next.slice(-maxLines) : next;
+        });
+      } else {
+        setLines((prev) => {
+          const next = [...prev, ...formatted];
+          return next.length > maxLines ? next.slice(-maxLines) : next;
+        });
+      }
+    };
+
+    emitter.on("agent:prompt", handler);
+    return () => {
+      emitter.off("agent:prompt", handler);
     };
   }, [emitter, agent, maxLines]);
 


### PR DESCRIPTION
## Summary

- Add `agent:prompt` event and `PromptSink` callback type so each pipeline stage surfaces the outgoing prompt before invoking the agent CLI
- Format prompts with a separator header, `▶` line prefix, and truncation after 8 lines to keep panes readable
- Render prompt lines in dimmed style to visually distinguish them from agent output
- Wire prompt sinks into all stages: implement, self-check, test-plan, review, squash, create-PR, CI-check (including follow-ups and clarification retries)

Closes #32

## Test plan

- [x] `agent:prompt` event is emitted and received (unit test)
- [x] `formatPromptForDisplay` formats short prompts with separator and prefix
- [x] Long prompts are truncated to 8 lines with remainder count
- [x] Prompts with exactly 8 lines are not truncated
- [x] Single-line prompts display correctly
- [x] Prompt lines integrate into the line accumulator alongside agent output
- [x] Prompt lines render with dimmed styling in the agent pane
- [x] All pipeline stages (implement, self-check, test-plan, review, squash, create-PR, CI-check) emit prompts before agent invocation