### PR TITLE
Auto-update issue and PR description during pipeline (#58)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -189,6 +189,17 @@ export const en: Messages = {
   "stageError.agentError": (context, detail) =>
     `Agent error${context}: ${detail}`,
 
+  // ---- issue sync ---------------------------------------------------------
+
+  "issueSync.summaryHeader": (issueNumber) => `Issue #${issueNumber}:`,
+  "issueSync.summaryMinor": (description) =>
+    `  - Updated (minor): ${description}`,
+  "issueSync.summaryMajor": (description) =>
+    `  - Comment added (major): ${description}`,
+  "issueSync.summaryNoChanges": "  - No changes",
+  "issueSync.summarySkipped": "  - Sync skipped",
+  "issueSync.summaryFailed": "  - Sync failed",
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path) =>

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -223,6 +223,17 @@ export const ko: Messages = {
   "stageError.agentError": (context, detail) =>
     `\uC5D0\uC774\uC804\uD2B8 \uC624\uB958${context}: ${detail}`,
 
+  // ---- issue sync ---------------------------------------------------------
+
+  "issueSync.summaryHeader": (issueNumber) => `\uC774\uC288 #${issueNumber}:`,
+  "issueSync.summaryMinor": (description) =>
+    `  - \uC5C5\uB370\uC774\uD2B8 (\uC18C\uADDC\uBAA8): ${description}`,
+  "issueSync.summaryMajor": (description) =>
+    `  - \uCF54\uBA58\uD2B8 \uCD94\uAC00 (\uB300\uADDC\uBAA8): ${description}`,
+  "issueSync.summaryNoChanges": "  - \uBCC0\uACBD \uC5C6\uC74C",
+  "issueSync.summarySkipped": "  - \uB3D9\uAE30\uD654 \uAC74\uB108\uB6F0",
+  "issueSync.summaryFailed": "  - \uB3D9\uAE30\uD654 \uC2E4\uD328",
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path) =>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -176,6 +176,15 @@ export interface Messages {
   "stageError.configParsing": (context: string, detail: string) => string;
   "stageError.agentError": (context: string, detail: string) => string;
 
+  // ---- issue sync ---------------------------------------------------------
+
+  "issueSync.summaryHeader": (issueNumber: number) => string;
+  "issueSync.summaryMinor": (description: string) => string;
+  "issueSync.summaryMajor": (description: string) => string;
+  "issueSync.summaryNoChanges": string;
+  "issueSync.summarySkipped": string;
+  "issueSync.summaryFailed": string;
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path: string) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ import type { PipelineSettings } from "./config.js";
 import { loadConfig } from "./config.js";
 import { getGitHubUsername, getIssue } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
+import {
+  formatIssueSyncSummary,
+  type IssueChange,
+  type IssueSyncStatus,
+} from "./issue-sync.js";
 import type {
   PipelineOptions,
   PipelineResult,
@@ -164,7 +169,7 @@ try {
   const { owner, repo, issueNumber } = target;
 
   // Phase 2: check for resumable state and collect run parameters.
-  const savedState = loadRunState(owner, repo, issueNumber);
+  let savedState = loadRunState(owner, repo, issueNumber);
   let params: RunParams;
   let userChoseFresh = false;
 
@@ -219,6 +224,10 @@ try {
         }
       }
       deleteRunState(owner, repo, issueNumber);
+      // Clear the in-memory reference so downstream code does not
+      // hydrate stale issue-sync state (or any other fields) from a
+      // previous run into the fresh pipeline.
+      savedState = undefined;
       userChoseFresh = true;
     }
   }
@@ -314,6 +323,9 @@ try {
   );
 
   const issueCtx = { issueTitle, issueBody };
