### PR TITLE
Replace --thinking-budget with --effort flag

### DIFF
--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -525,6 +525,24 @@ describe("buildClaudeArgs", () => {
     expect(args).not.toContain("--model");
   });
 
+  test("includes --effort when effortLevel is set", () => {
+    const args = buildClaudeArgs("prompt", {
+      permissionMode: "auto",
+      effortLevel: "high",
+    });
+
+    expect(args).toContain("--effort");
+    expect(args).toContain("high");
+  });
+
+  test("omits --effort when effortLevel is undefined", () => {
+    const args = buildClaudeArgs("prompt", {
+      permissionMode: "auto",
+    });
+
+    expect(args).not.toContain("--effort");
+  });
+
   test("includes --resume when sessionId is given", () => {
     const args = buildClaudeArgs(
       "continue",

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -137,12 +137,12 @@ export class ClaudeStreamTransformer extends JsonlLineTransformer {
 
 export type ClaudePermissionMode = "auto" | "bypass";
 
-export type ClaudeThinkingBudget = "low" | "medium" | "high";
+export type ClaudeEffortLevel = "low" | "medium" | "high";
 
 export interface ClaudeAdapterOptions {
   model?: string;
   permissionMode?: ClaudePermissionMode;
-  thinkingBudget?: ClaudeThinkingBudget;
+  effortLevel?: ClaudeEffortLevel;
   contextWindow?: string;
   inactivityTimeoutMs?: number;
 }
@@ -152,7 +152,7 @@ export function buildClaudeArgs(
   opts: {
     model?: string;
     permissionMode: ClaudePermissionMode;
-    thinkingBudget?: ClaudeThinkingBudget;
+    effortLevel?: ClaudeEffortLevel;
     contextWindow?: string;
   },
   sessionId?: string,
@@ -172,8 +172,8 @@ export function buildClaudeArgs(
   } else {
     args.push("--permission-mode", "auto");
   }
-  if (opts.thinkingBudget) {
-    args.push("--thinking-budget", opts.thinkingBudget);
+  if (opts.effortLevel) {
+    args.push("--effort", opts.effortLevel);
   }
   if (sessionId) {
     args.push("--resume", sessionId);
@@ -233,7 +233,7 @@ export function createClaudeAdapter(
 ): AgentAdapter {
   const model = opts.model;
   const permissionMode = opts.permissionMode ?? "auto";
-  const thinkingBudget = opts.thinkingBudget;
+  const effortLevel = opts.effortLevel;
   const contextWindow = opts.contextWindow;
   const inactivityTimeoutMs = opts.inactivityTimeoutMs;
 
@@ -244,7 +244,7 @@ export function createClaudeAdapter(
         args: buildClaudeArgs(prompt, {
           model,
           permissionMode,
-          thinkingBudget,
+          effortLevel,
           contextWindow,
         }),
         cwd: options?.cwd,
@@ -258,7 +258,7 @@ export function createClaudeAdapter(
         command: "claude",
         args: buildClaudeArgs(
           prompt,
-          { model, permissionMode, thinkingBudget, contextWindow },
+          { model, permissionMode, effortLevel, contextWindow },
           sessionId,
         ),
         cwd: options?.cwd,

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,7 +72,7 @@ function createAdapter(
     return createClaudeAdapter({
       model: agentConfig.model,
       permissionMode,
-      thinkingBudget: agentConfig.effortLevel as
+      effortLevel: agentConfig.effortLevel as
         | "low"
         | "medium"
         | "high"


### PR DESCRIPTION
## Summary

- Rename the Claude CLI flag from `--thinking-budget` to `--effort` in `buildClaudeArgs`, matching the current CLI interface.
- Rename the adapter option from `thinkingBudget` to `effortLevel` so config, adapter API, and CLI terminology stay aligned.
- Add tests verifying the correct `--effort` flag is emitted when an effort level is set.

Closes #69