### PR TITLE
Add Ctrl+L shortcut hint and increase default iteration counts (#121)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -38,8 +38,8 @@ describe("loadConfig", () => {
       cloneBaseDir: "~/projects",
       language: "en",
       pipelineSettings: {
-        selfCheckAutoIterations: 3,
-        reviewAutoRounds: 3,
+        selfCheckAutoIterations: 5,
+        reviewAutoRounds: 5,
         inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
@@ -55,8 +55,8 @@ describe("loadConfig", () => {
       cloneBaseDir: "~/projects",
       language: "en",
       pipelineSettings: {
-        selfCheckAutoIterations: 3,
-        reviewAutoRounds: 3,
+        selfCheckAutoIterations: 5,
+        reviewAutoRounds: 5,
         inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
@@ -85,8 +85,8 @@ describe("loadConfig", () => {
     expect(config.cloneBaseDir).toBe("~/projects");
     expect(config.language).toBe("en");
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -263,8 +263,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -277,8 +277,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -291,7 +291,7 @@ describe("loadConfig", () => {
     rmSync(configPath());
 
     const config2 = loadConfig();
-    expect(config2.pipelineSettings.selfCheckAutoIterations).toBe(3);
+    expect(config2.pipelineSettings.selfCheckAutoIterations).toBe(5);
   });
 
   test("partially valid pipelineSettings keeps valid values", () => {
@@ -309,7 +309,7 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings.selfCheckAutoIterations).toBe(10);
-    expect(config.pipelineSettings.reviewAutoRounds).toBe(3);
+    expect(config.pipelineSettings.reviewAutoRounds).toBe(5);
     expect(config.pipelineSettings.inactivityTimeoutMinutes).toBe(20);
     expect(config.pipelineSettings.autoResumeAttempts).toBe(5);
   });
@@ -329,8 +329,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -369,8 +369,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -392,8 +392,8 @@ describe("loadConfig", () => {
     const config = loadConfig();
     // Strings are not valid — all should fall back.
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -414,8 +414,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -428,8 +428,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -442,8 +442,8 @@ describe("loadConfig", () => {
     );
     const config = loadConfig();
     expect(config.pipelineSettings).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -456,8 +456,8 @@ describe("saveConfig", () => {
   });
 
   const defaultPS = {
-    selfCheckAutoIterations: 3,
-    reviewAutoRounds: 3,
+    selfCheckAutoIterations: 5,
+    reviewAutoRounds: 5,
     inactivityTimeoutMinutes: 20,
     autoResumeAttempts: 3,
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,8 +10,8 @@ export interface PipelineSettings {
 }
 
 export const DEFAULT_PIPELINE_SETTINGS: PipelineSettings = {
-  selfCheckAutoIterations: 3,
-  reviewAutoRounds: 3,
+  selfCheckAutoIterations: 5,
+  reviewAutoRounds: 5,
   inactivityTimeoutMinutes: 20,
   autoResumeAttempts: 3,
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -152,7 +152,7 @@ export const en: Messages = {
   "statusBar.layoutHorizontal": "horizontal",
   "statusBar.layoutVertical": "vertical",
   "statusBar.keyHints":
-    "Tab:Switch pane  \u2191\u2193:Scroll  PgUp/Dn:Page scroll  Ctrl+C:Quit",
+    "\u25CF:Active  [*]:Focused  Tab:Switch pane  \u2191\u2193:Scroll  PgUp/Dn:Page scroll  Ctrl+L:Layout  Ctrl+C:Quit",
   "outcome.completed": "completed",
   "outcome.fixed": "fixed",
   "outcome.approved": "approved",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -180,7 +180,7 @@ export const ko: Messages = {
   "statusBar.layoutVertical": "\uC218\uC9C1",
 
   "statusBar.keyHints":
-    "Tab:\uD328\uB110 \uC804\uD658  \u2191\u2193:\uC2A4\uD06C\uB864  PgUp/Dn:\uD398\uC774\uC9C0 \uC2A4\uD06C\uB864  Ctrl+C:\uC885\uB8CC",
+    "\u25CF:\uD65C\uC131  [*]:\uD3EC\uCEE4\uC2A4  Tab:\uD328\uB110 \uC804\uD658  \u2191\u2193:\uC2A4\uD06C\uB864  PgUp/Dn:\uD398\uC774\uC9C0 \uC2A4\uD06C\uB864  Ctrl+L:\uB808\uC774\uC544\uC6C3  Ctrl+C:\uC885\uB8CC",
   "outcome.completed": "완료",
   "outcome.fixed": "수정됨",
   "outcome.approved": "승인됨",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -179,8 +179,8 @@ describe("module exports", () => {
   test("config module exports DEFAULT_PIPELINE_SETTINGS", async () => {
     const config = await import("../dist/config.js");
     expect(config.DEFAULT_PIPELINE_SETTINGS).toEqual({
-      selfCheckAutoIterations: 3,
-      reviewAutoRounds: 3,
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });


### PR DESCRIPTION
## Summary

- Added `Ctrl+L:Layout` shortcut hint to the status bar key hints (English and Korean)
- Added `●:Active` and `[*]:Focused` pane indicator legend to the status bar so users can understand what those symbols mean
- Increased `selfCheckAutoIterations` and `reviewAutoRounds` defaults from 3 to 5
- Updated all tests that asserted the old default value of 3

Closes #121

## Test plan

- [x] Verify the status bar displays `●:Active  [*]:Focused  Tab:Switch pane  ↑↓:Scroll  PgUp/Dn:Page scroll  Ctrl+L:Layout  Ctrl+C:Quit`
- [x] Verify the Korean locale status bar shows the equivalent translated hints
- [x] Verify `Ctrl+L` shortcut still toggles pane layout direction correctly
- [x] Verify `DEFAULT_PIPELINE_SETTINGS.selfCheckAutoIterations` is 5
- [x] Verify `DEFAULT_PIPELINE_SETTINGS.reviewAutoRounds` is 5
- [x] Verify all tests pass (`pnpm vitest run`)