### PR TITLE
Show pipeline settings in quick-start preview (#128)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -8,6 +8,7 @@ export const en: Messages = {
   "quickStart.agentB": (model) => `  Agent B: ${model}`,
   "quickStart.mode": (exec) => `  Mode: ${exec}`,
   "quickStart.language": (lang) => `  Language: ${lang}`,
+  "quickStart.pipelineSettings": "  Pipeline settings:",
   "quickStart.usePrevious": "Use previous settings?",
 
   // ---- startup / config --------------------------------------------------

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -8,6 +8,7 @@ export const ko: Messages = {
   "quickStart.agentB": (model) => `  에이전트 B: ${model}`,
   "quickStart.mode": (exec) => `  모드: ${exec}`,
   "quickStart.language": (lang) => `  언어: ${lang}`,
+  "quickStart.pipelineSettings": "  파이프라인 설정:",
   "quickStart.usePrevious": "이전 설정을 사용하시겠습니까?",
 
   // ---- startup / config --------------------------------------------------

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -12,6 +12,7 @@ export interface Messages {
   "quickStart.agentB": (model: string) => string;
   "quickStart.mode": (exec: string) => string;
   "quickStart.language": (lang: string) => string;
+  "quickStart.pipelineSettings": string;
   "quickStart.usePrevious": string;
 
   // ---- startup / config (startup.ts) -------------------------------------

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -1629,6 +1629,11 @@ describe("runStartup — quick-start", () => {
     expect(logs).toContain("Agent B: GPT-5.4 / Extra High");
     expect(logs).toContain("Mode: auto");
     expect(logs).toContain("Language: English");
+    expect(logs).toContain("Pipeline settings:");
+    expect(logs).toContain("Self-check auto iterations");
+    expect(logs).toContain("Review auto rounds");
+    expect(logs).toContain("Inactivity timeout");
+    expect(logs).toContain("Auto-resume attempts");
 
     consoleSpy.mockRestore();
   });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -165,6 +165,13 @@ export async function runStartup(
           : m["startup.languageEnglish"],
       ),
     );
+    const ps = config.pipelineSettings;
+    const labels = settingLabels();
+    console.log(m["quickStart.pipelineSettings"]);
+    for (const key of SETTING_KEYS) {
+      const label = labels[key].padEnd(30);
+      console.log(`    ${label} ${formatSettingValue(key, ps[key])}`);
+    }
     console.log();
 
     const reuse = await confirm({


### PR DESCRIPTION
## Summary

- Display all pipeline settings (self-check auto iterations, review rounds, inactivity timeout, auto-resume attempts) in the quick-start saved configuration preview
- Reuse existing `settingLabels()` and `formatSettingValue()` helpers with `SETTING_KEYS` to stay consistent with the settings adjustment screen
- Add i18n support for the "Pipeline settings:" label in English and Korean
- Add test assertions verifying all pipeline settings appear in the quick-start output

Closes #128

## Test plan

- [x] Run `pnpm vitest run` — all tests pass including new quick-start assertions
- [x] Launch the app with a saved configuration and verify the quick-start preview now shows pipeline settings (self-check auto iterations, review rounds, inactivity timeout, auto-resume attempts) below the agent/mode/language summary
- [x] Verify the pipeline settings display matches the format used in the settings adjustment screen
- [x] Test with Korean locale to verify the translated "파이프라인 설정:" label appears correctly