### PR TITLE
Fix AgentPane scroll viewport issues and add persistent scroll indicators (#112)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -164,6 +164,7 @@ export const en: Messages = {
   "agentPane.waiting": "(waiting for output)",
   "agentPane.idle": "(idle — active in review stage)",
   "agentPane.linesAbove": (count) => `\u2191 ${count} more lines`,
+  "agentPane.linesBelow": (count) => `\u2193 ${count} more lines`,
   "agent.labelA": "Agent A",
   "agent.labelB": "Agent B",
   "agent.labelARole": "Agent A (implementer)",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -198,6 +198,8 @@ export const ko: Messages = {
     "(\uB300\uAE30 \uC911 \u2014 \uB9AC\uBDF0 \uB2E8\uACC4\uC5D0\uC11C \uD65C\uC131\uD654)",
   "agentPane.linesAbove": (count) =>
     `\u2191 ${count}\uC904 \uB354 \uC788\uC74C`,
+  "agentPane.linesBelow": (count) =>
+    `\u2193 ${count}\uC904 \uB354 \uC788\uC74C`,
   "agent.labelA": "에이전트 A",
   "agent.labelB": "에이전트 B",
   "agent.labelARole": "에이전트 A (구현자)",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -161,6 +161,7 @@ export interface Messages {
   "agentPane.waiting": string;
   "agentPane.idle": string;
   "agentPane.linesAbove": (count: number) => string;
+  "agentPane.linesBelow": (count: number) => string;
   "agent.labelA": string;
   "agent.labelB": string;
   "agent.labelARole": string;

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -102,7 +102,19 @@ export function AgentPane({
   }
 
   const totalRows = allRows.length;
-  const maxOffset = Math.max(0, totalRows - visibleRows);
+  // Compute maxOffset so the user can scroll far enough to see the first
+  // row.  Add 1 only when a bottom indicator would actually appear at max
+  // scroll (i.e. when the viewport at that position cannot reach the last
+  // logical line).  For a single wrapped line, no bottom indicator is ever
+  // shown, so no extra row is needed.
+  let maxOffset = Math.max(0, totalRows - visibleRows);
+  if (maxOffset > 0 && visibleRows > 0) {
+    const endRowAtMax = totalRows - maxOffset; // = visibleRows
+    const lastIdxAtMax = allRows[endRowAtMax - 1]?.lineIdx ?? 0;
+    if (allLines.length - 1 - lastIdxAtMax > 0) {
+      maxOffset += 1;
+    }
+  }
   const effectiveOffset = Math.min(scrollOffset, maxOffset);
 
   // Auto-adjust scrollOffset when total rows grow (new completed lines
@@ -149,32 +161,49 @@ export function AgentPane({
   );
 
   // Compute the visible window from the flat row array.
+  //
+  // To avoid viewport size discontinuity at scroll transitions, we
+  // determine which indicators are needed first, then consistently
+  // allocate the remaining rows to content.
   let visibleRowEntries: RowEntry[];
   let linesAbove = 0;
+  let linesBelow = 0;
 
   if (visibleRows === 0) {
     visibleRowEntries = [];
   } else if (effectiveOffset === 0) {
     // Bottom-pinned (auto-follow).
-    const startRow = Math.max(0, totalRows - visibleRows);
+    // Tentatively check if a top indicator is needed.
+    const tentativeStart = Math.max(0, totalRows - visibleRows);
+    const needTopIndicator =
+      tentativeStart > 0 && allRows[tentativeStart].lineIdx > 0;
+
+    const contentRows = visibleRows - (needTopIndicator ? 1 : 0);
+    const startRow = Math.max(0, totalRows - contentRows);
     visibleRowEntries = allRows.slice(startRow);
     linesAbove = startRow > 0 ? allRows[startRow].lineIdx : 0;
   } else {
     // Scrolled up: row-level window.
     const endRow = totalRows - effectiveOffset;
 
-    // First pass: fill the viewport without the indicator.
-    let startRow = Math.max(0, endRow - visibleRows);
-    linesAbove = startRow > 0 ? allRows[startRow].lineIdx : 0;
+    // Tentatively check if indicators are needed using the full viewport.
+    const tentativeStart = Math.max(0, endRow - visibleRows);
+    const needTopIndicator =
+      tentativeStart > 0 && allRows[tentativeStart].lineIdx > 0;
+    // Count logical lines fully below the viewport (determined by
+    // endRow alone, independent of the top indicator).
+    const lastVisibleLineIdx = allRows[endRow - 1]?.lineIdx ?? 0;
+    const totalLogicalLines = allLines.length;
+    linesBelow = totalLogicalLines - 1 - lastVisibleLineIdx;
 
-    // If there are logical lines fully above the viewport the scroll
-    // indicator will be rendered, so reclaim 1 row for it.
-    if (linesAbove > 0) {
-      startRow = Math.max(0, endRow - (visibleRows - 1));
-      linesAbove = allRows[startRow].lineIdx;
-    }
+    const needBottomIndicator = linesBelow > 0;
+
+    const contentRows =
+      visibleRows - (needTopIndicator ? 1 : 0) - (needBottomIndicator ? 1 : 0);
+    const startRow = Math.max(0, endRow - contentRows);
 
     visibleRowEntries = allRows.slice(startRow, endRow);
+    linesAbove = startRow > 0 ? allRows[startRow].lineIdx : 0;
   }
 
   const hasOutput = allLines.length > 0;
@@ -195,10 +224,10 @@ export function AgentPane({
     }
   }
 
-  const scrollIndicator =
-    effectiveOffset > 0 && linesAbove > 0
-      ? t()["agentPane.linesAbove"](linesAbove)
-      : undefined;
+  const topIndicator =
+    linesAbove > 0 ? t()["agentPane.linesAbove"](linesAbove) : undefined;
+  const bottomIndicator =
+    linesBelow > 0 ? t()["agentPane.linesBelow"](linesBelow) : undefined;
 
   // Dim unfocused pane border so the focused pane is always distinguishable.
   const borderCol = isFocused ? color : "gray";
@@ -224,13 +253,14 @@ export function AgentPane({
         <Text dimColor>{placeholder}</Text>
       ) : (
         <>
-          {scrollIndicator && <Text dimColor>{scrollIndicator}</Text>}
+          {topIndicator && <Text dimColor>{topIndicator}</Text>}
           {visibleRowEntries.map((row, i) => (
             // biome-ignore lint/suspicious/noArrayIndexKey: rows are derived without stable IDs
             <Text key={i} dimColor={row.isPrompt}>
               {row.text}
             </Text>
           ))}
+          {bottomIndicator && <Text dimColor>{bottomIndicator}</Text>}
         </>
       )}
     </Box>

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -327,8 +327,8 @@ describe("AgentPane", () => {
 
     const frame = lastFrame() ?? "";
     expect(frame).toContain("line20");
-    // Indicator should be gone (back at bottom).
-    expect(frame).not.toContain("\u2191");
+    // Back at bottom — no "lines below" indicator.
+    expect(frame).not.toContain("\u2193");
   });
 
   test("Page Up still works when arrowScrollEnabled is false", async () => {
@@ -384,9 +384,9 @@ describe("AgentPane", () => {
     stdin.write("\x1b[A"); // Up arrow
     await new Promise((r) => setTimeout(r, 50));
 
-    // Arrow keys should be disabled — still at bottom.
+    // Arrow keys should be disabled — still at bottom (no "lines below").
     expect(lastFrame()).toContain("line20");
-    expect(lastFrame()).not.toContain("\u2191");
+    expect(lastFrame()).not.toContain("\u2193");
   });
 
   test("scrolling is disabled when isFocused is false", async () => {
@@ -413,8 +413,9 @@ describe("AgentPane", () => {
     stdin.write("\x1b[5~");
     await new Promise((r) => setTimeout(r, 50));
 
+    // Scrolling should be disabled — still at bottom (no "lines below").
     expect(lastFrame()).toContain("line20");
-    expect(lastFrame()).not.toContain("\u2191");
+    expect(lastFrame()).not.toContain("\u2193");
   });
 
   test("auto-follow keeps view at bottom when new lines arrive", async () => {
@@ -446,7 +447,8 @@ describe("AgentPane", () => {
 
     const frame = lastFrame() ?? "";
     expect(frame).toContain("newtail");
-    expect(frame).not.toContain("\u2191");
+    // Bottom-pinned — no "lines below" indicator.
+    expect(frame).not.toContain("\u2193");
   });
 
   test("scrolling through a single long wrapped line reveals earlier rows", async () => {
@@ -478,7 +480,11 @@ describe("AgentPane", () => {
     // HEAD_ should be scrolled out of view at the bottom-pinned position.
     expect(lastFrame()).not.toContain("HEAD_");
 
-    // Page Up — scroll through the content including wrapped rows.
+    // Page Up twice — scroll through the content including wrapped rows.
+    // The first Page Up may not reach HEAD_ because scroll indicators
+    // reduce the content area; a second Page Up ensures we get there.
+    stdin.write("\x1b[5~");
+    await new Promise((r) => setTimeout(r, 50));
     stdin.write("\x1b[5~");
     await new Promise((r) => setTimeout(r, 50));
 
@@ -695,6 +701,107 @@ describe("AgentPane", () => {
     // Neither pane should show the active indicator.
     const activeCount = (frame.match(/\u25CF/g) ?? []).length;
     expect(activeCount).toBe(0);
+  });
+
+  test("bottom-pinned mode shows lines-above indicator when content overflows", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          arrowScrollEnabled
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // Bottom-pinned with lines above — top indicator must appear.
+    expect(frame).toContain("\u2191");
+    expect(frame).toContain("more lines");
+    // No bottom indicator at the very bottom.
+    expect(frame).not.toContain("\u2193");
+    // Newest line must still be visible.
+    expect(frame).toContain("line20");
+  });
+
+  test("scrolled-up mode shows lines-below indicator", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          arrowScrollEnabled
+        />
+      </Box>,
+    );
+
+    const chunk = Array.from({ length: 20 }, (_, i) => `line${i + 1}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Scroll up one line.
+    stdin.write("\x1b[A");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // Both indicators should be visible.
+    expect(frame).toContain("\u2191");
+    expect(frame).toContain("\u2193");
+  });
+
+  test("single wrapped line scrolled up does not leave blank rows", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, stdin } = render(
+      <Box height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          isFocused
+          arrowScrollEnabled
+        />
+      </Box>,
+    );
+
+    // Emit a single long line that wraps across many terminal rows.
+    const longLine = "x".repeat(900);
+    emitter.emit("agent:chunk", { agent: "a", chunk: `${longLine}\n` });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Scroll up one row.
+    stdin.write("\x1b[A");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // A single logical line produces no "lines below" indicator, so no
+    // row should be reserved for it.  Every content row must contain
+    // part of the wrapped text — no blank trailing row.
+    expect(frame).not.toContain("\u2193");
+    const rows = frame.split("\n");
+    // The last row inside the box is the bottom border.  The row just
+    // above it should be filled with content, not empty.
+    const bottomBorderIdx = rows.findLastIndex((r) => r.includes("\u2514"));
+    if (bottomBorderIdx > 0) {
+      const lastContentRow = rows[bottomBorderIdx - 1].trim();
+      expect(lastContentRow.length).toBeGreaterThan(0);
+    }
   });
 
   test("pane header and content are separated by a horizontal line", () => {


### PR DESCRIPTION
## Summary

- Fix viewport size discontinuity when transitioning between bottom-pinned and scrolled-up states by computing indicator presence first, then allocating remaining rows to content.
- Show "↑ N more lines" indicator in bottom-pinned mode when content overflows above the viewport.
- Add "↓ N more lines" indicator when scrolled up so users know there is content below.
- Adjust `maxOffset` to account for the bottom indicator row only when the indicator would actually render, avoiding a blank trailing row for single wrapped lines.

Closes #112

## Test plan

- [x] Scroll up from bottom-pinned state: no lines disappear at the transition
- [x] Bottom-pinned mode with overflow: "↑ N more lines" indicator is visible
- [x] Scrolled-up mode: "↓ N more lines" indicator is visible
- [x] Scroll back to bottom: "↓" indicator disappears, "↑" remains if content overflows
- [x] Content fills available space without gaps at the bottom
- [x] Single long wrapped line scrolled up: no blank row at the bottom
- [x] Page Up/Down and arrow key scrolling still work correctly
- [x] All existing and new tests pass (`pnpm vitest run`)