### PR TITLE
Display keyboard shortcut hints in status bar (#109)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -151,6 +151,8 @@ export const en: Messages = {
   "statusBar.layout": (mode) => `Layout: ${mode}`,
   "statusBar.layoutHorizontal": "horizontal",
   "statusBar.layoutVertical": "vertical",
+  "statusBar.keyHints":
+    "Tab:Switch pane  \u2191\u2193:Scroll  PgUp/Dn:Page scroll  Ctrl+C:Quit",
   "outcome.completed": "completed",
   "outcome.fixed": "fixed",
   "outcome.approved": "approved",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -179,6 +179,8 @@ export const ko: Messages = {
   "statusBar.layoutHorizontal": "\uC218\uD3C9",
   "statusBar.layoutVertical": "\uC218\uC9C1",
 
+  "statusBar.keyHints":
+    "Tab:\uD328\uB110 \uC804\uD658  \u2191\u2193:\uC2A4\uD06C\uB864  PgUp/Dn:\uD398\uC774\uC9C0 \uC2A4\uD06C\uB864  Ctrl+C:\uC885\uB8CC",
   "outcome.completed": "완료",
   "outcome.fixed": "수정됨",
   "outcome.approved": "승인됨",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -156,6 +156,7 @@ export interface Messages {
   "statusBar.layout": (mode: string) => string;
   "statusBar.layoutHorizontal": string;
   "statusBar.layoutVertical": string;
+  "statusBar.keyHints": string;
   "outcome.completed": string;
   "outcome.fixed": string;
   "outcome.approved": string;

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -103,36 +103,44 @@ export function StatusBar({
     : "";
 
   return (
-    <Box borderStyle="single" borderColor="gray" paddingX={1}>
-      <Text bold color="cyan">
-        {issueLabel}
-      </Text>
-      {baseText && (
-        <Text>
-          {"  |  "}
-          {baseText}
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      paddingX={1}
+      flexDirection="column"
+    >
+      <Box>
+        <Text bold color="cyan">
+          {issueLabel}
         </Text>
-      )}
-      <Text>{"  |  "}</Text>
-      <Text bold>{stageText}</Text>
-      {outcomeText && (
-        <Text>
-          {"  |  "}
-          {outcomeText}
-        </Text>
-      )}
-      {(selfCheckCount > 0 || reviewCount > 0) && (
-        <Text>
-          {"  |  "}
-          {m["statusBar.completed"](selfCheckCount, reviewCount)}
-        </Text>
-      )}
-      {layoutText && (
-        <Text>
-          {"  |  "}
-          {layoutText}
-        </Text>
-      )}
+        {baseText && (
+          <Text>
+            {"  |  "}
+            {baseText}
+          </Text>
+        )}
+        <Text>{"  |  "}</Text>
+        <Text bold>{stageText}</Text>
+        {outcomeText && (
+          <Text>
+            {"  |  "}
+            {outcomeText}
+          </Text>
+        )}
+        {(selfCheckCount > 0 || reviewCount > 0) && (
+          <Text>
+            {"  |  "}
+            {m["statusBar.completed"](selfCheckCount, reviewCount)}
+          </Text>
+        )}
+        {layoutText && (
+          <Text>
+            {"  |  "}
+            {layoutText}
+          </Text>
+        )}
+      </Box>
+      <Text dimColor>{m["statusBar.keyHints"]}</Text>
     </Box>
   );
 }

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1100,6 +1100,22 @@ describe("StatusBar", () => {
     const frame = lastFrame() ?? "";
     expect(frame).not.toContain("Layout:");
   });
+
+  test("renders key hints line", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Tab:Switch pane");
+    expect(frame).toContain("Ctrl+C:Quit");
+  });
 });
 
 // ---- InputArea ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Split the status bar into two lines: existing pipeline status on line 1, key hints on line 2
- Added `statusBar.keyHints` i18n string with English and Korean translations
- Rendered hints in a dimmed style so they stay visible without distracting from status info
- Added test coverage for the new key hints line

Closes #109

## Test plan

- [x] Verify the status bar renders two lines: status info on top, key hints below
- [x] Confirm key hints show `Tab:Switch pane`, `↑↓:Scroll`, `PgUp/Dn:Page scroll`, `Ctrl+C:Quit`
- [x] Switch locale to Korean and verify translated key hints appear
- [x] Confirm the existing status info (issue, base SHA, stage, outcome, counters) still renders correctly on line 1
- [x] Run `pnpm vitest run` and confirm all tests pass, including the new `renders key hints line` test