### PR TITLE
Add graceful cancellation and cleanup on exit (#95)

### DIFF
--- a/src/cleanup.test.ts
+++ b/src/cleanup.test.ts
@@ -1,0 +1,126 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { describe, expect, test, vi } from "vitest";
+import {
+  closePr,
+  deleteRemoteBranch,
+  hasDockerComposeFile,
+  hasDockerComposeRunning,
+  remoteBranchExists,
+  stopDockerCompose,
+} from "./cleanup.js";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+const mockExec = vi.mocked(execFileSync);
+const mockExists = vi.mocked(existsSync);
+
+describe("hasDockerComposeFile", () => {
+  test("returns true when docker-compose.yml exists", () => {
+    mockExists.mockImplementation((path) =>
+      String(path).endsWith("docker-compose.yml"),
+    );
+    expect(hasDockerComposeFile("/tmp/wt")).toBe(true);
+  });
+
+  test("returns true when compose.yaml exists", () => {
+    mockExists.mockImplementation((path) =>
+      String(path).endsWith("compose.yaml"),
+    );
+    expect(hasDockerComposeFile("/tmp/wt")).toBe(true);
+  });
+
+  test("returns false when no compose file exists", () => {
+    mockExists.mockReturnValue(false);
+    expect(hasDockerComposeFile("/tmp/wt")).toBe(false);
+  });
+});
+
+describe("hasDockerComposeRunning", () => {
+  test("returns false when no compose file exists", () => {
+    mockExists.mockReturnValue(false);
+    expect(hasDockerComposeRunning("/tmp/wt")).toBe(false);
+  });
+
+  test("returns true when services are running", () => {
+    mockExists.mockReturnValue(true);
+    mockExec.mockReturnValue("abc123\n" as never);
+    expect(hasDockerComposeRunning("/tmp/wt")).toBe(true);
+  });
+
+  test("returns false when no services are running", () => {
+    mockExists.mockReturnValue(true);
+    mockExec.mockReturnValue("" as never);
+    expect(hasDockerComposeRunning("/tmp/wt")).toBe(false);
+  });
+
+  test("returns false when docker command fails", () => {
+    mockExists.mockReturnValue(true);
+    mockExec.mockImplementation(() => {
+      throw new Error("docker not found");
+    });
+    expect(hasDockerComposeRunning("/tmp/wt")).toBe(false);
+  });
+});
+
+describe("stopDockerCompose", () => {
+  test("runs docker compose down", () => {
+    mockExec.mockReturnValue("" as never);
+    stopDockerCompose("/tmp/wt");
+    expect(mockExec).toHaveBeenCalledWith(
+      "docker",
+      ["compose", "down"],
+      expect.objectContaining({ cwd: "/tmp/wt" }),
+    );
+  });
+
+  test("does not throw when docker command fails", () => {
+    mockExec.mockImplementation(() => {
+      throw new Error("docker not found");
+    });
+    expect(() => stopDockerCompose("/tmp/wt")).not.toThrow();
+  });
+});
+
+describe("remoteBranchExists", () => {
+  test("returns true when API call succeeds", () => {
+    mockExec.mockReturnValue("" as never);
+    expect(remoteBranchExists("owner", "repo", "my-branch")).toBe(true);
+  });
+
+  test("returns false when API call fails", () => {
+    mockExec.mockImplementation(() => {
+      throw new Error("Not Found");
+    });
+    expect(remoteBranchExists("owner", "repo", "my-branch")).toBe(false);
+  });
+});
+
+describe("deleteRemoteBranch", () => {
+  test("calls gh api to delete the branch ref", () => {
+    mockExec.mockReturnValue("" as never);
+    deleteRemoteBranch("owner", "repo", "my-branch");
+    expect(mockExec).toHaveBeenCalledWith(
+      "gh",
+      ["api", "-X", "DELETE", "repos/owner/repo/git/refs/heads/my-branch"],
+      expect.any(Object),
+    );
+  });
+});
+
+describe("closePr", () => {
+  test("calls gh pr close with correct arguments", () => {
+    mockExec.mockReturnValue("" as never);
+    closePr("owner", "repo", 42);
+    expect(mockExec).toHaveBeenCalledWith(
+      "gh",
+      ["pr", "close", "42", "--repo", "owner/repo"],
+      expect.any(Object),
+    );
+  });
+});

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -1,0 +1,113 @@
+/**
+ * Cleanup utilities — docker compose, remote branch, and PR management.
+ *
+ * Provides functions that detect and tear down resources created during
+ * a pipeline run so the user does not have to clean up manually.
+ */
+
+import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const EXEC_OPTS: ExecFileSyncOptions = { encoding: "utf-8", stdio: "pipe" };
+
+// ---- docker compose -------------------------------------------------------
+
+const COMPOSE_FILES = [
+  "docker-compose.yml",
+  "docker-compose.yaml",
+  "compose.yml",
+  "compose.yaml",
+];
+
+/**
+ * Whether the worktree contains a docker compose file.
+ */
+export function hasDockerComposeFile(worktreePath: string): boolean {
+  return COMPOSE_FILES.some((f) => existsSync(join(worktreePath, f)));
+}
+
+/**
+ * Whether docker compose services are currently running in the worktree.
+ *
+ * Returns `false` when docker is not installed, no compose file exists,
+ * or no services are up.
+ */
+export function hasDockerComposeRunning(worktreePath: string): boolean {
+  if (!hasDockerComposeFile(worktreePath)) return false;
+  try {
+    const output = execFileSync(
+      "docker",
+      ["compose", "ps", "--status", "running", "-q"],
+      { ...EXEC_OPTS, cwd: worktreePath },
+    ) as string;
+    return output.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Stop docker compose services in the worktree.  Errors are silently
+ * ignored (docker may not be installed or no services may be running).
+ */
+export function stopDockerCompose(worktreePath: string): void {
+  try {
+    execFileSync("docker", ["compose", "down"], {
+      ...EXEC_OPTS,
+      cwd: worktreePath,
+    });
+  } catch {
+    // Ignore — docker may not be available.
+  }
+}
+
+// ---- remote branch --------------------------------------------------------
+
+/**
+ * Check whether a remote branch exists on GitHub.
+ */
+export function remoteBranchExists(
+  owner: string,
+  repo: string,
+  branch: string,
+): boolean {
+  try {
+    execFileSync(
+      "gh",
+      ["api", `repos/${owner}/${repo}/git/ref/heads/${branch}`, "--silent"],
+      EXEC_OPTS,
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Delete a remote branch on GitHub.
+ */
+export function deleteRemoteBranch(
+  owner: string,
+  repo: string,
+  branch: string,
+): void {
+  execFileSync(
+    "gh",
+    ["api", "-X", "DELETE", `repos/${owner}/${repo}/git/refs/heads/${branch}`],
+    EXEC_OPTS,
+  );
+}
+
+// ---- pull request ---------------------------------------------------------
+
+/**
+ * Close an open PR on GitHub without merging.
+ */
+export function closePr(owner: string, repo: string, prNumber: number): void {
+  execFileSync(
+    "gh",
+    ["pr", "close", String(prNumber), "--repo", `${owner}/${repo}`],
+    EXEC_OPTS,
+  );
+}

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, test } from "vitest";
+import { EventEmitter } from "node:events";
+import { describe, expect, test, vi } from "vitest";
+import type { AgentResult, AgentStream } from "./agent.js";
 import {
   buildCodexInvokeArgs,
   buildCodexResumeArgs,
@@ -10,6 +12,7 @@ import {
   parseCodexJsonl,
   parseCodexPlainText,
   validateCodexReasoningEffort,
+  withXhighFallback,
 } from "./codex-adapter.js";
 
 // ---------------------------------------------------------------------------
@@ -1042,5 +1045,102 @@ describe("validateCodexReasoningEffort", () => {
 
   test("rejects empty string", () => {
     expect(() => validateCodexReasoningEffort("")).toThrow(/Unsupported/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withXhighFallback — child tracking during fallback retry
+// ---------------------------------------------------------------------------
+
+function makeMockChild(): EventEmitter & { kill: ReturnType<typeof vi.fn> } {
+  const child = new EventEmitter();
+  (child as EventEmitter & { kill: ReturnType<typeof vi.fn> }).kill = vi.fn();
+  return child as EventEmitter & { kill: ReturnType<typeof vi.fn> };
+}
+
+function makeMockStream(
+  result: AgentResult,
+  child?: ReturnType<typeof makeMockChild>,
+): AgentStream {
+  const c = child ?? makeMockChild();
+  return {
+    async *[Symbol.asyncIterator]() {
+      // no chunks
+    },
+    result: Promise.resolve(result),
+    child: c as unknown as import("node:child_process").ChildProcess,
+  };
+}
+
+const CONFIG_PARSING_RESULT: AgentResult = {
+  sessionId: undefined,
+  responseText: "",
+  status: "error",
+  errorType: "config_parsing",
+  stderrText: "unknown variant `xhigh`",
+};
+
+const SUCCESS_RESULT: AgentResult = {
+  sessionId: "sess-1",
+  responseText: "ok",
+  status: "success",
+  errorType: undefined,
+  stderrText: "",
+};
+
+describe("withXhighFallback", () => {
+  test("child points to original child before fallback", () => {
+    const originalChild = makeMockChild();
+    const stream = makeMockStream(SUCCESS_RESULT, originalChild);
+    const wrapped = withXhighFallback(stream, () =>
+      makeMockStream(SUCCESS_RESULT),
+    );
+    expect(wrapped.child).toBe(originalChild);
+  });
+
+  test("child follows retry child after fallback triggers", async () => {
+    const originalChild = makeMockChild();
+    const retryChild = makeMockChild();
+    const firstStream = makeMockStream(CONFIG_PARSING_RESULT, originalChild);
+    const retryStream = makeMockStream(SUCCESS_RESULT, retryChild);
+
+    const wrapped = withXhighFallback(firstStream, () => retryStream);
+
+    // Wait for the result chain to settle so the fallback triggers.
+    await wrapped.result;
+
+    // child should now point to the retry child, not the original.
+    expect(wrapped.child).toBe(retryChild);
+    expect(wrapped.child).not.toBe(originalChild);
+  });
+
+  test("killing child during fallback targets the retry process", async () => {
+    const originalChild = makeMockChild();
+    const retryChild = makeMockChild();
+    const firstStream = makeMockStream(CONFIG_PARSING_RESULT, originalChild);
+    const retryStream = makeMockStream(SUCCESS_RESULT, retryChild);
+
+    const wrapped = withXhighFallback(firstStream, () => retryStream);
+
+    // Wait for fallback to trigger.
+    await wrapped.result;
+
+    // Simulate Ctrl+C: kill whatever .child currently points to.
+    wrapped.child.kill();
+
+    expect(retryChild.kill).toHaveBeenCalled();
+    expect(originalChild.kill).not.toHaveBeenCalled();
+  });
+
+  test("child stays as original when no fallback is needed", async () => {
+    const originalChild = makeMockChild();
+    const stream = makeMockStream(SUCCESS_RESULT, originalChild);
+    const retryFn = vi.fn();
+
+    const wrapped = withXhighFallback(stream, retryFn);
+    await wrapped.result;
+
+    expect(wrapped.child).toBe(originalChild);
+    expect(retryFn).not.toHaveBeenCalled();
   });
 });

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -435,8 +435,12 @@ function parseCodexInvokeOutput(
  * retry: the iterator first drains the failed attempt, then — on
  * fallback — continues yielding chunks from the retry stream so that
  * the pipeline UI keeps receiving output.
+ *
+ * The `child` property is a getter that always returns the currently
+ * active child process, so that cancellation (Ctrl+C) kills the right
+ * process even when the fallback retry is running.
  */
-function withXhighFallback(
+export function withXhighFallback(
   stream: AgentStream,
   retryFn: () => AgentStream,
 ): AgentStream {
@@ -465,7 +469,9 @@ function withXhighFallback(
 
   return {
     [Symbol.asyncIterator]: () => chunks(),
-    child: stream.child,
+    get child() {
+      return retryStream?.child ?? stream.child;
+    },
     result,
   };
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -224,6 +224,25 @@ export const en: Messages = {
   "issueSync.summarySkipped": "  - Sync skipped",
   "issueSync.summaryFailed": "  - Sync failed",
 
+  // ---- cancellation / cleanup --------------------------------------------
+
+  "pipeline.cancelled": "Pipeline cancelled.",
+  "pipeline.cancelledSaved":
+    "Run state saved — you can resume this pipeline later.",
+  "cleanup.header": "Cleanup options:",
+  "cleanup.stopDockerCompose":
+    "Docker Compose services are running. Stop them?",
+  "cleanup.deleteWorktree": "Delete local worktree and branch?",
+  "cleanup.deleteRemoteBranch": (branch) => `Delete remote branch "${branch}"?`,
+  "cleanup.closePr": (prNumber) => `Close PR #${prNumber}?`,
+  "cleanup.stoppingServices": "  Stopping Docker Compose services...",
+  "cleanup.deletingWorktree": "  Deleting local worktree and branch...",
+  "cleanup.deletingRemoteBranch": "  Deleting remote branch...",
+  "cleanup.closingPr": "  Closing PR...",
+  "cleanup.done": "Cleanup complete.",
+  "prompt.yesCleanup": "Yes",
+  "prompt.noSkipCleanup": "No",
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path) =>

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -257,6 +257,32 @@ export const ko: Messages = {
   "issueSync.summarySkipped": "  - \uB3D9\uAE30\uD654 \uAC74\uB108\uB6F0",
   "issueSync.summaryFailed": "  - \uB3D9\uAE30\uD654 \uC2E4\uD328",
 
+  // ---- cancellation / cleanup --------------------------------------------
+
+  "pipeline.cancelled":
+    "\uD30C\uC774\uD504\uB77C\uC778\uC774 \uCDE8\uC18C\uB418\uC5C8\uC2B5\uB2C8\uB2E4.",
+  "pipeline.cancelledSaved":
+    "\uC2E4\uD589 \uC0C1\uD0DC\uAC00 \uC800\uC7A5\uB418\uC5C8\uC2B5\uB2C8\uB2E4 \u2014 \uB098\uC911\uC5D0 \uC7AC\uAC1C\uD560 \uC218 \uC788\uC2B5\uB2C8\uB2E4.",
+  "cleanup.header": "\uC815\uB9AC \uC635\uC158:",
+  "cleanup.stopDockerCompose":
+    "Docker Compose \uC11C\uBE44\uC2A4\uAC00 \uC2E4\uD589 \uC911\uC785\uB2C8\uB2E4. \uC911\uC9C0\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?",
+  "cleanup.deleteWorktree":
+    "\uB85C\uCEEC \uC6CC\uD06C\uD2B8\uB9AC\uC640 \uBE0C\uB79C\uCE58\uB97C \uC0AD\uC81C\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?",
+  "cleanup.deleteRemoteBranch": (branch) =>
+    `\uC6D0\uACA9 \uBE0C\uB79C\uCE58 "${branch}"\uB97C \uC0AD\uC81C\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?`,
+  "cleanup.closePr": (prNumber) =>
+    `PR #${prNumber}\uC744(\uB97C) \uB2EB\uC73C\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?`,
+  "cleanup.stoppingServices":
+    "  Docker Compose \uC11C\uBE44\uC2A4 \uC911\uC9C0 \uC911...",
+  "cleanup.deletingWorktree":
+    "  \uB85C\uCEEC \uC6CC\uD06C\uD2B8\uB9AC \uBC0F \uBE0C\uB79C\uCE58 \uC0AD\uC81C \uC911...",
+  "cleanup.deletingRemoteBranch":
+    "  \uC6D0\uACA9 \uBE0C\uB79C\uCE58 \uC0AD\uC81C \uC911...",
+  "cleanup.closingPr": "  PR \uB2EB\uB294 \uC911...",
+  "cleanup.done": "\uC815\uB9AC \uC644\uB8CC.",
+  "prompt.yesCleanup": "\uC608",
+  "prompt.noSkipCleanup": "\uC544\uB2C8\uC624",
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path) =>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -219,6 +219,23 @@ export interface Messages {
   "issueSync.summarySkipped": string;
   "issueSync.summaryFailed": string;
 
+  // ---- cancellation / cleanup --------------------------------------------
+
+  "pipeline.cancelled": string;
+  "pipeline.cancelledSaved": string;
+  "cleanup.header": string;
+  "cleanup.stopDockerCompose": string;
+  "cleanup.deleteWorktree": string;
+  "cleanup.deleteRemoteBranch": (branch: string) => string;
+  "cleanup.closePr": (prNumber: number) => string;
+  "cleanup.stoppingServices": string;
+  "cleanup.deletingWorktree": string;
+  "cleanup.deletingRemoteBranch": string;
+  "cleanup.closingPr": string;
+  "cleanup.done": string;
+  "prompt.yesCleanup": string;
+  "prompt.noSkipCleanup": string;
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path: string) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,15 @@ import { confirm, select } from "@inquirer/prompts";
 import { render } from "ink";
 import React from "react";
 
-import type { AgentAdapter } from "./agent.js";
+import type { AgentAdapter, AgentStream } from "./agent.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
+import {
+  closePr,
+  deleteRemoteBranch,
+  hasDockerComposeRunning,
+  remoteBranchExists,
+  stopDockerCompose,
+} from "./cleanup.js";
 import { createCodexAdapter } from "./codex-adapter.js";
 import type { PipelineSettings } from "./config.js";
 import { loadConfig } from "./config.js";
@@ -96,6 +103,124 @@ function createAdapter(
       | undefined,
     inactivityTimeoutMs,
   });
+}
+
+/**
+ * Wrap an `AgentAdapter` to track running agent streams.  When a stream
+ * starts, it is added to the set; when it finishes, it is removed.
+ * This enables the SIGINT handler to kill all running agents.
+ *
+ * Streams are tracked (rather than individual `ChildProcess` objects)
+ * so that the `child` property can be read at kill-time.  This is
+ * important for fallback streams (e.g. `withXhighFallback`) where the
+ * active child may change after the stream is created.
+ */
+function trackProcesses(
+  adapter: AgentAdapter,
+  tracker: Set<AgentStream>,
+): AgentAdapter {
+  function track(stream: AgentStream) {
+    tracker.add(stream);
+    stream.result.finally(() => tracker.delete(stream));
+    return stream;
+  }
+
+  return {
+    invoke(prompt, options) {
+      return track(adapter.invoke(prompt, options));
+    },
+    resume(sessionId, prompt, options) {
+      return track(adapter.resume(sessionId, prompt, options));
+    },
+  };
+}
+
+/** What cleanup actions were performed during cancellation. */
+interface CleanupResult {
+  deletedWorktree: boolean;
+  deletedRemoteBranch: boolean;
+  closedPr: boolean;
+}
+
+/**
+ * Run post-pipeline cancellation cleanup using interactive prompts.
+ */
+async function runCancellationCleanup(opts: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  branch: string;
+  worktreePath: string;
+  prNumber: number | undefined;
+}): Promise<CleanupResult> {
+  const m = t();
+  const result: CleanupResult = {
+    deletedWorktree: false,
+    deletedRemoteBranch: false,
+    closedPr: false,
+  };
+  console.log();
+  console.log(m["cleanup.header"]);
+
+  // Stop docker compose services.
+  if (hasDockerComposeRunning(opts.worktreePath)) {
+    const stop = await confirm({
+      message: m["cleanup.stopDockerCompose"],
+      default: true,
+    });
+    if (stop) {
+      console.log(m["cleanup.stoppingServices"]);
+      stopDockerCompose(opts.worktreePath);
+    }
+  }
+
+  // Delete local worktree and branch.
+  const deleteWt = await confirm({
+    message: m["cleanup.deleteWorktree"],
+    default: false,
+  });
+  if (deleteWt) {
+    console.log(m["cleanup.deletingWorktree"]);
+    removeWorktree(opts.owner, opts.repo, opts.issueNumber, opts.branch);
+    result.deletedWorktree = true;
+  }
+
+  // Delete remote branch (only if one was pushed).
+  if (remoteBranchExists(opts.owner, opts.repo, opts.branch)) {
+    const delRemote = await confirm({
+      message: m["cleanup.deleteRemoteBranch"](opts.branch),
+      default: false,
+    });
+    if (delRemote) {
+      console.log(m["cleanup.deletingRemoteBranch"]);
+      try {
+        deleteRemoteBranch(opts.owner, opts.repo, opts.branch);
+        result.deletedRemoteBranch = true;
+      } catch {
+        // Ignore — branch may already be deleted.
+      }
+    }
+  }
+
+  // Close PR (only if one exists).
+  if (opts.prNumber !== undefined) {
+    const close = await confirm({
+      message: m["cleanup.closePr"](opts.prNumber),
+      default: false,
+    });
+    if (close) {
+      console.log(m["cleanup.closingPr"]);
+      try {
+        closePr(opts.owner, opts.repo, opts.prNumber);
+        result.closedPr = true;
+      } catch {
+        // Ignore — PR may already be closed or merged.
+      }
+    }
+  }
+
+  console.log(m["cleanup.done"]);
+  return result;
 }
 
 // ---- stage name lookup (for display) -------------------------------------
@@ -308,18 +433,17 @@ try {
     console.log(m["boot.resumingFromStage"](startFromStage));
   }
 
-  // Create agent adapters.
+  // Create agent adapters with process tracking for Ctrl+C cleanup.
+  const activeStreams = new Set<AgentStream>();
   const inactivityTimeoutMs =
     pipelineSettings.inactivityTimeoutMinutes * 60_000;
-  const agentA = createAdapter(
-    agentAConfig,
-    claudePermissionMode,
-    inactivityTimeoutMs,
+  const agentA = trackProcesses(
+    createAdapter(agentAConfig, claudePermissionMode, inactivityTimeoutMs),
+    activeStreams,
   );
-  const agentB = createAdapter(
-    agentBConfig,
-    claudePermissionMode,
-    inactivityTimeoutMs,
+  const agentB = trackProcesses(
+    createAdapter(agentBConfig, claudePermissionMode, inactivityTimeoutMs),
+    activeStreams,
   );
 
   const issueCtx = { issueTitle, issueBody };
@@ -426,6 +550,7 @@ try {
     | {
         confirmMerge: UserPrompt["confirmMerge"];
         reportCompletion: UserPrompt["reportCompletion"];
+        confirmCleanup: UserPrompt["confirmCleanup"];
       }
     | undefined;
 
@@ -439,11 +564,71 @@ try {
       return true;
     },
     cleanup: () => removeWorktree(owner, repo, issueNumber, wt.branch),
+    stopServices: () => {
+      if (hasDockerComposeRunning(wt.path)) {
+        stopDockerCompose(wt.path);
+      }
+    },
+    hasRunningServices: () => hasDockerComposeRunning(wt.path),
+    onNotMerged: async (signal) => {
+      if (!tuiPrompt) return;
+      const m = t();
+
+      // Stop docker compose services.
+      if (hasDockerComposeRunning(wt.path)) {
+        const stop = await tuiPrompt.confirmCleanup(
+          m["cleanup.stopDockerCompose"],
+        );
+        if (signal?.aborted) return;
+        if (stop) stopDockerCompose(wt.path);
+      }
+
+      // Delete local worktree and branch.
+      const deleteWt = await tuiPrompt.confirmCleanup(
+        m["cleanup.deleteWorktree"],
+      );
+      if (signal?.aborted) return;
+      if (deleteWt) {
+        removeWorktree(owner, repo, issueNumber, wt.branch);
+      }
+
+      // Delete remote branch (only if pushed).
+      if (remoteBranchExists(owner, repo, wt.branch)) {
+        const delRemote = await tuiPrompt.confirmCleanup(
+          m["cleanup.deleteRemoteBranch"](wt.branch),
+        );
+        if (signal?.aborted) return;
+        if (delRemote) {
+          try {
+            deleteRemoteBranch(owner, repo, wt.branch);
+          } catch {
+            // Ignore — branch may already be deleted.
+          }
+        }
+      }
+
+      // Close PR (only if one exists).
+      // Refresh PR number in case it was detected during the pipeline.
+      const prNum = runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
+      if (prNum !== undefined) {
+        const close = await tuiPrompt.confirmCleanup(
+          m["cleanup.closePr"](prNum),
+        );
+        if (signal?.aborted) return;
+        if (close) {
+          try {
+            closePr(owner, repo, prNum);
+          } catch {
+            // Ignore — PR may already be closed or merged.
+          }
+        }
+      }
+    },
   });
 
   // The `prompt` field is intentionally omitted here — it will be
   // supplied by the ink <App> component via TuiUserPrompt.
-  const pipelineOpts: Omit<PipelineOptions, "prompt" | "events"> = {
+  const pipelineOpts: Omit<PipelineOptions, "prompt" | "events" | "signal"> = {
     mode: executionMode,
     stages: [
       implementStage,
@@ -498,6 +683,14 @@ try {
   }
   process.stdin.ref();
 
+  // Suppress the default SIGINT handler so Ctrl+C does not kill the
+  // process before Ink can handle it.  The TUI component catches the
+  // Ctrl+C keypress and performs graceful cancellation instead.
+  const sigintHandler = () => {
+    // Handled by Ink useInput — do nothing at process level.
+  };
+  process.on("SIGINT", sigintHandler);
+
   const emitter = new PipelineEventEmitter();
 
   const pipelineResult = await new Promise<PipelineResult>((resolve) => {
@@ -512,26 +705,76 @@ try {
         onPromptReady: (prompt) => {
           tuiPrompt = prompt;
         },
+        onCancel: () => {
+          // Kill all tracked agent child processes so the pipeline
+          // can unwind quickly.  We read `.child` at kill-time so
+          // that fallback streams (withXhighFallback) target the
+          // currently active child, not the original one.
+          for (const stream of activeStreams) {
+            stream.child.kill();
+          }
+        },
         modelNameA: modelDisplayName(agentAConfig),
         modelNameB: modelDisplayName(agentBConfig),
       }),
     );
   });
 
+  // Remove the SIGINT suppressor so the default handler takes over
+  // (allows Ctrl+C to kill during cleanup prompts).
+  process.off("SIGINT", sigintHandler);
+
   console.log();
   console.log(pipelineResult.message);
 
-  console.log();
-  for (const line of formatIssueSyncSummary(
-    issueNumber,
-    issueChanges,
-    issueSyncStatus,
-  )) {
-    console.log(line);
-  }
+  // Handle graceful cancellation (Ctrl+C during pipeline).
+  if (pipelineResult.cancelled) {
+    const m = t();
+    console.log(m["pipeline.cancelledSaved"]);
 
-  if (pipelineResult.success) {
-    deleteRunState(owner, repo, issueNumber);
+    // Restore stdin for @inquirer/prompts cleanup flow.
+    if (process.stdin.isPaused()) {
+      process.stdin.resume();
+    }
+    process.stdin.ref();
+
+    try {
+      const cleanup = await runCancellationCleanup({
+        owner,
+        repo,
+        issueNumber,
+        branch: wt.branch,
+        worktreePath: wt.path,
+        prNumber: runState.prNumber ?? findPrNumber(owner, repo, wt.branch),
+      });
+
+      // If the user destroyed resume prerequisites (worktree, remote
+      // branch, or PR), the saved state would point at artifacts that
+      // no longer exist.  Delete it so the next run starts fresh
+      // instead of resuming into an inconsistent stage.
+      if (
+        cleanup.deletedWorktree ||
+        cleanup.deletedRemoteBranch ||
+        cleanup.closedPr
+      ) {
+        deleteRunState(owner, repo, issueNumber);
+      }
+    } catch {
+      // If cleanup prompts fail (e.g. second Ctrl+C), just exit.
+    }
+  } else {
+    console.log();
+    for (const line of formatIssueSyncSummary(
+      issueNumber,
+      issueChanges,
+      issueSyncStatus,
+    )) {
+      console.log(line);
+    }
+
+    if (pipelineResult.success) {
+      deleteRunState(owner, repo, issueNumber);
+    }
   }
 } catch (error) {
   if (

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -39,6 +39,7 @@ function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
       .mockResolvedValue({ action: "halt" satisfies UserAction }),
     confirmMerge: vi.fn().mockResolvedValue(true),
     reportCompletion: vi.fn().mockResolvedValue(undefined),
+    confirmCleanup: vi.fn().mockResolvedValue(false),
     ...overrides,
   };
 }
@@ -1055,6 +1056,9 @@ function makeDoneOpts(
     reportCompletion: vi.fn().mockResolvedValue(undefined),
     confirmMerge: vi.fn().mockResolvedValue(true),
     cleanup: vi.fn(),
+    stopServices: vi.fn(),
+    hasRunningServices: vi.fn().mockReturnValue(false),
+    onNotMerged: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -1066,7 +1070,7 @@ describe("createDoneStageHandler", () => {
     expect(stage.name).toBe("Done");
   });
 
-  test("reports completion, confirms merge, then cleans up", async () => {
+  test("reports completion, confirms merge, stops services, then cleans up", async () => {
     const opts = makeDoneOpts();
     const stage = createDoneStageHandler(opts);
     const ctx: StageContext = {
@@ -1078,13 +1082,14 @@ describe("createDoneStageHandler", () => {
     const result = await stage.handler(ctx);
     expect(opts.reportCompletion).toHaveBeenCalledOnce();
     expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.stopServices).toHaveBeenCalledOnce();
     expect(opts.cleanup).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
     expect(result.message).toContain("org/repo#5");
     expect(result.message).toContain("cleaned up");
   });
 
-  test("preserves worktree when merge not confirmed", async () => {
+  test("calls onNotMerged when merge not confirmed", async () => {
     const opts = makeDoneOpts({
       confirmMerge: vi.fn().mockResolvedValue(false),
     });
@@ -1099,8 +1104,294 @@ describe("createDoneStageHandler", () => {
     expect(opts.reportCompletion).toHaveBeenCalledOnce();
     expect(opts.confirmMerge).toHaveBeenCalledOnce();
     expect(opts.cleanup).not.toHaveBeenCalled();
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
-    expect(result.message).toContain("preserved");
+    expect(result.message).toContain("org/repo#5");
+  });
+
+  test("abort during reportCompletion skips confirmMerge", async () => {
+    const controller = new AbortController();
+    const opts = makeDoneOpts({
+      reportCompletion: vi.fn().mockImplementation(async () => {
+        controller.abort();
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+      signal: controller.signal,
+    };
+    await stage.handler(ctx);
+    expect(opts.reportCompletion).toHaveBeenCalledOnce();
+    expect(opts.confirmMerge).not.toHaveBeenCalled();
+    expect(opts.cleanup).not.toHaveBeenCalled();
+    expect(opts.onNotMerged).not.toHaveBeenCalled();
+  });
+
+  test("abort during confirmMerge skips cleanup and onNotMerged", async () => {
+    const controller = new AbortController();
+    const opts = makeDoneOpts({
+      confirmMerge: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return false;
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+      signal: controller.signal,
+    };
+    await stage.handler(ctx);
+    expect(opts.reportCompletion).toHaveBeenCalledOnce();
+    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.cleanup).not.toHaveBeenCalled();
+    expect(opts.stopServices).not.toHaveBeenCalled();
+    expect(opts.onNotMerged).not.toHaveBeenCalled();
+  });
+
+  test("abort during onNotMerged propagates signal", async () => {
+    const controller = new AbortController();
+    const opts = makeDoneOpts({
+      confirmMerge: vi.fn().mockResolvedValue(false),
+      onNotMerged: vi.fn().mockImplementation(async (signal?: AbortSignal) => {
+        expect(signal).toBe(controller.signal);
+        controller.abort();
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+      signal: controller.signal,
+    };
+    await stage.handler(ctx);
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
+    expect(opts.onNotMerged).toHaveBeenCalledWith(controller.signal);
+  });
+
+  test("full pipeline abort during stage 9 reportCompletion returns cancelled", async () => {
+    const controller = new AbortController();
+    const opts = makeDoneOpts({
+      reportCompletion: vi.fn().mockImplementation(async () => {
+        controller.abort();
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const result = await runPipeline(
+      makePipelineOpts({
+        stages: [stage],
+        signal: controller.signal,
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(opts.confirmMerge).not.toHaveBeenCalled();
+  });
+
+  test("full pipeline abort during stage 9 confirmMerge returns cancelled", async () => {
+    const controller = new AbortController();
+    const opts = makeDoneOpts({
+      confirmMerge: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return true;
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const result = await runPipeline(
+      makePipelineOpts({
+        stages: [stage],
+        signal: controller.signal,
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(opts.cleanup).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal cancellation
+// ---------------------------------------------------------------------------
+describe("AbortSignal cancellation", () => {
+  test("pipeline returns cancelled result when aborted before first stage", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const stages = [
+      makeStage(2, async () => ({ outcome: "completed", message: "done" })),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(result.stoppedAt).toBe(2);
+  });
+
+  test("pipeline returns cancelled when aborted during stage execution", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const stages = [
+      makeStage(2, async () => {
+        calls++;
+        if (calls === 1) {
+          // Abort during first iteration.
+          controller.abort();
+          return { outcome: "not_approved", message: "loop" };
+        }
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  test("pipeline does not set cancelled when abort signal is not used", async () => {
+    const stages = [
+      makeStage(2, async () => ({ outcome: "completed", message: "done" })),
+    ];
+    const prompt = makePrompt();
+    const result = await runPipeline(makePipelineOpts({ stages, prompt }));
+    expect(result.success).toBe(true);
+    expect(result.cancelled).toBeUndefined();
+  });
+
+  test("pipeline stops between stages when aborted", async () => {
+    const controller = new AbortController();
+    const calls: number[] = [];
+    const stages = [
+      makeStage(2, async () => {
+        calls.push(2);
+        controller.abort(); // abort after stage 2 completes
+        return { outcome: "completed", message: "" };
+      }),
+      makeStage(3, async () => {
+        calls.push(3);
+        return { outcome: "completed", message: "" };
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(calls).toEqual([2]); // stage 3 never ran
+  });
+
+  test("step mode: abort during confirmNextStage returns cancelled", async () => {
+    const controller = new AbortController();
+    const prompt = makePrompt({
+      confirmNextStage: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return false;
+      }),
+    });
+    const stages = [
+      makeStage(2, async () => ({ outcome: "completed", message: "done" })),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({
+        mode: "step",
+        stages,
+        prompt,
+        signal: controller.signal,
+      }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    expect(result.stoppedAt).toBe(2);
+  });
+
+  test("abort during handleBlocked returns cancelled", async () => {
+    const controller = new AbortController();
+    const prompt = makePrompt({
+      handleBlocked: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return { action: "proceed" };
+      }),
+    });
+    const stages = [
+      makeStage(2, async () => ({ outcome: "blocked", message: "stuck" })),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, prompt, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+  });
+
+  test("abort during handleAmbiguous returns cancelled", async () => {
+    const controller = new AbortController();
+    let calls = 0;
+    const prompt = makePrompt({
+      handleAmbiguous: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return { action: "proceed" };
+      }),
+    });
+    const stages = [
+      makeStage(2, async () => {
+        calls++;
+        return { outcome: "needs_clarification", message: "vague" };
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, prompt, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    // Two calls: first triggers auto-clarification, second triggers handleAmbiguous.
+    expect(calls).toBe(2);
+  });
+
+  test("abort during confirmContinueLoop returns cancelled", async () => {
+    const controller = new AbortController();
+    const prompt = makePrompt({
+      confirmContinueLoop: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return false;
+      }),
+    });
+    const stages = [
+      makeStage(2, async () => ({
+        outcome: "not_approved",
+        message: "loop",
+      })),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, prompt, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+  });
+
+  test("abort during handler exception skips error prompt", async () => {
+    const controller = new AbortController();
+    const prompt = makePrompt();
+    const stages = [
+      makeStage(2, async () => {
+        controller.abort();
+        throw new Error("killed");
+      }),
+    ];
+    const result = await runPipeline(
+      makePipelineOpts({ stages, prompt, signal: controller.signal }),
+    );
+    expect(result.success).toBe(false);
+    expect(result.cancelled).toBe(true);
+    // handleError should not have been called — signal was checked first.
+    expect(prompt.handleError).not.toHaveBeenCalled();
   });
 });
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -135,6 +135,11 @@ export interface StageContext {
    * so the UI can display per-agent token consumption.
    */
   usageSinks?: { a?: UsageSink; b?: UsageSink };
+  /**
+   * Abort signal for cancellation.  Stage handlers can check this after
+   * async operations to bail out early when the user presses Ctrl+C.
+   */
+  signal?: AbortSignal;
 }
 
 // ---- user interaction interface ------------------------------------------
@@ -193,6 +198,12 @@ export interface UserPrompt {
    * Report completion to the user (stage 9).
    */
   reportCompletion(message: string): Promise<void>;
+
+  /**
+   * Ask user to confirm a cleanup action (e.g. stop services, delete
+   * worktree).  Used in stage 9 "not merged" path.
+   */
+  confirmCleanup(message: string): Promise<boolean>;
 }
 
 // ---- loop control --------------------------------------------------------
@@ -305,6 +316,12 @@ export interface PipelineOptions {
    * agent-chunk events are emitted so the UI can render in real time.
    */
   events?: PipelineEventEmitter;
+  /**
+   * When provided, the pipeline checks this signal before each stage
+   * and handler invocation.  If aborted, the pipeline returns early
+   * with `cancelled: true`.
+   */
+  signal?: AbortSignal;
 }
 
 export interface PipelineResult {
@@ -313,6 +330,8 @@ export interface PipelineResult {
   /** The stage number where the pipeline stopped (on abort/halt). */
   stoppedAt: number | undefined;
   message: string;
+  /** True when the pipeline was stopped via an AbortSignal (Ctrl+C). */
+  cancelled?: boolean;
 }
 
 /**
@@ -333,6 +352,7 @@ export async function runPipeline(
     savedAgentASessionId,
     savedAgentBSessionId,
     events,
+    signal,
   } = options;
 
   // Sort stages by number to guarantee order.
@@ -372,11 +392,31 @@ export async function runPipeline(
   }
 
   while (i < sorted.length) {
+    // Check for cancellation before entering the next stage.
+    if (signal?.aborted) {
+      return {
+        success: false,
+        cancelled: true,
+        stoppedAt: sorted[i].number,
+        message: t()["pipeline.cancelled"],
+      };
+    }
+
     const stage = sorted[i];
 
     // In step mode, ask the user before entering each stage.
     if (mode === "step") {
       const ok = await prompt.confirmNextStage(stage.name);
+      // Re-check for cancellation after the prompt resolves — the signal
+      // may have been aborted while the user prompt was pending (Ctrl+C).
+      if (signal?.aborted) {
+        return {
+          success: false,
+          cancelled: true,
+          stoppedAt: stage.number,
+          message: t()["pipeline.cancelled"],
+        };
+      }
       if (!ok) {
         return {
           success: false,
@@ -407,6 +447,7 @@ export async function runPipeline(
       isResumeStage ? savedAgentASessionId : undefined,
       isResumeStage ? savedAgentBSessionId : undefined,
       events,
+      signal,
     );
 
     if (result.action === "abort") {
@@ -414,6 +455,7 @@ export async function runPipeline(
         success: false,
         stoppedAt: stage.number,
         message: result.message,
+        cancelled: signal?.aborted === true ? true : undefined,
       };
     }
 
@@ -446,6 +488,14 @@ export async function runPipeline(
           lc.iteration,
           result.message,
         );
+        if (signal?.aborted) {
+          return {
+            success: false,
+            cancelled: true,
+            stoppedAt: stage.number,
+            message: t()["pipeline.cancelled"],
+          };
+        }
         if (!approved) {
           return {
             success: false,
@@ -519,6 +569,7 @@ async function runStage(
   savedAgentASessionId?: string,
   savedAgentBSessionId?: string,
   events?: PipelineEventEmitter,
+  signal?: AbortSignal,
 ): Promise<StageRunResult> {
   const lc = createLoopControl(stage.autoBudget);
 
@@ -567,6 +618,11 @@ async function runStage(
     : undefined;
 
   while (true) {
+    // Check for cancellation before each handler invocation.
+    if (signal?.aborted) {
+      return { action: "abort", message: t()["pipeline.cancelled"] };
+    }
+
     // Notify caller before each handler invocation for persistence.
     onStageTransition?.(stage.number, lc.iteration);
 
@@ -587,6 +643,7 @@ async function runStage(
       streamSinks,
       promptSinks,
       usageSinks,
+      signal,
     };
 
     // Clear one-shot fields after use.
@@ -598,6 +655,9 @@ async function runStage(
     try {
       result = await stage.handler(ctx);
     } catch (err) {
+      if (signal?.aborted) {
+        return { action: "abort", message: t()["pipeline.cancelled"] };
+      }
       const errMsg = err instanceof Error ? err.message : String(err);
       const dispatched = await dispatchError(prompt, errMsg);
       if (dispatched === undefined) continue; // retry
@@ -608,6 +668,11 @@ async function runStage(
       stageNumber: stage.number,
       outcome: result.outcome,
     });
+
+    // Check for cancellation after handler returns.
+    if (signal?.aborted) {
+      return { action: "abort", message: t()["pipeline.cancelled"] };
+    }
 
     // ---- evaluate outcome ------------------------------------------------
 
@@ -634,6 +699,9 @@ async function runStage(
         result.message,
         !stage.requiresArtifact,
       );
+      if (signal?.aborted) {
+        return { action: "abort", message: t()["pipeline.cancelled"] };
+      }
       if (decision.action === "halt") {
         return { action: "abort", message: t()["pipeline.userHaltedBlocked"] };
       }
@@ -652,6 +720,9 @@ async function runStage(
         // Clarification already tried once — fall back to user.
         clarificationAttempted = false;
         const decision = await prompt.handleAmbiguous(result.message);
+        if (signal?.aborted) {
+          return { action: "abort", message: t()["pipeline.cancelled"] };
+        }
         if (decision.action === "halt") {
           return {
             action: "abort",
@@ -684,6 +755,9 @@ async function runStage(
         loopMessage,
       );
       loopMessage = "";
+      if (signal?.aborted) {
+        return { action: "abort", message: t()["pipeline.cancelled"] };
+      }
       if (!approved) {
         return {
           action: "abort",
@@ -711,6 +785,17 @@ export function createDoneStageHandler(options: {
   confirmMerge: (message: string) => Promise<boolean>;
   /** Called to remove the worktree after merge is confirmed. */
   cleanup: () => void;
+  /** Called to stop docker compose services. */
+  stopServices: () => void;
+  /** Called to check whether docker compose services are running. */
+  hasRunningServices: () => boolean;
+  /**
+   * Called when the user chooses "not merged".  Presents cleanup options
+   * (stop services, delete worktree, delete remote branch, close PR)
+   * and performs the selected actions.  Receives the abort signal so it
+   * can bail out early on cancellation.
+   */
+  onNotMerged: (signal?: AbortSignal) => Promise<void>;
 }): StageDefinition {
   return {
     name: t()["stage.done"],
@@ -724,9 +809,20 @@ export function createDoneStageHandler(options: {
       );
       await options.reportCompletion(summary);
 
+      // Bail out if cancelled during reportCompletion — runStage's
+      // post-handler signal check converts this into an abort result.
+      if (ctx.signal?.aborted) {
+        return { outcome: "completed", message: "" };
+      }
+
       const merged = await options.confirmMerge(m["pipeline.mergeConfirm"]);
 
+      if (ctx.signal?.aborted) {
+        return { outcome: "completed", message: "" };
+      }
+
       if (merged) {
+        options.stopServices();
         options.cleanup();
         return {
           outcome: "completed",
@@ -734,9 +830,10 @@ export function createDoneStageHandler(options: {
         };
       }
 
+      await options.onNotMerged(ctx.signal);
       return {
         outcome: "completed",
-        message: `${summary} ${m["pipeline.worktreePreserved"]}`,
+        message: summary,
       };
     },
   };

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,5 @@
 import { Box, useInput, useStdout } from "ink";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { t } from "../i18n/index.js";
 import type {
   PipelineOptions,
@@ -39,7 +39,7 @@ export function useTerminalHeight(): number | undefined {
 
 export interface AppProps {
   emitter: PipelineEventEmitter;
-  pipelineOptions: Omit<PipelineOptions, "prompt" | "events">;
+  pipelineOptions: Omit<PipelineOptions, "prompt" | "events" | "signal">;
   onExit: (result: PipelineResult) => void;
   /** Called once the TUI prompt is ready, so callers can late-bind to it. */
   onPromptReady?: (prompt: UserPrompt) => void;
@@ -47,6 +47,11 @@ export interface AppProps {
   modelNameA?: string;
   /** Short model identifier for Agent B (e.g., "gpt-5.4"). */
   modelNameB?: string;
+  /**
+   * Called when the user presses Ctrl+C so the caller can kill running
+   * agent child processes before the pipeline unwinds.
+   */
+  onCancel?: () => void;
 }
 
 export function App({
@@ -56,6 +61,7 @@ export function App({
   onPromptReady,
   modelNameA,
   modelNameB,
+  onCancel,
 }: AppProps) {
   const terminalHeight = useTerminalHeight();
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
@@ -64,11 +70,16 @@ export function App({
   const [activeAgent, setActiveAgent] = useState<"a" | "b" | null>(null);
   const [layout, setLayout] = useState<"row" | "column">("row");
 
+  // AbortController for pipeline cancellation on Ctrl+C.
+  const abortController = useMemo(() => new AbortController(), []);
+  const cancelledRef = useRef(false);
+
   // Store props in refs so the mount effect never re-runs.
   const emitterRef = useRef(emitter);
   const optsRef = useRef(pipelineOptions);
   const onExitRef = useRef(onExit);
   const onPromptReadyRef = useRef(onPromptReady);
+  const onCancelRef = useRef(onCancel);
 
   const dispatch = useCallback((request: InputRequest): Promise<string> => {
     return new Promise<string>((resolve) => {
@@ -87,12 +98,27 @@ export function App({
   }, []);
 
   // Switch focused pane with Tab; toggle layout with Ctrl+L.
+  // Ctrl+C triggers graceful cancellation.
   useInput((input, key) => {
     if (key.tab) {
       setFocusedPane((prev) => (prev === "a" ? "b" : "a"));
     }
     if (input === "l" && key.ctrl) {
       setLayout((prev) => (prev === "row" ? "column" : "row"));
+    }
+    if (input === "c" && key.ctrl && !cancelledRef.current) {
+      cancelledRef.current = true;
+      // Kill running agent child processes.
+      onCancelRef.current?.();
+      // Abort the pipeline.
+      abortController.abort();
+      // Force-resolve any pending dispatch so the pipeline can unwind.
+      if (resolveRef.current) {
+        const resolve = resolveRef.current;
+        resolveRef.current = null;
+        setInputRequest(null);
+        setTimeout(() => resolve("__cancelled__"), 0);
+      }
     }
   });
 
@@ -118,6 +144,7 @@ export function App({
       ...optsRef.current,
       prompt,
       events: emitterRef.current,
+      signal: abortController.signal,
     }).then(
       (result) => onExitRef.current(result),
       (err) => {
@@ -128,7 +155,7 @@ export function App({
         });
       },
     );
-  }, [dispatch]);
+  }, [dispatch, abortController]);
 
   return (
     <Box flexDirection="column" width="100%" height={terminalHeight ?? "100%"}>

--- a/src/ui/TuiUserPrompt.test.ts
+++ b/src/ui/TuiUserPrompt.test.ts
@@ -216,4 +216,33 @@ describe("TuiUserPrompt", () => {
       );
     });
   });
+
+  describe("confirmCleanup", () => {
+    test("returns true for yes", async () => {
+      const dispatch = makeDispatch("yes");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmCleanup("Delete worktree?")).toBe(true);
+    });
+
+    test("returns false for no", async () => {
+      const dispatch = makeDispatch("no");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmCleanup("Delete worktree?")).toBe(false);
+    });
+
+    test("dispatches with yes/no choices", async () => {
+      const dispatch = makeDispatch("no");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.confirmCleanup("Stop services?");
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Stop services?",
+          choices: expect.arrayContaining([
+            expect.objectContaining({ value: "yes" }),
+            expect.objectContaining({ value: "no" }),
+          ]),
+        }),
+      );
+    });
+  });
 });

--- a/src/ui/TuiUserPrompt.ts
+++ b/src/ui/TuiUserPrompt.ts
@@ -130,5 +130,17 @@ export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
         choices: [{ label: t()["prompt.ok"], value: "ok" }],
       });
     },
+
+    async confirmCleanup(message: string): Promise<boolean> {
+      const m = t();
+      const response = await dispatch({
+        message,
+        choices: [
+          { label: m["prompt.yesCleanup"], value: "yes" },
+          { label: m["prompt.noSkipCleanup"], value: "no" },
+        ],
+      });
+      return response === "yes";
+    },
   };
 }


### PR DESCRIPTION
## Summary

- Intercept Ctrl+C in the TUI via Ink's `useInput` and abort the pipeline through an `AbortSignal`, killing tracked agent child processes so the pipeline can unwind quickly.
- Add a cleanup module (`cleanup.ts`) that detects running Docker Compose services, checks for remote branches via the GitHub API, and closes PRs — all offered as interactive prompts on both Ctrl+C cancellation and the stage 9 "not merged" path.
- Make stage 9 cancellation-aware: check the abort signal after each prompt (`reportCompletion`, `confirmMerge`, and each `confirmCleanup` in the "not merged" path) so Ctrl+C during these prompts short-circuits immediately into the cancellation flow instead of continuing the normal stage-9 path.
- Stop Docker Compose services in the "yes, merged" path before deleting the worktree.
- Delete saved run state when cancellation cleanup removes resume prerequisites (worktree, remote branch, or PR), preventing stale state from resuming into an inconsistent stage.
- Track agent streams (not raw child processes) so Ctrl+C during a `withXhighFallback` retry kills the active retry child, not the already-exited original.
- Add i18n messages for all cleanup prompts in English and Korean.

Closes #95

## Test plan

- [x] Press Ctrl+C during pipeline execution — verify the pipeline pauses, agent processes are killed, and cleanup prompts appear
- [x] During Ctrl+C cleanup, confirm each option (stop services, delete worktree, delete remote branch, close PR) works correctly
- [x] During Ctrl+C cleanup, decline all options — verify resources are preserved and run state is saved for later resume
- [x] Ctrl+C cleanup with destructive actions (delete worktree/branch/PR) — verify run state is deleted so next run starts fresh
- [x] Complete a pipeline run and choose "Yes, merged" — verify Docker Compose services are stopped and worktree is cleaned up
- [x] Complete a pipeline run and choose "No, not merged" — verify cleanup options are presented (services, worktree, remote branch, PR)
- [x] Press Ctrl+C during stage 9 `reportCompletion` — verify `confirmMerge` is not reached
- [x] Press Ctrl+C during stage 9 `confirmMerge` — verify neither cleanup nor onNotMerged runs
- [x] Press Ctrl+C during a `confirmCleanup` prompt in the "not merged" path — verify remaining prompts are skipped
- [x] Cancel during `withXhighFallback` retry — verify the retry child is killed, not the original
- [x] Run `pnpm vitest run` — all 1133 tests pass including new AbortSignal cancellation tests, cleanup module tests, and fallback child tracking tests
- [x] Run `pnpm tsc --noEmit` — no type errors
- [x] Run `pnpm biome check` — no lint issues