### PR TITLE
Fix 1M context window model ID format

### DIFF
--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -543,6 +543,27 @@ describe("buildClaudeArgs", () => {
     expect(args).not.toContain("--effort");
   });
 
+  test("appends [1m] to model when contextWindow is 1m", () => {
+    const args = buildClaudeArgs("prompt", {
+      model: "opus",
+      permissionMode: "auto",
+      contextWindow: "1m",
+    });
+
+    expect(args).toContain("opus[1m]");
+  });
+
+  test("does not modify model when contextWindow is 200k", () => {
+    const args = buildClaudeArgs("prompt", {
+      model: "opus",
+      permissionMode: "auto",
+      contextWindow: "200k",
+    });
+
+    expect(args).toContain("opus");
+    expect(args).not.toContain("opus[1m]");
+  });
+
   test("includes --resume when sessionId is given", () => {
     const args = buildClaudeArgs(
       "continue",

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -160,10 +160,11 @@ export function buildClaudeArgs(
   // --verbose is required for --output-format stream-json.
   const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
   if (opts.model) {
-    // Append context window variant to model ID when extended (1M).
+    // Append context window variant as a bracketed suffix (e.g. opus[1m])
+    // when the extended 1M window is selected.
     let modelId = opts.model;
     if (opts.contextWindow === "1m") {
-      modelId = `${modelId}-1m`;
+      modelId = `${modelId}[1m]`;
     }
     args.push("--model", modelId);
   }


### PR DESCRIPTION
## Summary

- Change the 1M context window suffix from `-1m` to `[1m]` in `buildClaudeArgs` (e.g. `opus[1m]` instead of `opus-1m`), matching the format the Claude CLI expects.
- Add tests for context window model ID construction.

Closes #71