### PR TITLE
Add max effort level for Claude Opus 4.6 (#82)

### DIFF
--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -535,6 +535,17 @@ describe("buildClaudeArgs", () => {
     expect(args).toContain("high");
   });
 
+  test("includes --effort max for Opus max effort", () => {
+    const args = buildClaudeArgs("prompt", {
+      model: "opus",
+      permissionMode: "auto",
+      effortLevel: "max",
+    });
+
+    expect(args).toContain("--effort");
+    expect(args).toContain("max");
+  });
+
   test("omits --effort when effortLevel is undefined", () => {
     const args = buildClaudeArgs("prompt", {
       permissionMode: "auto",

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -137,7 +137,7 @@ export class ClaudeStreamTransformer extends JsonlLineTransformer {
 
 export type ClaudePermissionMode = "auto" | "bypass";
 
-export type ClaudeEffortLevel = "low" | "medium" | "high";
+export type ClaudeEffortLevel = "low" | "medium" | "high" | "max";
 
 export interface ClaudeAdapterOptions {
   model?: string;

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -36,7 +36,9 @@ vi.mock("./github.js", () => ({
   getIssue: (...args: unknown[]) => mockGetIssue(...args),
 }));
 
-const { runStartup, selectTarget } = await import("./startup.js");
+const { runStartup, selectTarget, modelDisplayName } = await import(
+  "./startup.js"
+);
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -586,6 +588,77 @@ describe("runStartup — model selection", () => {
     expect(result.agentA.model).toBe("sonnet");
     expect(result.agentB.cli).toBe("codex");
     expect(result.agentB.model).toBe("gpt-5.3-codex");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Effort level selection
+// ---------------------------------------------------------------------------
+describe("runStartup — effort level choices", () => {
+  test("offers max effort for Opus but not for Sonnet", async () => {
+    setupHappyPath();
+    mockSelect
+      .mockReset()
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("claude") // agent A CLI
+      .mockResolvedValueOnce("opus") // agent A model
+      .mockResolvedValueOnce("200k") // agent A context window
+      .mockResolvedValueOnce("max") // agent A effort
+      .mockResolvedValueOnce("claude") // agent B CLI
+      .mockResolvedValueOnce("sonnet") // agent B model
+      .mockResolvedValueOnce("200k") // agent B context window
+      .mockResolvedValueOnce("high") // agent B effort
+      .mockResolvedValueOnce("auto") // execution mode
+      .mockResolvedValueOnce("bypass") // permission mode
+      .mockResolvedValueOnce("en"); // language
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+
+    // Agent A (Opus) effort prompt should include "max"
+    // index: 0=owner, 1=agentA CLI, 2=agentA model, 3=agentA context, 4=agentA effort
+    const agentAEffortCall = mockSelect.mock.calls[4][0];
+    const agentAValues = agentAEffortCall.choices.map(
+      (c: { value: string }) => c.value,
+    );
+    expect(agentAValues).toContain("max");
+    expect(agentAValues).toEqual(["low", "medium", "high", "max"]);
+
+    // Agent B (Sonnet) effort prompt should NOT include "max"
+    // index: 5=agentB CLI, 6=agentB model, 7=agentB context, 8=agentB effort
+    const agentBEffortCall = mockSelect.mock.calls[8][0];
+    const agentBValues = agentBEffortCall.choices.map(
+      (c: { value: string }) => c.value,
+    );
+    expect(agentBValues).not.toContain("max");
+    expect(agentBValues).toEqual(["low", "medium", "high"]);
+
+    expect(result.agentA.effortLevel).toBe("max");
+    expect(result.agentB.effortLevel).toBe("high");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// modelDisplayName
+// ---------------------------------------------------------------------------
+describe("modelDisplayName", () => {
+  test("shows Max label for Opus with max effort", () => {
+    const name = modelDisplayName({
+      cli: "claude",
+      model: "opus",
+      contextWindow: "1m",
+      effortLevel: "max",
+    });
+    expect(name).toBe("Claude Opus 4.6 (1M) / Max");
+  });
+
+  test("shows High label for Sonnet with high effort", () => {
+    const name = modelDisplayName({
+      cli: "claude",
+      model: "sonnet",
+      effortLevel: "high",
+    });
+    expect(name).toBe("Claude Sonnet 4.6 / High");
   });
 });
 

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -66,6 +66,15 @@ const CLAUDE_EFFORT_LEVELS = [
   { name: "High", value: "high" },
 ];
 
+const CLAUDE_OPUS_EFFORT_LEVELS = [
+  ...CLAUDE_EFFORT_LEVELS,
+  { name: "Max", value: "max" },
+];
+
+function claudeEffortChoices(model: string) {
+  return model === "opus" ? CLAUDE_OPUS_EFFORT_LEVELS : CLAUDE_EFFORT_LEVELS;
+}
+
 const CODEX_REASONING_LEVELS = [
   { name: "Low", value: "low" },
   { name: "Medium", value: "medium" },
@@ -85,7 +94,9 @@ function modelDisplayName(config: AgentConfig): string {
   }
   if (config.effortLevel) {
     const effortChoices =
-      config.cli === "claude" ? CLAUDE_EFFORT_LEVELS : CODEX_REASONING_LEVELS;
+      config.cli === "claude"
+        ? claudeEffortChoices(config.model)
+        : CODEX_REASONING_LEVELS;
     const effortName =
       effortChoices.find((e) => e.value === config.effortLevel)?.name ??
       config.effortLevel;
@@ -319,7 +330,7 @@ async function selectAgent(
   }
 
   const effortChoices =
-    cli === "claude" ? CLAUDE_EFFORT_LEVELS : CODEX_REASONING_LEVELS;
+    cli === "claude" ? claudeEffortChoices(model) : CODEX_REASONING_LEVELS;
   const effortLevel = await select({
     message: m["startup.agentEffort"](label),
     choices: effortChoices,


### PR DESCRIPTION
## Summary

- Widen `ClaudeEffortLevel` to include `"max"` in `src/claude-adapter.ts`.
- Make the effort-level prompt choices dynamic based on the selected model: Opus 4.6 offers Low / Medium / High / Max, while Sonnet 4.6 keeps the existing Low / Medium / High.
- Update `modelDisplayName` to resolve the "Max" label correctly for Opus.

Closes #82

## Test plan

- [x] Selecting Opus as the model shows four effort choices: Low, Medium, High, Max
- [x] Selecting Sonnet as the model shows three effort choices: Low, Medium, High (no Max)
- [x] Choosing "Max" for an Opus agent passes `--effort max` to the Claude CLI
- [x] `modelDisplayName` displays "Max" in the summary for Opus agents configured with max effort
- [x] All existing tests pass (`pnpm vitest run`)
- [x] Type checks pass (`pnpm tsc --noEmit`)
- [x] Lint passes (`pnpm biome check`)