### PR TITLE
Add quick-start option to reuse previous configuration (#103)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -1,6 +1,15 @@
 import type { Messages } from "./messages.js";
 
 export const en: Messages = {
+  // ---- quick-start -------------------------------------------------------
+
+  "quickStart.header": "Found saved configuration:",
+  "quickStart.agentA": (model) => `  Agent A: ${model}`,
+  "quickStart.agentB": (model) => `  Agent B: ${model}`,
+  "quickStart.mode": (exec, perm) => `  Mode: ${exec} / ${perm}`,
+  "quickStart.language": (lang) => `  Language: ${lang}`,
+  "quickStart.usePrevious": "Use previous settings?",
+
   // ---- startup / config --------------------------------------------------
 
   "startup.enterOwner": "Enter GitHub owner:",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -1,6 +1,15 @@
 import type { Messages } from "./messages.js";
 
 export const ko: Messages = {
+  // ---- quick-start -------------------------------------------------------
+
+  "quickStart.header": "저장된 설정 발견:",
+  "quickStart.agentA": (model) => `  에이전트 A: ${model}`,
+  "quickStart.agentB": (model) => `  에이전트 B: ${model}`,
+  "quickStart.mode": (exec, perm) => `  모드: ${exec} / ${perm}`,
+  "quickStart.language": (lang) => `  언어: ${lang}`,
+  "quickStart.usePrevious": "이전 설정을 사용하시겠습니까?",
+
   // ---- startup / config --------------------------------------------------
 
   "startup.enterOwner": "GitHub \uC18C\uC720\uC790 \uC785\uB825:",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -5,6 +5,15 @@
  * Template parameters use functions; plain strings are literals.
  */
 export interface Messages {
+  // ---- quick-start (startup.ts) -------------------------------------------
+
+  "quickStart.header": string;
+  "quickStart.agentA": (model: string) => string;
+  "quickStart.agentB": (model: string) => string;
+  "quickStart.mode": (exec: string, perm: string) => string;
+  "quickStart.language": (lang: string) => string;
+  "quickStart.usePrevious": string;
+
   // ---- startup / config (startup.ts) -------------------------------------
 
   "startup.enterOwner": string;

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -773,7 +773,9 @@ describe("runStartup — config dirty tracking", () => {
       { name: "agentcoop", description: "" },
     ]);
     mockGetIssue.mockReturnValue(defaultIssue());
-    mockConfirm.mockResolvedValueOnce(true);
+    mockConfirm
+      .mockResolvedValueOnce(false) // decline quick-start
+      .mockResolvedValueOnce(true); // confirm issue
 
     await runStartup();
     expect(mockSaveConfig).not.toHaveBeenCalled();
@@ -1451,5 +1453,241 @@ describe("runStartup with target parameter", () => {
     expect(result.agentB.model).toBe("gpt-5.4");
     // Should NOT have called search (repo) or input (issue number).
     expect(mockSearch).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Quick-start — reuse previous configuration
+// ---------------------------------------------------------------------------
+describe("runStartup — quick-start", () => {
+  function configWithAgents(): Config {
+    return {
+      ...defaultConfig(),
+      agentA: {
+        cli: "claude" as const,
+        model: "opus",
+        contextWindow: "1m",
+        effortLevel: "high",
+      },
+      agentB: {
+        cli: "codex" as const,
+        model: "gpt-5.4",
+        effortLevel: "xhigh",
+      },
+      executionMode: "auto" as const,
+      claudePermissionMode: "bypass" as const,
+    };
+  }
+
+  test("reuses saved config when user accepts quick-start", async () => {
+    mockLoadConfig.mockReturnValue(configWithAgents());
+    mockSelect.mockResolvedValueOnce("aicers"); // owner
+    mockSearch.mockResolvedValueOnce("agentcoop"); // repo
+    mockInput.mockResolvedValueOnce("42"); // issue number
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm
+      .mockResolvedValueOnce(true) // accept quick-start
+      .mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+
+    expect(result.agentA).toEqual({
+      cli: "claude",
+      model: "opus",
+      contextWindow: "1m",
+      effortLevel: "high",
+    });
+    expect(result.agentB).toEqual({
+      cli: "codex",
+      model: "gpt-5.4",
+      effortLevel: "xhigh",
+    });
+    expect(result.executionMode).toBe("auto");
+    expect(result.claudePermissionMode).toBe("bypass");
+    expect(result.language).toBe("en");
+    // No agent selection prompts should have been shown.
+    // select is called once for owner only.
+    expect(mockSelect).toHaveBeenCalledTimes(1);
+    expect(mockCheckbox).not.toHaveBeenCalled();
+  });
+
+  test("falls through to full flow when user declines quick-start", async () => {
+    mockLoadConfig.mockReturnValue(configWithAgents());
+    mockSelect
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("claude") // agent A CLI
+      .mockResolvedValueOnce("sonnet") // agent A model (different!)
+      .mockResolvedValueOnce("200k") // agent A context window
+      .mockResolvedValueOnce("medium") // agent A effort
+      .mockResolvedValueOnce("codex") // agent B CLI
+      .mockResolvedValueOnce("gpt-5.4") // agent B model
+      .mockResolvedValueOnce("high") // agent B effort
+      .mockResolvedValueOnce("step") // execution mode
+      .mockResolvedValueOnce("auto") // permission mode
+      .mockResolvedValueOnce("en"); // language
+    mockSearch.mockResolvedValueOnce("agentcoop"); // repo
+    mockInput.mockResolvedValueOnce("42"); // issue number
+    mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm
+      .mockResolvedValueOnce(false) // decline quick-start
+      .mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+
+    expect(result.agentA.model).toBe("sonnet");
+    expect(result.executionMode).toBe("step");
+  });
+
+  test("is not shown on first run (no saved agents)", async () => {
+    setupHappyPath();
+
+    await runStartup();
+
+    // confirm is called once for issue confirmation only.
+    // If quick-start were shown, confirm would be called twice.
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("is not shown when only agentA is saved", async () => {
+    const config = {
+      ...defaultConfig(),
+      agentA: {
+        cli: "claude" as const,
+        model: "opus",
+        contextWindow: "1m",
+        effortLevel: "high",
+      },
+    };
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("claude") // agent A CLI
+      .mockResolvedValueOnce("opus") // agent A model
+      .mockResolvedValueOnce("1m") // agent A context window
+      .mockResolvedValueOnce("high") // agent A effort
+      .mockResolvedValueOnce("codex") // agent B CLI
+      .mockResolvedValueOnce("gpt-5.4") // agent B model
+      .mockResolvedValueOnce("xhigh") // agent B effort
+      .mockResolvedValueOnce("auto") // execution mode
+      .mockResolvedValueOnce("bypass") // permission mode
+      .mockResolvedValueOnce("en"); // language
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockCheckbox.mockResolvedValueOnce([]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true); // confirm issue
+
+    await runStartup();
+
+    // confirm called once (issue only), not twice (quick-start + issue).
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  test("throws when user declines issue confirmation after quick-start", async () => {
+    mockLoadConfig.mockReturnValue(configWithAgents());
+    mockSelect.mockResolvedValueOnce("aicers");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm
+      .mockResolvedValueOnce(true) // accept quick-start
+      .mockResolvedValueOnce(false); // decline issue
+
+    await expect(runStartup()).rejects.toThrow("Issue not confirmed");
+    expect(mockSaveConfig).not.toHaveBeenCalled();
+  });
+
+  test("saves config when configDirty and quick-start accepted", async () => {
+    const config = configWithAgents();
+    config.owners = [];
+    mockLoadConfig.mockReturnValue(config);
+    mockInput
+      .mockResolvedValueOnce("new-org") // new owner (marks dirty)
+      .mockResolvedValueOnce("42"); // issue number
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm
+      .mockResolvedValueOnce(true) // accept quick-start
+      .mockResolvedValueOnce(true); // confirm issue
+
+    await runStartup();
+
+    expect(mockSaveConfig).toHaveBeenCalledOnce();
+  });
+
+  test("displays saved config summary", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    mockLoadConfig.mockReturnValue(configWithAgents());
+    mockSelect.mockResolvedValueOnce("aicers");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm
+      .mockResolvedValueOnce(true) // accept quick-start
+      .mockResolvedValueOnce(true); // confirm issue
+
+    await runStartup();
+
+    const logs = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
+    expect(logs).toContain("Found saved configuration:");
+    expect(logs).toContain("Agent A: Claude Opus 4.6 (1M) / High");
+    expect(logs).toContain("Agent B: GPT-5.4 / Extra High");
+    expect(logs).toContain("Mode: auto / bypass");
+    expect(logs).toContain("Language: English");
+
+    consoleSpy.mockRestore();
+  });
+
+  test("defaults executionMode and permissionMode when not saved", async () => {
+    const config = {
+      ...defaultConfig(),
+      agentA: {
+        cli: "claude" as const,
+        model: "opus",
+        contextWindow: "1m",
+        effortLevel: "high",
+      },
+      agentB: {
+        cli: "codex" as const,
+        model: "gpt-5.4",
+        effortLevel: "xhigh",
+      },
+      // executionMode and claudePermissionMode are undefined
+    };
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect.mockResolvedValueOnce("aicers");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput.mockResolvedValueOnce("42");
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm
+      .mockResolvedValueOnce(true) // accept quick-start
+      .mockResolvedValueOnce(true); // confirm issue
+
+    const result = await runStartup();
+
+    expect(result.executionMode).toBe("auto");
+    expect(result.claudePermissionMode).toBe("bypass");
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -151,6 +151,58 @@ export async function runStartup(
   } = target ?? (await selectTarget());
   let configDirty = initialDirty;
 
+  // Quick-start: offer to reuse saved configuration when both agents exist.
+  if (config.agentA && config.agentB) {
+    const m = t();
+    console.log();
+    console.log(m["quickStart.header"]);
+    console.log(m["quickStart.agentA"](modelDisplayName(config.agentA)));
+    console.log(m["quickStart.agentB"](modelDisplayName(config.agentB)));
+    console.log(
+      m["quickStart.mode"](
+        config.executionMode ?? "auto",
+        config.claudePermissionMode ?? "bypass",
+      ),
+    );
+    console.log(
+      m["quickStart.language"](
+        config.language === "ko"
+          ? m["startup.languageKorean"]
+          : m["startup.languageEnglish"],
+      ),
+    );
+    console.log();
+
+    const reuse = await confirm({
+      message: m["quickStart.usePrevious"],
+      default: true,
+    });
+
+    if (reuse) {
+      const issue = getIssue(owner, repo, issueNumber);
+      const confirmed = await confirmIssue(owner, repo, issue);
+      if (!confirmed) {
+        throw new Error(m["startup.issueNotConfirmed"]);
+      }
+
+      if (configDirty) {
+        saveConfig(config);
+      }
+
+      return {
+        owner,
+        repo,
+        issue,
+        agentA: config.agentA,
+        agentB: config.agentB,
+        executionMode: config.executionMode ?? "auto",
+        claudePermissionMode: config.claudePermissionMode ?? "bypass",
+        language: config.language,
+        pipelineSettings: config.pipelineSettings,
+      };
+    }
+  }
+
   const agentA = await selectAgent(
     t()["agent.labelARole"],
     config.agentA ?? DEFAULT_AGENT_A,


### PR DESCRIPTION
## Summary

- After target selection (owner/repo/issue), if both agents are already configured in `~/.agentcoop/config.json`, display a summary of saved settings and prompt the user to reuse them
- Accepting skips all configuration prompts (~10) and goes straight to issue confirmation and pipeline launch
- Declining enters the full configuration flow as before
- First-time users (no saved agents) see no change in behavior

Closes #103

## Test plan

- [x] Fresh first run (no config): full configuration flow runs, no quick-start prompt shown
- [x] Run with only one agent saved: full flow runs, no quick-start prompt
- [x] Run with both agents saved, accept quick-start: all config prompts skipped, pipeline launches with saved settings
- [x] Run with both agents saved, decline quick-start: full configuration flow runs
- [x] Quick-start summary displays correct agent names, modes, and language
- [x] Issue confirmation still shown after accepting quick-start
- [x] Declining issue after quick-start throws as expected
- [x] Config saved when dirty flag is set and quick-start is accepted
- [x] Default values applied for executionMode and claudePermissionMode when not saved
- [x] All 1061 tests pass, type checks and linting clean