### PR TITLE
Add conflict detection and agent rebase to done stage (#135)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -110,6 +110,15 @@ export const en: Messages = {
     "Has the PR been merged? Confirm to clean up the worktree.",
   "pipeline.worktreeCleanedUp": "Worktree cleaned up.",
   "pipeline.worktreePreserved": "Worktree preserved (merge not confirmed).",
+  "pipeline.conflictsDetected":
+    "Pipeline completed, but merge conflicts with main detected.",
+  "pipeline.unknownMergeable":
+    "Could not determine merge status after retries.",
+  "pipeline.rebaseSuccess": "Agent rebased onto main successfully.",
+  "pipeline.rebaseFailed":
+    "Agent could not resolve conflicts. Please resolve manually.",
+  "pipeline.stillConflicting": "Still conflicting after resolution attempt.",
+  "pipeline.ciPassedAfterRebase": "CI passed after rebase.",
 
   // ---- TUI user prompts --------------------------------------------------
 
@@ -133,7 +142,11 @@ export const en: Messages = {
   "prompt.proceed": "Proceed",
   "prompt.yesMerged": "Yes, merged",
   "prompt.noKeepWorktree": "No, keep worktree",
-  "prompt.ok": "OK",
+  "prompt.agentRebase": "Let agent rebase",
+  "prompt.manualResolve": "Resolve manually",
+  "prompt.recheck": "Re-check",
+  "prompt.exit": "Exit",
+  "prompt.pressAnyKeyWhenDone": "Press Enter when done.",
 
   // ---- status bar --------------------------------------------------------
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -129,11 +129,18 @@ export const ko: Messages = {
   "pipeline.pipelineCompleted": (owner, repo, issue) =>
     `${owner}/${repo}#${issue} \uD30C\uC774\uD504\uB77C\uC778\uC774 \uC644\uB8CC\uB418\uC5C8\uC2B5\uB2C8\uB2E4.`,
   "pipeline.mergeConfirm":
-    "PR\uC774 \uBCD1\uD569\uB418\uC5C8\uC2B5\uB2C8\uAE4C? \uD655\uC778\uD558\uBA74 \uC6CC\uD06C\uD2B8\uB9AC\uB97C \uC815\uB9AC\uD569\uB2C8\uB2E4.",
-  "pipeline.worktreeCleanedUp":
-    "\uC6CC\uD06C\uD2B8\uB9AC\uAC00 \uC815\uB9AC\uB418\uC5C8\uC2B5\uB2C8\uB2E4.",
-  "pipeline.worktreePreserved":
-    "\uC6CC\uD06C\uD2B8\uB9AC\uAC00 \uBCF4\uC874\uB418\uC5C8\uC2B5\uB2C8\uB2E4 (\uBCD1\uD569 \uBBF8\uD655\uC778).",
+    "PR이 병합되었습니까? 확인하면 워크트리를 정리합니다.",
+  "pipeline.worktreeCleanedUp": "워크트리가 정리되었습니다.",
+  "pipeline.worktreePreserved": "워크트리가 보존되었습니다 (병합 미확인).",
+  "pipeline.conflictsDetected":
+    "파이프라인이 완료되었지만 main과 병합 충돌이 감지되었습니다.",
+  "pipeline.unknownMergeable": "재시도 후에도 병합 상태를 확인할 수 없습니다.",
+  "pipeline.rebaseSuccess":
+    "에이전트가 main으로 리베이스를 성공적으로 완료했습니다.",
+  "pipeline.rebaseFailed":
+    "에이전트가 충돌을 해결하지 못했습니다. 수동으로 해결해 주세요.",
+  "pipeline.stillConflicting": "해결 시도 후에도 여전히 충돌이 있습니다.",
+  "pipeline.ciPassedAfterRebase": "리베이스 후 CI를 통과했습니다.",
 
   // ---- TUI user prompts --------------------------------------------------
 
@@ -157,10 +164,13 @@ export const ko: Messages = {
   "prompt.ambiguous": (message) =>
     `\uBAA8\uD638\uD55C \uC5D0\uC774\uC804\uD2B8 \uC751\uB2F5:\n${message}`,
   "prompt.proceed": "\uC9C4\uD589",
-  "prompt.yesMerged": "\uC608, \uBCD1\uD569\uB428",
-  "prompt.noKeepWorktree":
-    "\uC544\uB2C8\uC624, \uC6CC\uD06C\uD2B8\uB9AC \uC720\uC9C0",
-  "prompt.ok": "\uD655\uC778",
+  "prompt.yesMerged": "예, 병합됨",
+  "prompt.noKeepWorktree": "아니오, 워크트리 유지",
+  "prompt.agentRebase": "에이전트 리베이스",
+  "prompt.manualResolve": "수동 해결",
+  "prompt.recheck": "재확인",
+  "prompt.exit": "종료",
+  "prompt.pressAnyKeyWhenDone": "완료되면 Enter를 누르세요.",
 
   // ---- status bar --------------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -109,6 +109,12 @@ export interface Messages {
   "pipeline.mergeConfirm": string;
   "pipeline.worktreeCleanedUp": string;
   "pipeline.worktreePreserved": string;
+  "pipeline.conflictsDetected": string;
+  "pipeline.unknownMergeable": string;
+  "pipeline.rebaseSuccess": string;
+  "pipeline.rebaseFailed": string;
+  "pipeline.stillConflicting": string;
+  "pipeline.ciPassedAfterRebase": string;
 
   // ---- TUI user prompts (TuiUserPrompt.ts) -------------------------------
 
@@ -130,7 +136,11 @@ export interface Messages {
   "prompt.proceed": string;
   "prompt.yesMerged": string;
   "prompt.noKeepWorktree": string;
-  "prompt.ok": string;
+  "prompt.agentRebase": string;
+  "prompt.manualResolve": string;
+  "prompt.recheck": string;
+  "prompt.exit": string;
+  "prompt.pressAnyKeyWhenDone": string;
 
   // ---- status bar (StatusBar.tsx) ----------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { render } from "ink";
 import React from "react";
 
 import type { AgentAdapter, AgentStream } from "./agent.js";
+import { pollCiAndFix } from "./ci-poll.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
 import {
   closePr,
@@ -30,7 +31,7 @@ import type {
 } from "./pipeline.js";
 import { createDoneStageHandler } from "./pipeline.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
-import { findPrNumber } from "./pr.js";
+import { checkMergeable, findPrNumber } from "./pr.js";
 import {
   deleteRunState,
   loadRunState,
@@ -45,8 +46,10 @@ import { createReviewStageHandler } from "./stage-review.js";
 import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
 import { createSquashStageHandler } from "./stage-squash.js";
 import { createTestPlanStageHandler } from "./stage-testplan.js";
+import { drainToSink } from "./stage-util.js";
 import type { AgentConfig } from "./startup.js";
 import { modelDisplayName, runStartup, selectTarget } from "./startup.js";
+import { parseStepStatus } from "./step-parser.js";
 import { App } from "./ui/App.js";
 import {
   bootstrapRepo,
@@ -541,19 +544,92 @@ try {
   let tuiPrompt:
     | {
         confirmMerge: UserPrompt["confirmMerge"];
-        reportCompletion: UserPrompt["reportCompletion"];
+        handleConflict: UserPrompt["handleConflict"];
+        handleUnknownMergeable: UserPrompt["handleUnknownMergeable"];
+        waitForManualResolve: UserPrompt["waitForManualResolve"];
         confirmCleanup: UserPrompt["confirmCleanup"];
       }
     | undefined;
 
   const doneStage = createDoneStageHandler({
-    reportCompletion: async (msg) => {
-      if (tuiPrompt) return tuiPrompt.reportCompletion(msg);
-      console.log(msg);
+    checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
+    prompt: {
+      confirmMerge: async (msg) => {
+        if (tuiPrompt) return tuiPrompt.confirmMerge(msg);
+        return true;
+      },
+      handleConflict: async (msg) => {
+        if (tuiPrompt) return tuiPrompt.handleConflict(msg);
+        return "manual";
+      },
+      handleUnknownMergeable: async (msg) => {
+        if (tuiPrompt) return tuiPrompt.handleUnknownMergeable(msg);
+        return "exit";
+      },
+      waitForManualResolve: async (msg) => {
+        if (tuiPrompt) return tuiPrompt.waitForManualResolve(msg);
+      },
     },
-    confirmMerge: async (msg) => {
-      if (tuiPrompt) return tuiPrompt.confirmMerge(msg);
-      return true;
+    rebaseOntoMain: async (ctx) => {
+      const rebasePrompt = [
+        `You are rebasing a feature branch onto the latest main.`,
+        ``,
+        `## Repository`,
+        `- Owner: ${ctx.owner}`,
+        `- Repo: ${ctx.repo}`,
+        `- Branch: ${ctx.branch}`,
+        `- Worktree: ${ctx.worktreePath}`,
+        ``,
+        `## Instructions`,
+        ``,
+        `1. Run \`git fetch origin ${defaultBranch}\` to get the latest main.`,
+        `2. Run \`git rebase origin/${defaultBranch}\` to rebase onto main.`,
+        `3. Resolve any merge conflicts that arise.`,
+        `4. After resolving conflicts, verify the result locally:`,
+        `   - Build the project to ensure it compiles.`,
+        `   - Run the full test suite to ensure nothing is broken.`,
+        `5. Only if the build and all tests pass, force-push the branch:`,
+        `   \`git push --force-with-lease\``,
+        ``,
+        `IMPORTANT: If you cannot resolve conflicts cleanly or if the`,
+        `build/tests fail after resolution, do NOT push. Instead, abort`,
+        `the rebase (\`git rebase --abort\`) and report failure.`,
+        ``,
+        `When you are done, end your response with exactly one of:`,
+        `- COMPLETED — if the rebase succeeded and was force-pushed.`,
+        `- BLOCKED — if you could not resolve conflicts or tests failed.`,
+      ].join("\n");
+
+      ctx.promptSinks?.a?.(rebasePrompt);
+      const stream = agentA.invoke(rebasePrompt, {
+        cwd: ctx.worktreePath,
+        onUsage: ctx.usageSinks?.a,
+      });
+      if (ctx.streamSinks?.a) {
+        drainToSink(stream, ctx.streamSinks.a);
+      }
+      const result = await stream.result;
+
+      if (result.sessionId) {
+        ctx.onSessionId?.("a", result.sessionId);
+      }
+
+      if (result.status === "error") {
+        return { success: false, message: result.responseText };
+      }
+
+      const parsed = parseStepStatus(result.responseText);
+      const success =
+        parsed.status === "completed" || parsed.status === "fixed";
+      return { success, message: result.responseText };
+    },
+    pollCiAndFix: async (ctx) => {
+      return pollCiAndFix({
+        ctx,
+        agent: agentA,
+        issueTitle,
+        issueBody,
+      });
     },
     cleanup: () => removeWorktree(owner, repo, issueNumber, wt.branch),
     stopServices: () => {

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -38,7 +38,9 @@ function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
       .fn()
       .mockResolvedValue({ action: "halt" satisfies UserAction }),
     confirmMerge: vi.fn().mockResolvedValue(true),
-    reportCompletion: vi.fn().mockResolvedValue(undefined),
+    handleConflict: vi.fn().mockResolvedValue("manual"),
+    handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
+    waitForManualResolve: vi.fn().mockResolvedValue(undefined),
     confirmCleanup: vi.fn().mockResolvedValue(false),
     ...overrides,
   };
@@ -1049,17 +1051,36 @@ describe("runPipeline — backward stage transition", () => {
 // ---------------------------------------------------------------------------
 // createDoneStageHandler
 // ---------------------------------------------------------------------------
+function makeDonePrompt(
+  overrides: Partial<
+    Parameters<typeof createDoneStageHandler>[0]["prompt"]
+  > = {},
+) {
+  return {
+    confirmMerge: vi.fn().mockResolvedValue(true),
+    handleConflict: vi.fn().mockResolvedValue("manual"),
+    handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
+    waitForManualResolve: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
 function makeDoneOpts(
   overrides: Partial<Parameters<typeof createDoneStageHandler>[0]> = {},
 ) {
+  const { prompt: promptOverrides, ...rest } = overrides;
   return {
-    reportCompletion: vi.fn().mockResolvedValue(undefined),
-    confirmMerge: vi.fn().mockResolvedValue(true),
+    checkMergeable: vi.fn().mockResolvedValue("MERGEABLE"),
+    prompt: makeDonePrompt(promptOverrides),
+    rebaseOntoMain: vi.fn().mockResolvedValue({ success: true, message: "ok" }),
+    pollCiAndFix: vi
+      .fn()
+      .mockResolvedValue({ passed: true, message: "CI passed" }),
     cleanup: vi.fn(),
     stopServices: vi.fn(),
     hasRunningServices: vi.fn().mockReturnValue(false),
     onNotMerged: vi.fn().mockResolvedValue(undefined),
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -1070,7 +1091,7 @@ describe("createDoneStageHandler", () => {
     expect(stage.name).toBe("Done");
   });
 
-  test("reports completion, confirms merge, stops services, then cleans up", async () => {
+  test("MERGEABLE: confirms merge, stops services, then cleans up", async () => {
     const opts = makeDoneOpts();
     const stage = createDoneStageHandler(opts);
     const ctx: StageContext = {
@@ -1080,8 +1101,8 @@ describe("createDoneStageHandler", () => {
       userInstruction: undefined,
     };
     const result = await stage.handler(ctx);
-    expect(opts.reportCompletion).toHaveBeenCalledOnce();
-    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.checkMergeable).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
     expect(opts.stopServices).toHaveBeenCalledOnce();
     expect(opts.cleanup).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
@@ -1089,9 +1110,9 @@ describe("createDoneStageHandler", () => {
     expect(result.message).toContain("cleaned up");
   });
 
-  test("calls onNotMerged when merge not confirmed", async () => {
+  test("MERGEABLE: calls onNotMerged when merge not confirmed", async () => {
     const opts = makeDoneOpts({
-      confirmMerge: vi.fn().mockResolvedValue(false),
+      prompt: { confirmMerge: vi.fn().mockResolvedValue(false) },
     });
     const stage = createDoneStageHandler(opts);
     const ctx: StageContext = {
@@ -1101,19 +1122,237 @@ describe("createDoneStageHandler", () => {
       userInstruction: undefined,
     };
     const result = await stage.handler(ctx);
-    expect(opts.reportCompletion).toHaveBeenCalledOnce();
-    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
     expect(opts.cleanup).not.toHaveBeenCalled();
     expect(opts.onNotMerged).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
     expect(result.message).toContain("org/repo#5");
   });
 
-  test("abort during reportCompletion skips confirmMerge", async () => {
+  test("UNKNOWN: exits to cleanup when user chooses exit", async () => {
+    const opts = makeDoneOpts({
+      checkMergeable: vi.fn().mockResolvedValue("UNKNOWN"),
+      prompt: { handleUnknownMergeable: vi.fn().mockResolvedValue("exit") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.prompt.handleUnknownMergeable).toHaveBeenCalledOnce();
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("UNKNOWN: re-check then MERGEABLE proceeds to merge confirmation", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("UNKNOWN")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { handleUnknownMergeable: vi.fn().mockResolvedValue("recheck") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(checkMergeable).toHaveBeenCalledTimes(2);
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("cleaned up");
+  });
+
+  test("CONFLICTING: agent rebase succeeds, CI passes, then merge confirmation", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { handleConflict: vi.fn().mockResolvedValue("agent_rebase") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.rebaseOntoMain).toHaveBeenCalledOnce();
+    expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("cleaned up");
+  });
+
+  test("CONFLICTING: manual resolve, CI passes, then merge confirmation", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { handleConflict: vi.fn().mockResolvedValue("manual") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.rebaseOntoMain).not.toHaveBeenCalled();
+    expect(opts.prompt.waitForManualResolve).toHaveBeenCalledOnce();
+    expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("CONFLICTING: agent rebase fails, falls back to manual", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      rebaseOntoMain: vi
+        .fn()
+        .mockResolvedValue({ success: false, message: "conflict" }),
+      prompt: {
+        handleConflict: vi.fn().mockResolvedValue("agent_rebase"),
+      },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.rebaseOntoMain).toHaveBeenCalledOnce();
+    // After agent failure, user sees rebaseFailed notification (via
+    // waitForManualResolve), not a second handleConflict prompt.
+    expect(opts.prompt.handleConflict).toHaveBeenCalledOnce();
+    expect(opts.prompt.waitForManualResolve).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("CONFLICTING: CI failure after resolution calls onNotMerged", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      pollCiAndFix: vi
+        .fn()
+        .mockResolvedValue({ passed: false, message: "CI fix exhausted" }),
+      prompt: { handleConflict: vi.fn().mockResolvedValue("manual") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toBe("CI fix exhausted");
+  });
+
+  test("CONFLICTING: still conflicting after manual resolve loops back", async () => {
+    // Flow: mergeableLoop → CONFLICTING → handleConflicting → manual →
+    // waitForManualResolve → afterResolution → CONFLICTING → undefined →
+    // loop back → mergeableLoop → CONFLICTING → handleConflicting →
+    // manual → waitForManualResolve → afterResolution → MERGEABLE →
+    // pollCiAndFix → askMerge.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const handleConflict = vi.fn().mockResolvedValue("manual");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { handleConflict },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(checkMergeable).toHaveBeenCalledTimes(4);
+    expect(handleConflict).toHaveBeenCalledTimes(2);
+    expect(opts.prompt.waitForManualResolve).toHaveBeenCalledTimes(2);
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("agent rebase limited to 1 attempt across loop-backs", async () => {
+    // Flow: mergeableLoop → CONFLICTING → handleConflicting → agent_rebase
+    // → rebaseOntoMain (rebaseAttempted=true) → afterResolution →
+    // CONFLICTING → undefined → loop back → mergeableLoop → CONFLICTING →
+    // handleConflicting (rebaseAttempted=true, skips to manual) →
+    // waitForManualResolve → afterResolution → MERGEABLE → pollCiAndFix →
+    // askMerge.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const handleConflict = vi.fn().mockResolvedValue("agent_rebase");
+    const rebaseOntoMain = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "ok" });
+    const opts = makeDoneOpts({
+      checkMergeable,
+      rebaseOntoMain,
+      prompt: { handleConflict },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    // Rebase called only once despite two CONFLICTING states.
+    expect(rebaseOntoMain).toHaveBeenCalledOnce();
+    // handleConflict shown only for the first CONFLICTING — the loop-back
+    // skips straight to waitForManualResolve because rebase was attempted.
+    expect(handleConflict).toHaveBeenCalledOnce();
+    // waitForManualResolve called for the loop-back (rebase already used).
+    expect(opts.prompt.waitForManualResolve).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("abort during checkMergeable skips everything", async () => {
     const controller = new AbortController();
     const opts = makeDoneOpts({
-      reportCompletion: vi.fn().mockImplementation(async () => {
+      checkMergeable: vi.fn().mockImplementation(async () => {
         controller.abort();
+        return "MERGEABLE";
       }),
     });
     const stage = createDoneStageHandler(opts);
@@ -1125,19 +1364,19 @@ describe("createDoneStageHandler", () => {
       signal: controller.signal,
     };
     await stage.handler(ctx);
-    expect(opts.reportCompletion).toHaveBeenCalledOnce();
-    expect(opts.confirmMerge).not.toHaveBeenCalled();
+    expect(opts.prompt.confirmMerge).not.toHaveBeenCalled();
     expect(opts.cleanup).not.toHaveBeenCalled();
-    expect(opts.onNotMerged).not.toHaveBeenCalled();
   });
 
   test("abort during confirmMerge skips cleanup and onNotMerged", async () => {
     const controller = new AbortController();
     const opts = makeDoneOpts({
-      confirmMerge: vi.fn().mockImplementation(async () => {
-        controller.abort();
-        return false;
-      }),
+      prompt: {
+        confirmMerge: vi.fn().mockImplementation(async () => {
+          controller.abort();
+          return false;
+        }),
+      },
     });
     const stage = createDoneStageHandler(opts);
     const ctx: StageContext = {
@@ -1148,40 +1387,18 @@ describe("createDoneStageHandler", () => {
       signal: controller.signal,
     };
     await stage.handler(ctx);
-    expect(opts.reportCompletion).toHaveBeenCalledOnce();
-    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
     expect(opts.cleanup).not.toHaveBeenCalled();
     expect(opts.stopServices).not.toHaveBeenCalled();
     expect(opts.onNotMerged).not.toHaveBeenCalled();
   });
 
-  test("abort during onNotMerged propagates signal", async () => {
+  test("full pipeline abort during stage 9 checkMergeable returns cancelled", async () => {
     const controller = new AbortController();
     const opts = makeDoneOpts({
-      confirmMerge: vi.fn().mockResolvedValue(false),
-      onNotMerged: vi.fn().mockImplementation(async (signal?: AbortSignal) => {
-        expect(signal).toBe(controller.signal);
+      checkMergeable: vi.fn().mockImplementation(async () => {
         controller.abort();
-      }),
-    });
-    const stage = createDoneStageHandler(opts);
-    const ctx: StageContext = {
-      ...BASE_CTX,
-      iteration: 0,
-      lastAutoIteration: false,
-      userInstruction: undefined,
-      signal: controller.signal,
-    };
-    await stage.handler(ctx);
-    expect(opts.onNotMerged).toHaveBeenCalledOnce();
-    expect(opts.onNotMerged).toHaveBeenCalledWith(controller.signal);
-  });
-
-  test("full pipeline abort during stage 9 reportCompletion returns cancelled", async () => {
-    const controller = new AbortController();
-    const opts = makeDoneOpts({
-      reportCompletion: vi.fn().mockImplementation(async () => {
-        controller.abort();
+        return "MERGEABLE";
       }),
     });
     const stage = createDoneStageHandler(opts);
@@ -1193,16 +1410,18 @@ describe("createDoneStageHandler", () => {
     );
     expect(result.success).toBe(false);
     expect(result.cancelled).toBe(true);
-    expect(opts.confirmMerge).not.toHaveBeenCalled();
+    expect(opts.prompt.confirmMerge).not.toHaveBeenCalled();
   });
 
   test("full pipeline abort during stage 9 confirmMerge returns cancelled", async () => {
     const controller = new AbortController();
     const opts = makeDoneOpts({
-      confirmMerge: vi.fn().mockImplementation(async () => {
-        controller.abort();
-        return true;
-      }),
+      prompt: {
+        confirmMerge: vi.fn().mockImplementation(async () => {
+          controller.abort();
+          return true;
+        }),
+      },
     });
     const stage = createDoneStageHandler(opts);
     const result = await runPipeline(
@@ -1214,6 +1433,78 @@ describe("createDoneStageHandler", () => {
     expect(result.success).toBe(false);
     expect(result.cancelled).toBe(true);
     expect(opts.cleanup).not.toHaveBeenCalled();
+  });
+
+  test("CONFLICTING: agent rebase returning success: false does not advance to CI", async () => {
+    // When rebaseOntoMain returns success: false (e.g. agent could not
+    // resolve conflicts), the handler should fall back to manual resolve
+    // and NOT proceed directly to pollCiAndFix.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const rebaseOntoMain = vi.fn().mockResolvedValue({
+      success: false,
+      message: "I could not resolve the conflicts and aborted the rebase.",
+    });
+    const opts = makeDoneOpts({
+      checkMergeable,
+      rebaseOntoMain,
+      prompt: {
+        handleConflict: vi.fn().mockResolvedValue("agent_rebase"),
+      },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(rebaseOntoMain).toHaveBeenCalledOnce();
+    // After agent failure, waitForManualResolve is shown (not pollCiAndFix).
+    expect(opts.prompt.waitForManualResolve).toHaveBeenCalledOnce();
+    // CI polling still happens after the manual resolve re-check.
+    expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("CONFLICTING: resolve then UNKNOWN routes to unknown-state prompt", async () => {
+    // Flow: CONFLICTING → manual resolve → afterResolution →
+    // checkMergeable UNKNOWN → handleUnknownMergeable (exit).
+    // afterResolution shows the unknown-state prompt directly instead
+    // of returning to the outer loop for another full backoff cycle.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("UNKNOWN");
+    const handleUnknownMergeable = vi.fn().mockResolvedValue("exit");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: {
+        handleConflict: vi.fn().mockResolvedValue("manual"),
+        handleUnknownMergeable,
+      },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    // checkMergeable called only 2 times: initial CONFLICTING, then
+    // afterResolution UNKNOWN.  No second backoff cycle.
+    expect(checkMergeable).toHaveBeenCalledTimes(2);
+    // The unknown-state prompt must be shown directly from afterResolution.
+    expect(handleUnknownMergeable).toHaveBeenCalledOnce();
+    // pollCiAndFix must NOT be called — UNKNOWN was not treated as MERGEABLE.
+    expect(opts.pollCiAndFix).not.toHaveBeenCalled();
+    // onNotMerged is called because user chose "exit".
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
   });
 });
 
@@ -1521,8 +1812,8 @@ describe("E2E — multi-stage pipeline", () => {
     ];
     const result = await runPipeline(makePipelineOpts({ stages }));
     expect(result.success).toBe(true);
-    expect(opts.reportCompletion).toHaveBeenCalledOnce();
-    expect(opts.confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.checkMergeable).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).toHaveBeenCalledOnce();
     expect(opts.cleanup).toHaveBeenCalledOnce();
   });
 });

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -195,9 +195,22 @@ export interface UserPrompt {
   confirmMerge(message: string): Promise<boolean>;
 
   /**
-   * Report completion to the user (stage 9).
+   * Present a conflict notification and let the user choose between
+   * agent rebase and manual resolution (stage 9).
    */
-  reportCompletion(message: string): Promise<void>;
+  handleConflict(message: string): Promise<"agent_rebase" | "manual">;
+
+  /**
+   * Notify the user that the mergeable state could not be determined
+   * and let them choose to re-check or exit (stage 9).
+   */
+  handleUnknownMergeable(message: string): Promise<"recheck" | "exit">;
+
+  /**
+   * Wait for the user to signal that they have finished manual
+   * conflict resolution (stage 9).
+   */
+  waitForManualResolve(message: string): Promise<void>;
 
   /**
    * Ask user to confirm a cleanup action (e.g. stop services, delete
@@ -771,18 +784,45 @@ async function runStage(
 
 // ---- Stage 9: Done -------------------------------------------------------
 
-/**
- * Built-in stage-9 handler.  Reports completion, waits for the user to
- * confirm merge, then cleans up the worktree.
- *
- * Callbacks are injected so the handler stays independent of the
- * worktree module, keeping the engine testable.
- */
-export function createDoneStageHandler(options: {
-  /** Called to report completion before asking about merge. */
-  reportCompletion: (message: string) => Promise<void>;
-  /** Called to ask the user whether the PR has been merged. */
-  confirmMerge: (message: string) => Promise<boolean>;
+/** Result of the `checkMergeable` callback. */
+export type MergeableState = "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+
+/** Result of the `rebaseOntoMain` callback. */
+export interface RebaseResult {
+  /** Whether the rebase succeeded and was force-pushed. */
+  success: boolean;
+  /** Descriptive message (success note or error detail). */
+  message: string;
+}
+
+/** Options for {@link createDoneStageHandler}. */
+export interface DoneStageOptions {
+  /**
+   * Check whether the PR has merge conflicts with the base branch.
+   * Returns the resolved mergeable state (with retries for UNKNOWN).
+   */
+  checkMergeable: (ctx: StageContext) => Promise<MergeableState>;
+  /** Prompt the user for conflict/unknown/merge choices. */
+  prompt: {
+    confirmMerge: (message: string) => Promise<boolean>;
+    handleConflict: (message: string) => Promise<"agent_rebase" | "manual">;
+    handleUnknownMergeable: (message: string) => Promise<"recheck" | "exit">;
+    waitForManualResolve: (message: string) => Promise<void>;
+  };
+  /**
+   * Invoke agent A to rebase onto origin/main, resolve conflicts,
+   * verify locally (build + full test suite), and only force-push
+   * when confident.  Limited to 1 attempt.
+   */
+  rebaseOntoMain: (ctx: StageContext) => Promise<RebaseResult>;
+  /**
+   * Poll CI and invoke the agent to fix failures after a rebase
+   * or manual conflict resolution.  Re-uses the `pollCiAndFix`
+   * pattern from the ci-check stage.
+   */
+  pollCiAndFix: (
+    ctx: StageContext,
+  ) => Promise<{ passed: boolean; message: string }>;
   /** Called to remove the worktree after merge is confirmed. */
   cleanup: () => void;
   /** Called to stop docker compose services. */
@@ -796,7 +836,18 @@ export function createDoneStageHandler(options: {
    * can bail out early on cancellation.
    */
   onNotMerged: (signal?: AbortSignal) => Promise<void>;
-}): StageDefinition {
+}
+
+/**
+ * Built-in stage-9 handler.  Checks for merge conflicts, offers
+ * agent rebase or manual resolution, then asks about merge.
+ *
+ * Callbacks are injected so the handler stays independent of the
+ * worktree module and GitHub CLI, keeping the engine testable.
+ */
+export function createDoneStageHandler(
+  options: DoneStageOptions,
+): StageDefinition {
   return {
     name: t()["stage.done"],
     number: 9,
@@ -807,34 +858,188 @@ export function createDoneStageHandler(options: {
         ctx.repo,
         ctx.issueNumber,
       );
-      await options.reportCompletion(summary);
 
-      // Bail out if cancelled during reportCompletion — runStage's
-      // post-handler signal check converts this into an abort result.
-      if (ctx.signal?.aborted) {
-        return { outcome: "completed", message: "" };
-      }
+      // Agent rebase is limited to 1 attempt across all loop-backs.
+      let rebaseAttempted = false;
 
-      const merged = await options.confirmMerge(m["pipeline.mergeConfirm"]);
+      // ---- Check mergeable state ------------------------------------------
+      const mergeableLoop = async (): Promise<
+        { done: true; result: StageResult } | { done: false }
+      > => {
+        const state = await options.checkMergeable(ctx);
+        if (ctx.signal?.aborted) {
+          return { done: true, result: { outcome: "completed", message: "" } };
+        }
 
-      if (ctx.signal?.aborted) {
-        return { outcome: "completed", message: "" };
-      }
+        if (state === "UNKNOWN") {
+          const choice = await options.prompt.handleUnknownMergeable(
+            m["pipeline.unknownMergeable"],
+          );
+          if (ctx.signal?.aborted) {
+            return {
+              done: true,
+              result: { outcome: "completed", message: "" },
+            };
+          }
+          if (choice === "recheck") {
+            return { done: false }; // caller will loop
+          }
+          // "exit" — fall through to onNotMerged cleanup
+          await options.onNotMerged(ctx.signal);
+          return {
+            done: true,
+            result: { outcome: "completed", message: summary },
+          };
+        }
 
-      if (merged) {
-        options.stopServices();
-        options.cleanup();
-        return {
-          outcome: "completed",
-          message: `${summary} ${m["pipeline.worktreeCleanedUp"]}`,
-        };
-      }
+        if (state === "CONFLICTING") {
+          const resolved = await handleConflicting(ctx, summary);
+          if (resolved === undefined) {
+            return { done: false }; // still conflicting after manual, re-check
+          }
+          return { done: true, result: resolved };
+        }
 
-      await options.onNotMerged(ctx.signal);
-      return {
-        outcome: "completed",
-        message: summary,
+        // MERGEABLE — proceed to merge confirmation.
+        return { done: true, result: await askMerge(ctx, summary) };
       };
+
+      // Allow the user to loop back via "re-check" or "still conflicting
+      // after manual resolve".
+      for (;;) {
+        const outcome = await mergeableLoop();
+        if (outcome.done) return outcome.result;
+      }
+
+      // ---- helper: CONFLICTING path --------------------------------------
+
+      async function handleConflicting(
+        ctx: StageContext,
+        summary: string,
+      ): Promise<StageResult | undefined> {
+        const m = t();
+
+        // When agent rebase was already attempted, skip straight to manual.
+        if (rebaseAttempted) {
+          await options.prompt.waitForManualResolve(
+            m["prompt.pressAnyKeyWhenDone"],
+          );
+          if (ctx.signal?.aborted) {
+            return { outcome: "completed", message: "" };
+          }
+          return afterResolution(ctx, summary);
+        }
+
+        const choice = await options.prompt.handleConflict(
+          m["pipeline.conflictsDetected"],
+        );
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+
+        if (choice === "agent_rebase") {
+          rebaseAttempted = true;
+          const rebaseResult = await options.rebaseOntoMain(ctx);
+          if (ctx.signal?.aborted) {
+            return { outcome: "completed", message: "" };
+          }
+          if (!rebaseResult.success) {
+            // Agent could not resolve — notify and fall back to manual.
+            await options.prompt.waitForManualResolve(
+              m["pipeline.rebaseFailed"],
+            );
+            if (ctx.signal?.aborted) {
+              return { outcome: "completed", message: "" };
+            }
+            return afterResolution(ctx, summary);
+          }
+          // Agent rebase succeeded — re-check mergeable.
+          return afterResolution(ctx, summary);
+        }
+
+        // Manual resolve.
+        await options.prompt.waitForManualResolve(
+          m["prompt.pressAnyKeyWhenDone"],
+        );
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+        return afterResolution(ctx, summary);
+      }
+
+      // ---- helper: after conflict resolution -------------------------------
+
+      async function afterResolution(
+        ctx: StageContext,
+        summary: string,
+      ): Promise<StageResult | undefined> {
+        // Re-check mergeable after resolution.
+        const state = await options.checkMergeable(ctx);
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+        if (state === "CONFLICTING") {
+          // Still conflicting — return undefined so the top-level loop
+          // re-enters mergeableLoop → handleConflicting.
+          return undefined;
+        }
+        if (state === "UNKNOWN") {
+          // checkMergeable already exhausted its retry budget.  Show the
+          // unknown-state prompt immediately instead of re-running the
+          // full backoff cycle a second time.
+          const choice = await options.prompt.handleUnknownMergeable(
+            m["pipeline.unknownMergeable"],
+          );
+          if (ctx.signal?.aborted) {
+            return { outcome: "completed", message: "" };
+          }
+          if (choice === "recheck") {
+            return undefined; // re-enter outer loop (one fresh check)
+          }
+          // "exit"
+          await options.onNotMerged(ctx.signal);
+          return { outcome: "completed", message: summary };
+        }
+
+        // MERGEABLE — poll CI after resolution.
+        const ciResult = await options.pollCiAndFix(ctx);
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+        if (!ciResult.passed) {
+          // CI fix exhausted — notify user, still complete the stage.
+          await options.onNotMerged(ctx.signal);
+          return { outcome: "completed", message: ciResult.message };
+        }
+
+        // CI green — ask about merge.
+        return askMerge(ctx, summary);
+      }
     },
   };
+
+  // ---- helper: MERGEABLE path (merge confirmation) -----------------------
+
+  async function askMerge(
+    ctx: StageContext,
+    summary: string,
+  ): Promise<StageResult> {
+    const m = t();
+    const merged = await options.prompt.confirmMerge(
+      `${summary}\n\n${m["pipeline.mergeConfirm"]}`,
+    );
+    if (ctx.signal?.aborted) {
+      return { outcome: "completed", message: "" };
+    }
+    if (merged) {
+      options.stopServices();
+      options.cleanup();
+      return {
+        outcome: "completed",
+        message: `${summary} ${m["pipeline.worktreeCleanedUp"]}`,
+      };
+    }
+    await options.onNotMerged(ctx.signal);
+    return { outcome: "completed", message: summary };
+  }
 }

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -5,7 +5,9 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
-const { findPrNumber } = await import("./pr.js");
+const { checkMergeable, findPrNumber, queryMergeableState } = await import(
+  "./pr.js"
+);
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -67,5 +69,163 @@ describe("findPrNumber", () => {
   test("returns undefined on malformed JSON output", () => {
     mockExecFileSync.mockReturnValue("not json at all");
     expect(findPrNumber("org", "repo", "issue-5")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryMergeableState
+// ---------------------------------------------------------------------------
+describe("queryMergeableState", () => {
+  test("returns MERGEABLE when gh reports mergeable", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ mergeable: "MERGEABLE" }),
+    );
+    expect(queryMergeableState("org", "repo", "branch")).toBe("MERGEABLE");
+  });
+
+  test("returns CONFLICTING when gh reports conflicting", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ mergeable: "CONFLICTING" }),
+    );
+    expect(queryMergeableState("org", "repo", "branch")).toBe("CONFLICTING");
+  });
+
+  test("returns UNKNOWN when gh reports unknown", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ mergeable: "UNKNOWN" }));
+    expect(queryMergeableState("org", "repo", "branch")).toBe("UNKNOWN");
+  });
+
+  test("returns UNKNOWN for unexpected mergeable value", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ mergeable: "SOMETHING_ELSE" }),
+    );
+    expect(queryMergeableState("org", "repo", "branch")).toBe("UNKNOWN");
+  });
+
+  test("returns UNKNOWN when gh command throws", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("gh: not authenticated");
+    });
+    expect(queryMergeableState("org", "repo", "branch")).toBe("UNKNOWN");
+  });
+
+  test("returns UNKNOWN on malformed JSON output", () => {
+    mockExecFileSync.mockReturnValue("not json");
+    expect(queryMergeableState("org", "repo", "branch")).toBe("UNKNOWN");
+  });
+
+  test("calls gh with correct arguments", () => {
+    mockExecFileSync.mockReturnValue(
+      JSON.stringify({ mergeable: "MERGEABLE" }),
+    );
+    queryMergeableState("aicers", "agentcoop", "feature-branch");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "pr",
+        "view",
+        "--repo",
+        "aicers/agentcoop",
+        "feature-branch",
+        "--json",
+        "mergeable",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkMergeable
+// ---------------------------------------------------------------------------
+describe("checkMergeable", () => {
+  const noDelay = async () => {};
+
+  test("returns MERGEABLE immediately when first query succeeds", async () => {
+    const query = vi.fn().mockReturnValue("MERGEABLE");
+    const result = await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay: noDelay,
+    });
+    expect(result).toBe("MERGEABLE");
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  test("returns CONFLICTING immediately without retrying", async () => {
+    const query = vi.fn().mockReturnValue("CONFLICTING");
+    const result = await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay: noDelay,
+    });
+    expect(result).toBe("CONFLICTING");
+    expect(query).toHaveBeenCalledOnce();
+  });
+
+  test("retries on UNKNOWN and resolves to MERGEABLE", async () => {
+    const query = vi
+      .fn()
+      .mockReturnValueOnce("UNKNOWN")
+      .mockReturnValueOnce("UNKNOWN")
+      .mockReturnValueOnce("MERGEABLE");
+    const result = await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay: noDelay,
+      maxRetries: 5,
+    });
+    expect(result).toBe("MERGEABLE");
+    expect(query).toHaveBeenCalledTimes(3);
+  });
+
+  test("returns UNKNOWN after exhausting retries", async () => {
+    const query = vi.fn().mockReturnValue("UNKNOWN");
+    const result = await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay: noDelay,
+      maxRetries: 3,
+    });
+    expect(result).toBe("UNKNOWN");
+    // 1 initial + 3 retries = 4 total
+    expect(query).toHaveBeenCalledTimes(4);
+  });
+
+  test("uses exponential backoff delays", async () => {
+    const query = vi.fn().mockReturnValue("UNKNOWN");
+    const delays: number[] = [];
+    const delay = async (ms: number) => {
+      delays.push(ms);
+    };
+    await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay,
+      maxRetries: 3,
+      initialDelayMs: 100,
+    });
+    expect(delays).toEqual([100, 200, 400]);
+  });
+
+  test("does not delay after last retry", async () => {
+    const query = vi.fn().mockReturnValue("UNKNOWN");
+    const delays: number[] = [];
+    const delay = async (ms: number) => {
+      delays.push(ms);
+    };
+    await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay,
+      maxRetries: 2,
+      initialDelayMs: 50,
+    });
+    // 2 retries → 2 delays (after attempt 0 and 1, not after attempt 2)
+    expect(delays).toEqual([50, 100]);
+  });
+
+  test("defaults to 5 retries when maxRetries not specified", async () => {
+    const query = vi.fn().mockReturnValue("UNKNOWN");
+    await checkMergeable("o", "r", "b", {
+      queryMergeable: query,
+      delay: noDelay,
+    });
+    // 1 initial + 5 retries = 6 total
+    expect(query).toHaveBeenCalledTimes(6);
   });
 });

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -1,7 +1,7 @@
 /**
  * Pull request utilities.
  *
- * Wraps `gh pr list` to extract the PR number for a given branch.
+ * Wraps `gh` CLI commands to query PR metadata.
  */
 
 import { execFileSync } from "node:child_process";
@@ -40,4 +40,109 @@ export function findPrNumber(
     return undefined;
   }
   return prs.length > 0 ? prs[0].number : undefined;
+}
+
+// ---- mergeable state ---------------------------------------------------------
+
+/**
+ * Possible values for the `mergeable` field returned by the GitHub
+ * GraphQL API via `gh pr view --json mergeable`.
+ */
+export type MergeableState = "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+
+/**
+ * Options for {@link checkMergeable}.  Every field is optional and
+ * has a sensible default; the explicit fields exist for testability.
+ */
+export interface CheckMergeableOptions {
+  /** Maximum number of retries when GitHub returns `UNKNOWN`. Default 5. */
+  maxRetries?: number;
+  /** Initial backoff delay in ms (doubles each retry). Default 2 000. */
+  initialDelayMs?: number;
+  /** Injected for testability.  Defaults to a real `setTimeout` delay. */
+  delay?: (ms: number) => Promise<void>;
+  /** Injected for testability.  Defaults to `gh pr view`. */
+  queryMergeable?: (
+    owner: string,
+    repo: string,
+    branch: string,
+  ) => MergeableState;
+}
+
+function defaultDelay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Query the raw mergeable state for the PR associated with `branch`.
+ *
+ * Shells out to `gh pr view --json mergeable`.  Returns `"UNKNOWN"`
+ * if the command fails or the output cannot be parsed.
+ */
+export function queryMergeableState(
+  owner: string,
+  repo: string,
+  branch: string,
+): MergeableState {
+  try {
+    const output = execFileSync(
+      "gh",
+      [
+        "pr",
+        "view",
+        "--repo",
+        `${owner}/${repo}`,
+        branch,
+        "--json",
+        "mergeable",
+      ],
+      { encoding: "utf-8" },
+    );
+    const parsed = JSON.parse(output) as { mergeable: string };
+    const state = parsed.mergeable;
+    if (
+      state === "MERGEABLE" ||
+      state === "CONFLICTING" ||
+      state === "UNKNOWN"
+    ) {
+      return state;
+    }
+    return "UNKNOWN";
+  } catch {
+    return "UNKNOWN";
+  }
+}
+
+/**
+ * Check whether the PR for `branch` is mergeable, retrying with
+ * exponential backoff when GitHub returns `UNKNOWN` (merge check
+ * still computing).
+ *
+ * Returns the resolved {@link MergeableState}.
+ */
+export async function checkMergeable(
+  owner: string,
+  repo: string,
+  branch: string,
+  options: CheckMergeableOptions = {},
+): Promise<MergeableState> {
+  const maxRetries = options.maxRetries ?? 5;
+  const initialDelay = options.initialDelayMs ?? 2_000;
+  const delay = options.delay ?? defaultDelay;
+  const query = options.queryMergeable ?? queryMergeableState;
+
+  let backoff = initialDelay;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const state = query(owner, repo, branch);
+    if (state !== "UNKNOWN") {
+      return state;
+    }
+    if (attempt < maxRetries) {
+      await delay(backoff);
+      backoff *= 2;
+    }
+  }
+
+  return "UNKNOWN";
 }

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -87,7 +87,9 @@ function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
       .fn()
       .mockResolvedValue({ action: "halt" satisfies UserAction }),
     confirmMerge: vi.fn().mockResolvedValue(true),
-    reportCompletion: vi.fn().mockResolvedValue(undefined),
+    handleConflict: vi.fn().mockResolvedValue("manual"),
+    handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
+    waitForManualResolve: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }

--- a/src/ui/TuiUserPrompt.test.ts
+++ b/src/ui/TuiUserPrompt.test.ts
@@ -201,17 +201,61 @@ describe("TuiUserPrompt", () => {
     });
   });
 
-  describe("reportCompletion", () => {
-    test("dispatches message and waits for acknowledgement", async () => {
-      const dispatch = makeDispatch("ok");
+  describe("handleConflict", () => {
+    test("returns agent_rebase when user selects agent rebase", async () => {
+      const dispatch = makeDispatch("agent_rebase");
       const prompt = createTuiUserPrompt(dispatch);
-      await prompt.reportCompletion("Pipeline done.");
+      expect(await prompt.handleConflict("conflicts detected")).toBe(
+        "agent_rebase",
+      );
+    });
+
+    test("returns manual when user selects manual resolve", async () => {
+      const dispatch = makeDispatch("manual");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.handleConflict("conflicts detected")).toBe("manual");
+    });
+
+    test("dispatches with agent_rebase and manual choices", async () => {
+      const dispatch = makeDispatch("manual");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.handleConflict("conflicts");
       expect(dispatch).toHaveBeenCalledWith(
         expect.objectContaining({
-          message: "Pipeline done.",
+          message: "conflicts",
           choices: expect.arrayContaining([
-            expect.objectContaining({ value: "ok" }),
+            expect.objectContaining({ value: "agent_rebase" }),
+            expect.objectContaining({ value: "manual" }),
           ]),
+        }),
+      );
+    });
+  });
+
+  describe("handleUnknownMergeable", () => {
+    test("returns recheck when user selects re-check", async () => {
+      const dispatch = makeDispatch("recheck");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.handleUnknownMergeable("unknown state")).toBe(
+        "recheck",
+      );
+    });
+
+    test("returns exit when user selects exit", async () => {
+      const dispatch = makeDispatch("exit");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.handleUnknownMergeable("unknown state")).toBe("exit");
+    });
+  });
+
+  describe("waitForManualResolve", () => {
+    test("dispatches message and waits for user input", async () => {
+      const dispatch = makeDispatch("");
+      const prompt = createTuiUserPrompt(dispatch);
+      await prompt.waitForManualResolve("Press Enter when done.");
+      expect(dispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Press Enter when done.",
         }),
       );
     });

--- a/src/ui/TuiUserPrompt.ts
+++ b/src/ui/TuiUserPrompt.ts
@@ -124,11 +124,32 @@ export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
       return response === "yes";
     },
 
-    async reportCompletion(message: string): Promise<void> {
-      await dispatch({
+    async handleConflict(message: string): Promise<"agent_rebase" | "manual"> {
+      const m = t();
+      const response = await dispatch({
         message,
-        choices: [{ label: t()["prompt.ok"], value: "ok" }],
+        choices: [
+          { label: m["prompt.agentRebase"], value: "agent_rebase" },
+          { label: m["prompt.manualResolve"], value: "manual" },
+        ],
       });
+      return response as "agent_rebase" | "manual";
+    },
+
+    async handleUnknownMergeable(message: string): Promise<"recheck" | "exit"> {
+      const m = t();
+      const response = await dispatch({
+        message,
+        choices: [
+          { label: m["prompt.recheck"], value: "recheck" },
+          { label: m["prompt.exit"], value: "exit" },
+        ],
+      });
+      return response as "recheck" | "exit";
+    },
+
+    async waitForManualResolve(message: string): Promise<void> {
+      await dispatch({ message });
     },
 
     async confirmCleanup(message: string): Promise<boolean> {


### PR DESCRIPTION
## Summary

- Replace the single-choice `reportCompletion` prompt with a proper conflict-aware flow in the done stage (stage 9)
- Add `checkMergeable` helper to `pr.ts` that queries `gh pr view --json mergeable` with exponential backoff retry for GitHub's `UNKNOWN` state
- When conflicts are detected, offer the user two choices: let agent A rebase onto `origin/main` (with local build + full test verification before force-push), or resolve manually
- After conflict resolution, re-check CI using the existing `pollCiAndFix` pattern; agent rebase is limited to 1 attempt
- Add `handleConflict`, `handleUnknownMergeable`, and `waitForManualResolve` methods to `TuiUserPrompt` with corresponding i18n keys (en + ko)
- Parse agent rebase response with `parseStepStatus` to distinguish actual success (COMPLETED) from failure (BLOCKED/ambiguous), instead of assuming any non-error response is success
- Route `UNKNOWN` mergeable state after conflict resolution back through the unknown-state prompt, instead of treating it optimistically as MERGEABLE

Closes #135

## Test plan

- [x] `checkMergeable` returns `MERGEABLE`/`CONFLICTING` immediately without retrying
- [x] `checkMergeable` retries with exponential backoff on `UNKNOWN` and resolves when state changes
- [x] `checkMergeable` returns `UNKNOWN` after exhausting retries
- [x] MERGEABLE path goes straight to merge confirmation (no conflict prompt)
- [x] CONFLICTING + agent rebase succeeds → CI poll → merge confirmation
- [x] CONFLICTING + agent rebase fails → falls back to manual resolve prompt
- [x] CONFLICTING + manual resolve → CI poll → merge confirmation
- [x] Still conflicting after manual resolve loops back to conflict prompt
- [x] Agent rebase limited to 1 attempt across loop-backs (second conflict skips to manual)
- [x] UNKNOWN + user chooses re-check → loops back to check mergeable
- [x] UNKNOWN + user chooses exit → cleanup flow
- [x] Abort signal during any step (checkMergeable, confirmMerge, rebase) cancels correctly
- [x] `reportCompletion` / `prompt.ok` fully removed from codebase
- [x] Agent rebase success: false does not advance to CI polling
- [x] CONFLICTING → resolve → UNKNOWN routes to unknown-state prompt (not optimistic)
- [x] All existing tests pass, new tests cover the conflict/unknown/rebase paths
- [x] Type check (`tsc --noEmit`) and lint (`biome check`) pass