### PR TITLE
Add keyboard scroll to agent output panes (#54)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -153,6 +153,7 @@ export const en: Messages = {
   "agentPane.tooSmall": "(pane too small)",
   "agentPane.waiting": "(waiting for output)",
   "agentPane.idle": "(idle — active in review stage)",
+  "agentPane.linesAbove": (count) => `\u2191 ${count} more lines`,
   "agent.labelA": "Agent A",
   "agent.labelB": "Agent B",
   "agent.labelARole": "Agent A (implementer)",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -186,6 +186,8 @@ export const ko: Messages = {
   "agentPane.waiting": "(\uCD9C\uB825 \uB300\uAE30 \uC911)",
   "agentPane.idle":
     "(\uB300\uAE30 \uC911 \u2014 \uB9AC\uBDF0 \uB2E8\uACC4\uC5D0\uC11C \uD65C\uC131\uD654)",
+  "agentPane.linesAbove": (count) =>
+    `\u2191 ${count}\uC904 \uB354 \uC788\uC74C`,
   "agent.labelA": "에이전트 A",
   "agent.labelB": "에이전트 B",
   "agent.labelARole": "에이전트 A (구현자)",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -150,6 +150,7 @@ export interface Messages {
   "agentPane.tooSmall": string;
   "agentPane.waiting": string;
   "agentPane.idle": string;
+  "agentPane.linesAbove": (count: number) => string;
   "agent.labelA": string;
   "agent.labelB": string;
   "agent.labelARole": string;

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -1,4 +1,4 @@
-import { Box, type DOMElement, measureElement, Text } from "ink";
+import { Box, type DOMElement, measureElement, Text, useInput } from "ink";
 import { useEffect, useRef, useState } from "react";
 import { t } from "../i18n/index.js";
 import type {
@@ -14,12 +14,34 @@ import {
 /** Stage number at which Agent B becomes active. */
 const REVIEW_STAGE = 7;
 
+/** Split a logical line into terminal rows of the given width. */
+function splitIntoRows(line: string, width: number): string[] {
+  if (line.length <= width) return [line];
+  const rows: string[] = [];
+  for (let i = 0; i < line.length; i += width) {
+    rows.push(line.slice(i, i + width));
+  }
+  return rows;
+}
+
+/** A single terminal row tagged with display metadata. */
+interface RowEntry {
+  text: string;
+  isPrompt: boolean;
+  /** Index of the parent logical line in allLines. */
+  lineIdx: number;
+}
+
 interface AgentPaneProps {
   label: string;
   modelName?: string;
   agent: "a" | "b";
   emitter: PipelineEventEmitter;
   color: string;
+  /** Whether this pane currently has keyboard focus for scrolling. */
+  isFocused?: boolean;
+  /** Whether scroll keyboard shortcuts are active (false when input area is active). */
+  scrollEnabled?: boolean;
 }
 
 export function AgentPane({
@@ -28,12 +50,16 @@ export function AgentPane({
   agent,
   emitter,
   color,
+  isFocused = false,
+  scrollEnabled = false,
 }: AgentPaneProps) {
   const { lines, pendingLine } = useAgentLines(emitter, agent);
   const containerRef = useRef<DOMElement>(null);
   const [visibleRows, setVisibleRows] = useState(20);
   const [contentWidth, setContentWidth] = useState(80);
   const [currentStage, setCurrentStage] = useState<number | null>(null);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const prevTotalRowsRef = useRef(0);
 
   // Track the current pipeline stage for idle status display.
   useEffect(() => {
@@ -60,32 +86,92 @@ export function AgentPane({
 
   const allLines = pendingLine ? [...lines, pendingLine] : lines;
 
-  // Tail by rendered rows, not logical lines. Each logical line may
-  // wrap into multiple terminal rows when wrap="wrap" is active.
-  let visible: string[];
-  if (visibleRows === 0) {
-    visible = [];
-  } else {
-    let rowBudget = visibleRows;
-    let startIdx = allLines.length;
-    while (startIdx > 0 && rowBudget > 0) {
-      startIdx--;
-      const lineRows = Math.max(
-        1,
-        Math.ceil(allLines[startIdx].length / contentWidth),
-      );
-      rowBudget -= lineRows;
+  // Build a flat array of terminal rows from logical lines so that
+  // scrolling operates at the row level, correctly handling wrapped
+  // lines that span multiple terminal rows.
+  const allRows: RowEntry[] = [];
+  for (let i = 0; i < allLines.length; i++) {
+    const line = allLines[i];
+    const isPrompt =
+      line.startsWith(PROMPT_LINE_PREFIX) ||
+      line.startsWith(PROMPT_SEPARATOR_CHAR);
+    for (const row of splitIntoRows(line, contentWidth)) {
+      allRows.push({ text: row, isPrompt, lineIdx: i });
     }
-    // If the first included line overflows the budget, still include it
-    // (Ink will clip the top via overflow="hidden", showing the tail).
-    if (startIdx < 0) startIdx = 0;
-    visible = allLines.slice(startIdx);
+  }
+
+  const totalRows = allRows.length;
+  const maxOffset = Math.max(0, totalRows - visibleRows);
+  const effectiveOffset = Math.min(scrollOffset, maxOffset);
+
+  // Auto-adjust scrollOffset when total rows grow (new completed lines
+  // or pendingLine wrapping further) to keep the viewport stable while
+  // the user is scrolled up.
+  useEffect(() => {
+    const prev = prevTotalRowsRef.current;
+    prevTotalRowsRef.current = totalRows;
+    if (totalRows > prev && prev > 0) {
+      setScrollOffset((o) => (o > 0 ? o + (totalRows - prev) : 0));
+    }
+  }, [totalRows]);
+
+  // Clamp scrollOffset when it exceeds the valid range (e.g. after
+  // the pane is resized or the user over-scrolls with Page Up).
+  useEffect(() => {
+    if (scrollOffset > 0 && scrollOffset > maxOffset) {
+      setScrollOffset(Math.max(0, maxOffset));
+    }
+  }, [scrollOffset, maxOffset]);
+
+  // Handle scroll keyboard input.
+  useInput(
+    (_input, key) => {
+      if (key.pageUp) {
+        setScrollOffset((o) => o + visibleRows);
+      } else if (key.pageDown) {
+        setScrollOffset((o) => Math.max(0, o - visibleRows));
+      } else if (key.upArrow) {
+        setScrollOffset((o) => o + 1);
+      } else if (key.downArrow) {
+        setScrollOffset((o) => Math.max(0, o - 1));
+      }
+    },
+    { isActive: isFocused && scrollEnabled },
+  );
+
+  // Compute the visible window from the flat row array.
+  let visibleRowEntries: RowEntry[];
+  let linesAbove = 0;
+
+  if (visibleRows === 0) {
+    visibleRowEntries = [];
+  } else if (effectiveOffset === 0) {
+    // Bottom-pinned (auto-follow).
+    const startRow = Math.max(0, totalRows - visibleRows);
+    visibleRowEntries = allRows.slice(startRow);
+    linesAbove = startRow > 0 ? allRows[startRow].lineIdx : 0;
+  } else {
+    // Scrolled up: row-level window.
+    const endRow = totalRows - effectiveOffset;
+
+    // First pass: fill the viewport without the indicator.
+    let startRow = Math.max(0, endRow - visibleRows);
+    linesAbove = startRow > 0 ? allRows[startRow].lineIdx : 0;
+
+    // If there are logical lines fully above the viewport the scroll
+    // indicator will be rendered, so reclaim 1 row for it.
+    if (linesAbove > 0) {
+      startRow = Math.max(0, endRow - (visibleRows - 1));
+      linesAbove = allRows[startRow].lineIdx;
+    }
+
+    visibleRowEntries = allRows.slice(startRow, endRow);
   }
 
   const hasOutput = allLines.length > 0;
 
   let placeholder: string | undefined;
-  if (visible.length === 0) {
+  if (visibleRowEntries.length === 0 && effectiveOffset === 0) {
     const m = t();
     if (hasOutput) {
       placeholder = m["agentPane.tooSmall"];
@@ -100,6 +186,14 @@ export function AgentPane({
     }
   }
 
+  const scrollIndicator =
+    effectiveOffset > 0 && linesAbove > 0
+      ? t()["agentPane.linesAbove"](linesAbove)
+      : undefined;
+
+  // Dim unfocused pane border when scroll mode is available.
+  const borderCol = scrollEnabled ? (isFocused ? color : "gray") : color;
+
   return (
     <Box
       ref={containerRef}
@@ -107,27 +201,25 @@ export function AgentPane({
       flexGrow={1}
       flexBasis={0}
       borderStyle="single"
-      borderColor={color}
+      borderColor={borderCol}
       paddingX={1}
       overflow="hidden"
     >
-      <Text bold color={color}>
+      <Text bold color={borderCol}>
         {modelName ? `${label} \u2014 ${modelName}` : label}
       </Text>
       {placeholder !== undefined ? (
         <Text dimColor>{placeholder}</Text>
       ) : (
-        visible.map((line, i) => {
-          const isPromptLine =
-            line.startsWith(PROMPT_LINE_PREFIX) ||
-            line.startsWith(PROMPT_SEPARATOR_CHAR);
-          return (
-            // biome-ignore lint/suspicious/noArrayIndexKey: lines are plain strings without stable IDs
-            <Text key={i} wrap="wrap" dimColor={isPromptLine}>
-              {line}
+        <>
+          {scrollIndicator && <Text dimColor>{scrollIndicator}</Text>}
+          {visibleRowEntries.map((row, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: rows are derived without stable IDs
+            <Text key={i} dimColor={row.isPrompt}>
+              {row.text}
             </Text>
-          );
-        })
+          ))}
+        </>
       )}
     </Box>
   );

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { Box } from "ink";
+import { Box, useInput } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { t } from "../i18n/index.js";
 import type {
@@ -35,6 +35,7 @@ export function App({
 }: AppProps) {
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
   const resolveRef = useRef<((value: string) => void) | null>(null);
+  const [focusedPane, setFocusedPane] = useState<"a" | "b">("a");
 
   // Store props in refs so the mount effect never re-runs.
   const emitterRef = useRef(emitter);
@@ -54,6 +55,16 @@ export function App({
     resolveRef.current = null;
     setInputRequest(null);
   }, []);
+
+  // Switch focused pane with Tab when input area is not active.
+  useInput(
+    (_input, key) => {
+      if (key.tab) {
+        setFocusedPane((prev) => (prev === "a" ? "b" : "a"));
+      }
+    },
+    { isActive: !inputRequest },
+  );
 
   // Run the pipeline once on mount.
   useEffect(() => {
@@ -86,6 +97,8 @@ export function App({
           agent="a"
           emitter={emitter}
           color="blue"
+          isFocused={focusedPane === "a"}
+          scrollEnabled={!inputRequest}
         />
         <AgentPane
           label={t()["agent.labelBRole"]}
@@ -93,6 +106,8 @@ export function App({
           agent="b"
           emitter={emitter}
           color="green"
+          isFocused={focusedPane === "b"}
+          scrollEnabled={!inputRequest}
         />
       </Box>
 

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -254,6 +254,273 @@ describe("AgentPane", () => {
     expect(frame).not.toContain("waiting for output");
     expect(frame).toContain("pane too small");
   });
+
+  test("Page Up reveals earlier lines and shows scroll indicator", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("line20");
+
+    // Page Up.
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // Scroll indicator must appear.
+    expect(frame).toContain("\u2191");
+    expect(frame).toContain("more lines");
+    // Newest line should be scrolled out of view.
+    expect(frame).not.toContain("line20");
+  });
+
+  test("Page Down returns to newest output after scrolling up", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Scroll up.
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).not.toContain("line20");
+
+    // Scroll back down.
+    stdin.write("\x1b[6~");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("line20");
+    // Indicator should be gone (back at bottom).
+    expect(frame).not.toContain("\u2191");
+  });
+
+  test("scrolling is disabled when scrollEnabled is false", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          scrollEnabled={false}
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
+
+    // View should not have moved — still at bottom.
+    expect(lastFrame()).toContain("line20");
+    expect(lastFrame()).not.toContain("\u2191");
+  });
+
+  test("scrolling is disabled when isFocused is false", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused={false}
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("line20");
+    expect(lastFrame()).not.toContain("\u2191");
+  });
+
+  test("auto-follow keeps view at bottom when new lines arrive", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 15 }, (_, i) => `old${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(lastFrame()).toContain("old15");
+
+    // New line arrives while at bottom — view should follow.
+    emitter.emit("agent:chunk", { agent: "a", chunk: "newtail\n" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("newtail");
+    expect(frame).not.toContain("\u2191");
+  });
+
+  test("scrolling through a single long wrapped line reveals earlier rows", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    // Emit a long wrapped line followed by short lines that push its
+    // first rows above the viewport.  The line wraps to ~5 terminal rows
+    // at the default contentWidth; 8 filler lines are enough to scroll
+    // it out while keeping it reachable with a single Page Up.
+    const longLine = `HEAD_${"x".repeat(390)}_TAIL`;
+    emitter.emit("agent:chunk", {
+      agent: "a",
+      chunk: `${longLine}\n${"filler\n".repeat(8)}`,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // HEAD_ should be scrolled out of view at the bottom-pinned position.
+    expect(lastFrame()).not.toContain("HEAD_");
+
+    // Page Up — scroll through the content including wrapped rows.
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // The earlier rows of the wrapped line must be reachable via
+    // row-level scrolling (not dropped as a whole logical line).
+    expect(frame).toContain("HEAD_");
+  });
+
+  test("viewport stays stable when pendingLine wraps further while scrolled up", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    // Emit enough lines to enable scrolling.
+    const chunk = Array.from({ length: 25 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Scroll up so line10 is visible and line25 is hidden.
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
+    const frameBefore = lastFrame() ?? "";
+    expect(frameBefore).not.toContain("line25");
+
+    // Simulate a streaming pendingLine that wraps into extra rows.
+    // Each chunk extends the pending line, potentially adding wrapped rows.
+    emitter.emit("agent:chunk", { agent: "a", chunk: "x".repeat(100) });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frameAfter = lastFrame() ?? "";
+    // The viewport must NOT shift to reveal the newest content;
+    // the user is scrolled up and should stay in place.
+    expect(frameAfter).not.toContain("line25");
+  });
+
+  test("unfocused pane border dims when scrollEnabled", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused={false}
+          scrollEnabled
+        />
+        <AgentPane
+          label="Agent B"
+          agent="b"
+          emitter={emitter}
+          color="green"
+          isFocused
+          scrollEnabled
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Both labels must be present.
+    expect(frame).toContain("Agent A");
+    expect(frame).toContain("Agent B");
+  });
 });
 
 // ---- StatusBar ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds Page Up/Down and arrow key scrolling to `AgentPane` so users can review earlier agent output that has scrolled past the visible area.
- Tab key switches keyboard focus between the two panes; the unfocused pane border dims to indicate which pane will receive scroll input.
- Scroll keys are disabled while the input area is active to avoid conflicts with `InputArea`'s `useInput`.
- Auto-follow behavior: the viewport stays pinned to the bottom when new lines arrive, unless the user has scrolled up — in that case, the offset adjusts to keep the view stable.
- A scroll indicator (e.g., "↑ 42 more lines") appears when there is content above the visible area.
- i18n strings added for English and Korean.

Closes #54

## Test plan

- [x] Page Up scrolls the output up and shows the scroll indicator
- [x] Page Down scrolls back to the newest output and hides the indicator
- [x] Arrow Up/Down scroll one line at a time
- [x] Scrolling is disabled when the input area is active (typing a review response)
- [x] Tab switches keyboard focus between Agent A and Agent B panes
- [x] Unfocused pane border dims to gray; focused pane keeps its color
- [x] Auto-follow: when at the bottom, new output keeps the view pinned to the latest lines
- [x] When scrolled up, new arriving output does not jump the viewport
- [x] Scroll indicator shows correct count of lines above the viewport
- [x] All existing component tests continue to pass