### PR TITLE
Add conflict check and rebase option to done stage (#143)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -114,11 +114,11 @@ export const en: Messages = {
     "Pipeline completed, but merge conflicts with main detected.",
   "pipeline.unknownMergeable":
     "Could not determine merge status after retries.",
-  "pipeline.rebaseSuccess": "Agent rebased onto main successfully.",
+  "pipeline.noConflicts": "No conflicts found — already up to date with main.",
   "pipeline.rebaseFailed":
     "Agent could not resolve conflicts. Please resolve manually.",
-  "pipeline.stillConflicting": "Still conflicting after resolution attempt.",
-  "pipeline.ciPassedAfterRebase": "CI passed after rebase.",
+  "pipeline.rebaseAlreadyAttempted":
+    "Agent rebase was already attempted. Please resolve conflicts manually.",
 
   // ---- TUI user prompts --------------------------------------------------
 
@@ -141,7 +141,8 @@ export const en: Messages = {
   "prompt.ambiguous": (message) => `Ambiguous agent response:\n${message}`,
   "prompt.proceed": "Proceed",
   "prompt.yesMerged": "Yes, merged",
-  "prompt.noKeepWorktree": "No, keep worktree",
+  "prompt.checkConflictsRebase": "No, check conflicts and rebase",
+  "prompt.noExit": "No, exit",
   "prompt.agentRebase": "Let agent rebase",
   "prompt.manualResolve": "Resolve manually",
   "prompt.recheck": "Re-check",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -135,12 +135,11 @@ export const ko: Messages = {
   "pipeline.conflictsDetected":
     "파이프라인이 완료되었지만 main과 병합 충돌이 감지되었습니다.",
   "pipeline.unknownMergeable": "재시도 후에도 병합 상태를 확인할 수 없습니다.",
-  "pipeline.rebaseSuccess":
-    "에이전트가 main으로 리베이스를 성공적으로 완료했습니다.",
+  "pipeline.noConflicts": "충돌이 없습니다 — main과 이미 최신 상태입니다.",
   "pipeline.rebaseFailed":
     "에이전트가 충돌을 해결하지 못했습니다. 수동으로 해결해 주세요.",
-  "pipeline.stillConflicting": "해결 시도 후에도 여전히 충돌이 있습니다.",
-  "pipeline.ciPassedAfterRebase": "리베이스 후 CI를 통과했습니다.",
+  "pipeline.rebaseAlreadyAttempted":
+    "에이전트 리베이스가 이미 시도되었습니다. 수동으로 충돌을 해결해 주세요.",
 
   // ---- TUI user prompts --------------------------------------------------
 
@@ -165,7 +164,8 @@ export const ko: Messages = {
     `\uBAA8\uD638\uD55C \uC5D0\uC774\uC804\uD2B8 \uC751\uB2F5:\n${message}`,
   "prompt.proceed": "\uC9C4\uD589",
   "prompt.yesMerged": "예, 병합됨",
-  "prompt.noKeepWorktree": "아니오, 워크트리 유지",
+  "prompt.checkConflictsRebase": "아니오, 충돌 확인 및 리베이스",
+  "prompt.noExit": "아니오, 종료",
   "prompt.agentRebase": "에이전트 리베이스",
   "prompt.manualResolve": "수동 해결",
   "prompt.recheck": "재확인",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -111,10 +111,9 @@ export interface Messages {
   "pipeline.worktreePreserved": string;
   "pipeline.conflictsDetected": string;
   "pipeline.unknownMergeable": string;
-  "pipeline.rebaseSuccess": string;
+  "pipeline.noConflicts": string;
   "pipeline.rebaseFailed": string;
-  "pipeline.stillConflicting": string;
-  "pipeline.ciPassedAfterRebase": string;
+  "pipeline.rebaseAlreadyAttempted": string;
 
   // ---- TUI user prompts (TuiUserPrompt.ts) -------------------------------
 
@@ -135,7 +134,8 @@ export interface Messages {
   "prompt.ambiguous": (message: string) => string;
   "prompt.proceed": string;
   "prompt.yesMerged": string;
-  "prompt.noKeepWorktree": string;
+  "prompt.checkConflictsRebase": string;
+  "prompt.noExit": string;
   "prompt.agentRebase": string;
   "prompt.manualResolve": string;
   "prompt.recheck": string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,7 +554,7 @@ try {
     prompt: {
       confirmMerge: async (msg) => {
         if (tuiPrompt) return tuiPrompt.confirmMerge(msg);
-        return true;
+        return "merged";
       },
       handleConflict: async (msg) => {
         if (tuiPrompt) return tuiPrompt.handleConflict(msg);
@@ -588,6 +588,11 @@ try {
         `   - Run the full test suite to ensure nothing is broken.`,
         `5. Only if the build and all tests pass, force-push the branch:`,
         `   \`git push --force-with-lease\``,
+        `6. After a successful force-push, post a brief PR comment noting`,
+        `   which main commit the branch was rebased onto and a short`,
+        `   summary of resolved conflicts. Use:`,
+        `   \`gh pr comment --body "<your summary>"\``,
+        `   If no PR exists or the comment fails, continue without failing.`,
         ``,
         `IMPORTANT: If you cannot resolve conflicts cleanly or if the`,
         `build/tests fail after resolution, do NOT push. Instead, abort`,

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -37,7 +37,7 @@ function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
     handleAmbiguous: vi
       .fn()
       .mockResolvedValue({ action: "halt" satisfies UserAction }),
-    confirmMerge: vi.fn().mockResolvedValue(true),
+    confirmMerge: vi.fn().mockResolvedValue("merged"),
     handleConflict: vi.fn().mockResolvedValue("manual"),
     handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
     waitForManualResolve: vi.fn().mockResolvedValue(undefined),
@@ -1057,7 +1057,7 @@ function makeDonePrompt(
   > = {},
 ) {
   return {
-    confirmMerge: vi.fn().mockResolvedValue(true),
+    confirmMerge: vi.fn().mockResolvedValue("merged"),
     handleConflict: vi.fn().mockResolvedValue("manual"),
     handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
     waitForManualResolve: vi.fn().mockResolvedValue(undefined),
@@ -1110,9 +1110,9 @@ describe("createDoneStageHandler", () => {
     expect(result.message).toContain("cleaned up");
   });
 
-  test("MERGEABLE: calls onNotMerged when merge not confirmed", async () => {
+  test("MERGEABLE: calls onNotMerged when user exits", async () => {
     const opts = makeDoneOpts({
-      prompt: { confirmMerge: vi.fn().mockResolvedValue(false) },
+      prompt: { confirmMerge: vi.fn().mockResolvedValue("exit") },
     });
     const stage = createDoneStageHandler(opts);
     const ctx: StageContext = {
@@ -1374,7 +1374,7 @@ describe("createDoneStageHandler", () => {
       prompt: {
         confirmMerge: vi.fn().mockImplementation(async () => {
           controller.abort();
-          return false;
+          return "exit";
         }),
       },
     });
@@ -1419,7 +1419,7 @@ describe("createDoneStageHandler", () => {
       prompt: {
         confirmMerge: vi.fn().mockImplementation(async () => {
           controller.abort();
-          return true;
+          return "merged";
         }),
       },
     });
@@ -1467,6 +1467,233 @@ describe("createDoneStageHandler", () => {
     expect(opts.prompt.waitForManualResolve).toHaveBeenCalledOnce();
     // CI polling still happens after the manual resolve re-check.
     expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  // ---- askMerge "check_conflicts" sub-path --------------------------------
+
+  test("check_conflicts → MERGEABLE shows noConflicts message and loops back", async () => {
+    // User selects "check_conflicts" first time (no conflicts),
+    // then "merged" on the loop-back.
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("merged");
+    const waitForManualResolve = vi.fn().mockResolvedValue(undefined);
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge, waitForManualResolve },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    // checkMergeable: once at entry (MERGEABLE), once inside askMerge.
+    expect(opts.checkMergeable).toHaveBeenCalledTimes(2);
+    // "No conflicts" message shown via waitForManualResolve.
+    expect(waitForManualResolve).toHaveBeenCalledWith(
+      expect.stringContaining("No conflicts"),
+    );
+    expect(confirmMerge).toHaveBeenCalledTimes(2);
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("check_conflicts → CONFLICTING → rebase succeeds → CI → loops back", async () => {
+    // Initial checkMergeable: MERGEABLE → askMerge.
+    // User: "check_conflicts" → checkMergeable: CONFLICTING → rebase → CI → loop.
+    // User: "merged" → cleanup.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE") // initial
+      .mockResolvedValueOnce("CONFLICTING"); // inside askMerge
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("merged");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { confirmMerge },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.rebaseOntoMain).toHaveBeenCalledOnce();
+    expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
+    expect(confirmMerge).toHaveBeenCalledTimes(2);
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("check_conflicts → CONFLICTING → rebase succeeds → CI result shown before loop", async () => {
+    // Regression: pollCiAndFix result must be surfaced via waitForManualResolve
+    // before looping back to confirmMerge (for both pass and fail).
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE") // initial
+      .mockResolvedValueOnce("CONFLICTING"); // inside askMerge
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("merged");
+    const waitForManualResolve = vi.fn().mockResolvedValue(undefined);
+    const ciMessage = "CI failed: lint errors in src/foo.ts";
+    const opts = makeDoneOpts({
+      checkMergeable,
+      pollCiAndFix: vi
+        .fn()
+        .mockResolvedValue({ passed: false, message: ciMessage }),
+      prompt: { confirmMerge, waitForManualResolve },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    // The CI result message must be shown to the user before re-prompting.
+    expect(waitForManualResolve).toHaveBeenCalledWith(ciMessage);
+  });
+
+  test("check_conflicts → CONFLICTING → rebase fails → loops back", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE")
+      .mockResolvedValueOnce("CONFLICTING");
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("exit");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      rebaseOntoMain: vi
+        .fn()
+        .mockResolvedValue({ success: false, message: "conflict" }),
+      prompt: { confirmMerge },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(opts.rebaseOntoMain).toHaveBeenCalledOnce();
+    // CI not polled because rebase failed.
+    expect(opts.pollCiAndFix).not.toHaveBeenCalled();
+    // Loop back to confirmMerge, user exits.
+    expect(confirmMerge).toHaveBeenCalledTimes(2);
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("check_conflicts respects rebaseAttempted guard across loop-backs", async () => {
+    // Flow: initial CONFLICTING → handleConflicting → agent_rebase
+    // (rebaseAttempted=true) → afterResolution → MERGEABLE → CI → askMerge.
+    // User: "check_conflicts" → CONFLICTING → guard fires (manual resolve)
+    // → loop back → "merged".
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING") // initial mergeableLoop
+      .mockResolvedValueOnce("MERGEABLE") // afterResolution
+      .mockResolvedValueOnce("MERGEABLE") // afterResolution (CI pass)
+      .mockResolvedValueOnce("CONFLICTING"); // inside askMerge
+    const handleConflict = vi.fn().mockResolvedValue("agent_rebase");
+    const rebaseOntoMain = vi
+      .fn()
+      .mockResolvedValue({ success: true, message: "ok" });
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("merged");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      rebaseOntoMain,
+      prompt: { handleConflict, confirmMerge },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    // Rebase called only once — the askMerge CONFLICTING path must not
+    // trigger a second rebase because the guard is shared.
+    expect(rebaseOntoMain).toHaveBeenCalledOnce();
+    // waitForManualResolve called for the guard hit inside askMerge.
+    expect(opts.prompt.waitForManualResolve).toHaveBeenCalled();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("check_conflicts → UNKNOWN → user exits", async () => {
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE")
+      .mockResolvedValueOnce("UNKNOWN");
+    const confirmMerge = vi.fn().mockResolvedValueOnce("check_conflicts");
+    const handleUnknownMergeable = vi.fn().mockResolvedValue("exit");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { confirmMerge, handleUnknownMergeable },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(handleUnknownMergeable).toHaveBeenCalledOnce();
+    expect(opts.onNotMerged).toHaveBeenCalledOnce();
+    expect(opts.cleanup).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("check_conflicts → UNKNOWN → user rechecks → retries checkMergeable", async () => {
+    // Flow: top-level MERGEABLE → askMerge check_conflicts →
+    // inner UNKNOWN → recheck → inner MERGEABLE → no-conflicts →
+    // confirmMerge merged → cleanup.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE") // top-level done stage
+      .mockResolvedValueOnce("UNKNOWN") // inner loop 1st attempt
+      .mockResolvedValueOnce("MERGEABLE"); // inner loop retry after recheck
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("merged");
+    const handleUnknownMergeable = vi.fn().mockResolvedValue("recheck");
+    const waitForManualResolve = vi.fn().mockResolvedValue(undefined);
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { confirmMerge, handleUnknownMergeable, waitForManualResolve },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(checkMergeable).toHaveBeenCalledTimes(3);
+    expect(handleUnknownMergeable).toHaveBeenCalledOnce();
+    expect(confirmMerge).toHaveBeenCalledTimes(2);
+    expect(opts.cleanup).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
   });
 

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -191,8 +191,11 @@ export interface UserPrompt {
 
   /**
    * Ask user to confirm merge and final cleanup (stage 9).
+   * - `"merged"` — user confirms the PR has been merged.
+   * - `"check_conflicts"` — check for conflicts and rebase if needed.
+   * - `"exit"` — stop asking and proceed to cleanup options.
    */
-  confirmMerge(message: string): Promise<boolean>;
+  confirmMerge(message: string): Promise<"merged" | "check_conflicts" | "exit">;
 
   /**
    * Present a conflict notification and let the user choose between
@@ -804,7 +807,9 @@ export interface DoneStageOptions {
   checkMergeable: (ctx: StageContext) => Promise<MergeableState>;
   /** Prompt the user for conflict/unknown/merge choices. */
   prompt: {
-    confirmMerge: (message: string) => Promise<boolean>;
+    confirmMerge: (
+      message: string,
+    ) => Promise<"merged" | "check_conflicts" | "exit">;
     handleConflict: (message: string) => Promise<"agent_rebase" | "manual">;
     handleUnknownMergeable: (message: string) => Promise<"recheck" | "exit">;
     waitForManualResolve: (message: string) => Promise<void>;
@@ -848,6 +853,9 @@ export interface DoneStageOptions {
 export function createDoneStageHandler(
   options: DoneStageOptions,
 ): StageDefinition {
+  // Agent rebase is limited to 1 attempt across all loop-backs.
+  let rebaseAttempted = false;
+
   return {
     name: t()["stage.done"],
     number: 9,
@@ -858,9 +866,6 @@ export function createDoneStageHandler(
         ctx.repo,
         ctx.issueNumber,
       );
-
-      // Agent rebase is limited to 1 attempt across all loop-backs.
-      let rebaseAttempted = false;
 
       // ---- Check mergeable state ------------------------------------------
       const mergeableLoop = async (): Promise<
@@ -1025,21 +1030,86 @@ export function createDoneStageHandler(
     summary: string,
   ): Promise<StageResult> {
     const m = t();
-    const merged = await options.prompt.confirmMerge(
-      `${summary}\n\n${m["pipeline.mergeConfirm"]}`,
-    );
-    if (ctx.signal?.aborted) {
-      return { outcome: "completed", message: "" };
+    for (;;) {
+      const choice = await options.prompt.confirmMerge(
+        `${summary}\n\n${m["pipeline.mergeConfirm"]}`,
+      );
+      if (ctx.signal?.aborted) {
+        return { outcome: "completed", message: "" };
+      }
+
+      if (choice === "merged") {
+        options.stopServices();
+        options.cleanup();
+        return {
+          outcome: "completed",
+          message: `${summary} ${m["pipeline.worktreeCleanedUp"]}`,
+        };
+      }
+
+      if (choice === "exit") {
+        await options.onNotMerged(ctx.signal);
+        return { outcome: "completed", message: summary };
+      }
+
+      // "check_conflicts" — inner loop lets UNKNOWN → "recheck" retry
+      // checkMergeable without going through confirmMerge again.
+      for (;;) {
+        const state = await options.checkMergeable(ctx);
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+
+        if (state === "MERGEABLE") {
+          await options.prompt.waitForManualResolve(m["pipeline.noConflicts"]);
+          if (ctx.signal?.aborted) {
+            return { outcome: "completed", message: "" };
+          }
+          break; // back to confirmMerge
+        }
+
+        if (state === "UNKNOWN") {
+          const unk = await options.prompt.handleUnknownMergeable(
+            m["pipeline.unknownMergeable"],
+          );
+          if (ctx.signal?.aborted) {
+            return { outcome: "completed", message: "" };
+          }
+          if (unk === "recheck") continue; // retry checkMergeable
+          await options.onNotMerged(ctx.signal);
+          return { outcome: "completed", message: summary };
+        }
+
+        // CONFLICTING — invoke agent rebase (one attempt only).
+        if (rebaseAttempted) {
+          await options.prompt.waitForManualResolve(
+            m["pipeline.rebaseAlreadyAttempted"],
+          );
+          if (ctx.signal?.aborted) {
+            return { outcome: "completed", message: "" };
+          }
+          break; // back to confirmMerge
+        }
+        rebaseAttempted = true;
+        const rebaseResult = await options.rebaseOntoMain(ctx);
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+        if (!rebaseResult.success) {
+          break; // rebase failed — back to confirmMerge
+        }
+
+        // Rebase succeeded — poll CI and surface the result.
+        const ciResult = await options.pollCiAndFix(ctx);
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+        await options.prompt.waitForManualResolve(ciResult.message);
+        if (ctx.signal?.aborted) {
+          return { outcome: "completed", message: "" };
+        }
+        break; // back to confirmMerge
+      }
     }
-    if (merged) {
-      options.stopServices();
-      options.cleanup();
-      return {
-        outcome: "completed",
-        message: `${summary} ${m["pipeline.worktreeCleanedUp"]}`,
-      };
-    }
-    await options.onNotMerged(ctx.signal);
-    return { outcome: "completed", message: summary };
   }
 }

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -86,7 +86,7 @@ function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
     handleAmbiguous: vi
       .fn()
       .mockResolvedValue({ action: "halt" satisfies UserAction }),
-    confirmMerge: vi.fn().mockResolvedValue(true),
+    confirmMerge: vi.fn().mockResolvedValue("merged"),
     handleConflict: vi.fn().mockResolvedValue("manual"),
     handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
     waitForManualResolve: vi.fn().mockResolvedValue(undefined),

--- a/src/ui/TuiUserPrompt.test.ts
+++ b/src/ui/TuiUserPrompt.test.ts
@@ -188,16 +188,26 @@ describe("TuiUserPrompt", () => {
   });
 
   describe("confirmMerge", () => {
-    test("returns true for yes", async () => {
-      const dispatch = makeDispatch("yes");
+    test("returns merged for merged choice", async () => {
+      const dispatch = makeDispatch("merged");
       const prompt = createTuiUserPrompt(dispatch);
-      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe(true);
+      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe(
+        "merged",
+      );
     });
 
-    test("returns false for no", async () => {
-      const dispatch = makeDispatch("no");
+    test("returns check_conflicts for check conflicts choice", async () => {
+      const dispatch = makeDispatch("check_conflicts");
       const prompt = createTuiUserPrompt(dispatch);
-      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe(false);
+      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe(
+        "check_conflicts",
+      );
+    });
+
+    test("returns exit for exit choice", async () => {
+      const dispatch = makeDispatch("exit");
+      const prompt = createTuiUserPrompt(dispatch);
+      expect(await prompt.confirmMerge("Has the PR been merged?")).toBe("exit");
     });
   });
 

--- a/src/ui/TuiUserPrompt.ts
+++ b/src/ui/TuiUserPrompt.ts
@@ -112,16 +112,22 @@ export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
       return { action: action as UserAction };
     },
 
-    async confirmMerge(message: string): Promise<boolean> {
+    async confirmMerge(
+      message: string,
+    ): Promise<"merged" | "check_conflicts" | "exit"> {
       const m = t();
       const response = await dispatch({
         message,
         choices: [
-          { label: m["prompt.yesMerged"], value: "yes" },
-          { label: m["prompt.noKeepWorktree"], value: "no" },
+          { label: m["prompt.yesMerged"], value: "merged" },
+          {
+            label: m["prompt.checkConflictsRebase"],
+            value: "check_conflicts",
+          },
+          { label: m["prompt.noExit"], value: "exit" },
         ],
       });
-      return response === "yes";
+      return response as "merged" | "check_conflicts" | "exit";
     },
 
     async handleConflict(message: string): Promise<"agent_rebase" | "manual"> {


### PR DESCRIPTION
## Summary

- Changes the "Has the PR been merged?" prompt from 2 choices (Yes/No) to 3: **Yes, merged**, **No, check conflicts and rebase**, and **No, exit**.
- When the user selects "check conflicts and rebase", the pipeline checks mergeable state, invokes the existing `rebaseOntoMain` agent for conflicts, polls CI via `pollCiAndFix`, and loops back to the merge prompt.
- The `askMerge` CONFLICTING branch shares the `rebaseAttempted` guard with `handleConflicting`, ensuring the agent rebase is limited to one attempt across all loop-backs (initial done-stage loop and merge-confirmation loop).
- After rebase succeeds and CI is polled, the CI result message is surfaced to the user (via `waitForManualResolve`) before looping back to the merge prompt, for both pass and fail cases.
- Updates the `rebaseOntoMain` agent prompt to post a PR comment after successful force-push summarizing the rebase base commit and resolved conflicts.
- Adds i18n keys (English and Korean) for the new option and "no conflicts" message.
- `confirmMerge` return type changed from `boolean` to `"merged" | "check_conflicts" | "exit"`.

Closes #143

## Not addressed

- **`src/ui/components.test.tsx` confirmMerge stubs**: The issue listed this file, but the existing stubs in `components.test.tsx` do not directly exercise `confirmMerge` — they test UI rendering components. No changes were needed there beyond what was already committed for other UI updates.

## Test plan

- [x] `pnpm vitest run` passes all 1217 tests
- [x] `pnpm tsc --noEmit` has no type errors
- [x] `pnpm biome check` reports no issues
- [x] Done stage shows 3 choices: "Yes, merged", "No, check conflicts and rebase", "No, exit"
- [x] Selecting "Yes, merged" cleans up worktree (existing behavior preserved)
- [x] Selecting "No, exit" proceeds to cleanup options (existing behavior preserved)
- [x] Selecting "No, check conflicts and rebase" when branch is mergeable shows "No conflicts found" message and loops back
- [x] Selecting "No, check conflicts and rebase" when branch has conflicts invokes rebase agent, polls CI, shows CI result, then loops back
- [x] Selecting "No, check conflicts and rebase" when mergeable state is unknown shows re-check/exit prompt
- [x] Rebase agent posts a PR comment after successful force-push
- [x] Agent rebase limited to 1 attempt across all loop-backs (including via askMerge path)
- [x] CI result message shown to user after rebase+CI path (regression test added)