### PR TITLE
Fix git fetch failure with checked-out worktrees (#81)

### DIFF
--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -124,7 +124,7 @@ describe("bootstrapRepo", () => {
     const dest = bootstrapRepo("org", "repo");
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "git",
-      ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
+      ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"],
       expect.objectContaining({ encoding: "utf-8", cwd: dest }),
     );
   });
@@ -135,7 +135,7 @@ describe("bootstrapRepo", () => {
     // Return existing refspec so ensureFetchRefspec is a no-op
     mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "config" && args.length === 2)
-        return "+refs/heads/*:refs/heads/*\n";
+        return "+refs/heads/*:refs/remotes/origin/*\n";
       return "" as never;
     }) as typeof execFileSync);
     bootstrapRepo("org", "repo");
@@ -161,7 +161,7 @@ describe("bootstrapRepo", () => {
     // Should set the refspec before fetching
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "git",
-      ["config", "remote.origin.fetch", "+refs/heads/*:refs/heads/*"],
+      ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"],
       expect.objectContaining({ cwd: dest }),
     );
     const configSetIdx = calls.findIndex(
@@ -175,7 +175,7 @@ describe("bootstrapRepo", () => {
     mockExistsSync.mockReturnValue(true);
     mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
       if (cmd === "git" && args[0] === "config" && args.length === 2)
-        return "+refs/heads/*:refs/heads/*\n";
+        return "+refs/heads/*:refs/remotes/origin/*\n";
       return "" as never;
     }) as typeof execFileSync);
     bootstrapRepo("org", "repo");
@@ -187,6 +187,47 @@ describe("bootstrapRepo", () => {
         (c[1] as string[]).length === 3,
     );
     expect(configSetCalls).toHaveLength(0);
+  });
+
+  test("fetches after clone to populate remote-tracking refs", () => {
+    const dest = repoPath("org", "repo");
+    mockExistsSync.mockReturnValue(false);
+    const calls: string[][] = [];
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      calls.push([cmd, ...args]);
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        throw new Error("key missing");
+      return "" as never;
+    }) as typeof execFileSync);
+    bootstrapRepo("org", "repo");
+    // A fetch must follow the refspec config set so that
+    // refs/remotes/origin/* is populated for createWorktree().
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["fetch", "--all", "--prune"],
+      expect.objectContaining({ cwd: dest }),
+    );
+    const configSetIdx = calls.findIndex(
+      (c) => c[0] === "git" && c[1] === "config" && c.length === 4,
+    );
+    const fetchIdx = calls.findIndex((c) => c[0] === "git" && c[1] === "fetch");
+    expect(configSetIdx).toBeLessThan(fetchIdx);
+  });
+
+  test("replaces legacy refspec on existing bare repo", () => {
+    const dest = repoPath("org", "repo");
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        return "+refs/heads/*:refs/heads/*\n";
+      return "" as never;
+    }) as typeof execFileSync);
+    bootstrapRepo("org", "repo");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"],
+      expect.objectContaining({ cwd: dest }),
+    );
   });
 });
 
@@ -261,7 +302,7 @@ describe("createWorktree", () => {
     expect(result.branch).toBe("issue-5");
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "git",
-      ["worktree", "add", "-b", "issue-5", result.path, "main"],
+      ["worktree", "add", "-b", "issue-5", result.path, "origin/main"],
       expect.objectContaining({ cwd: repoPath("org", "repo") }),
     );
   });
@@ -276,7 +317,7 @@ describe("createWorktree", () => {
     expect(result.branch).toBe("alice/issue-5");
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "git",
-      ["worktree", "add", "-b", "alice/issue-5", result.path, "main"],
+      ["worktree", "add", "-b", "alice/issue-5", result.path, "origin/main"],
       expect.objectContaining({ cwd: repoPath("org", "repo") }),
     );
   });

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -100,32 +100,45 @@ export function bootstrapRepo(owner: string, repo: string): string {
         EXEC_OPTS,
       );
       ensureFetchRefspec(dest);
+      // After a bare clone the repo only has refs/heads/*; fetch once
+      // to populate refs/remotes/origin/* so createWorktree() can
+      // reference origin/<baseBranch>.
+      execFileSync("git", ["fetch", "--all", "--prune"], {
+        ...EXEC_OPTS,
+        cwd: dest,
+      });
     }
   });
 
   return dest;
 }
 
