### PR TITLE
Display per-agent token usage in TUI (#97)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,6 +10,12 @@ export type AgentErrorType =
   | "inactivity_timeout"
   | "unknown";
 
+export interface TokenUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cachedInputTokens: number;
+}
+
 export interface AgentResult {
   sessionId: string | undefined;
   responseText: string;
@@ -21,6 +27,8 @@ export interface AgentResult {
   exitCode?: number | null;
   /** Signal that terminated the process (e.g. SIGTERM, SIGKILL), if any. */
   signal?: NodeJS.Signals | null;
+  /** Token usage from the agent invocation, when available. */
+  usage?: TokenUsage;
 }
 
 export interface AgentStream {
@@ -48,6 +56,8 @@ export interface AgentAdapter {
 
 export interface InvokeOptions {
   cwd?: string;
+  /** Real-time usage callback, invoked as usage events stream in. */
+  onUsage?: (usage: TokenUsage) => void;
 }
 
 /**
@@ -62,6 +72,8 @@ export interface ChunkTransformer {
   push(raw: string): string;
   /** Flush any remaining buffered content at stream end. */
   flush(): string;
+  /** When set, called with token usage extracted from streaming events. */
+  onUsage?: (usage: TokenUsage) => void;
 }
 
 /**
@@ -71,6 +83,7 @@ export interface ChunkTransformer {
  */
 export abstract class JsonlLineTransformer implements ChunkTransformer {
   private buffer = "";
+  onUsage?: (usage: TokenUsage) => void;
 
   push(raw: string): string {
     this.buffer += raw;
@@ -82,8 +95,13 @@ export abstract class JsonlLineTransformer implements ChunkTransformer {
       const trimmed = part.trim();
       if (!trimmed) continue;
       try {
-        const extracted = this.extractTextFromEvent(JSON.parse(trimmed));
+        const parsed = JSON.parse(trimmed);
+        const extracted = this.extractTextFromEvent(parsed);
         if (extracted) text += `${extracted}\n`;
+        if (this.onUsage) {
+          const usage = this.extractUsageFromEvent(parsed);
+          if (usage) this.onUsage(usage);
+        }
       } catch {
         // Non-JSON line — ignore.
       }
@@ -96,7 +114,12 @@ export abstract class JsonlLineTransformer implements ChunkTransformer {
     this.buffer = "";
     if (!trimmed) return "";
     try {
-      const extracted = this.extractTextFromEvent(JSON.parse(trimmed));
+      const parsed = JSON.parse(trimmed);
+      const extracted = this.extractTextFromEvent(parsed);
+      if (this.onUsage) {
+        const usage = this.extractUsageFromEvent(parsed);
+        if (usage) this.onUsage(usage);
+      }
       if (extracted) return `${extracted}\n`;
       return "";
     } catch {
@@ -109,4 +132,13 @@ export abstract class JsonlLineTransformer implements ChunkTransformer {
    * (or empty string to skip).
    */
   protected abstract extractTextFromEvent(event: unknown): string;
+
+  /**
+   * Given a parsed JSONL event, return token usage if the event carries
+   * usage data, or `undefined` to skip.  Subclasses override this to
+   * extract usage from their format-specific events.
+   */
+  protected extractUsageFromEvent(_event: unknown): TokenUsage | undefined {
+    return undefined;
+  }
 }

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -206,7 +206,10 @@ export async function pollCiAndFix(
       failureLogs,
     );
     ctx.promptSinks?.a?.(fixPrompt);
-    const fixStream = agent.invoke(fixPrompt, { cwd: ctx.worktreePath });
+    const fixStream = agent.invoke(fixPrompt, {
+      cwd: ctx.worktreePath,
+      onUsage: ctx.usageSinks?.a,
+    });
     if (ctx.streamSinks?.a) {
       drainToSink(fixStream, ctx.streamSinks.a);
     }

--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -277,6 +277,156 @@ describe("parseClaudeStreamJson", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Token usage extraction
+// ---------------------------------------------------------------------------
+describe("parseClaudeStreamJson token usage", () => {
+  function streamJsonl(events: object[]): string {
+    return events.map((e) => JSON.stringify(e)).join("\n");
+  }
+
+  test("extracts usage from assistant event", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "text", text: "Hello" }],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 20,
+          },
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "Hello",
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedInputTokens: 20,
+    });
+  });
+
+  test("accumulates usage across multiple assistant events", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "text", text: "Turn 1" }],
+          usage: { input_tokens: 100, output_tokens: 30 },
+        },
+      },
+      {
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "text", text: "Turn 2" }],
+          usage: {
+            input_tokens: 200,
+            output_tokens: 40,
+            cache_creation_input_tokens: 10,
+          },
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "Turn 2",
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.usage).toEqual({
+      inputTokens: 300,
+      outputTokens: 70,
+      cachedInputTokens: 10,
+    });
+  });
+
+  test("extracts usage from result event", () => {
+    const jsonl = streamJsonl([
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "ok",
+        usage: { input_tokens: 500, output_tokens: 100 },
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.usage).toEqual({
+      inputTokens: 500,
+      outputTokens: 100,
+      cachedInputTokens: 0,
+    });
+  });
+
+  test("does not double-count when both assistant and result have usage", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "text", text: "Hello" }],
+          usage: { input_tokens: 100, output_tokens: 50 },
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "Hello",
+        usage: { input_tokens: 100, output_tokens: 50 },
+      },
+    ]);
+
+    const result = parseClaudeStreamJson(jsonl);
+    expect(result.usage).toEqual({
+      inputTokens: 100,
+      outputTokens: 50,
+      cachedInputTokens: 0,
+    });
+  });
+
+  test("returns undefined usage when no usage data present", () => {
+    const jsonl = streamJsonl([
+      { type: "system", subtype: "init", session_id: "s1" },
+      {
+        type: "assistant",
+        session_id: "s1",
+        message: { content: [{ type: "text", text: "Hi" }] },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "Hi",
+      },
+    ]);
+
+    expect(parseClaudeStreamJson(jsonl).usage).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ClaudeStreamTransformer
 // ---------------------------------------------------------------------------
 describe("ClaudeStreamTransformer", () => {
@@ -470,6 +620,88 @@ describe("ClaudeStreamTransformer", () => {
     const t = new ClaudeStreamTransformer();
     t.push("garbage without newline");
     expect(t.flush()).toBe("");
+  });
+
+  test("emits usage via onUsage callback for assistant events", () => {
+    const t = new ClaudeStreamTransformer();
+    const usages: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
+    }[] = [];
+    t.onUsage = (u) => usages.push(u);
+
+    const chunk = [
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "text", text: "Hello" }],
+          usage: {
+            input_tokens: 200,
+            output_tokens: 50,
+            cache_read_input_tokens: 30,
+          },
+        },
+      }),
+      "",
+    ].join("\n");
+
+    t.push(chunk);
+    expect(usages).toEqual([
+      { inputTokens: 200, outputTokens: 50, cachedInputTokens: 30 },
+    ]);
+  });
+
+  test("does not emit usage for result events (avoids double-counting)", () => {
+    const t = new ClaudeStreamTransformer();
+    const usages: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
+    }[] = [];
+    t.onUsage = (u) => usages.push(u);
+
+    const chunk = [
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        session_id: "s1",
+        is_error: false,
+        result: "ok",
+        usage: { input_tokens: 500, output_tokens: 100 },
+      }),
+      "",
+    ].join("\n");
+
+    t.push(chunk);
+    expect(usages).toHaveLength(0);
+  });
+
+  test("emits usage on flush for buffered assistant event", () => {
+    const t = new ClaudeStreamTransformer();
+    const usages: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
+    }[] = [];
+    t.onUsage = (u) => usages.push(u);
+
+    t.push(
+      JSON.stringify({
+        type: "assistant",
+        session_id: "s1",
+        message: {
+          content: [{ type: "text", text: "end" }],
+          usage: { input_tokens: 100, output_tokens: 25 },
+        },
+      }),
+    );
+    expect(usages).toHaveLength(0);
+    t.flush();
+    expect(usages).toEqual([
+      { inputTokens: 100, outputTokens: 25, cachedInputTokens: 0 },
+    ]);
   });
 });
 

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -3,6 +3,7 @@ import type {
   AgentErrorType,
   AgentResult,
   InvokeOptions,
+  TokenUsage,
 } from "./agent.js";
 import { JsonlLineTransformer } from "./agent.js";
 import { spawnAgent } from "./spawn-agent.js";
