### PR TITLE
Restore stdin after prompts and improve pane UI (#94)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -491,6 +491,13 @@ try {
   };
 
   // Launch the ink TUI.
+  // @inquirer/prompts leaves stdin paused/unref'd after its prompts resolve.
+  // Ink's useInput hooks expect stdin to be readable, so restore it here.
+  if (process.stdin.isPaused()) {
+    process.stdin.resume();
+  }
+  process.stdin.ref();
+
   const emitter = new PipelineEventEmitter();
 
   const pipelineResult = await new Promise<PipelineResult>((resolve) => {
@@ -505,8 +512,8 @@ try {
         onPromptReady: (prompt) => {
           tuiPrompt = prompt;
         },
-        modelNameA: agentAConfig.model,
-        modelNameB: agentBConfig.model,
+        modelNameA: modelDisplayName(agentAConfig),
+        modelNameB: modelDisplayName(agentBConfig),
       }),
     );
   });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -535,13 +535,18 @@ async function runStage(
       }
     : undefined;
 
-  // Build per-agent prompt sinks so the UI can display outgoing prompts.
+  // Build per-agent prompt sinks so the UI can display outgoing prompts
+  // and track which agent is currently running.
   const promptSinks = events
     ? {
-        a: (prompt: string) =>
-          events.emit("agent:prompt", { agent: "a", prompt }),
-        b: (prompt: string) =>
-          events.emit("agent:prompt", { agent: "b", prompt }),
+        a: (prompt: string) => {
+          events.emit("agent:invoke", { agent: "a", type: "invoke" });
+          events.emit("agent:prompt", { agent: "a", prompt });
+        },
+        b: (prompt: string) => {
+          events.emit("agent:invoke", { agent: "b", type: "invoke" });
+          events.emit("agent:prompt", { agent: "b", prompt });
+        },
       }
     : undefined;
 

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -38,6 +38,8 @@ interface AgentPaneProps {
   color: string;
   /** Whether this pane currently has keyboard focus for scrolling. */
   isFocused?: boolean;
+  /** Whether this agent is currently running (producing output). */
+  isActive?: boolean;
   /** Whether up/down arrow scrolling is active (false during input prompts). */
   arrowScrollEnabled?: boolean;
 }
