### PR TITLE
Fix agent pane word wrapping (#79)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@inquirer/prompts": "^8.3.2",
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
-    "react": "^19.2.4"
+    "react": "^19.2.4",
+    "wrap-ansi": "^10.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react:
         specifier: ^19.2.4
         version: 19.2.4
+      wrap-ansi:
+        specifier: ^10.0.0
+        version: 10.0.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.7
@@ -863,6 +866,10 @@ packages:
     resolution: {integrity: sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA==}
     engines: {node: '>=20'}
 
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
@@ -1554,6 +1561,12 @@ snapshots:
   widest-line@6.0.0:
     dependencies:
       string-width: 8.2.0
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.0
+      strip-ansi: 7.2.0
 
   wrap-ansi@9.0.2:
     dependencies:

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -1,5 +1,6 @@
 import { Box, type DOMElement, measureElement, Text, useInput } from "ink";
 import { useEffect, useRef, useState } from "react";
+import wrapAnsi from "wrap-ansi";
 import { t } from "../i18n/index.js";
 import type {
   PipelineEventEmitter,
@@ -15,13 +16,10 @@ import {
 const REVIEW_STAGE = 7;
 
 /** Split a logical line into terminal rows of the given width. */
-function splitIntoRows(line: string, width: number): string[] {
-  if (line.length <= width) return [line];
-  const rows: string[] = [];
-  for (let i = 0; i < line.length; i += width) {
-    rows.push(line.slice(i, i + width));
-  }
-  return rows;
+export function splitIntoRows(line: string, width: number): string[] {
+  if (width < 1) return [line];
+  const wrapped = wrapAnsi(line, width, { hard: true, trim: false });
+  return wrapped.split("\n");
 }
 
 /** A single terminal row tagged with display metadata. */

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -8,7 +8,7 @@ import { Box } from "ink";
 import { cleanup, render } from "ink-testing-library";
 import { afterEach, describe, expect, test } from "vitest";
 import { PipelineEventEmitter } from "../pipeline-events.js";
-import { AgentPane } from "./AgentPane.js";
+import { AgentPane, splitIntoRows } from "./AgentPane.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
 
@@ -520,6 +520,36 @@ describe("AgentPane", () => {
     // Both labels must be present.
     expect(frame).toContain("Agent A");
     expect(frame).toContain("Agent B");
+  });
+});
+
+// ---- splitIntoRows -----------------------------------------------------------
+
+describe("splitIntoRows", () => {
+  test("wraps at word boundaries instead of mid-word", () => {
+    const rows = splitIntoRows("No code changes were needed.", 15);
+    expect(rows).toEqual(["No code changes", " were needed."]);
+  });
+
+  test("hard-breaks a single word longer than width", () => {
+    const rows = splitIntoRows("abcdefghij", 4);
+    expect(rows).toEqual(["abcd", "efgh", "ij"]);
+  });
+
+  test("returns single row for text shorter than width", () => {
+    expect(splitIntoRows("short", 80)).toEqual(["short"]);
+  });
+
+  test("preserves empty string", () => {
+    expect(splitIntoRows("", 40)).toEqual([""]);
+  });
+
+  test("preserves leading whitespace (trim: false)", () => {
+    const rows = splitIntoRows("  indented text", 20);
+    expect(rows).toEqual(["  indented text"]);
+    // Ensure indentation survives wrapping when the line must break.
+    const wrapped = splitIntoRows("  indented text here", 10);
+    expect(wrapped[0]).toMatch(/^\s{2}/);
   });
 });
 


### PR DESCRIPTION
## Summary

- Replace `splitIntoRows` character-slicing with `wrap-ansi` for word-aware line wrapping
- Pass `trim: false` to match Ink's own `wrap-text.js` behavior, preserving leading whitespace in indented output (e.g. code blocks)
- Add `wrap-ansi` dependency (same library Ink uses internally)
- Add tests for word wrapping, long-word hard breaks, short text, empty strings, and leading-whitespace preservation

Closes #79

## Test plan

- [x] Verify normal text wraps at word boundaries, not mid-word
- [x] Verify a single word longer than the column width is hard-broken
- [x] Verify short lines (under column width) are returned unchanged
- [x] Verify empty strings are preserved
- [x] Verify leading whitespace is preserved on indented lines (`trim: false`)
- [x] Verify ANSI escape sequences in agent output are not corrupted by wrapping