@@ -25,6 +26,12 @@ export type ClaudeStreamEvent =
       type: "assistant";
       message: {
         content: { type: string; text?: string }[];
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          cache_read_input_tokens?: number;
+          cache_creation_input_tokens?: number;
+        };
       };
       session_id: string;
     }
@@ -35,6 +42,13 @@ export type ClaudeStreamEvent =
       is_error: boolean;
       result?: string;
       error?: string;
+      total_cost_usd?: number;
+      usage?: {
+        input_tokens?: number;
+        output_tokens?: number;
+        cache_read_input_tokens?: number;
+        cache_creation_input_tokens?: number;
+      };
     }
   | { type: string };
 
@@ -59,6 +73,10 @@ export function parseClaudeStreamJson(jsonl: string): AgentResult {
   let resultText = "";
   let isError = false;
   let subtype = "";
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cachedInputTokens = 0;
+  let hasAssistantUsage = false;
 
   for (const line of lines) {
     let event: ClaudeStreamEvent;
@@ -73,21 +91,48 @@ export function parseClaudeStreamJson(jsonl: string): AgentResult {
       sessionId ??= e.session_id;
     }
 
+    if (event.type === "assistant" && "message" in event) {
+      const e = event as Extract<ClaudeStreamEvent, { type: "assistant" }>;
+      const u = e.message.usage;
+      if (u) {
+        hasAssistantUsage = true;
+        inputTokens += u.input_tokens ?? 0;
+        outputTokens += u.output_tokens ?? 0;
+        cachedInputTokens +=
+          (u.cache_read_input_tokens ?? 0) +
+          (u.cache_creation_input_tokens ?? 0);
+      }
+    }
+
     if (event.type === "result") {
       const e = event as Extract<ClaudeStreamEvent, { type: "result" }>;
       sessionId = e.session_id || sessionId;
       resultText = e.result ?? e.error ?? "";
       isError = e.is_error;
       subtype = e.subtype;
+      if (!hasAssistantUsage) {
+        const u = e.usage;
+        if (u) {
+          inputTokens += u.input_tokens ?? 0;
+          outputTokens += u.output_tokens ?? 0;
+          cachedInputTokens +=
+            (u.cache_read_input_tokens ?? 0) +
+            (u.cache_creation_input_tokens ?? 0);
+        }
+      }
     }
   }
 
+  const hasUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
   return {
     sessionId: sessionId || undefined,
     responseText: resultText,
     status: isError ? "error" : "success",
     errorType: isError ? claudeErrorType(subtype) : undefined,
     stderrText: "",
+    usage: hasUsage
+      ? { inputTokens, outputTokens, cachedInputTokens }
+      : undefined,
   };
 }
 
