### PR TITLE
Remove non-functional auto permission mode (#119)

### DIFF
--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -709,10 +709,8 @@ describe("ClaudeStreamTransformer", () => {
 // buildClaudeArgs
 // ---------------------------------------------------------------------------
 describe("buildClaudeArgs", () => {
-  test("builds basic args with auto permission mode and --verbose", () => {
-    const args = buildClaudeArgs("do something", {
-      permissionMode: "auto",
-    });
+  test("builds basic args with bypassPermissions and --verbose", () => {
+    const args = buildClaudeArgs("do something", {});
 
     expect(args).toEqual([
       "-p",
@@ -721,19 +719,17 @@ describe("buildClaudeArgs", () => {
       "stream-json",
       "--verbose",
       "--permission-mode",
-      "auto",
+      "bypassPermissions",
     ]);
   });
 
   test("always includes --verbose (required by stream-json)", () => {
-    const args = buildClaudeArgs("prompt", { permissionMode: "auto" });
+    const args = buildClaudeArgs("prompt", {});
     expect(args).toContain("--verbose");
   });
 
-  test("builds args with bypass permission mode", () => {
-    const args = buildClaudeArgs("prompt", {
-      permissionMode: "bypass",
-    });
+  test("always passes bypassPermissions", () => {
+    const args = buildClaudeArgs("prompt", {});
 
     expect(args).toContain("--permission-mode");
     expect(args).toContain("bypassPermissions");
@@ -742,7 +738,6 @@ describe("buildClaudeArgs", () => {
   test("includes --model when model is specified", () => {
     const args = buildClaudeArgs("prompt", {
       model: "opus",
-      permissionMode: "auto",
     });
 
     expect(args).toContain("--model");
@@ -750,16 +745,13 @@ describe("buildClaudeArgs", () => {
   });
 
   test("omits --model when model is undefined", () => {
-    const args = buildClaudeArgs("prompt", {
-      permissionMode: "auto",
-    });
+    const args = buildClaudeArgs("prompt", {});
 
     expect(args).not.toContain("--model");
   });
 
   test("includes --effort when effortLevel is set", () => {
     const args = buildClaudeArgs("prompt", {
-      permissionMode: "auto",
       effortLevel: "high",
     });
 
@@ -770,7 +762,6 @@ describe("buildClaudeArgs", () => {
   test("includes --effort max for Opus max effort", () => {
     const args = buildClaudeArgs("prompt", {
       model: "opus",
-      permissionMode: "auto",
       effortLevel: "max",
     });
 
@@ -779,9 +770,7 @@ describe("buildClaudeArgs", () => {
   });
 
   test("omits --effort when effortLevel is undefined", () => {
-    const args = buildClaudeArgs("prompt", {
-      permissionMode: "auto",
-    });
+    const args = buildClaudeArgs("prompt", {});
 
     expect(args).not.toContain("--effort");
   });
@@ -789,7 +778,6 @@ describe("buildClaudeArgs", () => {
   test("appends [1m] to model when contextWindow is 1m", () => {
     const args = buildClaudeArgs("prompt", {
       model: "opus",
-      permissionMode: "auto",
       contextWindow: "1m",
     });
 
@@ -799,7 +787,6 @@ describe("buildClaudeArgs", () => {
   test("does not modify model when contextWindow is 200k", () => {
     const args = buildClaudeArgs("prompt", {
       model: "opus",
-      permissionMode: "auto",
       contextWindow: "200k",
     });
 
@@ -808,20 +795,14 @@ describe("buildClaudeArgs", () => {
   });
 
   test("includes --resume when sessionId is given", () => {
-    const args = buildClaudeArgs(
-      "continue",
-      { permissionMode: "auto" },
-      "sess-123",
-    );
+    const args = buildClaudeArgs("continue", {}, "sess-123");
 
     expect(args).toContain("--resume");
     expect(args).toContain("sess-123");
   });
 
   test("omits --resume when sessionId is undefined", () => {
-    const args = buildClaudeArgs("prompt", {
-      permissionMode: "auto",
-    });
+    const args = buildClaudeArgs("prompt", {});
 
     expect(args).not.toContain("--resume");
   });
@@ -829,7 +810,7 @@ describe("buildClaudeArgs", () => {
   test("combines all options together", () => {
     const args = buildClaudeArgs(
       "full prompt",
-      { model: "sonnet", permissionMode: "bypass" },
+      { model: "sonnet" },
       "sess-xyz",
     );
 

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -197,13 +197,10 @@ export class ClaudeStreamTransformer extends JsonlLineTransformer {
 // Adapter options + args builder
 // ---------------------------------------------------------------------------
 
-export type ClaudePermissionMode = "auto" | "bypass";
-
 export type ClaudeEffortLevel = "low" | "medium" | "high" | "max";
 
 export interface ClaudeAdapterOptions {
   model?: string;
-  permissionMode?: ClaudePermissionMode;
   effortLevel?: ClaudeEffortLevel;
   contextWindow?: string;
   inactivityTimeoutMs?: number;
@@ -213,7 +210,6 @@ export function buildClaudeArgs(
   prompt: string,
   opts: {
     model?: string;
-    permissionMode: ClaudePermissionMode;
     effortLevel?: ClaudeEffortLevel;
     contextWindow?: string;
   },
@@ -230,11 +226,7 @@ export function buildClaudeArgs(
     }
     args.push("--model", modelId);
   }
-  if (opts.permissionMode === "bypass") {
-    args.push("--permission-mode", "bypassPermissions");
-  } else {
-    args.push("--permission-mode", "auto");
-  }
+  args.push("--permission-mode", "bypassPermissions");
   if (opts.effortLevel) {
     args.push("--effort", opts.effortLevel);
   }
@@ -295,7 +287,6 @@ export function createClaudeAdapter(
   opts: ClaudeAdapterOptions = {},
 ): AgentAdapter {
   const model = opts.model;
-  const permissionMode = opts.permissionMode ?? "auto";
   const effortLevel = opts.effortLevel;
   const contextWindow = opts.contextWindow;
   const inactivityTimeoutMs = opts.inactivityTimeoutMs;
@@ -308,7 +299,6 @@ export function createClaudeAdapter(
         command: "claude",
         args: buildClaudeArgs(prompt, {
           model,
-          permissionMode,
           effortLevel,
           contextWindow,
         }),
@@ -325,7 +315,7 @@ export function createClaudeAdapter(
         command: "claude",
         args: buildClaudeArgs(
           prompt,
-          { model, permissionMode, effortLevel, contextWindow },
+          { model, effortLevel, contextWindow },
           sessionId,
         ),
         cwd: options?.cwd,

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,6 @@ export interface Config {
   agentA?: SavedAgentConfig;
   agentB?: SavedAgentConfig;
   executionMode?: "auto" | "step";
-  claudePermissionMode?: "auto" | "bypass";
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -127,11 +126,6 @@ export function loadConfig(): Config {
     executionMode:
       raw.executionMode === "auto" || raw.executionMode === "step"
         ? raw.executionMode
-        : undefined,
-    claudePermissionMode:
-      raw.claudePermissionMode === "auto" ||
-      raw.claudePermissionMode === "bypass"
-        ? raw.claudePermissionMode
         : undefined,
   };
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -6,7 +6,7 @@ export const en: Messages = {
   "quickStart.header": "Found saved configuration:",
   "quickStart.agentA": (model) => `  Agent A: ${model}`,
   "quickStart.agentB": (model) => `  Agent B: ${model}`,
-  "quickStart.mode": (exec, perm) => `  Mode: ${exec} / ${perm}`,
+  "quickStart.mode": (exec) => `  Mode: ${exec}`,
   "quickStart.language": (lang) => `  Language: ${lang}`,
   "quickStart.usePrevious": "Use previous settings?",
 
@@ -24,7 +24,6 @@ export const en: Messages = {
   "startup.agentContext": (label) => `${label} context window:`,
   "startup.agentEffort": (label) => `${label} effort level:`,
   "startup.executionMode": "Execution mode:",
-  "startup.claudePermission": "Claude permission mode:",
   "startup.language": "Language:",
   "startup.languageEnglish": "English",
   "startup.languageKorean": "Korean",
@@ -78,7 +77,6 @@ export const en: Messages = {
   "boot.agentA": (model) => `  Agent A: ${model}`,
   "boot.agentB": (model) => `  Agent B: ${model}`,
   "boot.mode": (mode) => `  Mode: ${mode}`,
-  "boot.permission": (mode) => `  Permission: ${mode}`,
   "boot.resumingFromStage": (stage) => `  Resuming from stage: ${stage}`,
 
   // ---- stage names -------------------------------------------------------

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -64,7 +64,6 @@ describe("catalogs are complete", () => {
       "boot.agentA": ["sonnet"],
       "boot.agentB": ["sonnet"],
       "boot.mode": ["auto"],
-      "boot.permission": ["auto"],
       "boot.resumingFromStage": [3],
       "pipeline.userSkipped": [1, "Implement"],
       "pipeline.userDeclinedLoop": [2],

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -6,7 +6,7 @@ export const ko: Messages = {
   "quickStart.header": "저장된 설정 발견:",
   "quickStart.agentA": (model) => `  에이전트 A: ${model}`,
   "quickStart.agentB": (model) => `  에이전트 B: ${model}`,
-  "quickStart.mode": (exec, perm) => `  모드: ${exec} / ${perm}`,
+  "quickStart.mode": (exec) => `  모드: ${exec}`,
   "quickStart.language": (lang) => `  언어: ${lang}`,
   "quickStart.usePrevious": "이전 설정을 사용하시겠습니까?",
 
@@ -29,7 +29,6 @@ export const ko: Messages = {
     `${label} \uCEE8\uD14D\uC2A4\uD2B8 \uC708\uB3C4\uC6B0:`,
   "startup.agentEffort": (label) => `${label} \uB178\uB825 \uC218\uC900:`,
   "startup.executionMode": "\uC2E4\uD589 \uBAA8\uB4DC:",
-  "startup.claudePermission": "Claude \uAD8C\uD55C \uBAA8\uB4DC:",
   "startup.language": "\uC5B8\uC5B4:",
   "startup.languageEnglish": "English",
   "startup.languageKorean": "\uD55C\uAD6D\uC5B4",
@@ -96,7 +95,6 @@ export const ko: Messages = {
   "boot.agentA": (model) => `  \uC5D0\uC774\uC804\uD2B8 A: ${model}`,
   "boot.agentB": (model) => `  \uC5D0\uC774\uC804\uD2B8 B: ${model}`,
   "boot.mode": (mode) => `  \uBAA8\uB4DC: ${mode}`,
-  "boot.permission": (mode) => `  \uAD8C\uD55C: ${mode}`,
   "boot.resumingFromStage": (stage) =>
     `  ${stage}\uB2E8\uACC4\uBD80\uD130 \uC7AC\uAC1C`,
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -10,7 +10,7 @@ export interface Messages {
   "quickStart.header": string;
   "quickStart.agentA": (model: string) => string;
   "quickStart.agentB": (model: string) => string;
-  "quickStart.mode": (exec: string, perm: string) => string;
+  "quickStart.mode": (exec: string) => string;
   "quickStart.language": (lang: string) => string;
   "quickStart.usePrevious": string;
 
@@ -28,7 +28,6 @@ export interface Messages {
   "startup.agentContext": (label: string) => string;
   "startup.agentEffort": (label: string) => string;
   "startup.executionMode": string;
-  "startup.claudePermission": string;
   "startup.language": string;
   "startup.languageEnglish": string;
   "startup.languageKorean": string;
@@ -79,7 +78,6 @@ export interface Messages {
   "boot.agentA": (model: string) => string;
   "boot.agentB": (model: string) => string;
   "boot.mode": (mode: string) => string;
-  "boot.permission": (mode: string) => string;
   "boot.resumingFromStage": (stage: number) => string;
 
   // ---- stage names -------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,6 @@ interface RunParams {
   agentAConfig: AgentConfig;
   agentBConfig: AgentConfig;
   executionMode: "auto" | "step";
-  claudePermissionMode: "auto" | "bypass";
   pipelineSettings: PipelineSettings;
   issueTitle: string;
   issueBody: string;
@@ -77,13 +76,11 @@ interface RunParams {
 
 function createAdapter(
   agentConfig: AgentConfig,
-  permissionMode: "auto" | "bypass",
   inactivityTimeoutMs?: number,
 ): AgentAdapter {
   if (agentConfig.cli === "claude") {
     return createClaudeAdapter({
       model: agentConfig.model,
-      permissionMode,
       effortLevel: agentConfig.effortLevel as
         | "low"
         | "medium"
@@ -328,7 +325,6 @@ try {
           effortLevel: savedState.agentB.effortLevel,
         },
         executionMode: savedState.executionMode,
-        claudePermissionMode: savedState.claudePermissionMode,
         pipelineSettings: target.config.pipelineSettings,
         issueTitle: issue.title,
         issueBody: issue.body,
@@ -367,7 +363,6 @@ try {
       agentAConfig: result.agentA,
       agentBConfig: result.agentB,
       executionMode: result.executionMode,
-      claudePermissionMode: result.claudePermissionMode,
       pipelineSettings: result.pipelineSettings,
       issueTitle: result.issue.title,
       issueBody: result.issue.body,
@@ -381,7 +376,6 @@ try {
     agentAConfig,
     agentBConfig,
     executionMode,
-    claudePermissionMode,
     pipelineSettings,
     issueTitle,
     issueBody,
@@ -428,7 +422,6 @@ try {
   console.log(m["boot.agentA"](modelDisplayName(agentAConfig)));
   console.log(m["boot.agentB"](modelDisplayName(agentBConfig)));
   console.log(m["boot.mode"](executionMode));
-  console.log(m["boot.permission"](claudePermissionMode));
   if (startFromStage !== undefined) {
     console.log(m["boot.resumingFromStage"](startFromStage));
   }
@@ -438,11 +431,11 @@ try {
   const inactivityTimeoutMs =
     pipelineSettings.inactivityTimeoutMinutes * 60_000;
   const agentA = trackProcesses(
-    createAdapter(agentAConfig, claudePermissionMode, inactivityTimeoutMs),
+    createAdapter(agentAConfig, inactivityTimeoutMs),
     activeStreams,
   );
   const agentB = trackProcesses(
-    createAdapter(agentBConfig, claudePermissionMode, inactivityTimeoutMs),
+    createAdapter(agentBConfig, inactivityTimeoutMs),
     activeStreams,
   );
 
@@ -521,7 +514,6 @@ try {
     stageLoopCount: 0,
     reviewRound: 0,
     executionMode,
-    claudePermissionMode,
     agentA: {
       cli: agentAConfig.cli,
       model: agentAConfig.model,

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -34,7 +34,6 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
     stageLoopCount: 0,
     reviewRound: 0,
     executionMode: "auto",
-    claudePermissionMode: "auto",
     agentA: {
       cli: "claude",
       model: "opus",

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -53,7 +53,6 @@ export interface RunState {
   stageLoopCount: number;
   reviewRound: number;
   executionMode: "auto" | "step";
-  claudePermissionMode: "auto" | "bypass";
   agentA: AgentState;
   agentB: AgentState;
   issueSyncStatus: IssueSyncStatus;
@@ -125,8 +124,6 @@ function isValidRunState(
     typeof r.stageLoopCount === "number" &&
     typeof r.reviewRound === "number" &&
     (r.executionMode === "auto" || r.executionMode === "step") &&
-    (r.claudePermissionMode === "auto" ||
-      r.claudePermissionMode === "bypass") &&
     isValidAgentState(r.agentA) &&
     isValidAgentState(r.agentB) &&
     // issueSyncStatus and issueChanges are optional for backward compat

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -712,7 +712,6 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
 
     const adapter = createClaudeAdapter({
       model: "opus",
-      permissionMode: "auto",
     });
 
     const stream = adapter.invoke("write tests");
@@ -754,7 +753,7 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
-    const adapter = createClaudeAdapter({ permissionMode: "bypass" });
+    const adapter = createClaudeAdapter();
     adapter.resume("sess-prev", "continue working");
 
     expect(mockSpawn).toHaveBeenCalledWith(

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -79,7 +79,6 @@ function setupHappyPath() {
     .mockResolvedValueOnce("gpt-5.4") // agent B model
     .mockResolvedValueOnce("high") // agent B effort
     .mockResolvedValueOnce("auto") // execution mode
-    .mockResolvedValueOnce("bypass") // permission mode
     .mockResolvedValueOnce("en"); // language
   mockSearch.mockResolvedValueOnce("agentcoop"); // repo
   mockInput.mockResolvedValueOnce("42"); // issue number
@@ -120,7 +119,6 @@ describe("runStartup — happy path", () => {
       effortLevel: "high",
     });
     expect(result.executionMode).toBe("auto");
-    expect(result.claudePermissionMode).toBe("bypass");
     expect(result.language).toBe("en");
     expect(result.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
@@ -184,7 +182,6 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("gpt-5.3-codex") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("step") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("ko"); // language
     mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
     mockSearch.mockResolvedValueOnce("repo1");
@@ -238,7 +235,6 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockCheckbox.mockResolvedValueOnce([]);
     mockSearch.mockResolvedValueOnce("repo1");
@@ -265,7 +261,6 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockCheckbox.mockResolvedValueOnce([]);
     mockSearch.mockResolvedValueOnce("repo1");
@@ -544,7 +539,6 @@ describe("runStartup — model selection", () => {
       .mockResolvedValueOnce("1m") // agent B context window
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -579,7 +573,6 @@ describe("runStartup — model selection", () => {
       .mockResolvedValueOnce("gpt-5.3-codex") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("step") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockConfirm.mockResolvedValueOnce(true);
 
@@ -609,7 +602,6 @@ describe("runStartup — effort level choices", () => {
       .mockResolvedValueOnce("200k") // agent B context window
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockConfirm.mockResolvedValueOnce(true);
 
@@ -679,7 +671,6 @@ describe("runStartup — language selection", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("ko"); // changed from "en" to "ko"
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -711,7 +702,6 @@ describe("runStartup — language selection", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("ko"); // same as config
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -726,8 +716,8 @@ describe("runStartup — language selection", () => {
 
     // Language select call index:
     // 0=owner, 1=agentA CLI, 2=agentA model, 3=agentA context, 4=agentA effort,
-    // 5=agentB CLI, 6=agentB model, 7=agentB effort, 8=exec, 9=perm, 10=lang
-    const langCall = mockSelect.mock.calls[10][0];
+    // 5=agentB CLI, 6=agentB model, 7=agentB effort, 8=exec, 9=lang
+    const langCall = mockSelect.mock.calls[9][0];
     expect(langCall.default).toBe("ko");
   });
 });
@@ -751,7 +741,6 @@ describe("runStartup — config dirty tracking", () => {
         effortLevel: "high",
       },
       executionMode: "auto" as const,
-      claudePermissionMode: "bypass" as const,
     };
     mockLoadConfig.mockReturnValue(config);
     mockSelect
@@ -764,7 +753,6 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -801,7 +789,6 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // same language
     mockCheckbox.mockResolvedValueOnce([]);
     mockSearch.mockResolvedValueOnce("repo1");
@@ -826,7 +813,6 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("ko"); // changed
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -1024,10 +1010,10 @@ describe("runStartup — confirm issue (Stage 1)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Full flow with step mode + bypass permission
+// Full flow with step mode
 // ---------------------------------------------------------------------------
 describe("runStartup — alternate selections", () => {
-  test("step mode + bypass permission + ko language", async () => {
+  test("step mode + ko language", async () => {
     const config = defaultConfig();
     mockLoadConfig.mockReturnValue(config);
     mockSelect
@@ -1040,7 +1026,6 @@ describe("runStartup — alternate selections", () => {
       .mockResolvedValueOnce("gpt-5.3-codex") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("step") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("ko"); // language
     mockSearch.mockResolvedValueOnce("my-repo");
     mockInput.mockResolvedValueOnce("99");
@@ -1066,7 +1051,6 @@ describe("runStartup — alternate selections", () => {
     expect(result.agentB.cli).toBe("codex");
     expect(result.agentB.model).toBe("gpt-5.3-codex");
     expect(result.executionMode).toBe("step");
-    expect(result.claudePermissionMode).toBe("bypass");
     expect(result.language).toBe("ko");
   });
 });
@@ -1174,7 +1158,6 @@ describe("runStartup — pipeline settings", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -1291,7 +1274,6 @@ describe("runStartup — pipeline settings", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -1328,7 +1310,6 @@ describe("runStartup — pipeline settings", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -1384,7 +1365,7 @@ describe("selectTarget", () => {
     ]);
 
     await selectTarget();
-    // select called only once for owner (not for models, mode, permission, language).
+    // select called only once for owner (not for models, mode, language).
     expect(mockSelect).toHaveBeenCalledTimes(1);
     // getIssue NOT called (that happens in runStartup).
     expect(mockGetIssue).not.toHaveBeenCalled();
@@ -1427,7 +1408,7 @@ describe("runStartup with target parameter", () => {
       configDirty: false,
     };
     // Only prompts needed: agentA (cli+model+context+effort), agentB (cli+model+effort),
-    // executionMode, permissionMode, language, settings, confirm.
+    // executionMode, language, settings, confirm.
     mockSelect
       .mockResolvedValueOnce("claude") // agent A CLI
       .mockResolvedValueOnce("opus") // agent A model
@@ -1437,7 +1418,6 @@ describe("runStartup with target parameter", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockCheckbox.mockResolvedValueOnce([]); // no settings adjusted
     mockConfirm.mockResolvedValueOnce(true); // confirm issue
@@ -1475,7 +1455,6 @@ describe("runStartup — quick-start", () => {
         effortLevel: "xhigh",
       },
       executionMode: "auto" as const,
-      claudePermissionMode: "bypass" as const,
     };
   }
 
@@ -1506,7 +1485,6 @@ describe("runStartup — quick-start", () => {
       effortLevel: "xhigh",
     });
     expect(result.executionMode).toBe("auto");
-    expect(result.claudePermissionMode).toBe("bypass");
     expect(result.language).toBe("en");
     // No agent selection prompts should have been shown.
     // select is called once for owner only.
@@ -1526,7 +1504,6 @@ describe("runStartup — quick-start", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("step") // execution mode
-      .mockResolvedValueOnce("auto") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop"); // repo
     mockInput.mockResolvedValueOnce("42"); // issue number
@@ -1576,7 +1553,6 @@ describe("runStartup — quick-start", () => {
       .mockResolvedValueOnce("gpt-5.4") // agent B model
       .mockResolvedValueOnce("xhigh") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
-      .mockResolvedValueOnce("bypass") // permission mode
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
@@ -1651,13 +1627,13 @@ describe("runStartup — quick-start", () => {
     expect(logs).toContain("Found saved configuration:");
     expect(logs).toContain("Agent A: Claude Opus 4.6 (1M) / High");
     expect(logs).toContain("Agent B: GPT-5.4 / Extra High");
-    expect(logs).toContain("Mode: auto / bypass");
+    expect(logs).toContain("Mode: auto");
     expect(logs).toContain("Language: English");
 
     consoleSpy.mockRestore();
   });
 
-  test("defaults executionMode and permissionMode when not saved", async () => {
+  test("defaults executionMode when not saved", async () => {
     const config = {
       ...defaultConfig(),
       agentA: {
@@ -1671,7 +1647,7 @@ describe("runStartup — quick-start", () => {
         model: "gpt-5.4",
         effortLevel: "xhigh",
       },
-      // executionMode and claudePermissionMode are undefined
+      // executionMode is undefined
     };
     mockLoadConfig.mockReturnValue(config);
     mockSelect.mockResolvedValueOnce("aicers");
@@ -1688,6 +1664,5 @@ describe("runStartup — quick-start", () => {
     const result = await runStartup();
 
     expect(result.executionMode).toBe("auto");
-    expect(result.claudePermissionMode).toBe("bypass");
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -20,7 +20,6 @@ export interface StartupResult {
   agentA: AgentConfig;
   agentB: AgentConfig;
   executionMode: "auto" | "step";
-  claudePermissionMode: "auto" | "bypass";
   language: "en" | "ko";
   pipelineSettings: PipelineSettings;
 }
@@ -158,12 +157,7 @@ export async function runStartup(
     console.log(m["quickStart.header"]);
     console.log(m["quickStart.agentA"](modelDisplayName(config.agentA)));
     console.log(m["quickStart.agentB"](modelDisplayName(config.agentB)));
-    console.log(
-      m["quickStart.mode"](
-        config.executionMode ?? "auto",
-        config.claudePermissionMode ?? "bypass",
-      ),
-    );
+    console.log(m["quickStart.mode"](config.executionMode ?? "auto"));
     console.log(
       m["quickStart.language"](
         config.language === "ko"
@@ -196,7 +190,6 @@ export async function runStartup(
         agentA: config.agentA,
         agentB: config.agentB,
         executionMode: config.executionMode ?? "auto",
-        claudePermissionMode: config.claudePermissionMode ?? "bypass",
         language: config.language,
         pipelineSettings: config.pipelineSettings,
       };
@@ -214,9 +207,6 @@ export async function runStartup(
     : CLI_DEFAULTS[defaultBCli];
   const agentB = await selectAgent(t()["agent.labelBRole"], agentBDefaults);
   const executionMode = await selectExecutionMode(config.executionMode);
-  const claudePermissionMode = await selectClaudePermissionMode(
-    config.claudePermissionMode,
-  );
 
   const { language, dirty: langDirty } = await selectLanguage(config);
   configDirty ||= langDirty;
@@ -234,10 +224,9 @@ export async function runStartup(
     throw new Error(t()["startup.issueNotConfirmed"]);
   }
 
-  // Persist agent selections, execution mode, and permission mode only
-  // when they actually changed, to avoid rewriting the config file on
-  // every run (which would drop unknown keys that loadConfig() normalizes
-  // away).
+  // Persist agent selections and execution mode only when they actually
+  // changed, to avoid rewriting the config file on every run (which
+  // would drop unknown keys that loadConfig() normalizes away).
   if (!agentConfigEqual(config.agentA, agentA)) {
     config.agentA = agentA;
     configDirty = true;
@@ -248,10 +237,6 @@ export async function runStartup(
   }
   if (config.executionMode !== executionMode) {
     config.executionMode = executionMode;
-    configDirty = true;
-  }
-  if (config.claudePermissionMode !== claudePermissionMode) {
-    config.claudePermissionMode = claudePermissionMode;
     configDirty = true;
   }
 
@@ -268,7 +253,6 @@ export async function runStartup(
     agentA,
     agentB,
     executionMode,
-    claudePermissionMode,
     language,
     pipelineSettings,
   };
@@ -402,19 +386,6 @@ async function selectExecutionMode(
       { name: "step", value: "step" as const },
     ],
     default: defaultValue ?? "auto",
-  });
-}
-
-async function selectClaudePermissionMode(
-  defaultValue?: "auto" | "bypass",
-): Promise<"auto" | "bypass"> {
-  return select({
-    message: t()["startup.claudePermission"],
-    choices: [
-      { name: "auto", value: "auto" as const },
-      { name: "bypass", value: "bypass" as const },
-    ],
-    default: defaultValue ?? "bypass",
   });
 }
 


### PR DESCRIPTION
## Summary

- Removed the `claudePermissionMode` config field, `ClaudePermissionMode` type, and `selectClaudePermissionMode` startup prompt
- Changed `buildClaudeArgs` to always pass `--permission-mode bypassPermissions`
- Cleaned up related plumbing in `index.ts`, `run-state.ts`, i18n message catalogs, and all affected tests

The `auto` mode was non-functional: `spawnAgent` closes stdin, so Claude blocks waiting for approval input that never arrives, eventually hitting the inactivity timeout.

Closes #119

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes
- [x] `pnpm vitest run` passes (all 1133 tests)
- [x] Verify `buildClaudeArgs` always includes `--permission-mode bypassPermissions`
- [x] Verify `claudePermissionMode` no longer appears in config, startup, or run state
- [x] Verify the startup wizard no longer prompts for permission mode
- [x] Verify quick-start summary no longer displays permission mode