### PR TITLE
Add toggle between horizontal and vertical pane split (#108)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -148,6 +148,9 @@ export const en: Messages = {
   "statusBar.base": (sha) => `Base: ${sha}`,
   "statusBar.completed": (selfCheckCount, reviewCount) =>
     `Completed: self-check \u00d7${selfCheckCount}, review \u00d7${reviewCount}`,
+  "statusBar.layout": (mode) => `Layout: ${mode}`,
+  "statusBar.layoutHorizontal": "horizontal",
+  "statusBar.layoutVertical": "vertical",
   "outcome.completed": "completed",
   "outcome.fixed": "fixed",
   "outcome.approved": "approved",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -175,6 +175,9 @@ export const ko: Messages = {
   "statusBar.base": (sha) => `\uAE30\uC900: ${sha}`,
   "statusBar.completed": (selfCheckCount, reviewCount) =>
     `\uC644\uB8CC: \uC140\uD504 \uCCB4\uD06C \u00d7${selfCheckCount}, \uB9AC\uBDF0 \u00d7${reviewCount}`,
+  "statusBar.layout": (mode) => `\uB808\uC774\uC544\uC6C3: ${mode}`,
+  "statusBar.layoutHorizontal": "\uC218\uD3C9",
+  "statusBar.layoutVertical": "\uC218\uC9C1",
 
   "outcome.completed": "완료",
   "outcome.fixed": "수정됨",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -153,6 +153,9 @@ export interface Messages {
     selfCheckCount: number,
     reviewCount: number,
   ) => string;
+  "statusBar.layout": (mode: string) => string;
+  "statusBar.layoutHorizontal": string;
+  "statusBar.layoutVertical": string;
   "outcome.completed": string;
   "outcome.fixed": string;
   "outcome.approved": string;

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -61,6 +61,7 @@ export function App({
   const resolveRef = useRef<((value: string) => void) | null>(null);
   const [focusedPane, setFocusedPane] = useState<"a" | "b">("a");
   const [activeAgent, setActiveAgent] = useState<"a" | "b" | null>(null);
+  const [layout, setLayout] = useState<"row" | "column">("row");
 
   // Store props in refs so the mount effect never re-runs.
   const emitterRef = useRef(emitter);
@@ -84,10 +85,13 @@ export function App({
     setTimeout(() => resolve?.(value), 0);
   }, []);
 
-  // Switch focused pane with Tab (always active; no conflict with text input).
-  useInput((_input, key) => {
+  // Switch focused pane with Tab; toggle layout with Ctrl+L.
+  useInput((input, key) => {
     if (key.tab) {
       setFocusedPane((prev) => (prev === "a" ? "b" : "a"));
+    }
+    if (input === "l" && key.ctrl) {
+      setLayout((prev) => (prev === "row" ? "column" : "row"));
     }
   });
 
@@ -127,8 +131,8 @@ export function App({
 
   return (
     <Box flexDirection="column" width="100%" height={terminalHeight ?? "100%"}>
-      {/* Top row: two agent panes side by side */}
-      <Box flexDirection="row" flexGrow={1}>
+      {/* Agent panes: side by side (row) or stacked (column) */}
+      <Box flexDirection={layout} flexGrow={1}>
         <AgentPane
           label={t()["agent.labelARole"]}
           modelName={modelNameA}
@@ -158,6 +162,7 @@ export function App({
         repo={pipelineOptions.context.repo}
         issueNumber={pipelineOptions.context.issueNumber}
         baseSha={pipelineOptions.context.baseSha}
+        layout={layout}
       />
       <InputArea request={inputRequest} onSubmit={handleSubmit} />
     </Box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -19,6 +19,8 @@ interface StatusBarProps {
   issueNumber: number;
   /** Full SHA of the base commit; displayed abbreviated in the bar. */
   baseSha?: string;
+  /** Current pane layout direction. */
+  layout?: "row" | "column";
 }
 
 export function StatusBar({
@@ -27,6 +29,7 @@ export function StatusBar({
   repo,
   issueNumber,
   baseSha,
+  layout,
 }: StatusBarProps) {
   const [stage, setStage] = useState<StageEnterEvent | null>(null);
   const [lastOutcome, setLastOutcome] = useState<string | null>(null);
@@ -91,6 +94,13 @@ export function StatusBar({
 
   const issueLabel = `${owner}/${repo}#${issueNumber}`;
   const baseText = baseSha ? m["statusBar.base"](baseSha.slice(0, 7)) : "";
+  const layoutText = layout
+    ? m["statusBar.layout"](
+        layout === "row"
+          ? m["statusBar.layoutHorizontal"]
+          : m["statusBar.layoutVertical"],
+      )
+    : "";
 
   return (
     <Box borderStyle="single" borderColor="gray" paddingX={1}>
@@ -115,6 +125,12 @@ export function StatusBar({
         <Text>
           {"  |  "}
           {m["statusBar.completed"](selfCheckCount, reviewCount)}
+        </Text>
+      )}
+      {layoutText && (
+        <Text>
+          {"  |  "}
+          {layoutText}
         </Text>
       )}
     </Box>

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1049,6 +1049,57 @@ describe("StatusBar", () => {
     const frame = lastFrame() ?? "";
     expect(frame).not.toContain("Base:");
   });
+
+  test("shows layout indicator when layout prop is provided", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          layout="row"
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Layout: horizontal");
+  });
+
+  test("shows vertical layout label when layout is column", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          layout="column"
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Layout: vertical");
+  });
+
+  test("hides layout indicator when layout prop is omitted", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("Layout:");
+  });
 });
 
 // ---- InputArea ---------------------------------------------------------------
@@ -1284,6 +1335,67 @@ describe("viewport height constraint", () => {
     const bHeaderIdx = after.indexOf("Agent B");
     const markerIdx = after.lastIndexOf("[*]");
     expect(markerIdx).toBeGreaterThan(bHeaderIdx);
+  });
+
+  test("Ctrl+L toggles layout between row and column", async () => {
+    const emitter = new PipelineEventEmitter();
+
+    // Harness that mimics App's Ctrl+L handler and passes layout to StatusBar.
+    function LayoutHarness() {
+      const [layout, setLayout] = useState<"row" | "column">("row");
+      useInput((input, key) => {
+        if (input === "l" && key.ctrl) {
+          setLayout((prev) => (prev === "row" ? "column" : "row"));
+        }
+      });
+      return (
+        <Box flexDirection="column" width={120} height={12}>
+          <Box flexDirection={layout} flexGrow={1}>
+            <AgentPane
+              label="Agent A"
+              agent="a"
+              emitter={emitter}
+              color="blue"
+              isFocused
+              arrowScrollEnabled
+            />
+            <AgentPane
+              label="Agent B"
+              agent="b"
+              emitter={emitter}
+              color="green"
+            />
+          </Box>
+          <StatusBar
+            emitter={emitter}
+            owner="aicers"
+            repo="agentcoop"
+            issueNumber={49}
+            layout={layout}
+          />
+        </Box>
+      );
+    }
+
+    const { lastFrame, stdin } = render(<LayoutHarness />);
+
+    // Initially horizontal layout.
+    const before = lastFrame() ?? "";
+    expect(before).toContain("Layout: horizontal");
+
+    // Press Ctrl+L — should toggle to vertical.
+    stdin.write("\x0C"); // Ctrl+L
+    await new Promise((r) => setTimeout(r, 50));
+
+    const toggled = lastFrame() ?? "";
+    expect(toggled).toContain("Layout: vertical");
+
+    // Press Ctrl+L again — back to horizontal.
+    stdin.write("\x0C");
+    await new Promise((r) => setTimeout(r, 50));
+
+    const restored = lastFrame() ?? "";
+    expect(restored).toContain("Layout: horizontal");
   });
 
   test("PageUp/PageDown work during active input prompts", async () => {


### PR DESCRIPTION
## Summary

- Add `Ctrl+L` keyboard shortcut to toggle the two agent panes between horizontal (side-by-side) and vertical (stacked) layouts
- Display the current layout mode in the status bar
- Add i18n strings for the layout indicator (English and Korean)
- Add tests for the layout toggle and status bar indicator

Closes #108

## Test plan

- [x] Launch the TUI and verify panes default to horizontal (side-by-side) layout
- [x] Press `Ctrl+L` and verify panes switch to vertical (stacked) layout
- [x] Press `Ctrl+L` again and verify panes return to horizontal layout
- [x] Verify the status bar shows "Layout: horizontal" or "Layout: vertical" matching the current mode
- [x] Verify Tab-based focus switching works identically in both layouts
- [x] Verify scroll behavior works identically in both layouts
- [x] Verify the status bar and input area remain at the bottom in both modes
- [x] Verify both layouts distribute space equally between the two panes
- [x] Run `pnpm vitest run` — all tests pass
- [x] Run `pnpm tsc --noEmit` — no type errors
- [x] Run `pnpm biome check` — no lint issues