### PR TITLE
Fix Ctrl+C pipeline cancellation (#137)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,6 @@
 #!/usr/bin/env node
 
 import { confirm, select } from "@inquirer/prompts";
-import { render } from "ink";
-import React from "react";
 
 import type { AgentAdapter, AgentStream } from "./agent.js";
 import { pollCiAndFix } from "./ci-poll.js";
@@ -50,7 +48,7 @@ import { drainToSink } from "./stage-util.js";
 import type { AgentConfig } from "./startup.js";
 import { modelDisplayName, runStartup, selectTarget } from "./startup.js";
 import { parseStepStatus } from "./step-parser.js";
-import { App } from "./ui/App.js";
+import { renderApp } from "./ui/render-app.js";
 import {
   bootstrapRepo,
   createWorktree,
@@ -762,30 +760,28 @@ try {
   const emitter = new PipelineEventEmitter();
 
   const pipelineResult = await new Promise<PipelineResult>((resolve) => {
-    const { unmount } = render(
-      React.createElement(App, {
-        emitter,
-        pipelineOptions: pipelineOpts,
-        onExit: (result: PipelineResult) => {
-          unmount();
-          resolve(result);
-        },
-        onPromptReady: (prompt) => {
-          tuiPrompt = prompt;
-        },
-        onCancel: () => {
-          // Kill all tracked agent child processes so the pipeline
-          // can unwind quickly.  We read `.child` at kill-time so
-          // that fallback streams (withXhighFallback) target the
-          // currently active child, not the original one.
-          for (const stream of activeStreams) {
-            stream.child.kill();
-          }
-        },
-        modelNameA: modelDisplayName(agentAConfig),
-        modelNameB: modelDisplayName(agentBConfig),
-      }),
-    );
+    const { unmount } = renderApp({
+      emitter,
+      pipelineOptions: pipelineOpts,
+      onExit: (result: PipelineResult) => {
+        unmount();
+        resolve(result);
+      },
+      onPromptReady: (prompt) => {
+        tuiPrompt = prompt;
+      },
+      onCancel: () => {
+        // Kill all tracked agent child processes so the pipeline
+        // can unwind quickly.  We read `.child` at kill-time so
+        // that fallback streams (withXhighFallback) target the
+        // currently active child, not the original one.
+        for (const stream of activeStreams) {
+          stream.child.kill();
+        }
+      },
+      modelNameA: modelDisplayName(agentAConfig),
+      modelNameB: modelDisplayName(agentBConfig),
+    });
   });
 
   // Remove the SIGINT suppressor so the default handler takes over

--- a/src/ui/render-app.test.ts
+++ b/src/ui/render-app.test.ts
@@ -1,0 +1,23 @@
+import { render } from "ink";
+import { describe, expect, test, vi } from "vitest";
+
+vi.mock("ink", () => ({
+  render: vi.fn(() => ({ unmount: vi.fn() })),
+}));
+
+import { INK_RENDER_OPTIONS, renderApp } from "./render-app.js";
+
+describe("renderApp", () => {
+  test("disables Ink exitOnCtrlC", () => {
+    const onExit = vi.fn();
+
+    renderApp({
+      emitter: { on: vi.fn(), off: vi.fn() } as never,
+      pipelineOptions: {} as never,
+      onExit,
+    });
+
+    expect(render).toHaveBeenCalledWith(expect.anything(), INK_RENDER_OPTIONS);
+    expect(INK_RENDER_OPTIONS).toEqual({ exitOnCtrlC: false });
+  });
+});

--- a/src/ui/render-app.ts
+++ b/src/ui/render-app.ts
@@ -1,0 +1,11 @@
+import { render } from "ink";
+import React from "react";
+import { App, type AppProps } from "./App.js";
+
+export const INK_RENDER_OPTIONS = {
+  exitOnCtrlC: false,
+} as const;
+
+export function renderApp(props: AppProps) {
+  return render(React.createElement(App, props), INK_RENDER_OPTIONS);
+}


### PR DESCRIPTION
## Summary
- route the TUI render through a small helper that disables Ink's default Ctrl+C exit behavior
- ensure pipeline Ctrl+C is forwarded to the existing `useInput` cancellation path instead of being swallowed by Ink
- add a focused test that verifies the render options include `exitOnCtrlC: false`

Closes #137

## Test plan
- [x] Run `pnpm check`
- [x] Run `pnpm typecheck`
- [x] Run `pnpm test`
- [x] Run `pnpm build`
- [x] Start a pipeline and press Ctrl+C to confirm the graceful cancellation handler runs
- [x] Confirm Tab and Ctrl+L still behave as before during pipeline execution