@@ -128,6 +173,23 @@ export class ClaudeStreamTransformer extends JsonlLineTransformer {
       }
     }
     return text;
+  }
+
+  protected extractUsageFromEvent(event: unknown): TokenUsage | undefined {
+    const e = event as Record<string, unknown>;
+    if (e.type === "assistant" && "message" in e) {
+      const msg = e.message as Record<string, unknown> | undefined;
+      const u = msg?.usage as Record<string, number> | undefined;
+      if (!u) return undefined;
+      const inputTokens = u.input_tokens ?? 0;
+      const outputTokens = u.output_tokens ?? 0;
+      const cachedInputTokens =
+        (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0);
+      if (inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0) {
+        return { inputTokens, outputTokens, cachedInputTokens };
+      }
+    }
+    return undefined;
   }
 }
 
@@ -240,6 +302,8 @@ export function createClaudeAdapter(
 
   return {
     invoke(prompt, options?: InvokeOptions) {
+      const transformer = new ClaudeStreamTransformer();
+      if (options?.onUsage) transformer.onUsage = options.onUsage;
       return spawnAgent({
         command: "claude",
         args: buildClaudeArgs(prompt, {
@@ -250,11 +314,13 @@ export function createClaudeAdapter(
         }),
         cwd: options?.cwd,
         parseResult: parseClaudeOutput,
-        chunkTransformer: new ClaudeStreamTransformer(),
+        chunkTransformer: transformer,
         inactivityTimeoutMs,
       });
     },
     resume(sessionId, prompt, options?: InvokeOptions) {
+      const transformer = new ClaudeStreamTransformer();
+      if (options?.onUsage) transformer.onUsage = options.onUsage;
       return spawnAgent({
         command: "claude",
         args: buildClaudeArgs(
@@ -264,7 +330,7 @@ export function createClaudeAdapter(
         ),
         cwd: options?.cwd,
         parseResult: parseClaudeOutput,
-        chunkTransformer: new ClaudeStreamTransformer(),
+        chunkTransformer: transformer,
         inactivityTimeoutMs,
       });
     },

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -4,6 +4,7 @@ import {
   buildCodexResumeArgs,
   CodexStreamTransformer,
   detectCodexError,
+  extractCodexPlainTextTokens,
   extractCodexResumeResponse,
   extractSessionId,
   parseCodexJsonl,
@@ -42,6 +43,11 @@ describe("parseCodexJsonl", () => {
       status: "success",
       errorType: undefined,
       stderrText: "",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 5,
+        cachedInputTokens: 0,
+      },
     });
   });
 
@@ -624,6 +630,67 @@ describe("CodexStreamTransformer", () => {
     t.push("garbage without newline");
     expect(t.flush()).toBe("");
   });
+
+  test("emits usage via onUsage callback for turn.completed events", () => {
+    const t = new CodexStreamTransformer();
+    const usages: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
+    }[] = [];
+    t.onUsage = (u) => usages.push(u);
+
+    const chunk = [
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 100, output_tokens: 20, cached_input_tokens: 5 },
+      }),
+      "",
+    ].join("\n");
+
+    t.push(chunk);
+    expect(usages).toEqual([
+      { inputTokens: 100, outputTokens: 20, cachedInputTokens: 5 },
+    ]);
+  });
+
+  test("emits usage on flush for buffered turn.completed", () => {
+    const t = new CodexStreamTransformer();
+    const usages: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
+    }[] = [];
+    t.onUsage = (u) => usages.push(u);
+
+    // No trailing newline → stays in buffer
+    t.push(
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 50, output_tokens: 10 },
+      }),
+    );
+    expect(usages).toHaveLength(0);
+    t.flush();
+    expect(usages).toEqual([
+      { inputTokens: 50, outputTokens: 10, cachedInputTokens: 0 },
+    ]);
+  });
+
+  test("does not emit usage when onUsage is not set", () => {
+    const t = new CodexStreamTransformer();
+
+    const chunk = [
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 100, output_tokens: 20 },
+      }),
+      "",
+    ].join("\n");
+
+    // Should not throw
+    t.push(chunk);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -769,6 +836,129 @@ describe("buildCodexResumeArgs", () => {
     });
 
     expect(args).toContain("model_reasoning_effort=xhigh");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Token usage extraction
