### PR TITLE
Fix prompt separator length mismatch (#131)

### DIFF
--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -181,6 +181,40 @@ describe("formatPromptForDisplay", () => {
     expect(lines[lines.length - 1]).toContain(PROMPT_SEPARATOR_CHAR);
   });
 
+  test("footer length matches header length", () => {
+    const lines = formatPromptForDisplay("Hello");
+    const header = lines[0];
+    const footer = lines[lines.length - 1];
+
+    expect(footer).toBeDefined();
+    expect(footer).toHaveLength(header.length);
+    // Footer should be all separator chars
+    expect(footer).toBe(PROMPT_SEPARATOR_CHAR.repeat(header.length));
+  });
+
+  test("footer length matches header length with stage name", () => {
+    const lines = formatPromptForDisplay("Hello", "Create PR");
+    const header = lines[0];
+    const footer = lines[lines.length - 1];
+
+    expect(footer).toBeDefined();
+    expect(footer).toHaveLength(header.length);
+    expect(footer).toBe(PROMPT_SEPARATOR_CHAR.repeat(header.length));
+  });
+
+  test("includes stage name in header when provided", () => {
+    const lines = formatPromptForDisplay("Hello", "Self-check");
+
+    expect(lines[0]).toContain("Prompt (Self-check)");
+  });
+
+  test("omits stage name from header when not provided", () => {
+    const lines = formatPromptForDisplay("Hello");
+
+    expect(lines[0]).toContain(" Prompt ");
+    expect(lines[0]).not.toContain("(");
+  });
+
   test("truncates long prompts to 8 lines with remainder count", () => {
     const prompt = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
     const lines = formatPromptForDisplay(prompt);

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -17,23 +17,33 @@ export const PROMPT_LINE_PREFIX = "\u25B6 ";
 /** Prefix for the prompt separator lines. */
 export const PROMPT_SEPARATOR_CHAR = "\u2504";
 
+/** Number of separator characters on each side of the header label. */
+const SEPARATOR_HALF_LENGTH = 36;
+
 /**
  * Format a prompt string for display in the agent pane.
  *
  * The prompt is truncated to `MAX_PROMPT_LINES` lines with an
  * indicator showing how many lines were omitted.  Each line is
  * prefixed with `▶ ` so the renderer can apply distinct styling.
+ *
+ * When `stageName` is provided the header includes it for context,
+ * e.g. `┄┄ Prompt (Create PR) ┄┄`.  The footer is always computed
+ * dynamically to match the header length.
  */
-export function formatPromptForDisplay(prompt: string): string[] {
+export function formatPromptForDisplay(
+  prompt: string,
+  stageName?: string,
+): string[] {
   const rawLines = prompt.split("\n");
   const truncated = rawLines.length > MAX_PROMPT_LINES;
   const shown = truncated ? rawLines.slice(0, MAX_PROMPT_LINES) : rawLines;
 
-  const separator = PROMPT_SEPARATOR_CHAR.repeat(36);
-  const result = [
-    `${separator} Prompt ${separator}`,
-    ...shown.map((l) => `${PROMPT_LINE_PREFIX}${l}`),
-  ];
+  const label = stageName ? ` Prompt (${stageName}) ` : " Prompt ";
+  const halfSep = PROMPT_SEPARATOR_CHAR.repeat(SEPARATOR_HALF_LENGTH);
+  const header = `${halfSep}${label}${halfSep}`;
+
+  const result = [header, ...shown.map((l) => `${PROMPT_LINE_PREFIX}${l}`)];
 
   if (truncated) {
     result.push(
@@ -41,7 +51,7 @@ export function formatPromptForDisplay(prompt: string): string[] {
     );
   }
 
-  result.push(separator.repeat(2));
+  result.push(PROMPT_SEPARATOR_CHAR.repeat(header.length));
 
   return result;
 }
@@ -64,6 +74,19 @@ export function useAgentLines(
   const [lines, setLines] = useState<string[]>([]);
   const [pendingLine, setPendingLine] = useState("");
   const bufferRef = useRef("");
+  const stageNameRef = useRef<string | undefined>(undefined);
+
+  // Track the current stage name so prompt headers can include it.
+  useEffect(() => {
+    const handler = (ev: { stageName: string }) => {
+      stageNameRef.current = ev.stageName;
+    };
+
+    emitter.on("stage:enter", handler);
+    return () => {
+      emitter.off("stage:enter", handler);
+    };
+  }, [emitter]);
 
   useEffect(() => {
     const handler = (ev: { agent: "a" | "b"; chunk: string }) => {
@@ -96,7 +119,7 @@ export function useAgentLines(
     const handler = (ev: { agent: "a" | "b"; prompt: string }) => {
       if (ev.agent !== agent) return;
 
-      const formatted = formatPromptForDisplay(ev.prompt);
+      const formatted = formatPromptForDisplay(ev.prompt, stageNameRef.current);
 
       // Flush any pending partial line before injecting prompt lines
       // so the prompt appears on its own visual block.


### PR DESCRIPTION
## Summary

- Compute the prompt footer length dynamically from the header so header and footer always have the same width (previously 80 vs 72 chars).
- Include the current pipeline stage name in the prompt header (e.g. `┄┄ Prompt (Create PR) ┄┄`) so users can tell which stage generated the prompt when scrolling through output.
- Track `stage:enter` events in `useAgentLines` to supply the stage name to `formatPromptForDisplay`.

Closes #131
Part of #89

## Test plan

- [x] Header and footer have the same character length when no stage name is provided
- [x] Header and footer have the same character length when a stage name is provided
- [x] Header includes stage name in parentheses when a stage name is provided (e.g. `Prompt (Self-check)`)
- [x] Header shows only `Prompt` with no parentheses when no stage name is provided
- [x] All existing `formatPromptForDisplay` tests still pass
- [x] Type check (`pnpm tsc --noEmit`) passes
- [x] Linter (`pnpm biome check`) passes