+  const issueChanges: IssueChange[] = [...(savedState?.issueChanges ?? [])];
+  let issueSyncStatus: IssueSyncStatus =
+    savedState?.issueSyncStatus ?? "skipped";
 
   const implementStage = createImplementStageHandler({
     agent: agentA,
@@ -324,6 +336,16 @@ try {
     ...createSelfCheckStageHandler({
       agent: agentA,
       ...issueCtx,
+      onIssueChange: (change) => {
+        issueChanges.push(change);
+        runState.issueChanges = [...issueChanges];
+        saveRunState(runState);
+      },
+      onIssueSyncStatus: (status) => {
+        issueSyncStatus = status;
+        runState.issueSyncStatus = status;
+        saveRunState(runState);
+      },
     }),
     autoBudget: pipelineSettings.selfCheckAutoIterations,
   };
@@ -389,6 +411,8 @@ try {
       effortLevel: agentBConfig.effortLevel,
       sessionId: undefined,
     },
+    issueSyncStatus: "skipped",
+    issueChanges: [],
   };
 
   // Save initial state.
@@ -487,6 +511,15 @@ try {
 
   console.log();
   console.log(pipelineResult.message);
+
+  console.log();
+  for (const line of formatIssueSyncSummary(
+    issueNumber,
+    issueChanges,
+    issueSyncStatus,
+  )) {
+    console.log(line);
+  }
 
   if (pipelineResult.success) {
     deleteRunState(owner, repo, issueNumber);

--- a/src/issue-sync.test.ts
+++ b/src/issue-sync.test.ts
@@ -1,0 +1,216 @@
+import { beforeAll, describe, expect, test } from "vitest";
+import { initI18n } from "./i18n/index.js";
+import {
+  buildIssueSyncPrompt,
+  buildPrSyncInstructions,
+  formatIssueSyncSummary,
+  parseIssueSyncResponse,
+} from "./issue-sync.js";
+import type { StageContext } from "./pipeline.js";
+
+beforeAll(async () => {
+  await initI18n("en");
+});
+
+const BASE_CTX: StageContext = {
+  owner: "org",
+  repo: "repo",
+  issueNumber: 42,
+  branch: "issue-42",
+  worktreePath: "/tmp/wt",
+  iteration: 0,
+  lastAutoIteration: false,
+  userInstruction: undefined,
+};
+
+// ---- buildIssueSyncPrompt ------------------------------------------------
+
+describe("buildIssueSyncPrompt", () => {
+  const opts = {
+    issueTitle: "Fix the widget",
+    issueBody: "The widget is broken.",
+  };
+
+  test("includes issue context", () => {
+    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
+    expect(prompt).toContain("Issue #42: Fix the widget");
+    expect(prompt).toContain("The widget is broken.");
+  });
+
+  test("includes gh issue edit command with correct repo", () => {
+    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
+    expect(prompt).toContain("gh issue edit 42 --repo org/repo");
+  });
+
+  test("includes gh issue comment command with correct repo", () => {
+    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
+    expect(prompt).toContain("gh issue comment 42 --repo org/repo");
+  });
+
+  test("mentions ISSUE_NO_CHANGES keyword", () => {
+    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
+    expect(prompt).toContain("ISSUE_NO_CHANGES");
+  });
+
+  test("mentions ISSUE_UPDATED and ISSUE_COMMENTED keywords", () => {
+    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
+    expect(prompt).toContain("ISSUE_UPDATED");
+    expect(prompt).toContain("ISSUE_COMMENTED");
+  });
+
+  test("distinguishes minor and major discrepancies", () => {
+    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
+    expect(prompt).toContain("minor discrepancies");
+    expect(prompt).toContain("major discrepancies");
+  });
+});
+
+// ---- parseIssueSyncResponse ----------------------------------------------
+
+describe("parseIssueSyncResponse", () => {
+  test("returns empty array for ISSUE_NO_CHANGES", () => {
+    const result = parseIssueSyncResponse(
+      "Everything matches.\n\nISSUE_NO_CHANGES",
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("parses a single ISSUE_UPDATED line", () => {
+    const result = parseIssueSyncResponse(
+      "Updated the description.\n\nISSUE_UPDATED: corrected file path",
+    );
+    expect(result).toEqual([
+      { type: "minor", description: "corrected file path" },
+    ]);
+  });
+
+  test("parses a single ISSUE_COMMENTED line", () => {
+    const result = parseIssueSyncResponse(
+      "Left a comment.\n\nISSUE_COMMENTED: uses WebSocket instead of polling",
+    );
+    expect(result).toEqual([
+      { type: "major", description: "uses WebSocket instead of polling" },
+    ]);
+  });
+
+  test("parses both ISSUE_UPDATED and ISSUE_COMMENTED", () => {
+    const text = [
+      "Made some changes.",
+      "ISSUE_UPDATED: fixed typo in description",
+      "ISSUE_COMMENTED: scope expanded to include API changes",
+    ].join("\n");
+    const result = parseIssueSyncResponse(text);
+    expect(result).toEqual([
+      { type: "minor", description: "fixed typo in description" },
+      { type: "major", description: "scope expanded to include API changes" },
+    ]);
+  });
+
+  test("returns empty array for unrecognised response", () => {
+    const result = parseIssueSyncResponse(
+      "I looked at the issue and it seems fine.",
+    );
+    expect(result).toEqual([]);
+  });
+
+  test("is case-insensitive", () => {
+    const result = parseIssueSyncResponse("issue_updated: fixed path");
+    expect(result).toEqual([{ type: "minor", description: "fixed path" }]);
+  });
+
+  test("trims description whitespace", () => {
+    const result = parseIssueSyncResponse("ISSUE_UPDATED:   extra spaces  ");
+    expect(result).toEqual([{ type: "minor", description: "extra spaces" }]);
+  });
+
+  test("handles multiple ISSUE_UPDATED lines", () => {
+    const text = [
+      "ISSUE_UPDATED: fixed path in step 1",
+      "ISSUE_UPDATED: clarified wording in step 3",
+    ].join("\n");
+    const result = parseIssueSyncResponse(text);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("minor");
+    expect(result[1].type).toBe("minor");
+  });
+});
+
+// ---- buildPrSyncInstructions ---------------------------------------------
+
+describe("buildPrSyncInstructions", () => {
+  test("mentions gh pr view", () => {
+    const text = buildPrSyncInstructions(42);
+    expect(text).toContain("gh pr view");
+  });
+
+  test("mentions gh pr edit", () => {
+    const text = buildPrSyncInstructions(42);
+    expect(text).toContain("gh pr edit");
+  });
+
+  test("includes issue number in references", () => {
+    const text = buildPrSyncInstructions(99);
+    expect(text).toContain("Closes #99");
+    expect(text).toContain("Part of #99");
+  });
+});
+
+// ---- formatIssueSyncSummary ----------------------------------------------
+
+describe("formatIssueSyncSummary", () => {
+  test("prints no-change line when there are no changes", () => {
+    const lines = formatIssueSyncSummary(42, []);
+    expect(lines).toEqual(["Issue #42:", "  - No changes"]);
+  });
+
+  test("prints minor change", () => {
+    const lines = formatIssueSyncSummary(42, [
+      { type: "minor", description: "corrected file path" },
+    ]);
+    expect(lines).toEqual([
+      "Issue #42:",
+      "  - Updated (minor): corrected file path",
+    ]);
+  });
+
+  test("prints major change", () => {
+    const lines = formatIssueSyncSummary(42, [
+      { type: "major", description: "uses WebSocket instead of polling" },
+    ]);
+    expect(lines).toEqual([
+      "Issue #42:",
+      "  - Comment added (major): uses WebSocket instead of polling",
+    ]);
+  });
+
+  test("prints mixed minor and major changes", () => {
+    const lines = formatIssueSyncSummary(7, [
+      { type: "minor", description: "fixed typo" },
+      { type: "major", description: "scope expanded" },
+    ]);
+    expect(lines).toEqual([
+      "Issue #7:",
+      "  - Updated (minor): fixed typo",
+      "  - Comment added (major): scope expanded",
+    ]);
+  });
+
+  test("prints sync skipped when status is skipped", () => {
+    const lines = formatIssueSyncSummary(42, [], "skipped");
+    expect(lines).toEqual(["Issue #42:", "  - Sync skipped"]);
+  });
+
+  test("prints sync failed when status is failed", () => {
+    const lines = formatIssueSyncSummary(42, [], "failed");
+    expect(lines).toEqual(["Issue #42:", "  - Sync failed"]);
+  });
+
+  test("ignores changes array when status is skipped", () => {
+    const lines = formatIssueSyncSummary(
+      42,
+      [{ type: "minor", description: "should be ignored" }],
+      "skipped",
+    );
+    expect(lines).toEqual(["Issue #42:", "  - Sync skipped"]);
+  });
+});

--- a/src/issue-sync.ts
+++ b/src/issue-sync.ts
@@ -1,0 +1,161 @@
+/**
+ * Issue and PR description synchronisation.
+ *
+ * After the self-check stage completes (DONE), the agent compares the
+ * actual implementation against the original issue description.  Minor
+ * discrepancies (typos, added details) are auto-updated; major ones
+ * (scope changes, different approach) are reported as issue comments.
+ *
+ * PR description updates happen before each push — the agent checks
+ * whether the PR body still reflects the code changes and updates it
+ * via `gh pr edit` if not.
+ */
+
+import { t } from "./i18n/index.js";
+import type { StageContext } from "./pipeline.js";
+
+// ---- public types --------------------------------------------------------
+
+export interface IssueChange {
+  type: "minor" | "major";
+  description: string;
+}
+
+export type IssueSyncStatus = "completed" | "skipped" | "failed";
+
+// ---- issue sync prompt ---------------------------------------------------
+
+export function buildIssueSyncPrompt(
+  ctx: StageContext,
+  opts: { issueTitle: string; issueBody: string },
+): string {
+  return [
+    `You have completed the self-check.  Now compare the actual`,
+    `implementation against the original issue description below.`,
+    ``,
+    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
+    ``,
+    opts.issueBody,
+    ``,
+    `## Instructions`,
+    ``,
+    `1. Review the implementation in the worktree and compare it against`,
+    `   the issue description above.`,
+    `2. Determine if there are any discrepancies between what was`,
+    `   implemented and what the issue describes.`,
+    `3. For **minor discrepancies** (typos, corrected file paths,`,
+    `   clarified wording, added details): update the issue description`,
+    `   directly using:`,
+    `   \`gh issue edit ${ctx.issueNumber} --repo ${ctx.owner}/${ctx.repo} --body-file <(cat <<'ISSUE_BODY'`,
+    `   <new body here>`,
+    `   ISSUE_BODY`,
+    `   )\``,
+    `4. For **major discrepancies** (scope change, different approach,`,
+    `   modified requirements): leave a comment on the issue using:`,
+    `   \`gh issue comment ${ctx.issueNumber} --repo ${ctx.owner}/${ctx.repo} --body "..."\``,
+    `   Do NOT modify the issue description for major changes.`,
+    `5. If there are no discrepancies, do nothing.`,
+    ``,
+    `## Response format`,
+    ``,
+    `End your response with one of the following:`,
+    ``,
+    `- If no changes were needed:`,
+    `  \`ISSUE_NO_CHANGES\``,
+    `- If you updated the issue (minor):`,
+    `  \`ISSUE_UPDATED: <brief description of what changed>\``,
+    `- If you added a comment (major):`,
+    `  \`ISSUE_COMMENTED: <brief description of the discrepancy>\``,
+    ``,
+    `You may include both ISSUE_UPDATED and ISSUE_COMMENTED if there`,
+    `were both minor and major discrepancies.`,
+  ].join("\n");
+}
+
+// ---- issue sync response parser ------------------------------------------
+
+/**
+ * Parse the agent's issue sync response into a list of changes.
+ *
+ * Recognised line formats (case-insensitive):
+ *   ISSUE_NO_CHANGES
+ *   ISSUE_UPDATED: <description>
+ *   ISSUE_COMMENTED: <description>
+ */
+export function parseIssueSyncResponse(responseText: string): IssueChange[] {
+  const changes: IssueChange[] = [];
+
+  for (const line of responseText.split("\n")) {
+    const trimmed = line.trim();
+
+    const updatedMatch = trimmed.match(/^ISSUE_UPDATED:\s*(.+)$/i);
+    if (updatedMatch) {
+      changes.push({ type: "minor", description: updatedMatch[1].trim() });
+      continue;
+    }
+
+    const commentedMatch = trimmed.match(/^ISSUE_COMMENTED:\s*(.+)$/i);
+    if (commentedMatch) {
+      changes.push({ type: "major", description: commentedMatch[1].trim() });
+    }
+  }
+
+  return changes;
+}
+
+// ---- PR description sync prompt ------------------------------------------
+
+/**
+ * Build additional instructions for PR description synchronisation.
+ *
+ * Appended to prompts that precede a push so the agent checks and
+ * updates the PR description if it has drifted from the code.
+ */
+export function buildPrSyncInstructions(issueNumber: number): string {
+  return [
+    `Before pushing, check whether the PR description still accurately`,
+    `reflects the current code changes.  Run`,
+    `\`gh pr view --json body --jq .body\` to read the current`,
+    `description, then compare it against what the branch actually does.`,
+    `If the description is outdated or inaccurate, update it using`,
+    `\`gh pr edit --body "..."\`.  Keep the issue reference`,
+    `(Closes #${issueNumber} or Part of #${issueNumber}) in the body.`,
+  ].join("\n");
+}
+
+// ---- issue sync summary formatting --------------------------------------
+
+/**
+ * Format the issue sync summary lines for CLI output.
+ *
+ * Always returns at least the header and one detail line.  The
+ * {@link status} distinguishes a successful sync (where an empty
+ * {@link changes} array means "no discrepancies found") from one that
+ * was skipped or that failed.
+ */
+export function formatIssueSyncSummary(
+  issueNumber: number,
+  changes: readonly IssueChange[],
+  status: IssueSyncStatus = "completed",
+): string[] {
+  const im = t();
+  const lines: string[] = [im["issueSync.summaryHeader"](issueNumber)];
+
+  if (status === "skipped") {
+    lines.push(im["issueSync.summarySkipped"]);
+  } else if (status === "failed") {
+    lines.push(im["issueSync.summaryFailed"]);
+  } else if (changes.length === 0) {
+    lines.push(im["issueSync.summaryNoChanges"]);
+  } else {
+    for (const change of changes) {
+      if (change.type === "minor") {
+        lines.push(im["issueSync.summaryMinor"](change.description));
+      } else {
+        lines.push(im["issueSync.summaryMajor"](change.description));
+      }
+    }
+  }
+
+  return lines;
+}

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -48,6 +48,8 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
       effortLevel: undefined,
       sessionId: undefined,
     },
+    issueSyncStatus: "skipped",
+    issueChanges: [],
     ...overrides,
   };
 }
@@ -324,5 +326,104 @@ describe("resume preserves contextWindow and effortLevel", () => {
     expect(loaded?.agentA.effortLevel).toBeUndefined();
     expect(loaded?.agentB.contextWindow).toBeUndefined();
     expect(loaded?.agentB.effortLevel).toBeUndefined();
+  });
+});
+
+describe("start-fresh clears issue sync state", () => {
+  test("loadRunState returns undefined after deleteRunState so stale sync data is not hydrated", () => {
+    const state = makeRunState({
+      issueSyncStatus: "completed",
+      issueChanges: [
+        { type: "minor", description: "corrected file path" },
+        { type: "major", description: "scope expanded to include API" },
+      ],
+    });
+    saveRunState(state);
+    expect(loadRunState("org", "repo", 42)).toBeDefined();
+
+    // Simulate "Start fresh" path: delete on disk, then verify
+    // the hydration pattern from index.ts yields clean defaults.
+    deleteRunState("org", "repo", 42);
+    const afterFresh = loadRunState("org", "repo", 42);
+    expect(afterFresh).toBeUndefined();
+
+    // This mirrors the hydration in index.ts (lines 322-324):
+    //   const issueChanges = [...(savedState?.issueChanges ?? [])];
+    //   let issueSyncStatus = savedState?.issueSyncStatus ?? "skipped";
+    const issueChanges = [...(afterFresh?.issueChanges ?? [])];
+    const issueSyncStatus = afterFresh?.issueSyncStatus ?? "skipped";
+    expect(issueChanges).toEqual([]);
+    expect(issueSyncStatus).toBe("skipped");
+  });
+});
+
+describe("resume preserves issue sync state", () => {
+  test("round-trips issueSyncStatus and issueChanges", () => {
+    const state = makeRunState({
+      currentStage: 5,
+      issueSyncStatus: "completed",
+      issueChanges: [
+        { type: "minor", description: "corrected file path" },
+        { type: "major", description: "scope expanded to include API" },
+      ],
+    });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+
+    expect(loaded?.issueSyncStatus).toBe("completed");
+    expect(loaded?.issueChanges).toEqual([
+      { type: "minor", description: "corrected file path" },
+      { type: "major", description: "scope expanded to include API" },
+    ]);
+  });
+
+  test("round-trips completed status with empty changes", () => {
+    const state = makeRunState({
+      currentStage: 5,
+      issueSyncStatus: "completed",
+      issueChanges: [],
+    });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+
+    expect(loaded?.issueSyncStatus).toBe("completed");
+    expect(loaded?.issueChanges).toEqual([]);
+  });
+
+  test("round-trips failed status", () => {
+    const state = makeRunState({
+      currentStage: 5,
+      issueSyncStatus: "failed",
+      issueChanges: [],
+    });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+
+    expect(loaded?.issueSyncStatus).toBe("failed");
+  });
+
+  test("defaults to skipped and empty changes for old state files", () => {
+    // Simulate a state file written before issue sync fields existed.
+    const { issueSyncStatus: _, issueChanges: __, ...raw } = makeRunState();
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.issueSyncStatus).toBe("skipped");
+    expect(loaded?.issueChanges).toEqual([]);
+  });
+
+  test("rejects invalid issueSyncStatus value", () => {
+    const raw = { ...makeRunState(), issueSyncStatus: "unknown" };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    expect(loadRunState("org", "repo", 42)).toBeUndefined();
   });
 });

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -16,6 +16,8 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import type { IssueChange, IssueSyncStatus } from "./issue-sync.js";
+
 // ---- public types --------------------------------------------------------
 
 export interface AgentState {
@@ -52,6 +54,8 @@ export interface RunState {
   claudePermissionMode: "auto" | "bypass";
   agentA: AgentState;
   agentB: AgentState;
+  issueSyncStatus: IssueSyncStatus;
+  issueChanges: IssueChange[];
 }
 
 // ---- path helpers --------------------------------------------------------
@@ -121,7 +125,13 @@ function isValidRunState(
     (r.claudePermissionMode === "auto" ||
       r.claudePermissionMode === "bypass") &&
     isValidAgentState(r.agentA) &&
-    isValidAgentState(r.agentB)
+    isValidAgentState(r.agentB) &&
+    // issueSyncStatus and issueChanges are optional for backward compat
+    (r.issueSyncStatus === undefined ||
+      r.issueSyncStatus === "completed" ||
+      r.issueSyncStatus === "skipped" ||
+      r.issueSyncStatus === "failed") &&
+    (r.issueChanges === undefined || Array.isArray(r.issueChanges))
   );
 }
 