+// ---------------------------------------------------------------------------
+describe("parseCodexJsonl token usage", () => {
+  test("extracts usage from turn.completed events", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-t" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "ok" },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: {
+          input_tokens: 200,
+          cached_input_tokens: 50,
+          output_tokens: 30,
+        },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.usage).toEqual({
+      inputTokens: 200,
+      outputTokens: 30,
+      cachedInputTokens: 50,
+    });
+  });
+
+  test("accumulates usage across multiple turn.completed events", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-t2" }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 100, output_tokens: 10 },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 200, output_tokens: 20, cached_input_tokens: 5 },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.usage).toEqual({
+      inputTokens: 300,
+      outputTokens: 30,
+      cachedInputTokens: 5,
+    });
+  });
+
+  test("returns undefined usage when no turn.completed has usage", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-t3" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "hi" },
+      }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(lines).usage).toBeUndefined();
+  });
+
+  test("returns undefined usage when turn.completed lacks usage field", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-t4" }),
+      JSON.stringify({ type: "turn.completed" }),
+    ].join("\n");
+
+    expect(parseCodexJsonl(lines).usage).toBeUndefined();
+  });
+});
+
+describe("extractCodexPlainTextTokens", () => {
+  test("extracts token count from footer", () => {
+    const text = "codex\nresponse\ntokens used\n229\n";
+    expect(extractCodexPlainTextTokens(text)).toBe(229);
+  });
+
+  test("returns undefined when no footer", () => {
+    expect(extractCodexPlainTextTokens("just output")).toBeUndefined();
+  });
+
+  test("returns undefined for non-numeric count", () => {
+    expect(extractCodexPlainTextTokens("\ntokens used\nabc\n")).toBeUndefined();
+  });
+
+  test("returns undefined for zero count", () => {
+    expect(extractCodexPlainTextTokens("\ntokens used\n0\n")).toBeUndefined();
+  });
+});
+
+describe("parseCodexPlainText token usage", () => {
+  const BANNER = [
+    "OpenAI Codex v0.46.0 (research preview)",
+    "--------",
+    "workdir: /path",
+    "model: gpt-5.4",
+    "session id: sess-1",
+    "--------",
+  ].join("\n");
+
+  test("omits usage from resume output (combined total is ambiguous)", () => {
+    const text = [
+      BANNER,
+      "user",
+      "Question",
+      "codex",
+      "Answer",
+      "tokens used",
+      "500",
+    ].join("\n");
+
+    const result = parseCodexPlainText(text, 0, "");
+    expect(result.usage).toBeUndefined();
+  });
+
+  test("returns undefined usage when no tokens used footer", () => {
+    const text = [BANNER, "user", "Question", "codex", "Answer"].join("\n");
+    const result = parseCodexPlainText(text, 0, "");
+    expect(result.usage).toBeUndefined();
   });
 });
 

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -4,6 +4,7 @@ import type {
   AgentResult,
   AgentStream,
   InvokeOptions,
+  TokenUsage,
 } from "./agent.js";
 import { JsonlLineTransformer } from "./agent.js";
 import { spawnAgent } from "./spawn-agent.js";
@@ -37,6 +38,18 @@ interface TurnFailedEvent {
 }
 
 /**
+ * `{"type":"turn.completed","usage":{"input_tokens":100,...}}`
+ */
+interface TurnCompletedEvent {
+  type: "turn.completed";
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+    cached_input_tokens?: number;
+  };
+}
+
+/**
  * `{"type":"error","message":"..."}`
  */
 interface ErrorEvent {
@@ -47,6 +60,7 @@ interface ErrorEvent {
 export type CodexJsonEvent =
   | ThreadStartedEvent
   | ItemCompletedEvent
+  | TurnCompletedEvent
   | TurnFailedEvent
   | ErrorEvent
   | { type: string };
@@ -65,6 +79,9 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
   let responseText = "";
   let failed = false;
   let failMessage = "";
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cachedInputTokens = 0;
 
   for (const line of lines) {
     let event: CodexJsonEvent;
@@ -88,12 +105,26 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
       }
     }
 
+    if (event.type === "turn.completed") {
+      const e = event as TurnCompletedEvent;
+      if (e.usage) {
+        inputTokens += e.usage.input_tokens ?? 0;
+        outputTokens += e.usage.output_tokens ?? 0;
+        cachedInputTokens += e.usage.cached_input_tokens ?? 0;
+      }
+    }
+
     if (event.type === "turn.failed") {
       const e = event as TurnFailedEvent;
       failed = true;
       failMessage = e.error.message;
     }
   }
+
+  const hasUsage = inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0;
+  const usage: TokenUsage | undefined = hasUsage
+    ? { inputTokens, outputTokens, cachedInputTokens }
+    : undefined;
 
   if (failed) {
     return {
@@ -102,6 +133,7 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
       status: "error",
       errorType: detectCodexError(failMessage),
       stderrText: "",
+      usage,
     };
   }
 
@@ -111,6 +143,7 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
     status: "success",
     errorType: undefined,
     stderrText: "",
+    usage,
   };
 }
 
@@ -192,6 +225,22 @@ export function extractSessionId(text: string): string | undefined {
   return match?.[1];
 }
 
+/**
+ * Extract the total token count from the "tokens used\n<count>" footer
+ * in Codex plain text output.  Returns undefined when the footer is
+ * absent or the count is not a valid number.
+ */
+export function extractCodexPlainTextTokens(text: string): number | undefined {
+  const marker = "\ntokens used\n";
+  const idx = text.lastIndexOf(marker);
+  if (idx === -1) return undefined;
+  const rest = text.slice(idx + marker.length).trim();
+  // The count may be on the first line only (ignore trailing content).
+  const firstLine = rest.split("\n")[0].trim();
+  const n = Number.parseInt(firstLine, 10);
+  return Number.isFinite(n) && n > 0 ? n : undefined;
+}
+
 export function parseCodexPlainText(
   text: string,
   exitCode: number | null,
@@ -209,6 +258,9 @@ export function parseCodexPlainText(
     status: failed ? "error" : "success",
     errorType,
     stderrText,
+    // Resume mode only reports a combined total ("tokens used"), not
+    // split input/output.  Emitting it as inputTokens would be
+    // misleading, so we omit usage entirely for this path.
   };
 }
 
@@ -228,6 +280,22 @@ export class CodexStreamTransformer extends JsonlLineTransformer {
     const item = e.item as Record<string, unknown> | undefined;
     if (item?.type !== "agent_message") return "";
     return (item.text as string) ?? "";
+  }
+
+  protected extractUsageFromEvent(
+    event: unknown,
+  ): import("./agent.js").TokenUsage | undefined {
+    const e = event as Record<string, unknown>;
+    if (e.type !== "turn.completed") return undefined;
+    const u = (e as { usage?: Record<string, number> }).usage;
+    if (!u) return undefined;
+    const inputTokens = u.input_tokens ?? 0;
+    const outputTokens = u.output_tokens ?? 0;
+    const cachedInputTokens = u.cached_input_tokens ?? 0;
+    if (inputTokens > 0 || outputTokens > 0 || cachedInputTokens > 0) {
+      return { inputTokens, outputTokens, cachedInputTokens };
+    }
+    return undefined;
   }
 }
 