@@ -49,6 +51,7 @@ export function AgentPane({
   emitter,
   color,
   isFocused = false,
+  isActive = false,
   arrowScrollEnabled = false,
 }: AgentPaneProps) {
   const { lines, pendingLine } = useAgentLines(emitter, agent);
@@ -75,10 +78,10 @@ export function AgentPane({
   useEffect(() => {
     if (containerRef.current) {
       const { height, width } = measureElement(containerRef.current);
-      // Reserve 2 rows for the top/bottom border and 1 for the label.
-      setVisibleRows(height > 3 ? height - 3 : 0);
-      // Subtract 2 for paddingX={1} (left + right).
-      setContentWidth(width > 2 ? width - 2 : 1);
+      // Reserve 2 rows for top/bottom border, 1 for label, 1 for separator.
+      setVisibleRows(height > 4 ? height - 4 : 0);
+      // Subtract 4 for borderStyle="single" (2) + paddingX={1} (2).
+      setContentWidth(width > 4 ? width - 4 : 1);
     }
   });
 
@@ -213,8 +216,10 @@ export function AgentPane({
     >
       <Text bold color={borderCol}>
         {modelName ? `${label} \u2014 ${modelName}` : label}
+        {isActive ? " \u25CF" : ""}
         {isFocused ? " [*]" : ""}
       </Text>
+      <Text dimColor>{"\u2500".repeat(contentWidth)}</Text>
       {placeholder !== undefined ? (
         <Text dimColor>{placeholder}</Text>
       ) : (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -7,7 +7,10 @@ import type {
   UserPrompt,
 } from "../pipeline.js";
 import { runPipeline } from "../pipeline.js";
-import type { PipelineEventEmitter } from "../pipeline-events.js";
+import type {
+  AgentInvokeEvent,
+  PipelineEventEmitter,
+} from "../pipeline-events.js";
 import { AgentPane } from "./AgentPane.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
@@ -57,6 +60,7 @@ export function App({
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
   const resolveRef = useRef<((value: string) => void) | null>(null);
   const [focusedPane, setFocusedPane] = useState<"a" | "b">("a");
+  const [activeAgent, setActiveAgent] = useState<"a" | "b" | null>(null);
 
   // Store props in refs so the mount effect never re-runs.
   const emitterRef = useRef(emitter);
@@ -83,6 +87,19 @@ export function App({
       setFocusedPane((prev) => (prev === "a" ? "b" : "a"));
     }
   });
+
+  // Track which agent is currently running.
+  // Set on agent:invoke, cleared on stage:exit (no agent runs between stages).
+  useEffect(() => {
+    const onInvoke = (ev: AgentInvokeEvent) => setActiveAgent(ev.agent);
+    const onStageExit = () => setActiveAgent(null);
+    emitter.on("agent:invoke", onInvoke);
+    emitter.on("stage:exit", onStageExit);
+    return () => {
+      emitter.off("agent:invoke", onInvoke);
+      emitter.off("stage:exit", onStageExit);
+    };
+  }, [emitter]);
 
   // Run the pipeline once on mount.
   useEffect(() => {
@@ -116,6 +133,7 @@ export function App({
           emitter={emitter}
           color="blue"
           isFocused={focusedPane === "a"}
+          isActive={activeAgent === "a"}
           arrowScrollEnabled={!inputRequest}
         />
         <AgentPane
@@ -125,6 +143,7 @@ export function App({
           emitter={emitter}
           color="green"
           isFocused={focusedPane === "b"}
+          isActive={activeAgent === "b"}
           arrowScrollEnabled={!inputRequest}
         />
       </Box>

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -6,9 +6,12 @@
  */
 import { Box, Text, useInput, useStdout } from "ink";
 import { cleanup, render } from "ink-testing-library";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { afterEach, describe, expect, test } from "vitest";
-import { PipelineEventEmitter } from "../pipeline-events.js";
+import {
+  type AgentInvokeEvent,
+  PipelineEventEmitter,
+} from "../pipeline-events.js";
 import { AgentPane, splitIntoRows } from "./AgentPane.js";
 import { useTerminalHeight } from "./App.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
@@ -463,12 +466,12 @@ describe("AgentPane", () => {
 
     // Emit a long wrapped line followed by short lines that push its
     // first rows above the viewport.  The line wraps to ~5 terminal rows
-    // at the default contentWidth; 8 filler lines are enough to scroll
+    // at the default contentWidth; 6 filler lines are enough to scroll
     // it out while keeping it reachable with a single Page Up.
     const longLine = `HEAD_${"x".repeat(390)}_TAIL`;
     emitter.emit("agent:chunk", {
       agent: "a",
-      chunk: `${longLine}\n${"filler\n".repeat(8)}`,
+      chunk: `${longLine}\n${"filler\n".repeat(6)}`,
     });
     await new Promise((r) => setTimeout(r, 50));
 
@@ -580,6 +583,128 @@ describe("AgentPane", () => {
     // The marker must appear only once (only for the focused pane).
     const markerCount = (frame.match(/\[\*\]/g) ?? []).length;
     expect(markerCount).toBe(1);
+  });
+
+  test("active agent shows \u25CF indicator independently of focus", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused={false}
+          isActive
+        />
+        <AgentPane
+          label="Agent B"
+          agent="b"
+          emitter={emitter}
+          color="green"
+          isFocused
+          isActive={false}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Active indicator must appear once (only for the active pane).
+    const activeCount = (frame.match(/\u25CF/g) ?? []).length;
+    expect(activeCount).toBe(1);
+    // Focus marker must also appear once (on a different pane).
+    const focusCount = (frame.match(/\[\*\]/g) ?? []).length;
+    expect(focusCount).toBe(1);
+  });
+
+  test("active indicator clears after stage:exit", async () => {
+    // Regression: activeAgent must not remain stuck after an agent finishes.
+    // This mirrors App.tsx wiring: agent:invoke sets activeAgent, stage:exit
+    // clears it.
+    const emitter = new PipelineEventEmitter();
+
+    function ActiveTracker({ emitter }: { emitter: PipelineEventEmitter }) {
+      const [active, setActive] = useState<"a" | "b" | null>(null);
+      useEffect(() => {
+        const onInvoke = (ev: AgentInvokeEvent) => setActive(ev.agent);
+        const onExit = () => setActive(null);
+        emitter.on("agent:invoke", onInvoke);
+        emitter.on("stage:exit", onExit);
+        return () => {
+          emitter.off("agent:invoke", onInvoke);
+          emitter.off("stage:exit", onExit);
+        };
+      }, [emitter]);
+      return (
+        <Box>
+          <AgentPane
+            label="Agent A"
+            agent="a"
+            emitter={emitter}
+            color="blue"
+            isActive={active === "a"}
+          />
+          <AgentPane
+            label="Agent B"
+            agent="b"
+            emitter={emitter}
+            color="green"
+            isActive={active === "b"}
+          />
+        </Box>
+      );
+    }
+
+    const { lastFrame } = render(<ActiveTracker emitter={emitter} />);
+
+    // Invoke agent A → ● should appear.
+    emitter.emit("agent:invoke", { agent: "a", type: "invoke" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect((lastFrame() ?? "").match(/\u25CF/g)?.length).toBe(1);
+
+    // Stage exits → ● should disappear from both panes.
+    emitter.emit("stage:exit", { stageNumber: 2, outcome: "completed" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect((lastFrame() ?? "").match(/\u25CF/g) ?? []).toHaveLength(0);
+  });
+
+  test("no active indicator when isActive is false", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          isActive={false}
+        />
+        <AgentPane
+          label="Agent B"
+          agent="b"
+          emitter={emitter}
+          color="green"
+          isFocused={false}
+          isActive={false}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Neither pane should show the active indicator.
+    const activeCount = (frame.match(/\u25CF/g) ?? []).length;
+    expect(activeCount).toBe(0);
+  });
+
+  test("pane header and content are separated by a horizontal line", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("\u2500");
   });
 });
 


### PR DESCRIPTION
## Summary

- Resume `process.stdin` after `@inquirer/prompts` finishes so ink's `useInput` hooks receive keyboard events — fixes the complete loss of keyboard input in the TUI.
- Track the active (running) agent separately from the focused (Tab-controlled) pane. A `●` indicator shows which agent is currently running; `[*]` continues to show keyboard focus. Focus no longer auto-switches when the active agent changes. The `●` indicator clears on `stage:exit` so it does not remain stuck after an agent finishes its turn.
- Add a horizontal `─` separator between the pane title and scroll content for visual clarity.
- Pass `modelDisplayName()` to pane titles so they show the full model label (e.g., "Claude Opus 4.6 (1M) / Max") instead of just the short alias.

Closes #94

## Test plan

- [x] Launch the TUI — verify all keyboard input (Tab, arrows, Page Up/Down, alphanumeric) works after the inquirer prompts
- [x] Press Tab to switch focused pane — confirm `[*]` moves but `●` does not
- [x] Observe that `●` appears on the pane whose agent is currently running, independently of focus
- [x] Observe that `●` disappears when no agent is running (after stage exits)
- [x] Verify a horizontal line separates pane title from scroll content
- [x] Check that pane titles show the full model display name (e.g., "Claude Opus 4.6 (1M) / Max")
- [x] Run `pnpm vitest run` — all tests pass
- [x] Run `pnpm tsc --noEmit` and `pnpm biome check` — no errors