### PR TITLE
Include errorType in agent error messages (#67)

### DIFF
--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -87,26 +87,28 @@ describe("mapAgentError", () => {
     );
   });
 
-  test("uses stderrText when available", () => {
+  test("includes errorType alongside stderrText", () => {
     const result = mapAgentError({
       ...base,
       errorType: "execution_error",
       stderrText: "segfault",
     });
-    expect(result.message).toBe("Agent error: segfault");
+    expect(result.message).toBe("Agent error: execution_error (segfault)");
   });
 
-  test("includes exit code alongside stderrText", () => {
+  test("includes errorType, stderrText, and exit code", () => {
     const result = mapAgentError({
       ...base,
       errorType: "execution_error",
       stderrText: "segfault",
       exitCode: 1,
     });
-    expect(result.message).toBe("Agent error: segfault (exit code 1)");
+    expect(result.message).toBe(
+      "Agent error: execution_error (segfault, exit code 1)",
+    );
   });
 
-  test("uses responseText when stderrText is empty", () => {
+  test("includes errorType alongside responseText when no process details", () => {
     const result = mapAgentError({
       ...base,
       errorType: "execution_error",
@@ -114,10 +116,12 @@ describe("mapAgentError", () => {
       exitCode: null,
       responseText: "claude exited with code 1",
     });
-    expect(result.message).toBe("Agent error: claude exited with code 1");
+    expect(result.message).toBe(
+      "Agent error: execution_error (claude exited with code 1)",
+    );
   });
 
-  test("shows exit code alone when stderr and responseText are empty", () => {
+  test("includes errorType alongside exit code", () => {
     const result = mapAgentError({
       ...base,
       errorType: "unknown",
@@ -125,7 +129,7 @@ describe("mapAgentError", () => {
       exitCode: 137,
       responseText: "",
     });
-    expect(result.message).toBe("Agent error: exit code 137");
+    expect(result.message).toBe("Agent error: unknown (exit code 137)");
   });
 
   test("falls back to errorType when all details are empty", () => {
@@ -148,7 +152,7 @@ describe("mapAgentError", () => {
     expect(result.message).toBe("Agent error during fix: oops");
   });
 
-  test("shows signal when process is killed by signal", () => {
+  test("includes errorType alongside signal", () => {
     const result = mapAgentError({
       ...base,
       errorType: "unknown",
@@ -157,10 +161,10 @@ describe("mapAgentError", () => {
       signal: "SIGKILL",
       responseText: "",
     });
-    expect(result.message).toBe("Agent error: signal SIGKILL");
+    expect(result.message).toBe("Agent error: unknown (signal SIGKILL)");
   });
 
-  test("shows signal alongside stderr and exit code", () => {
+  test("includes errorType, stderr, and signal", () => {
     const result = mapAgentError({
       ...base,
       errorType: "unknown",
@@ -168,7 +172,9 @@ describe("mapAgentError", () => {
       exitCode: null,
       signal: "SIGKILL",
     });
-    expect(result.message).toBe("Agent error: out of memory (signal SIGKILL)");
+    expect(result.message).toBe(
+      "Agent error: unknown (out of memory, signal SIGKILL)",
+    );
   });
 
   test("logs full diagnostics to stderr on error", () => {

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -81,6 +81,10 @@ export function mapAgentError(
 export function buildErrorDetail(result: AgentResult): string {
   const parts: string[] = [];
 
+  if (result.errorType) {
+    parts.push(result.errorType);
+  }
+
   if (result.stderrText) {
     parts.push(result.stderrText.trim());
   }
@@ -93,12 +97,16 @@ export function buildErrorDetail(result: AgentResult): string {
     parts.push(`exit code ${result.exitCode}`);
   }
 
-  if (parts.length === 0 && result.responseText) {
+  const hasProcessDetails =
+    !!result.stderrText?.trim() ||
+    !!result.signal ||
+    (result.exitCode !== undefined && result.exitCode !== null);
+  if (!hasProcessDetails && result.responseText) {
     parts.push(result.responseText.trim());
   }
 
   if (parts.length === 0) {
-    parts.push(result.errorType ?? "unknown");
+    parts.push("unknown");
   }
 
   const [primary, ...rest] = parts;


### PR DESCRIPTION
## Summary

- `buildErrorDetail` in `src/stage-util.ts` now always includes `errorType` as the primary part of the detail string, rather than using it only as a last-resort fallback when stderr, signal, and exit code are all absent.
- Error messages now read e.g. `execution_error (exit code 1)` instead of just `exit code 1`, making failures actionable without requiring users to dig through logs.
- Updated tests to match the new output format.

Closes #67

## Test plan

- [x] `pnpm vitest run src/stage-util.test.ts` passes (66 tests)
- [x] Error with only exit code shows errorType: `"Agent error: unknown (exit code 137)"`
- [x] Error with stderr and exit code shows all three: `"Agent error: execution_error (segfault, exit code 1)"`
- [x] Error with only errorType (no stderr/signal/exitCode) shows just errorType: `"Agent error: execution_error"`
- [x] Error with no details at all falls back to `"Agent error: unknown"`
- [x] Error with signal shows errorType alongside: `"Agent error: unknown (signal SIGKILL)"`
- [x] `responseText` fallback still works when no process details present: `"Agent error: execution_error (claude exited with code 1)"`
- [x] Special error types (`max_turns`, `inactivity_timeout`, `config_parsing`) are unaffected