@@ -413,12 +481,17 @@ export function createCodexAdapter(
 
   return {
     invoke(prompt, options?: InvokeOptions) {
+      function makeTransformer(): CodexStreamTransformer {
+        const t = new CodexStreamTransformer();
+        if (options?.onUsage) t.onUsage = options.onUsage;
+        return t;
+      }
       const stream = spawnAgent({
         command: "codex",
         args: buildCodexInvokeArgs(prompt, { model, reasoningEffort }),
         cwd: options?.cwd,
         parseResult: parseCodexInvokeOutput,
-        chunkTransformer: new CodexStreamTransformer(),
+        chunkTransformer: makeTransformer(),
         inactivityTimeoutMs,
       });
       if (reasoningEffort !== "xhigh") return stream;
@@ -431,7 +504,7 @@ export function createCodexAdapter(
           }),
           cwd: options?.cwd,
           parseResult: parseCodexInvokeOutput,
-          chunkTransformer: new CodexStreamTransformer(),
+          chunkTransformer: makeTransformer(),
           inactivityTimeoutMs,
         }),
       );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -161,6 +161,12 @@ export const en: Messages = {
   "outcome.needs_clarification": "needs clarification",
   "outcome.error": "error",
 
+  // ---- token bar ----------------------------------------------------------
+
+  "tokenBar.agentUsage": (label, inputTokens, outputTokens) =>
+    `${label}: ${inputTokens} in / ${outputTokens} out`,
+  "tokenBar.noUsage": "No token data yet",
+
   // ---- input area --------------------------------------------------------
 
   "input.pipelineRunning": "Pipeline running...",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -189,6 +189,12 @@ export const ko: Messages = {
   "outcome.needs_clarification": "명확화 필요",
   "outcome.error": "오류",
 
+  // ---- token bar ----------------------------------------------------------
+
+  "tokenBar.agentUsage": (label, inputTokens, outputTokens) =>
+    `${label}: ${inputTokens} \uC785\uB825 / ${outputTokens} \uCD9C\uB825`,
+  "tokenBar.noUsage": "\uD1A0\uD070 \uB370\uC774\uD130 \uC5C6\uC74C",
+
   // ---- input area --------------------------------------------------------
 
   "input.pipelineRunning":

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -165,6 +165,15 @@ export interface Messages {
   "outcome.needs_clarification": string;
   "outcome.error": string;
 
+  // ---- token bar (TokenBar.tsx) ------------------------------------------
+
+  "tokenBar.agentUsage": (
+    label: string,
+    inputTokens: string,
+    outputTokens: string,
+  ) => string;
+  "tokenBar.noUsage": string;
+
   // ---- input area (InputArea.tsx) ----------------------------------------
 
   "input.pipelineRunning": string;

--- a/src/pipeline-events.test.ts
+++ b/src/pipeline-events.test.ts
@@ -3,6 +3,7 @@ import {
   type AgentChunkEvent,
   type AgentInvokeEvent,
   type AgentPromptEvent,
+  type AgentUsageEvent,
   PipelineEventEmitter,
   type StageEnterEvent,
   type StageExitEvent,
@@ -91,6 +92,20 @@ describe("PipelineEventEmitter", () => {
     emitter.emit("agent:chunk", { agent: "a", chunk: "data" });
 
     expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("emits and receives agent:usage events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("agent:usage", handler);
+
+    const event: AgentUsageEvent = {
+      agent: "a",
+      usage: { inputTokens: 100, outputTokens: 50, cachedInputTokens: 10 },
+    };
+    emitter.emit("agent:usage", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
   });
 
   test("different event types do not interfere", () => {

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import type { TokenUsage } from "./agent.js";
 
 export interface AgentChunkEvent {
   agent: "a" | "b";
@@ -26,9 +27,15 @@ export interface AgentPromptEvent {
   prompt: string;
 }
 
+export interface AgentUsageEvent {
+  agent: "a" | "b";
+  usage: TokenUsage;
+}
+
 interface PipelineEventMap {
   "agent:chunk": [AgentChunkEvent];
   "agent:prompt": [AgentPromptEvent];
+  "agent:usage": [AgentUsageEvent];
   "stage:enter": [StageEnterEvent];
   "stage:exit": [StageExitEvent];
   "agent:invoke": [AgentInvokeEvent];

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -11,7 +11,7 @@
 
 import { t } from "./i18n/index.js";
 import type { PipelineEventEmitter } from "./pipeline-events.js";
-import type { PromptSink, StreamSink } from "./stage-util.js";
+import type { PromptSink, StreamSink, UsageSink } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
 // ---- public types --------------------------------------------------------
@@ -129,6 +129,12 @@ export interface StageContext {
    * user can see what the agent was asked to do.
    */
   promptSinks?: { a?: PromptSink; b?: PromptSink };
+  /**
+   * Optional sinks for reporting token usage after an agent invocation.
+   * Stage handlers call these with the usage data from `AgentResult`
+   * so the UI can display per-agent token consumption.
+   */
+  usageSinks?: { a?: UsageSink; b?: UsageSink };
 }
 
 // ---- user interaction interface ------------------------------------------
@@ -550,6 +556,16 @@ async function runStage(
       }
     : undefined;
 
+  // Build per-agent usage sinks so the UI can display token consumption.
+  const usageSinks = events
+    ? {
+        a: (usage: import("./agent.js").TokenUsage) =>
+          events.emit("agent:usage", { agent: "a", usage }),
+        b: (usage: import("./agent.js").TokenUsage) =>
+          events.emit("agent:usage", { agent: "b", usage }),
+      }
+    : undefined;
+
   while (true) {
     // Notify caller before each handler invocation for persistence.
     onStageTransition?.(stage.number, lc.iteration);
@@ -570,6 +586,7 @@ async function runStage(
       savedAgentBSessionId,
       streamSinks,
       promptSinks,
+      usageSinks,
     };
 
     // Clear one-shot fields after use.

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -188,6 +188,8 @@ export function createCiCheckStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (fixResult.sessionId) {

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -106,6 +106,8 @@ export function createCreatePrStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (prResult.sessionId) {
@@ -128,6 +130,8 @@ export function createCreatePrStageHandler(
         prCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (checkResult.status === "error") {
@@ -147,6 +151,8 @@ export function createCreatePrStageHandler(
           clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
         );
 
         if (retryResult.status === "error") {

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -91,6 +91,8 @@ export function createImplementStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (implResult.sessionId) {
@@ -110,6 +112,8 @@ export function createImplementStageHandler(
         checkPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (checkResult.status === "error") {

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -37,6 +37,7 @@ import {
   type PromptSink,
   type StreamSink,
   sendFollowUp,
+  type UsageSink,
 } from "./stage-util.js";
 import { parseStepStatus } from "./step-parser.js";
 
@@ -198,6 +199,8 @@ export function createReviewStageHandler(
         reviewPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.b,
+        undefined,
+        ctx.usageSinks?.b,
       );
 
       if (reviewResult.sessionId) {
@@ -220,6 +223,7 @@ export function createReviewStageHandler(
           ctx.worktreePath,
           ctx.streamSinks?.b,
           ctx.promptSinks?.b,
+          ctx.usageSinks?.b,
         );
         if (error) return error;
 
@@ -246,6 +250,8 @@ export function createReviewStageHandler(
         fixPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (fixResult.sessionId) {
@@ -266,6 +272,8 @@ export function createReviewStageHandler(
         authorCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (checkResult.status === "error") {
@@ -286,6 +294,8 @@ export function createReviewStageHandler(
           retryPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
         );
 
         if (retryResult.status === "error") {
@@ -347,6 +357,7 @@ export function createReviewStageHandler(
           ctx.worktreePath,
           ctx.streamSinks?.b,
           ctx.promptSinks?.b,
+          ctx.usageSinks?.b,
         );
         if (error) return error;
         if (summary) {
@@ -380,6 +391,7 @@ async function handleUnresolvedSummary(
   cwd: string,
   sink?: StreamSink,
   promptSink?: PromptSink,
+  usageSink?: UsageSink,
 ): Promise<UnresolvedSummaryResult> {
   const summaryPrompt = buildUnresolvedSummaryPrompt(round);
   promptSink?.(summaryPrompt);
@@ -393,9 +405,14 @@ async function handleUnresolvedSummary(
       summaryPrompt,
       cwd,
       sink,
+      undefined,
+      usageSink,
     );
   } else {
-    const stream = opts.agentB.invoke(summaryPrompt, { cwd });
+    const stream = opts.agentB.invoke(summaryPrompt, {
+      cwd,
+      onUsage: usageSink,
+    });
     if (sink) drainToSink(stream, sink);
     result = await stream.result;
   }

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -121,6 +121,8 @@ export function createSelfCheckStageHandler(
         checkPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (checkResult.sessionId) {
@@ -140,6 +142,8 @@ export function createSelfCheckStageHandler(
         fixPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (fixResult.status === "error") {
@@ -159,6 +163,8 @@ export function createSelfCheckStageHandler(
             syncPrompt,
             ctx.worktreePath,
             ctx.streamSinks?.a,
+            undefined,
+            ctx.usageSinks?.a,
           );
 
           if (syncResult.status === "success") {

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -148,6 +148,8 @@ export function createSquashStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (squashResult.sessionId) {
@@ -168,6 +170,8 @@ export function createSquashStageHandler(
         squashCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (checkResult.status === "error") {
@@ -187,6 +191,8 @@ export function createSquashStageHandler(
           clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
         );
 
         if (retryResult.status === "error") {

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -121,6 +121,8 @@ export function createTestPlanStageHandler(
         verifyPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (verifyResult.sessionId) {
@@ -140,6 +142,8 @@ export function createTestPlanStageHandler(
         selfCheckPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
       );
 
       if (checkResult.status === "error") {

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -3,7 +3,12 @@
  * step-status-to-outcome conversion, and inactivity auto-resume.
  */
 
-import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import type {
+  AgentAdapter,
+  AgentResult,
+  AgentStream,
+  TokenUsage,
+} from "./agent.js";
 import { t } from "./i18n/index.js";
 import type { StageOutcome, StageResult } from "./pipeline.js";
 import { type ParsedStep, parseStepStatus } from "./step-parser.js";
@@ -18,6 +23,12 @@ export type StreamSink = (chunk: string) => void;
  * Used by the UI to display outgoing prompts in the agent's pane.
  */
 export type PromptSink = (prompt: string) => void;
+
+/**
+ * Callback that receives token usage data after an agent invocation completes.
+ * Used by the UI to display per-agent token consumption.
+ */
+export type UsageSink = (usage: TokenUsage) => void;
 
 /**
  * Log full diagnostic details for an agent process failure so that
@@ -177,6 +188,7 @@ async function retryOnTimeout(
   fallbackSessionId: string | undefined,
   sink: StreamSink | undefined,
   maxRetries: number,
+  usageSink?: UsageSink,
 ): Promise<AgentResult> {
   let result = initial;
   let left = maxRetries;
@@ -185,7 +197,10 @@ async function retryOnTimeout(
     const sid = result.sessionId ?? fallbackSessionId;
     if (!sid) break;
     left--;
-    const stream = agent.resume(sid, DEFAULT_RESUME_PROMPT, { cwd });
+    const stream = agent.resume(sid, DEFAULT_RESUME_PROMPT, {
+      cwd,
+      onUsage: usageSink,
+    });
     if (sink) drainToSink(stream, sink);
     result = await stream.result;
   }
@@ -208,6 +223,7 @@ export async function invokeOrResume(
   cwd: string,
   sink?: StreamSink,
   maxAutoResumes = 3,
+  usageSink?: UsageSink,
 ): Promise<AgentResult> {
   const result = await invokeOrResumeOnce(
     agent,
@@ -215,8 +231,17 @@ export async function invokeOrResume(
     prompt,
     cwd,
     sink,
+    usageSink,
   );
-  return retryOnTimeout(agent, result, cwd, undefined, sink, maxAutoResumes);
+  return retryOnTimeout(
+    agent,
+    result,
+    cwd,
+    undefined,
+    sink,
+    maxAutoResumes,
+    usageSink,
+  );
 }
 
 /**
@@ -228,9 +253,11 @@ async function invokeOrResumeOnce(
   prompt: string,
   cwd: string,
   sink?: StreamSink,
+  usageSink?: UsageSink,
 ): Promise<AgentResult> {
+  const opts = { cwd, onUsage: usageSink };
   if (savedSessionId) {
-    const stream = agent.resume(savedSessionId, prompt, { cwd });
+    const stream = agent.resume(savedSessionId, prompt, opts);
     if (sink) drainToSink(stream, sink);
     const result = await stream.result;
     if (result.status === "success") {
@@ -249,7 +276,7 @@ async function invokeOrResumeOnce(
     }
     // Session expired or unknown error — fall back to fresh invoke.
   }
-  const stream = agent.invoke(prompt, { cwd });
+  const stream = agent.invoke(prompt, opts);
   if (sink) drainToSink(stream, sink);
   return stream.result;
 }
@@ -269,6 +296,7 @@ export async function sendFollowUp(
   cwd: string,
   sink?: StreamSink,
   maxAutoResumes = 3,
+  usageSink?: UsageSink,
 ): Promise<AgentResult> {
   if (sessionId === undefined) {
     throw new Error(
@@ -276,10 +304,21 @@ export async function sendFollowUp(
         "The agent CLI may have failed to return a session.",
     );
   }
-  const stream = agent.resume(sessionId, prompt, { cwd });
+  const stream = agent.resume(sessionId, prompt, {
+    cwd,
+    onUsage: usageSink,
+  });
   if (sink) drainToSink(stream, sink);
   const result = await stream.result;
-  return retryOnTimeout(agent, result, cwd, sessionId, sink, maxAutoResumes);
+  return retryOnTimeout(
+    agent,
+    result,
+    cwd,
+    sessionId,
+    sink,
+    maxAutoResumes,
+    usageSink,
+  );
 }
 
 /**

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -14,6 +14,7 @@ import type {
 import { AgentPane } from "./AgentPane.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
+import { TokenBar } from "./TokenBar.js";
 import { createTuiUserPrompt } from "./TuiUserPrompt.js";
 
 /** Read terminal height from stdout.rows, re-rendering on resize. */
@@ -155,7 +156,8 @@ export function App({
         />
       </Box>
 
-      {/* Bottom: status bar + input area */}
+      {/* Bottom: token bar + status bar + input area */}
+      <TokenBar emitter={emitter} />
       <StatusBar
         emitter={emitter}
         owner={pipelineOptions.context.owner}

--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -1,0 +1,90 @@
+import { Box, Text } from "ink";
+import { useEffect, useState } from "react";
+import type { TokenUsage } from "../agent.js";
+import { t } from "../i18n/index.js";
+import type {
+  AgentUsageEvent,
+  PipelineEventEmitter,
+} from "../pipeline-events.js";
+
+/**
+ * Format a token count with K/M suffixes for readability.
+ *
+ * - Below 1 000: show the exact number (e.g. "842")
+ * - 1 000 – 999 999: show with one decimal K (e.g. "12.3K")
+ * - 1 000 000+: show with one decimal M (e.g. "1.2M")
+ */
+export function formatTokenCount(n: number): string {
+  if (n < 1_000) return String(n);
+  if (n < 1_000_000) {
+    const k = n / 1_000;
+    return k >= 100 ? `${Math.round(k)}K` : `${k.toFixed(1)}K`;
+  }
+  const m = n / 1_000_000;
+  return `${m.toFixed(1)}M`;
+}
+
+interface TokenBarProps {
+  emitter: PipelineEventEmitter;
+}
+
+export function TokenBar({ emitter }: TokenBarProps) {
+  const [usageA, setUsageA] = useState<TokenUsage>({
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+  });
+  const [usageB, setUsageB] = useState<TokenUsage>({
+    inputTokens: 0,
+    outputTokens: 0,
+    cachedInputTokens: 0,
+  });
+
+  useEffect(() => {
+    const onUsage = (ev: AgentUsageEvent) => {
+      const update = (prev: TokenUsage): TokenUsage => ({
+        inputTokens: prev.inputTokens + ev.usage.inputTokens,
+        outputTokens: prev.outputTokens + ev.usage.outputTokens,
+        cachedInputTokens: prev.cachedInputTokens + ev.usage.cachedInputTokens,
+      });
+      if (ev.agent === "a") setUsageA(update);
+      else setUsageB(update);
+    };
+    emitter.on("agent:usage", onUsage);
+    return () => {
+      emitter.off("agent:usage", onUsage);
+    };
+  }, [emitter]);
+
+  const m = t();
+  const hasData =
+    usageA.inputTokens > 0 ||
+    usageA.outputTokens > 0 ||
+    usageB.inputTokens > 0 ||
+    usageB.outputTokens > 0;
+
+  if (!hasData) return null;
+
+  const labelA = m["agent.labelA"];
+  const labelB = m["agent.labelB"];
+
+  return (
+    <Box borderStyle="single" borderColor="gray" paddingX={1}>
+      <Text>
+        {m["tokenBar.agentUsage"](
+          labelA,
+          formatTokenCount(usageA.inputTokens),
+          formatTokenCount(usageA.outputTokens),
+        )}
+      </Text>
+      <Text>{"  |  "}</Text>
+      <Text>
+        {m["tokenBar.agentUsage"](
+          labelB,
+          formatTokenCount(usageB.inputTokens),
+          formatTokenCount(usageB.outputTokens),
+        )}
+      </Text>
+    </Box>
+  );
+}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -16,6 +16,7 @@ import { AgentPane, splitIntoRows } from "./AgentPane.js";
 import { useTerminalHeight } from "./App.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
+import { formatTokenCount, TokenBar } from "./TokenBar.js";
 
 afterEach(() => {
   cleanup();
@@ -1510,5 +1511,90 @@ describe("viewport height constraint", () => {
     expect(after).not.toContain("A20");
     // Pane B must remain at the bottom (unaffected by pane A scroll).
     expect(after).toContain("B20");
+  });
+});
+
+// ---- formatTokenCount -------------------------------------------------------
+
+describe("formatTokenCount", () => {
+  test("returns exact number below 1000", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(42)).toBe("42");
+    expect(formatTokenCount(999)).toBe("999");
+  });
+
+  test("formats thousands with K suffix", () => {
+    expect(formatTokenCount(1000)).toBe("1.0K");
+    expect(formatTokenCount(1500)).toBe("1.5K");
+    expect(formatTokenCount(12345)).toBe("12.3K");
+    expect(formatTokenCount(99900)).toBe("99.9K");
+  });
+
+  test("rounds large K values without decimal", () => {
+    expect(formatTokenCount(100_000)).toBe("100K");
+    expect(formatTokenCount(500_000)).toBe("500K");
+  });
+
+  test("formats millions with M suffix", () => {
+    expect(formatTokenCount(1_000_000)).toBe("1.0M");
+    expect(formatTokenCount(2_500_000)).toBe("2.5M");
+  });
+});
+
+// ---- TokenBar ---------------------------------------------------------------
+
+describe("TokenBar", () => {
+  test("renders nothing when no usage events emitted", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<TokenBar emitter={emitter} />);
+    // TokenBar returns null when there is no data, so the frame should
+    // be empty or contain no agent labels.
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("Agent A");
+  });
+
+  test("renders cumulative token usage after events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<TokenBar emitter={emitter} />);
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 12300, outputTokens: 5100, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:usage", {
+      agent: "b",
+      usage: { inputTokens: 8700, outputTokens: 3200, cachedInputTokens: 0 },
+    });
+
+    // Allow React to re-render.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Agent A");
+    expect(frame).toContain("12.3K in");
+    expect(frame).toContain("5.1K out");
+    expect(frame).toContain("Agent B");
+    expect(frame).toContain("8.7K in");
+    expect(frame).toContain("3.2K out");
+  });
+
+  test("accumulates usage across multiple events for same agent", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<TokenBar emitter={emitter} />);
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 2000, outputTokens: 1000, cachedInputTokens: 0 },
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("3.0K in");
+    expect(frame).toContain("1.5K out");
   });
 });


### PR DESCRIPTION
## Summary

- Parse token usage (`inputTokens`, `outputTokens`, `cachedInputTokens`) from Claude stream-json and Codex JSONL CLI output in the respective adapters.
- Stream usage data in real time via `onUsage` callbacks on `ChunkTransformer`, wired through `InvokeOptions` → adapters → `invokeOrResume`/`sendFollowUp`. The UI receives per-turn updates as events arrive, not only after an invocation exits.
- Emit a new `agent:usage` pipeline event so the `TokenBar` component updates live.
- Add a `TokenBar` component that renders cumulative per-agent token stats (e.g., `12.3K in / 5.1K out`) between the agent panes and the status bar.
- Codex resume mode (`codex exec resume`) no longer emits split usage — the plain-text `tokens used` footer only reports a combined total that cannot be reliably split into input/output.
- Add i18n messages for the token bar labels.

Closes #97

## Test plan

- [x] Run `pnpm vitest run` — all tests pass, including new adapter and component tests
- [x] Run `pnpm tsc --noEmit` — no type errors
- [x] Run `pnpm biome check` — no lint/format issues
- [x] Verify Claude adapter extracts usage from `assistant` stream-json events in real time
- [x] Verify Codex adapter extracts usage from `turn.completed` JSONL events in real time
- [x] Verify Codex resume mode omits usage (combined total is ambiguous)
- [x] Verify TokenBar renders per-agent cumulative token counts with K/M suffixes
- [x] Verify TokenBar updates in real time as pipeline stages run
- [x] Verify the bar appears between agent panes and the status bar in the TUI