### PR TITLE
Show model names and cumulative round counts (#68)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -134,6 +134,8 @@ export const en: Messages = {
   "statusBar.roundInProgress": (round) => `Round: ${round} (in progress)`,
   "statusBar.roundDone": (round) => `Round: ${round} (done)`,
   "statusBar.last": (outcome) => `Last: ${outcome}`,
+  "statusBar.selfCheck": (count) => `SC: ${count}`,
+  "statusBar.review": (count) => `RV: ${count}`,
   "outcome.completed": "completed",
   "outcome.fixed": "fixed",
   "outcome.approved": "approved",

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -80,6 +80,8 @@ describe("catalogs are complete", () => {
       "statusBar.roundInProgress": [2],
       "statusBar.roundDone": [2],
       "statusBar.last": ["ok"],
+      "statusBar.selfCheck": [2],
+      "statusBar.review": [3],
       "stageError.maxTurns": [" (stage 1)"],
       "stageError.inactivityTimeout": [" (stage 2)"],
       "stageError.configParsing": [" (stage 8)", "unknown variant"],

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -163,6 +163,8 @@ export const ko: Messages = {
   "statusBar.roundDone": (round) =>
     `\uB77C\uC6B4\uB4DC: ${round} (\uC644\uB8CC)`,
   "statusBar.last": (outcome) => `\uC774\uC804: ${outcome}`,
+  "statusBar.selfCheck": (count: number) => `SC: ${count}`,
+  "statusBar.review": (count: number) => `RV: ${count}`,
 
   "outcome.completed": "완료",
   "outcome.fixed": "수정됨",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -131,6 +131,8 @@ export interface Messages {
   "statusBar.roundInProgress": (round: number) => string;
   "statusBar.roundDone": (round: number) => string;
   "statusBar.last": (outcome: string) => string;
+  "statusBar.selfCheck": (count: number) => string;
+  "statusBar.review": (count: number) => string;
   "outcome.completed": string;
   "outcome.fixed": string;
   "outcome.approved": string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -479,6 +479,8 @@ try {
         onPromptReady: (prompt) => {
           tuiPrompt = prompt;
         },
+        modelNameA: agentAConfig.model,
+        modelNameB: agentBConfig.model,
       }),
     );
   });

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -12,16 +12,23 @@ import {
 } from "./useEventEmitter.js";
 
 /** Stage number at which Agent B becomes active. */
-const REVIEW_STAGE = 8;
+const REVIEW_STAGE = 7;
 
 interface AgentPaneProps {
   label: string;
+  modelName?: string;
   agent: "a" | "b";
   emitter: PipelineEventEmitter;
   color: string;
 }
 
-export function AgentPane({ label, agent, emitter, color }: AgentPaneProps) {
+export function AgentPane({
+  label,
+  modelName,
+  agent,
+  emitter,
+  color,
+}: AgentPaneProps) {
   const { lines, pendingLine } = useAgentLines(emitter, agent);
   const containerRef = useRef<DOMElement>(null);
   const [visibleRows, setVisibleRows] = useState(20);
@@ -105,7 +112,7 @@ export function AgentPane({ label, agent, emitter, color }: AgentPaneProps) {
       overflow="hidden"
     >
       <Text bold color={color}>
-        {label}
+        {modelName ? `${label} \u2014 ${modelName}` : label}
       </Text>
       {placeholder !== undefined ? (
         <Text dimColor>{placeholder}</Text>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -19,6 +19,10 @@ export interface AppProps {
   onExit: (result: PipelineResult) => void;
   /** Called once the TUI prompt is ready, so callers can late-bind to it. */
   onPromptReady?: (prompt: UserPrompt) => void;
+  /** Short model identifier for Agent A (e.g., "opus"). */
+  modelNameA?: string;
+  /** Short model identifier for Agent B (e.g., "gpt-5.4"). */
+  modelNameB?: string;
 }
 
 export function App({
@@ -26,6 +30,8 @@ export function App({
   pipelineOptions,
   onExit,
   onPromptReady,
+  modelNameA,
+  modelNameB,
 }: AppProps) {
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
   const resolveRef = useRef<((value: string) => void) | null>(null);
@@ -76,12 +82,14 @@ export function App({
       <Box flexDirection="row" flexGrow={1}>
         <AgentPane
           label={t()["agent.labelARole"]}
+          modelName={modelNameA}
           agent="a"
           emitter={emitter}
           color="blue"
         />
         <AgentPane
           label={t()["agent.labelBRole"]}
+          modelName={modelNameB}
           agent="b"
           emitter={emitter}
           color="green"

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -7,6 +7,11 @@ import type {
   StageExitEvent,
 } from "../pipeline-events.js";
 
+/** Stage number for the self-check stage. */
+const SELF_CHECK_STAGE = 3;
+/** Stage number for the review stage. */
+const REVIEW_STAGE = 7;
+
 interface StatusBarProps {
   emitter: PipelineEventEmitter;
   owner: string;
@@ -23,6 +28,8 @@ export function StatusBar({
   const [stage, setStage] = useState<StageEnterEvent | null>(null);
   const [lastOutcome, setLastOutcome] = useState<string | null>(null);
   const [roundDone, setRoundDone] = useState(false);
+  const [selfCheckCount, setSelfCheckCount] = useState(0);
+  const [reviewCount, setReviewCount] = useState(0);
 
   useEffect(() => {
     const onEnter = (ev: StageEnterEvent) => {
@@ -33,6 +40,11 @@ export function StatusBar({
     const onExit = (ev: StageExitEvent) => {
       setLastOutcome(ev.outcome);
       setRoundDone(true);
+      if (ev.stageNumber === SELF_CHECK_STAGE) {
+        setSelfCheckCount((c) => c + 1);
+      } else if (ev.stageNumber === REVIEW_STAGE) {
+        setReviewCount((c) => c + 1);
+      }
     };
     emitter.on("stage:enter", onEnter);
     emitter.on("stage:exit", onExit);
@@ -82,6 +94,14 @@ export function StatusBar({
         <Text>
           {"  |  "}
           {outcomeText}
+        </Text>
+      )}
+      {(selfCheckCount > 0 || reviewCount > 0) && (
+        <Text>
+          {"  |  "}
+          {m["statusBar.selfCheck"](selfCheckCount)}
+          {"  |  "}
+          {m["statusBar.review"](reviewCount)}
         </Text>
       )}
     </Box>

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -59,6 +59,22 @@ describe("AgentPane", () => {
     expect(frame).toContain("Agent B (reviewer)");
   });
 
+  test("renders model name in header when provided", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane
+        label="Agent A (implementer)"
+        modelName="opus"
+        agent="a"
+        emitter={emitter}
+        color="blue"
+      />,
+    );
+
+    const frame = lastFrame();
+    expect(frame).toContain("Agent A (implementer) \u2014 opus");
+  });
+
   test("renders streamed lines after agent:chunk events", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
@@ -169,7 +185,7 @@ describe("AgentPane", () => {
     );
 
     emitter.emit("stage:enter", {
-      stageNumber: 8,
+      stageNumber: 7,
       stageName: "Review",
       iteration: 0,
     });
@@ -285,12 +301,14 @@ describe("StatusBar", () => {
   test("shows last outcome after stage:exit", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
-      <StatusBar
-        emitter={emitter}
-        owner="aicers"
-        repo="agentcoop"
-        issueNumber={49}
-      />,
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+        />
+      </Box>,
     );
 
     emitter.emit("stage:enter", {
@@ -305,17 +323,21 @@ describe("StatusBar", () => {
     expect(frame).toContain("Stage 3: Self-check");
     expect(frame).toContain("Round: 2 (done)");
     expect(frame).toContain("Last: not approved");
+    expect(frame).toContain("SC: 1");
+    expect(frame).toContain("RV: 0");
   });
 
   test("shows in-progress then done on successive events", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
-      <StatusBar
-        emitter={emitter}
-        owner="aicers"
-        repo="agentcoop"
-        issueNumber={49}
-      />,
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+        />
+      </Box>,
     );
 
     emitter.emit("stage:enter", {
@@ -366,6 +388,48 @@ describe("StatusBar", () => {
     const frame = lastFrame();
     expect(frame).toContain("Stage 3: Self-check");
     expect(frame).not.toContain("completed");
+  });
+
+  test("increments review count on stage:exit for review stage", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+        />
+      </Box>,
+    );
+
+    emitter.emit("stage:enter", {
+      stageNumber: 7,
+      stageName: "Review",
+      iteration: 0,
+    });
+    emitter.emit("stage:exit", { stageNumber: 7, outcome: "approved" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain("SC: 0");
+    expect(frame).toContain("RV: 1");
+  });
+
+  test("hides cumulative counts when both are zero", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("SC:");
+    expect(frame).not.toContain("RV:");
   });
 });
 


### PR DESCRIPTION
## Summary

- Display model names alongside agent labels in pane headers (e.g. `Agent A (implementer) — opus`)
- Track and display cumulative self-check and review round counts (`SC: N | RV: N`) in the status bar
- Pass model names from pipeline config through `App` to `AgentPane` components
- Add i18n messages for the new status bar labels
- Fix review stage number constant (`REVIEW_STAGE`: 8 → 7)

Closes #68

## Test plan

- [x] Model name appears in each agent pane header when provided
- [x] Agent pane header renders without model name when prop is omitted
- [x] Self-check count increments on `stage:exit` for the self-check stage
- [x] Review count increments on `stage:exit` for the review stage
- [x] Cumulative counts (`SC: N | RV: N`) appear in the status bar after at least one exit event
- [x] Counts are hidden when both are zero
- [x] Korean translations render correctly for the new labels
- [x] All existing tests pass (`pnpm vitest run`)
- [x] Type check passes (`pnpm tsc --noEmit`)
- [x] Lint passes (`pnpm biome check`)