### PR TITLE
Forbid issue/PR numbers in commit titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,12 @@
 ## Commit messages
 
 - Title: preferably under 50 characters, start with imperative verb (e.g.,
-  `Add`, `Fix`, `Remove`)
+  `Add`, `Fix`, `Remove`). Do NOT include issue or PR numbers in the title.
 - Body: wrap at 72 characters, free-form, explain *why* not *what*
 - Separate title and body with a blank line
 - Reference issues: use `Closes #N` to close an issue, or `Part of #N` when
-  the commit addresses part of an issue
+  the commit addresses part of an issue. These references go in the body, not
+  the title.
 
 ## Language
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,11 +3,12 @@
 ## Commit messages
 
 - Title: preferably under 50 characters, start with imperative verb (e.g.,
-  `Add`, `Fix`, `Remove`)
+  `Add`, `Fix`, `Remove`). Do NOT include issue or PR numbers in the title.
 - Body: wrap at 72 characters, free-form, explain *why* not *what*
 - Separate title and body with a blank line
 - Reference issues: use `Closes #N` to close an issue, or `Part of #N` when
-  the commit addresses part of an issue
+  the commit addresses part of an issue. These references go in the body, not
+  the title.
 
 ## Attribution
 


### PR DESCRIPTION
## Summary

- Add guideline to both `CLAUDE.md` and `AGENTS.md`: do not include issue or PR numbers (e.g., `#42`) in commit message titles
- Clarify that issue references (`Closes #N`, `Part of #N`) belong in the commit body

Closes #110