-const FETCH_REFSPEC = "+refs/heads/*:refs/heads/*";
+const FETCH_REFSPEC = "+refs/heads/*:refs/remotes/origin/*";
 
 /**
- * Set `remote.origin.fetch` if it is missing or empty.
+ * Ensure `remote.origin.fetch` uses the correct refspec.
  *
  * `git clone --bare` does not create this config entry, so without it
  * `git fetch --all` has nothing to fetch and local refs stay stale.
+ *
+ * Existing bare repos may still have the legacy refspec
+ * `+refs/heads/*:refs/heads/*` which writes directly into local branch
+ * refs and conflicts with checked-out worktree branches.  This function
+ * replaces it with the remote-tracking variant.
  */
 function ensureFetchRefspec(cwd: string): void {
+  let current = "";
   try {
-    const current = (
+    current = (
       execFileSync("git", ["config", "remote.origin.fetch"], {
         ...EXEC_OPTS,
         cwd,
       }) as string
     ).trim();
-    if (current) return;
   } catch {
     // Config key missing — fall through to set it.
   }
+  if (current === FETCH_REFSPEC) return;
   execFileSync("git", ["config", "remote.origin.fetch", FETCH_REFSPEC], {
     ...EXEC_OPTS,
     cwd,
@@ -170,7 +183,7 @@ function getCheckedOutBranch(wtPath: string): string {
 export function countBranchCommits(cwd: string, baseBranch: string): number {
   const output = execFileSync(
     "git",
-    ["rev-list", "--count", `${baseBranch}..HEAD`],
+    ["rev-list", "--count", `origin/${baseBranch}..HEAD`],
     { ...EXEC_OPTS, cwd },
   ) as string;
   return Number.parseInt(output.trim(), 10);
@@ -279,7 +292,7 @@ export function createWorktree(options: {
         // Recreate.
         execFileSync(
           "git",
-          ["worktree", "add", "-b", branch, wtPath, baseBranch],
+          ["worktree", "add", "-b", branch, wtPath, `origin/${baseBranch}`],
           { ...EXEC_OPTS, cwd: bare },
         );
       });
@@ -295,10 +308,11 @@ export function createWorktree(options: {
   // Create the worktree with a new branch tracking the base branch.
   const lockPath = repoLockPath(owner, repo);
   withLock(lockPath, () => {
-    execFileSync("git", ["worktree", "add", "-b", branch, wtPath, baseBranch], {
-      ...EXEC_OPTS,
-      cwd: bare,
-    });
+    execFileSync(
+      "git",
+      ["worktree", "add", "-b", branch, wtPath, `origin/${baseBranch}`],
+      { ...EXEC_OPTS, cwd: bare },
+    );
   });
 
   return { path: wtPath, branch, hadUncommittedChanges: false };


### PR DESCRIPTION
## Summary

- Change the fetch refspec from `+refs/heads/*:refs/heads/*` to `+refs/heads/*:refs/remotes/origin/*` so fetched branches land in remote-tracking refs instead of local branch refs, avoiding conflicts with checked-out worktree branches.
- Update `ensureFetchRefspec()` to replace the legacy refspec on existing bare repos (not just set it when missing).
- Base new worktrees on `origin/<baseBranch>` instead of the local branch name.
- Update `countBranchCommits()` to use `origin/<baseBranch>..HEAD` since local `refs/heads/<baseBranch>` is no longer updated by fetch.
- Fetch immediately after a fresh bare clone so that `refs/remotes/origin/*` is populated before `createWorktree()` references `origin/<baseBranch>`.

Closes #81

## Test plan

- [x] `bootstrapRepo()` succeeds even when existing worktrees have branches checked out
- [x] `ensureFetchRefspec()` replaces the legacy `+refs/heads/*:refs/heads/*` refspec
- [x] `ensureFetchRefspec()` is a no-op when the correct refspec already exists
- [x] `ensureFetchRefspec()` sets the refspec when the config key is missing
- [x] `createWorktree()` uses `origin/<baseBranch>` as the start point
- [x] Fresh clone path fetches after setting refspec to populate remote-tracking refs
- [x] All 38 tests pass