### PR TITLE
Fix StatusBar layout on short terminals (#124)

### DIFF
--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -108,6 +108,7 @@ export function StatusBar({
       borderColor="gray"
       paddingX={1}
       flexDirection="column"
+      flexShrink={0}
     >
       <Box>
         <Text bold color="cyan">

--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -69,7 +69,7 @@ export function TokenBar({ emitter }: TokenBarProps) {
   const labelB = m["agent.labelB"];
 
   return (
-    <Box borderStyle="single" borderColor="gray" paddingX={1}>
+    <Box borderStyle="single" borderColor="gray" paddingX={1} flexShrink={0}>
       <Text>
         {m["tokenBar.agentUsage"](
           labelA,


### PR DESCRIPTION
## Summary

- Add `flexShrink={0}` to the StatusBar and TokenBar outer `<Box>` so Ink's flex layout never compresses them below their natural height.
- AgentPane (which already handles insufficient height gracefully) now absorbs all vertical space changes instead.

Closes #124

## Test plan

- [x] Resize terminal to a short height (e.g. 10–15 rows) and verify the StatusBar border, repo info line, and key hints line all remain visible and correctly separated
- [x] Verify TokenBar (token usage row) also remains intact at short heights
- [x] Confirm that at normal terminal heights the layout is unchanged
- [x] Run `pnpm vitest run` — all tests pass
- [x] Run `pnpm tsc --noEmit` — no type errors
- [x] Run `pnpm biome check` — no lint issues