@@ -166,10 +176,14 @@ export function loadRunState(
   if (!isValidRunState(raw)) return undefined;
 
   // Normalise null → undefined for optional fields and backfill version.
+  const r = raw as Record<string, unknown>;
   const normalised: RunState = {
     ...raw,
-    version: ((raw as Record<string, unknown>).version as number) ?? 1,
+    version: (r.version as number) ?? 1,
     prNumber: raw.prNumber ?? undefined,
+    issueSyncStatus:
+      (raw.issueSyncStatus as IssueSyncStatus | undefined) ?? "skipped",
+    issueChanges: (raw.issueChanges as IssueChange[] | undefined) ?? [],
     agentA: {
       ...raw.agentA,
       contextWindow: raw.agentA.contextWindow ?? undefined,

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -19,6 +19,7 @@ import {
   normaliseCiConclusion,
 } from "./ci.js";
 import { t } from "./i18n/index.js";
+import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import { invokeOrResume, mapAgentError } from "./stage-util.js";
 import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
@@ -89,7 +90,11 @@ export function buildCiFixPrompt(
     `## Instructions`,
     ``,
     `Diagnose and fix the CI failures shown above.  After making your`,
-    `changes, commit and push the branch so a new CI run is triggered.`,
+    `changes:`,
+    ``,
+    `${buildPrSyncInstructions(ctx.issueNumber)}`,
+    ``,
+    `Then commit and push the branch so a new CI run is triggered.`,
   ];
 
   if (ctx.userInstruction) {

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -311,7 +311,10 @@ describe("Stage 3 (Self-check) through pipeline", () => {
         if (resumeCalls < 3) {
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
-        return makeStream(makeResult({ responseText: "DONE" }));
+        // resumeCalls 3 = DONE, resumeCalls 4 = issue sync follow-up
+        return makeStream(
+          makeResult({ responseText: "ISSUE_NO_CHANGES\n\nDONE" }),
+        );
       }),
     };
 
@@ -320,7 +323,7 @@ describe("Stage 3 (Self-check) through pipeline", () => {
 
     expect(result.success).toBe(true);
     expect(invokeCalls).toBe(3); // 3 self-check rounds
-    expect(resumeCalls).toBe(3); // 3 fix-or-done rounds
+    expect(resumeCalls).toBe(4); // 3 fix-or-done + 1 issue sync
   });
 
   test("FIXED 3x → budget exhausted → user approves → DONE", async () => {
@@ -338,7 +341,10 @@ describe("Stage 3 (Self-check) through pipeline", () => {
         if (resumeCalls <= 3) {
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
-        return makeStream(makeResult({ responseText: "DONE" }));
+        // resumeCalls 4 = DONE, resumeCalls 5 = issue sync follow-up
+        return makeStream(
+          makeResult({ responseText: "ISSUE_NO_CHANGES\n\nDONE" }),
+        );
       }),
     };
     const prompt = makePrompt({
@@ -1471,7 +1477,8 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
     expect(implInvokeCalls).toBe(1);
     expect(implResumeCalls).toBe(1);
     expect(scInvokeCalls).toBe(1);
-    expect(scResumeCalls).toBe(1);
+    // 1 fix-or-done + 1 issue sync follow-up
+    expect(scResumeCalls).toBe(2);
   });
 
   test("implement completes → self-check FIXED twice then DONE", async () => {
@@ -1496,7 +1503,10 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
         if (scResumeCalls <= 2) {
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
-        return makeStream(makeResult({ responseText: "DONE" }));
+        // scResumeCalls 3 = DONE, 4 = issue sync follow-up
+        return makeStream(
+          makeResult({ responseText: "ISSUE_NO_CHANGES\n\nDONE" }),
+        );
       }),
     };
 
@@ -1514,7 +1524,8 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(scResumeCalls).toBe(3);
+    // 2 FIXED + 1 DONE + 1 issue sync follow-up
+    expect(scResumeCalls).toBe(4);
   });
 
   test("step mode asks before each stage", async () => {

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -27,6 +27,7 @@ import {
 } from "./ci.js";
 import { pollCiAndFix } from "./ci-poll.js";
 import { t } from "./i18n/index.js";
+import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   drainToSink,
@@ -145,7 +146,8 @@ export function buildAuthorFixPrompt(
     `3. Fix all agreed-upon items from the review.`,
     `4. Post a response as a PR comment prefixed with`,
     `   \`**[Author Round ${round}]**\` summarising what you changed.`,
-    `5. Commit and push your changes so a new CI run is triggered.`,
+    `5. ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `6. Commit and push your changes so a new CI run is triggered.`,
   ];
 
   return lines.join("\n");

--- a/src/stage-selfcheck.test.ts
+++ b/src/stage-selfcheck.test.ts
@@ -269,4 +269,218 @@ describe("createSelfCheckStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
     expect(result.message).toBe(text);
   });
+
+  // -- issue sync step -------------------------------------------------------
+
+  test("reports completed sync status on successful sync", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.\n\nDONE",
+    });
+    const syncResult = makeResult({
+      responseText: "Everything matches.\n\nISSUE_NO_CHANGES",
+    });
+
+    let resumeCall = 0;
+    const resumeResults = [fixResult, syncResult];
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi
+        .fn()
+        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
+    };
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueSyncStatus }),
+    );
+    await stage.handler(BASE_CTX);
+
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("completed");
+  });
+
+  test("reports failed sync status when sendFollowUp throws", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.\n\nDONE",
+    });
+
+    let resumeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi.fn().mockImplementation(() => {
+        if (resumeCall++ === 0) return makeStream(fixResult);
+        throw new Error("network error");
+      }),
+    };
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueSyncStatus }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("failed");
+  });
+
+  test("sends issue sync prompt after DONE and reports changes", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.\n\nDONE",
+    });
+    const syncResult = makeResult({
+      responseText:
+        "Compared implementation.\n\nISSUE_UPDATED: corrected file path",
+    });
+
+    let resumeCall = 0;
+    const resumeResults = [fixResult, syncResult];
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi
+        .fn()
+        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
+    };
+    const onIssueChange = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(onIssueChange).toHaveBeenCalledWith({
+      type: "minor",
+      description: "corrected file path",
+    });
+  });
+
+  test("reports major changes via onIssueChange", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.\n\nDONE",
+    });
+    const syncResult = makeResult({
+      responseText: "ISSUE_COMMENTED: uses WebSocket instead of polling",
+    });
+
+    let resumeCall = 0;
+    const resumeResults = [fixResult, syncResult];
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi
+        .fn()
+        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
+    };
+    const onIssueChange = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange }),
+    );
+    await stage.handler(BASE_CTX);
+
+    expect(onIssueChange).toHaveBeenCalledWith({
+      type: "major",
+      description: "uses WebSocket instead of polling",
+    });
+  });
+
+  test("skips issue sync when fix response is FIXED (not DONE)", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Fixed.\n\nFIXED",
+    });
+    const agent = makeAgent(checkResult, fixResult);
+    const onIssueChange = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("not_approved");
+    // Only one resume call (fix-or-done), no issue sync
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect(onIssueChange).not.toHaveBeenCalled();
+  });
+
+  test("does not call onIssueChange when sync reports no changes", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.\n\nDONE",
+    });
+    const syncResult = makeResult({
+      responseText: "Everything matches.\n\nISSUE_NO_CHANGES",
+    });
+
+    let resumeCall = 0;
+    const resumeResults = [fixResult, syncResult];
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi
+        .fn()
+        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
+    };
+    const onIssueChange = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange }),
+    );
+    await stage.handler(BASE_CTX);
+
+    expect(onIssueChange).not.toHaveBeenCalled();
+  });
+
+  test("issue sync failure does not fail the stage and reports failed status", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.\n\nDONE",
+    });
+    const syncResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      responseText: "",
+    });
+
+    let resumeCall = 0;
+    const resumeResults = [fixResult, syncResult];
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi
+        .fn()
+        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
+    };
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueSyncStatus }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    // Stage should still complete successfully
+    expect(result.outcome).toBe("completed");
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("failed");
+  });
+
+  test("skips issue sync when fix response has no session ID and reports skipped status", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: undefined,
+      responseText: "All good.\n\nDONE",
+    });
+
+    const agent = makeAgent(checkResult, fixResult);
+    const onIssueChange = vi.fn();
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange, onIssueSyncStatus }),
+    );
+
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("completed");
+    expect(onIssueChange).not.toHaveBeenCalled();
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("skipped");
+  });
 });

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -13,6 +13,12 @@
 
 import type { AgentAdapter } from "./agent.js";
 import { t } from "./i18n/index.js";
+import {
+  buildIssueSyncPrompt,
+  type IssueChange,
+  type IssueSyncStatus,
+  parseIssueSyncResponse,
+} from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   invokeOrResume,
@@ -25,6 +31,16 @@ export interface SelfCheckStageOptions {
   agent: AgentAdapter;
   issueTitle: string;
   issueBody: string;
+  /**
+   * Called when the issue description is updated or a comment is added
+   * during issue sync.  The caller collects these for the final summary.
+   */
+  onIssueChange?: (change: IssueChange) => void;
+  /**
+   * Called with the overall outcome of the issue sync step so the
+   * caller can distinguish "no discrepancies" from "sync skipped/failed".
+   */
+  onIssueSyncStatus?: (status: IssueSyncStatus) => void;
 }
 
 export function buildSelfCheckPrompt(
@@ -120,7 +136,40 @@ export function createSelfCheckStageHandler(
         return mapAgentError(fixResult, "during fix");
       }
 
-      return mapFixOrDoneResponse(fixResult.responseText);
+      const result = mapFixOrDoneResponse(fixResult.responseText);
+
+      // Step 3: Issue description sync (only when self-check is done).
+      if (result.outcome === "completed" && fixResult.sessionId) {
+        try {
+          const syncPrompt = buildIssueSyncPrompt(ctx, opts);
+          ctx.promptSinks?.a?.(syncPrompt);
+          const syncResult = await sendFollowUp(
+            opts.agent,
+            fixResult.sessionId,
+            syncPrompt,
+            ctx.worktreePath,
+            ctx.streamSinks?.a,
+          );
+
+          if (syncResult.status === "success") {
+            const changes = parseIssueSyncResponse(syncResult.responseText);
+            for (const change of changes) {
+              opts.onIssueChange?.(change);
+            }
+            opts.onIssueSyncStatus?.("completed");
+          } else {
+            opts.onIssueSyncStatus?.("failed");
+          }
+        } catch {
+          // Issue sync is best-effort; do not fail the stage.
+          opts.onIssueSyncStatus?.("failed");
+        }
+      } else if (result.outcome === "completed") {
+        // Self-check passed but we could not run issue sync (no session ID).
+        opts.onIssueSyncStatus?.("skipped");
+      }
+
+      return result;
     },
   };
 }

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -110,6 +110,12 @@ describe("buildSquashPrompt", () => {
     expect(prompt).toContain("Force-push the branch");
   });
 
+  test("includes PR description sync instructions", () => {
+    const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("gh pr view");
+    expect(prompt).toContain("gh pr edit");
+  });
+
   test("includes user instruction when present", () => {
     const ctx = { ...BASE_CTX, userInstruction: "Keep merge commits" };
     const prompt = buildSquashPrompt(ctx, makeOpts());

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -20,6 +20,7 @@ import {
 } from "./ci.js";
 import { type CiPollResult, pollCiAndFix } from "./ci-poll.js";
 import { t } from "./i18n/index.js";
+import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   invokeOrResume,
@@ -77,12 +78,13 @@ export function buildSquashPrompt(
     ``,
     `## Instructions`,
     ``,
-    `1. Squash all commits on this branch into a single commit.  Use an`,
+    `1. ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `2. Squash all commits on this branch into a single commit.  Use an`,
     `   interactive rebase or reset-based approach — whichever is simpler.`,
-    `2. Write a clear, concise commit message that summarises all changes`,
+    `3. Write a clear, concise commit message that summarises all changes`,
     `   made for this issue.  Reference the issue number`,
     `   (e.g. "Implement widget rendering (#42)").`,
-    `3. Force-push the branch (\`git push --force-with-lease\`).`,
+    `4. Force-push the branch (\`git push --force-with-lease\`).`,
   ];
 
   if (ctx.userInstruction) {

--- a/src/stage-testplan.test.ts
+++ b/src/stage-testplan.test.ts
@@ -92,6 +92,13 @@ describe("buildTestPlanVerifyPrompt", () => {
     expect(prompt).toContain("commit and push");
   });
 
+  test("includes PR sync instructions before pushing", () => {
+    const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("gh pr view");
+    expect(prompt).toContain("gh pr edit");
+    expect(prompt).toContain("#42");
+  });
+
   test("includes user instruction when present", () => {
     const ctx = { ...BASE_CTX, userInstruction: "Skip flaky tests" };
     const prompt = buildTestPlanVerifyPrompt(ctx, makeOpts());

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -14,6 +14,7 @@
 
 import type { AgentAdapter } from "./agent.js";
 import { t } from "./i18n/index.js";
+import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   invokeOrResume,
@@ -53,8 +54,9 @@ export function buildTestPlanVerifyPrompt(
     `3. Check off each verified item in the PR using \`gh\` commands.`,
     `4. Also go through the task checklist in the GitHub issue.  Check`,
     `   off each completed task using \`gh\` commands.`,
-    `5. If you made any code changes, commit and push them so a new CI`,
-    `   run is triggered.`,
+    `5. If you made any code changes:`,
+    `   ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `   Then commit and push them so a new CI run is triggered.`,
     `6. Make sure CI is still passing after any changes.`,
   ];
 


### PR DESCRIPTION
## Summary

- Add `issue-sync.ts` module with prompt builders, response parser, and `IssueChange` type for comparing implementation against the original issue description.
- After the self-check stage completes, the agent syncs the issue description: minor discrepancies are auto-updated, major ones get an issue comment.
- Before every push (squash, CI-fix, review stages), the agent checks whether the PR description still reflects the code and updates it via `gh pr edit` if needed.
- At the end of the pipeline, print a summary of issue changes distinguishing minor (auto-applied) from major (comment only).
- Add i18n support (English and Korean) for the summary output.

Closes #58

## Test plan

- [x] `issue-sync.test.ts`: verify prompt building, response parsing, and PR sync instruction generation
- [x] `stage-selfcheck.test.ts`: verify issue sync prompt is sent after DONE, minor/major changes reported via `onIssueChange`, sync skipped on FIXED, sync failure does not fail the stage, sync skipped when no session ID
- [x] `stage-squash.test.ts`: verify squash prompt includes PR description sync instructions
- [x] `stage-e2e.test.ts`: verify end-to-end pipeline accounts for the extra issue sync resume call
- [x] All 991 tests pass (`pnpm vitest run`)
- [x] Biome lint and TypeScript type check pass