### PR TITLE
Add height-adaptive progressive UI collapse (#126)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ink": "^6.8.0",
     "ink-text-input": "^6.0.0",
     "react": "^19.2.4",
+    "string-width": "^8.2.0",
     "wrap-ansi": "^10.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react:
         specifier: ^19.2.4
         version: 19.2.4
+      string-width:
+        specifier: ^8.2.0
+        version: 8.2.0
       wrap-ansi:
         specifier: ^10.0.0
         version: 10.0.0

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -42,6 +42,8 @@ interface AgentPaneProps {
   isActive?: boolean;
   /** Whether up/down arrow scrolling is active (false during input prompts). */
   arrowScrollEnabled?: boolean;
+  /** Whether to show the separator line between header and content. */
+  showSeparator?: boolean;
 }
 
 export function AgentPane({
@@ -53,6 +55,7 @@ export function AgentPane({
   isFocused = false,
   isActive = false,
   arrowScrollEnabled = false,
+  showSeparator = true,
 }: AgentPaneProps) {
   const { lines, pendingLine } = useAgentLines(emitter, agent);
   const containerRef = useRef<DOMElement>(null);
@@ -78,8 +81,9 @@ export function AgentPane({
   useEffect(() => {
     if (containerRef.current) {
       const { height, width } = measureElement(containerRef.current);
-      // Reserve 2 rows for top/bottom border, 1 for label, 1 for separator.
-      setVisibleRows(height > 4 ? height - 4 : 0);
+      // Reserve rows: border (2) + label (1) + optional separator (1).
+      const overhead = showSeparator ? 4 : 3;
+      setVisibleRows(height > overhead ? height - overhead : 0);
       // Subtract 4 for borderStyle="single" (2) + paddingX={1} (2).
       setContentWidth(width > 4 ? width - 4 : 1);
     }
@@ -248,7 +252,7 @@ export function AgentPane({
         {isActive ? " \u25CF" : ""}
         {isFocused ? " [*]" : ""}
       </Text>
-      <Text dimColor>{"\u2500".repeat(contentWidth)}</Text>
+      {showSeparator && <Text dimColor>{"\u2500".repeat(contentWidth)}</Text>}
       {placeholder !== undefined ? (
         <Text dimColor>{placeholder}</Text>
       ) : (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -17,25 +17,167 @@ import { StatusBar } from "./StatusBar.js";
 import { TokenBar } from "./TokenBar.js";
 import { createTuiUserPrompt } from "./TuiUserPrompt.js";
 
-/** Read terminal height from stdout.rows, re-rendering on resize. */
-export function useTerminalHeight(): number | undefined {
+// ---- Terminal dimension hooks ------------------------------------------------
+
+/** Read terminal dimensions from stdout, re-rendering on resize. */
+export function useTerminalDimensions(): {
+  height: number | undefined;
+  width: number | undefined;
+} {
   const { stdout } = useStdout();
   const isTTY = stdout.isTTY === true;
-  const [height, setHeight] = useState<number | undefined>(
-    isTTY ? stdout.rows : undefined,
-  );
+  const [dims, setDims] = useState<{
+    height: number | undefined;
+    width: number | undefined;
+  }>({
+    height: isTTY ? stdout.rows : undefined,
+    width: isTTY ? stdout.columns : undefined,
+  });
 
   useEffect(() => {
     if (!isTTY) return;
-    const onResize = () => setHeight(stdout.rows);
+    const onResize = () =>
+      setDims({ height: stdout.rows, width: stdout.columns });
     stdout.on("resize", onResize);
     return () => {
       stdout.off("resize", onResize);
     };
   }, [stdout, isTTY]);
 
-  return height;
+  return dims;
 }
+
+/** Read terminal height from stdout.rows, re-rendering on resize. */
+export function useTerminalHeight(): number | undefined {
+  return useTerminalDimensions().height;
+}
+
+// ---- Visibility flag computation ---------------------------------------------
+
+/** Minimum content rows per agent pane before hiding UI elements. */
+export const MIN_PANE_CONTENT = 3;
+
+export interface VisibilityFlags {
+  showTokenBar: boolean;
+  showKeyHints: boolean;
+  showPaneSeparator: boolean;
+  allowColumnLayout: boolean;
+}
+
+/** Compute the height of the InputArea in terminal rows. */
+export function inputAreaHeight(request: InputRequest | null): number {
+  if (!request) return 1;
+  if (request.choices) return 1 + request.choices.length;
+  return 2;
+}
+
+/**
+ * Compute flags for a specific layout, progressively hiding elements
+ * until each agent pane has at least MIN_PANE_CONTENT rows.
+ */
+function computeFlagsForLayout(
+  terminalHeight: number,
+  inputHeight: number,
+  hasTokenData: boolean,
+  layout: "row" | "column",
+): VisibilityFlags {
+  let showTokenBar = hasTokenData;
+  let showKeyHints = true;
+  let showPaneSeparator = true;
+  let allowColumnLayout = true;
+
+  function paneContentRows(
+    tokenBar: boolean,
+    keyHints: boolean,
+    separator: boolean,
+  ): number {
+    // StatusBar: border (2) + info line (1) + optional key hints (1).
+    const statusBarHeight = keyHints ? 4 : 3;
+    const tokenBarHeight = tokenBar ? 3 : 0;
+    const bottomChrome = inputHeight + statusBarHeight + tokenBarHeight;
+    const paneArea = terminalHeight - bottomChrome;
+    // AgentPane overhead: border (2) + label (1) + optional separator (1).
+    const paneOverhead = separator ? 4 : 3;
+    if (layout === "column") {
+      return Math.floor(paneArea / 2) - paneOverhead;
+    }
+    return paneArea - paneOverhead;
+  }
+
+  // 1. Hide TokenBar (lowest information priority).
+  if (
+    paneContentRows(showTokenBar, showKeyHints, showPaneSeparator) <
+    MIN_PANE_CONTENT
+  ) {
+    showTokenBar = false;
+  }
+
+  // 2. Hide StatusBar key hints line.
+  if (
+    paneContentRows(showTokenBar, showKeyHints, showPaneSeparator) <
+    MIN_PANE_CONTENT
+  ) {
+    showKeyHints = false;
+  }
+
+  // 3. Hide AgentPane separator line (saves 1 row per pane).
+  if (
+    paneContentRows(showTokenBar, showKeyHints, showPaneSeparator) <
+    MIN_PANE_CONTENT
+  ) {
+    showPaneSeparator = false;
+  }
+
+  // 4. Restrict column layout to prevent both panes from being unusable.
+  if (
+    layout === "column" &&
+    paneContentRows(showTokenBar, showKeyHints, showPaneSeparator) <
+      MIN_PANE_CONTENT
+  ) {
+    allowColumnLayout = false;
+  }
+
+  return { showTokenBar, showKeyHints, showPaneSeparator, allowColumnLayout };
+}
+
+/**
+ * Compute which UI elements to show based on available terminal height.
+ * Elements are hidden in priority order until each agent pane has at least
+ * MIN_PANE_CONTENT rows of content space.
+ *
+ * When column layout is forced to row, the flags are recomputed for row
+ * layout so we don't unnecessarily hide elements that fit in row mode.
+ */
+export function computeVisibilityFlags(
+  terminalHeight: number,
+  inputHeight: number,
+  hasTokenData: boolean,
+  preferredLayout: "row" | "column",
+): VisibilityFlags {
+  const flags = computeFlagsForLayout(
+    terminalHeight,
+    inputHeight,
+    hasTokenData,
+    preferredLayout,
+  );
+
+  // When column is forced to row, recompute for the effective (row) layout
+  // so that elements which fit in row mode are not hidden unnecessarily.
+  if (!flags.allowColumnLayout && preferredLayout === "column") {
+    const rowFlags = computeFlagsForLayout(
+      terminalHeight,
+      inputHeight,
+      hasTokenData,
+      "row",
+    );
+    rowFlags.allowColumnLayout = false;
+    return rowFlags;
+  }
+
+  return flags;
+}
+
+// ---- App component -----------------------------------------------------------
 
 export interface AppProps {
   emitter: PipelineEventEmitter;
@@ -63,12 +205,16 @@ export function App({
   modelNameB,
   onCancel,
 }: AppProps) {
-  const terminalHeight = useTerminalHeight();
+  const { height: terminalHeight, width: terminalWidth } =
+    useTerminalDimensions();
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
   const resolveRef = useRef<((value: string) => void) | null>(null);
   const [focusedPane, setFocusedPane] = useState<"a" | "b">("a");
   const [activeAgent, setActiveAgent] = useState<"a" | "b" | null>(null);
-  const [layout, setLayout] = useState<"row" | "column">("row");
+  const [preferredLayout, setPreferredLayout] = useState<"row" | "column">(
+    "row",
+  );
+  const [hasTokenData, setHasTokenData] = useState(false);
 
   // AbortController for pipeline cancellation on Ctrl+C.
   const abortController = useMemo(() => new AbortController(), []);
@@ -80,6 +226,44 @@ export function App({
   const onExitRef = useRef(onExit);
   const onPromptReadyRef = useRef(onPromptReady);
   const onCancelRef = useRef(onCancel);
+
+  // Track whether any token usage has been reported.
+  useEffect(() => {
+    const onUsage = () => setHasTokenData(true);
+    emitter.on("agent:usage", onUsage);
+    return () => {
+      emitter.off("agent:usage", onUsage);
+    };
+  }, [emitter]);
+
+  // Compute visibility flags based on terminal dimensions.
+  const inputHeight = inputAreaHeight(inputRequest);
+  const flags = useMemo<VisibilityFlags>(() => {
+    if (terminalHeight === undefined) {
+      return {
+        showTokenBar: true,
+        showKeyHints: true,
+        showPaneSeparator: true,
+        allowColumnLayout: true,
+      };
+    }
+    return computeVisibilityFlags(
+      terminalHeight,
+      inputHeight,
+      hasTokenData,
+      preferredLayout,
+    );
+  }, [terminalHeight, inputHeight, hasTokenData, preferredLayout]);
+
+  const effectiveLayout =
+    preferredLayout === "column" && !flags.allowColumnLayout
+      ? "row"
+      : preferredLayout;
+
+  // Content width budget for bordered components (StatusBar, TokenBar):
+  // terminal width minus border (2) and paddingX (2).
+  const borderedContentWidth =
+    terminalWidth !== undefined ? terminalWidth - 4 : undefined;
 
   const dispatch = useCallback((request: InputRequest): Promise<string> => {
     return new Promise<string>((resolve) => {
@@ -104,7 +288,7 @@ export function App({
       setFocusedPane((prev) => (prev === "a" ? "b" : "a"));
     }
     if (input === "l" && key.ctrl) {
-      setLayout((prev) => (prev === "row" ? "column" : "row"));
+      setPreferredLayout((prev) => (prev === "row" ? "column" : "row"));
     }
     if (input === "c" && key.ctrl && !cancelledRef.current) {
       cancelledRef.current = true;
@@ -160,7 +344,7 @@ export function App({
   return (
     <Box flexDirection="column" width="100%" height={terminalHeight ?? "100%"}>
       {/* Agent panes: side by side (row) or stacked (column) */}
-      <Box flexDirection={layout} flexGrow={1}>
+      <Box flexDirection={effectiveLayout} flexGrow={1}>
         <AgentPane
           label={t()["agent.labelARole"]}
           modelName={modelNameA}
@@ -170,6 +354,7 @@ export function App({
           isFocused={focusedPane === "a"}
           isActive={activeAgent === "a"}
           arrowScrollEnabled={!inputRequest}
+          showSeparator={flags.showPaneSeparator}
         />
         <AgentPane
           label={t()["agent.labelBRole"]}
@@ -180,18 +365,25 @@ export function App({
           isFocused={focusedPane === "b"}
           isActive={activeAgent === "b"}
           arrowScrollEnabled={!inputRequest}
+          showSeparator={flags.showPaneSeparator}
         />
       </Box>
 
       {/* Bottom: token bar + status bar + input area */}
-      <TokenBar emitter={emitter} />
+      <TokenBar
+        emitter={emitter}
+        visible={flags.showTokenBar}
+        contentWidth={borderedContentWidth}
+      />
       <StatusBar
         emitter={emitter}
         owner={pipelineOptions.context.owner}
         repo={pipelineOptions.context.repo}
         issueNumber={pipelineOptions.context.issueNumber}
         baseSha={pipelineOptions.context.baseSha}
-        layout={layout}
+        layout={effectiveLayout}
+        showKeyHints={flags.showKeyHints}
+        contentWidth={borderedContentWidth}
       />
       <InputArea request={inputRequest} onSubmit={handleSubmit} />
     </Box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
+import stringWidth from "string-width";
 import { t } from "../i18n/index.js";
 import type {
   PipelineEventEmitter,
@@ -21,7 +22,107 @@ interface StatusBarProps {
   baseSha?: string;
   /** Current pane layout direction. */
   layout?: "row" | "column";
+  /** Whether to show the keyboard hints line. Defaults to true. */
+  showKeyHints?: boolean;
+  /** Content width budget for the info line (terminal width minus border and padding). */
+  contentWidth?: number;
 }
+
+// ---- Segment fitting helpers -------------------------------------------------
+
+/** A segment of the info line with styling and drop priority. */
+interface InfoSegment {
+  text: string;
+  bold?: boolean;
+  color?: string;
+  /** 0 = required (never dropped); higher values are dropped sooner. */
+  dropPriority: number;
+}
+
+const SEP = "  |  ";
+const SEP_LEN = 5;
+
+/** Compute the total display width of segments joined by separators. */
+function segmentsWidth(segs: InfoSegment[]): number {
+  let width = 0;
+  for (let i = 0; i < segs.length; i++) {
+    if (i > 0) width += SEP_LEN;
+    width += stringWidth(segs[i].text);
+  }
+  return width;
+}
+
+/**
+ * Truncate text with ellipsis if it exceeds maxWidth terminal columns.
+ * Uses display width (not string length) so CJK/wide characters are
+ * measured correctly.
+ */
+export function truncateWithEllipsis(text: string, maxWidth: number): string {
+  if (stringWidth(text) <= maxWidth) return text;
+  if (maxWidth <= 1) return "\u2026";
+  const target = maxWidth - 1; // reserve 1 column for ellipsis
+  let result = "";
+  let currentWidth = 0;
+  for (const char of text) {
+    const w = stringWidth(char);
+    if (currentWidth + w > target) break;
+    result += char;
+    currentWidth += w;
+  }
+  return `${result}\u2026`;
+}
+
+/**
+ * Fit segments within a width budget by progressively dropping optional
+ * segments (highest dropPriority first) and truncating required ones as
+ * a last resort.
+ */
+export function fitInfoSegments(
+  segments: InfoSegment[],
+  maxWidth: number,
+): InfoSegment[] {
+  let display = [...segments];
+
+  // Drop optional segments (highest dropPriority first) until they fit.
+  while (segmentsWidth(display) > maxWidth) {
+    let dropIdx = -1;
+    let dropPrio = 0;
+    for (let i = 0; i < display.length; i++) {
+      if (display[i].dropPriority > dropPrio) {
+        dropPrio = display[i].dropPriority;
+        dropIdx = i;
+      }
+    }
+    if (dropIdx === -1) break;
+    display = display.filter((_, i) => i !== dropIdx);
+  }
+
+  // Truncation as last resort for required segments.
+  if (segmentsWidth(display) > maxWidth && display.length > 0) {
+    const seps = Math.max(0, display.length - 1) * SEP_LEN;
+    const available = maxWidth - seps;
+
+    if (available < display.length) {
+      // Ultra-narrow: separator(s) alone consume too much of the budget.
+      // Merge all remaining segments into a single truncated string.
+      const merged = display.map((s) => s.text).join(" ");
+      display = [
+        { ...display[0], text: truncateWithEllipsis(merged, maxWidth) },
+      ];
+    } else {
+      const each = Math.floor(available / display.length);
+      const remainder = available - each * display.length;
+      display = display.map((seg, i) => ({
+        ...seg,
+        text: truncateWithEllipsis(seg.text, each + (i < remainder ? 1 : 0)),
+      }));
+    }
+  }
+
+  return display;
+}
+
+// ---- Component ---------------------------------------------------------------
 
 export function StatusBar({
   emitter,
@@ -30,6 +131,8 @@ export function StatusBar({
   issueNumber,
   baseSha,
   layout,
+  showKeyHints = true,
+  contentWidth,
 }: StatusBarProps) {
   const [stage, setStage] = useState<StageEnterEvent | null>(null);
   const [lastOutcome, setLastOutcome] = useState<string | null>(null);
@@ -101,6 +204,35 @@ export function StatusBar({
           : m["statusBar.layoutVertical"],
       )
     : "";
+  const completedText =
+    selfCheckCount > 0 || reviewCount > 0
+      ? m["statusBar.completed"](selfCheckCount, reviewCount)
+      : "";
+
+  // Build segments in display order with drop priorities.
+  // Priority 0 = required (never dropped); higher = dropped sooner.
+  // Drop order: layout (4) → completed (3) → outcome (2) → base (1).
+  const segments: InfoSegment[] = [
+    { text: issueLabel, bold: true, color: "cyan", dropPriority: 0 },
+  ];
+  if (baseText) {
+    segments.push({ text: baseText, dropPriority: 1 });
+  }
+  segments.push({ text: stageText, bold: true, dropPriority: 0 });
+  if (outcomeText) {
+    segments.push({ text: outcomeText, dropPriority: 2 });
+  }
+  if (completedText) {
+    segments.push({ text: completedText, dropPriority: 3 });
+  }
+  if (layoutText) {
+    segments.push({ text: layoutText, dropPriority: 4 });
+  }
+
+  const display =
+    contentWidth !== undefined
+      ? fitInfoSegments(segments, contentWidth)
+      : segments;
 
   return (
     <Box
@@ -109,39 +241,25 @@ export function StatusBar({
       paddingX={1}
       flexDirection="column"
       flexShrink={0}
+      height={contentWidth !== undefined ? (showKeyHints ? 4 : 3) : undefined}
+      overflow="hidden"
     >
       <Box>
-        <Text bold color="cyan">
-          {issueLabel}
-        </Text>
-        {baseText && (
-          <Text>
-            {"  |  "}
-            {baseText}
+        {display.map((seg, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: stable render-local array
+          <Text key={i} bold={seg.bold} color={seg.color}>
+            {i > 0 ? SEP : ""}
+            {seg.text}
           </Text>
-        )}
-        <Text>{"  |  "}</Text>
-        <Text bold>{stageText}</Text>
-        {outcomeText && (
-          <Text>
-            {"  |  "}
-            {outcomeText}
-          </Text>
-        )}
-        {(selfCheckCount > 0 || reviewCount > 0) && (
-          <Text>
-            {"  |  "}
-            {m["statusBar.completed"](selfCheckCount, reviewCount)}
-          </Text>
-        )}
-        {layoutText && (
-          <Text>
-            {"  |  "}
-            {layoutText}
-          </Text>
-        )}
+        ))}
       </Box>
-      <Text dimColor>{m["statusBar.keyHints"]}</Text>
+      {showKeyHints && (
+        <Text dimColor>
+          {contentWidth !== undefined
+            ? truncateWithEllipsis(m["statusBar.keyHints"], contentWidth)
+            : m["statusBar.keyHints"]}
+        </Text>
+      )}
     </Box>
   );
 }

--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -6,6 +6,7 @@ import type {
   AgentUsageEvent,
   PipelineEventEmitter,
 } from "../pipeline-events.js";
+import { truncateWithEllipsis } from "./StatusBar.js";
 
 /**
  * Format a token count with K/M suffixes for readability.
@@ -24,11 +25,27 @@ export function formatTokenCount(n: number): string {
   return `${m.toFixed(1)}M`;
 }
 
+const SEP = "  |  ";
+
 interface TokenBarProps {
   emitter: PipelineEventEmitter;
+  /** When false, the bar stays mounted (accumulating data) but renders nothing. */
+  visible?: boolean;
+  /**
+   * Available width for content inside the bordered box.
+   * When provided, the content is rendered as a single truncated line and the
+   * box height is fixed to 3 rows (top border + content + bottom border) so
+   * that wrapping can never inflate the bar beyond what the height model in
+   * App.tsx assumes.
+   */
+  contentWidth?: number;
 }
 
-export function TokenBar({ emitter }: TokenBarProps) {
+export function TokenBar({
+  emitter,
+  visible = true,
+  contentWidth,
+}: TokenBarProps) {
   const [usageA, setUsageA] = useState<TokenUsage>({
     inputTokens: 0,
     outputTokens: 0,
@@ -63,28 +80,38 @@ export function TokenBar({ emitter }: TokenBarProps) {
     usageB.inputTokens > 0 ||
     usageB.outputTokens > 0;
 
-  if (!hasData) return null;
+  if (!visible || !hasData) return null;
 
   const labelA = m["agent.labelA"];
   const labelB = m["agent.labelB"];
 
+  const textA = m["tokenBar.agentUsage"](
+    labelA,
+    formatTokenCount(usageA.inputTokens),
+    formatTokenCount(usageA.outputTokens),
+  );
+  const textB = m["tokenBar.agentUsage"](
+    labelB,
+    formatTokenCount(usageB.inputTokens),
+    formatTokenCount(usageB.outputTokens),
+  );
+  const fullLine = `${textA}${SEP}${textB}`;
+
+  const displayLine =
+    contentWidth !== undefined
+      ? truncateWithEllipsis(fullLine, contentWidth)
+      : fullLine;
+
   return (
-    <Box borderStyle="single" borderColor="gray" paddingX={1} flexShrink={0}>
-      <Text>
-        {m["tokenBar.agentUsage"](
-          labelA,
-          formatTokenCount(usageA.inputTokens),
-          formatTokenCount(usageA.outputTokens),
-        )}
-      </Text>
-      <Text>{"  |  "}</Text>
-      <Text>
-        {m["tokenBar.agentUsage"](
-          labelB,
-          formatTokenCount(usageB.inputTokens),
-          formatTokenCount(usageB.outputTokens),
-        )}
-      </Text>
+    <Box
+      borderStyle="single"
+      borderColor="gray"
+      paddingX={1}
+      flexShrink={0}
+      height={contentWidth !== undefined ? 3 : undefined}
+      overflow="hidden"
+    >
+      <Text>{displayLine}</Text>
     </Box>
   );
 }

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -7,15 +7,21 @@
 import { Box, Text, useInput, useStdout } from "ink";
 import { cleanup, render } from "ink-testing-library";
 import { useCallback, useEffect, useRef, useState } from "react";
+import stringWidth from "string-width";
 import { afterEach, describe, expect, test } from "vitest";
+import { initI18n } from "../i18n/index.js";
 import {
   type AgentInvokeEvent,
   PipelineEventEmitter,
 } from "../pipeline-events.js";
 import { AgentPane, splitIntoRows } from "./AgentPane.js";
-import { useTerminalHeight } from "./App.js";
+import {
+  computeVisibilityFlags,
+  inputAreaHeight,
+  useTerminalHeight,
+} from "./App.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
-import { StatusBar } from "./StatusBar.js";
+import { fitInfoSegments, StatusBar } from "./StatusBar.js";
 import { formatTokenCount, TokenBar } from "./TokenBar.js";
 
 afterEach(() => {
@@ -1596,5 +1602,448 @@ describe("TokenBar", () => {
     const frame = lastFrame() ?? "";
     expect(frame).toContain("3.0K in");
     expect(frame).toContain("1.5K out");
+  });
+
+  test("renders nothing when visible is false even with data", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} visible={false} />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("Agent A");
+    expect(frame).not.toContain("1.0K");
+  });
+
+  test("shows accumulated data when visible becomes true", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame, rerender } = render(
+      <TokenBar emitter={emitter} visible={false} />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 5000, outputTokens: 2000, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame() ?? "").not.toContain("Agent A");
+
+    rerender(<TokenBar emitter={emitter} visible />);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Agent A");
+    expect(frame).toContain("5.0K in");
+  });
+});
+
+describe("TokenBar width adaptation", () => {
+  test("truncates content to contentWidth so it cannot wrap", async () => {
+    const emitter = new PipelineEventEmitter();
+    // contentWidth=26 is narrower than the full token line (~60+ chars).
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} contentWidth={26} />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 5000, outputTokens: 2000, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:usage", {
+      agent: "b",
+      usage: { inputTokens: 6000, outputTokens: 3000, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // Content should be truncated (ends with ellipsis).
+    expect(frame).toContain("\u2026");
+    // The full Agent B text should not appear since it exceeds 26 columns.
+    expect(frame).not.toContain("Agent B");
+    // Each rendered content line must fit within the width budget.
+    for (const line of frame.split("\n")) {
+      // Skip border lines (box-drawing characters).
+      if (line.startsWith("│") || line.startsWith("┌") || line.startsWith("└"))
+        continue;
+      expect(stringWidth(line)).toBeLessThanOrEqual(26);
+    }
+  });
+
+  test("truncates Korean (wide-char) content correctly", async () => {
+    await initI18n("ko");
+    try {
+      const emitter = new PipelineEventEmitter();
+      const { lastFrame } = render(
+        <TokenBar emitter={emitter} contentWidth={26} />,
+      );
+
+      emitter.emit("agent:usage", {
+        agent: "a",
+        usage: {
+          inputTokens: 5000,
+          outputTokens: 2000,
+          cachedInputTokens: 0,
+        },
+      });
+      emitter.emit("agent:usage", {
+        agent: "b",
+        usage: {
+          inputTokens: 6000,
+          outputTokens: 3000,
+          cachedInputTokens: 0,
+        },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("\u2026");
+      for (const line of frame.split("\n")) {
+        if (
+          line.startsWith("│") ||
+          line.startsWith("┌") ||
+          line.startsWith("└")
+        )
+          continue;
+        expect(stringWidth(line)).toBeLessThanOrEqual(26);
+      }
+    } finally {
+      await initI18n("en");
+    }
+  });
+});
+
+// ---- computeVisibilityFlags --------------------------------------------------
+
+describe("computeVisibilityFlags", () => {
+  test("shows everything when terminal has plenty of height", () => {
+    const flags = computeVisibilityFlags(40, 1, true, "row");
+    expect(flags.showTokenBar).toBe(true);
+    expect(flags.showKeyHints).toBe(true);
+    expect(flags.showPaneSeparator).toBe(true);
+    expect(flags.allowColumnLayout).toBe(true);
+  });
+
+  test("hides token bar first when space is tight", () => {
+    // Row: paneContent = 14 - 1(input) - 4(status) - 3(token) - 4(overhead) = 2 < 3
+    // Without token: 14 - 1 - 4 - 0 - 4 = 5 >= 3
+    const flags = computeVisibilityFlags(14, 1, true, "row");
+    expect(flags.showTokenBar).toBe(false);
+    expect(flags.showKeyHints).toBe(true);
+    expect(flags.showPaneSeparator).toBe(true);
+  });
+
+  test("hides key hints after token bar", () => {
+    // No token data, token bar already hidden.
+    // paneContent = 11 - 1 - 4 - 0 - 4 = 2 < 3 → hide hints
+    // Without hints: 11 - 1 - 3 - 0 - 4 = 3 >= 3
+    const flags = computeVisibilityFlags(11, 1, false, "row");
+    expect(flags.showTokenBar).toBe(false);
+    expect(flags.showKeyHints).toBe(false);
+    expect(flags.showPaneSeparator).toBe(true);
+  });
+
+  test("hides separator after key hints", () => {
+    // paneContent = 10 - 1 - 3 - 0 - 4 = 2 < 3 → hide separator
+    // Without separator: 10 - 1 - 3 - 0 - 3 = 3 >= 3
+    const flags = computeVisibilityFlags(10, 1, false, "row");
+    expect(flags.showTokenBar).toBe(false);
+    expect(flags.showKeyHints).toBe(false);
+    expect(flags.showPaneSeparator).toBe(false);
+  });
+
+  test("forces row layout when column panes are too small", () => {
+    // Column layout can't fit MIN_PANE_CONTENT even with all hidden.
+    // After forcing row, flags are recomputed for row mode.
+    // Row: paneContent = 12 - 1 - 4 - 0 - 4 = 3 >= 3 → hints and sep shown
+    const flags = computeVisibilityFlags(12, 1, false, "column");
+    expect(flags.allowColumnLayout).toBe(false);
+    expect(flags.showKeyHints).toBe(true);
+    expect(flags.showPaneSeparator).toBe(true);
+  });
+
+  test("preserves column layout when panes have enough space", () => {
+    const flags = computeVisibilityFlags(30, 1, false, "column");
+    expect(flags.allowColumnLayout).toBe(true);
+  });
+
+  test("token bar stays hidden when hasTokenData is false", () => {
+    const flags = computeVisibilityFlags(100, 1, false, "row");
+    expect(flags.showTokenBar).toBe(false);
+  });
+
+  test("accounts for taller input area", () => {
+    // With inputHeight=4: paneContent = 17 - 4 - 4 - 3 - 4 = 2 < 3 → hide token
+    const flags = computeVisibilityFlags(17, 4, true, "row");
+    expect(flags.showTokenBar).toBe(false);
+    expect(flags.showKeyHints).toBe(true);
+  });
+});
+
+// ---- inputAreaHeight ---------------------------------------------------------
+
+describe("inputAreaHeight", () => {
+  test("returns 1 for null request", () => {
+    expect(inputAreaHeight(null)).toBe(1);
+  });
+
+  test("returns 2 for text input request", () => {
+    expect(inputAreaHeight({ message: "Enter:" })).toBe(2);
+  });
+
+  test("returns 1 plus choices count for choice request", () => {
+    expect(
+      inputAreaHeight({
+        message: "Choose:",
+        choices: [
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+        ],
+      }),
+    ).toBe(3);
+  });
+});
+
+// ---- fitInfoSegments ---------------------------------------------------------
+
+describe("fitInfoSegments", () => {
+  test("returns all segments when they fit", () => {
+    const segments = [
+      { text: "abc", dropPriority: 0 },
+      { text: "def", dropPriority: 1 },
+    ];
+    const result = fitInfoSegments(segments, 50);
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("abc");
+    expect(result[1].text).toBe("def");
+  });
+
+  test("drops highest priority segment first", () => {
+    const segments = [
+      { text: "required", dropPriority: 0 },
+      { text: "low-priority", dropPriority: 2 },
+      { text: "mid-priority", dropPriority: 1 },
+    ];
+    // "required"(8) + sep(5) + "low-priority"(12) + sep(5) + "mid-priority"(12) = 42
+    // Budget 30: drop "low-priority" (priority 2) first → 8+5+12 = 25 <= 30
+    const result = fitInfoSegments(segments, 30);
+    expect(result.map((s) => s.text)).toEqual(["required", "mid-priority"]);
+  });
+
+  test("drops multiple segments when needed", () => {
+    const segments = [
+      { text: "abc", dropPriority: 0 },
+      { text: "xxxxxxxx", dropPriority: 3 },
+      { text: "def", dropPriority: 0 },
+      { text: "yyyyyyyy", dropPriority: 2 },
+      { text: "zzzzzzzz", dropPriority: 1 },
+    ];
+    // Budget 15: drop priority 3, 2, 1 → "abc"(3) + sep(5) + "def"(3) = 11 <= 15
+    const result = fitInfoSegments(segments, 15);
+    expect(result.map((s) => s.text)).toEqual(["abc", "def"]);
+  });
+
+  test("truncates required segments as last resort", () => {
+    const segments = [
+      { text: "aicers/agentcoop#123", dropPriority: 0 },
+      { text: "Stage 2: Implement", dropPriority: 0 },
+    ];
+    // Both required, total = 20 + 5 + 18 = 43, budget = 20
+    // available = 20 - 5 = 15, each = 7, remainder = 1
+    // Seg 0: max 8 → "aicers/\u2026", Seg 1: max 7 → "Stage \u2026"
+    const result = fitInfoSegments(segments, 20);
+    expect(result).toHaveLength(2);
+    expect(result[0].text).toBe("aicers/\u2026");
+    expect(result[1].text).toBe("Stage \u2026");
+  });
+
+  test("merges segments when budget is smaller than separator + 1 col per segment", () => {
+    const segments = [
+      { text: "aicers/agentcoop#123", dropPriority: 0 },
+      { text: "Stage 2: Implement", dropPriority: 0 },
+    ];
+    // Two required segments need at least SEP(5) + 1 + 1 = 7 columns in
+    // separator mode. At budget=6 the separator form overflows, so the
+    // function should merge into one truncated string.
+    const result = fitInfoSegments(segments, 6);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("aicer\u2026");
+  });
+
+  test("merges segments at budget=1 producing single ellipsis", () => {
+    const segments = [
+      { text: "aicers/agentcoop#123", dropPriority: 0 },
+      { text: "Stage 2: Implement", dropPriority: 0 },
+    ];
+    const result = fitInfoSegments(segments, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].text).toBe("\u2026");
+  });
+
+  test("handles empty segments array", () => {
+    const result = fitInfoSegments([], 50);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---- StatusBar width adaptation ----------------------------------------------
+
+describe("StatusBar width adaptation", () => {
+  test("hides key hints when showKeyHints is false", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+        showKeyHints={false}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("Tab:Switch pane");
+    expect(frame).not.toContain("Ctrl+C:Quit");
+    // Info line should still be present.
+    expect(frame).toContain("aicers/agentcoop#49");
+  });
+
+  test("truncates key hints line to contentWidth so it cannot wrap", () => {
+    const emitter = new PipelineEventEmitter();
+    // contentWidth=26 is narrower than the full key-hints string (~100 chars).
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+        showKeyHints={true}
+        contentWidth={26}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Key hints should be present but truncated (ends with ellipsis).
+    expect(frame).toContain("\u2026");
+    // The full hints string should NOT appear since it exceeds 26 columns.
+    expect(frame).not.toContain("Ctrl+C:Quit");
+    // Each rendered line (excluding border box characters) should fit within
+    // the content width. Split by newlines and check non-border lines.
+    for (const line of frame.split("\n")) {
+      // Ink box border lines use box-drawing characters; skip them.
+      if (line.startsWith("│") || line.startsWith("┌") || line.startsWith("└"))
+        continue;
+      // Remaining content lines must not exceed contentWidth.
+      expect(stringWidth(line)).toBeLessThanOrEqual(26);
+    }
+  });
+
+  test("truncates Korean (wide-char) key hints correctly", async () => {
+    await initI18n("ko");
+    try {
+      const emitter = new PipelineEventEmitter();
+      const { lastFrame } = render(
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          showKeyHints={true}
+          contentWidth={26}
+        />,
+      );
+
+      const frame = lastFrame() ?? "";
+      expect(frame).toContain("\u2026");
+      // Korean key hints end with Ctrl+C:종료; it should be truncated.
+      expect(frame).not.toContain("종료");
+      for (const line of frame.split("\n")) {
+        if (
+          line.startsWith("│") ||
+          line.startsWith("┌") ||
+          line.startsWith("└")
+        )
+          continue;
+        expect(stringWidth(line)).toBeLessThanOrEqual(26);
+      }
+    } finally {
+      await initI18n("en");
+    }
+  });
+
+  test("drops layout indicator first when contentWidth is narrow", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+        layout="row"
+        contentWidth={50}
+      />,
+    );
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("aicers/agentcoop#49");
+    expect(frame).toContain("Stage 2: Implement");
+    // Layout indicator should be dropped due to narrow width.
+    expect(frame).not.toContain("Layout:");
+  });
+});
+
+// ---- AgentPane showSeparator -------------------------------------------------
+
+describe("AgentPane showSeparator", () => {
+  test("hides separator when showSeparator is false", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane
+        label="Agent A"
+        agent="a"
+        emitter={emitter}
+        color="blue"
+        showSeparator={false}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Agent A");
+    // The separator line has \u2500 characters inside the box (not in border).
+    // Border lines contain \u250C or \u2514; separator lines do not.
+    const lines = frame.split("\n");
+    const separatorLines = lines.filter(
+      (l) =>
+        l.includes("\u2500") && !l.includes("\u250C") && !l.includes("\u2514"),
+    );
+    expect(separatorLines).toHaveLength(0);
+  });
+
+  test("shows separator by default", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Separator line has \u2500 inside the box (no corner chars).
+    const lines = frame.split("\n");
+    const separatorLines = lines.filter(
+      (l) =>
+        l.includes("\u2500") && !l.includes("\u250C") && !l.includes("\u2514"),
+    );
+    expect(separatorLines.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- Centralize visibility decisions in `App.tsx`: compute `showTokenBar`, `showKeyHints`, `showPaneSeparator`, and `allowColumnLayout` flags from terminal dimensions and pass them as props to child components, avoiding circular layout dependencies.
- Progressively hide UI elements in priority order (TokenBar → key hints → pane separator → column layout) until each agent pane has at least 3 content rows. When column is forced to row, flags are recomputed for row layout so elements that fit aren't hidden unnecessarily.
- Fit StatusBar info-line segments and key-hints line within the content width budget: drop optional info segments (layout indicator → completed counts → last outcome → base SHA), truncate required ones with ellipsis as a last resort, and truncate the key-hints line to prevent wrapping. At ultra-narrow widths where even the separator between required segments exceeds the budget, merge them into a single truncated string. The StatusBar outer Box enforces an explicit height when `contentWidth` is provided and clips overflow as a safety net.
- Fit TokenBar content within the content width budget: render token usage as a single truncated line and enforce an explicit height of 3 rows so wrapping can never inflate the bar beyond what the centralized height model assumes.
- All width budgeting and truncation uses display width (terminal columns via `string-width`) instead of JavaScript string length, so CJK/wide characters in the Korean locale are measured and truncated correctly.
- Split layout state into `preferredLayout` (user preference via Ctrl+L, persisted across resizes) and `effectiveLayout` (used for rendering, may differ when column is restricted).

Closes #126

## Test plan

- [x] Resize terminal to very short height (~10 rows) and verify TokenBar disappears first, then key hints, then pane separators
- [x] Verify column layout is forced to row when terminal height is too small for two stacked panes with 3+ content rows each
- [x] Increase terminal height and verify hidden elements reappear in reverse order
- [x] Toggle Ctrl+L to column layout, shrink terminal until column is forced to row, then grow terminal and verify column preference is restored
- [x] Narrow terminal width and verify StatusBar info segments drop in priority order (layout indicator first, then completed counts, last outcome, base SHA)
- [x] Shrink terminal extremely narrow and verify required segments (issue label, stage) are truncated with ellipsis rather than wrapping
- [x] At ultra-narrow widths (content budget < 7), verify required segments are merged into one truncated string instead of overflowing
- [x] Narrow terminal and verify key-hints line is truncated to content width and does not wrap to multiple rows
- [x] Narrow terminal and verify TokenBar content is truncated to content width and does not wrap to multiple rows
- [x] Verify TokenBar stays mounted and accumulates data while hidden, showing correct totals when it becomes visible again
- [x] Switch to Korean locale and verify StatusBar/TokenBar truncation respects double-width characters
- [x] Run `pnpm vitest run` — all 1161 tests pass
- [x] Run `pnpm tsc --noEmit` and `pnpm biome check` — no errors