### PR TITLE
Fix TokenBar pane widths (#138)

### DIFF
--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -112,6 +112,7 @@ export function TokenBar({
     <Box flexDirection={layout} flexShrink={0}>
       <Box
         flexGrow={1}
+        flexBasis={0}
         borderStyle="single"
         borderColor="gray"
         paddingX={1}
@@ -122,6 +123,7 @@ export function TokenBar({
       </Box>
       <Box
         flexGrow={1}
+        flexBasis={0}
         borderStyle="single"
         borderColor="gray"
         paddingX={1}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1704,6 +1704,39 @@ describe("TokenBar width adaptation", () => {
 });
 
 describe("TokenBar layout prop", () => {
+  test("uses equal-width boxes in row layout regardless of content length", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={50}>
+        <TokenBar emitter={emitter} layout="row" />
+      </Box>,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: {
+        inputTokens: 999_999,
+        outputTokens: 999_999,
+        cachedInputTokens: 0,
+      },
+    });
+    emitter.emit("agent:usage", {
+      agent: "b",
+      usage: { inputTokens: 1, outputTokens: 1, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    const topBorder = frame.split("\n").find((line) => line.startsWith("┌"));
+    expect(topBorder).toBeDefined();
+
+    const match = topBorder?.match(/^┌([^┐]*)┐┌([^┐]*)┐$/u);
+    expect(match).not.toBeNull();
+
+    const [, leftBox, rightBox] = match ?? [];
+    expect(stringWidth(leftBox)).toBe(stringWidth(rightBox));
+  });
+
   test("renders two boxes side by side in row layout", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(<TokenBar emitter={emitter} layout="row" />);


### PR DESCRIPTION
## Summary
- add `flexBasis={0}` to both `TokenBar` boxes so horizontal layout matches the equal-width `AgentPane` sizing
- add a regression test covering row layout with uneven token text lengths

Closes #138

## Test plan
- [x] Verify the two `TokenBar` boxes render at equal widths in horizontal layout
- [x] Verify longer token usage text in one box does not make it wider than the other
- [x] Run `pnpm biome check src/ui/TokenBar.tsx src/ui/components.test.tsx`
- [x] Run `pnpm typecheck`
- [x] Run `pnpm test`
- [x] Run `pnpm build`
