### PR TITLE
Show author/reviewer roles in config display (#144)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -4,8 +4,8 @@ export const en: Messages = {
   // ---- quick-start -------------------------------------------------------
 
   "quickStart.header": "Found saved configuration:",
-  "quickStart.agentA": (model) => `  Agent A: ${model}`,
-  "quickStart.agentB": (model) => `  Agent B: ${model}`,
+  "quickStart.agentA": (model) => `  Agent A (author): ${model}`,
+  "quickStart.agentB": (model) => `  Agent B (reviewer): ${model}`,
   "quickStart.mode": (exec) => `  Mode: ${exec}`,
   "quickStart.language": (lang) => `  Language: ${lang}`,
   "quickStart.pipelineSettings": "  Pipeline settings:",
@@ -52,8 +52,8 @@ export const en: Messages = {
   "resume.pr": (prNumber) => `    PR: #${prNumber}`,
   "resume.reviewRound": (round) => `    Review round: ${round}`,
   "resume.mode": (mode) => `    Mode: ${mode}`,
-  "resume.agentA": (model) => `    Agent A: ${model}`,
-  "resume.agentB": (model) => `    Agent B: ${model}`,
+  "resume.agentA": (model) => `    Agent A (author): ${model}`,
+  "resume.agentB": (model) => `    Agent B (reviewer): ${model}`,
   "resume.resumeOrFresh": "Resume or start fresh?",
   "resume.resume": "Resume",
   "resume.startFresh": "Start fresh",
@@ -75,8 +75,8 @@ export const en: Messages = {
     "  PR already exists \u2014 skipping to stage 5 (CI check).",
   "boot.startingPipeline": (owner, repo, issue, resuming) =>
     `Starting pipeline for ${owner}/${repo}#${issue}${resuming ? " (resuming)" : ""}`,
-  "boot.agentA": (model) => `  Agent A: ${model}`,
-  "boot.agentB": (model) => `  Agent B: ${model}`,
+  "boot.agentA": (model) => `  Agent A (author): ${model}`,
+  "boot.agentB": (model) => `  Agent B (reviewer): ${model}`,
   "boot.mode": (mode) => `  Mode: ${mode}`,
   "boot.resumingFromStage": (stage) => `  Resuming from stage: ${stage}`,
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -4,8 +4,8 @@ export const ko: Messages = {
   // ---- quick-start -------------------------------------------------------
 
   "quickStart.header": "저장된 설정 발견:",
-  "quickStart.agentA": (model) => `  에이전트 A: ${model}`,
-  "quickStart.agentB": (model) => `  에이전트 B: ${model}`,
+  "quickStart.agentA": (model) => `  에이전트 A (작성자): ${model}`,
+  "quickStart.agentB": (model) => `  에이전트 B (리뷰어): ${model}`,
   "quickStart.mode": (exec) => `  모드: ${exec}`,
   "quickStart.language": (lang) => `  언어: ${lang}`,
   "quickStart.pipelineSettings": "  파이프라인 설정:",
@@ -68,8 +68,10 @@ export const ko: Messages = {
   "resume.reviewRound": (round) =>
     `    \uB9AC\uBDF0 \uB77C\uC6B4\uB4DC: ${round}`,
   "resume.mode": (mode) => `    \uBAA8\uB4DC: ${mode}`,
-  "resume.agentA": (model) => `    \uC5D0\uC774\uC804\uD2B8 A: ${model}`,
-  "resume.agentB": (model) => `    \uC5D0\uC774\uC804\uD2B8 B: ${model}`,
+  "resume.agentA": (model) =>
+    `    \uC5D0\uC774\uC804\uD2B8 A (\uC791\uC131\uC790): ${model}`,
+  "resume.agentB": (model) =>
+    `    \uC5D0\uC774\uC804\uD2B8 B (\uB9AC\uBDF0\uC5B4): ${model}`,
   "resume.resumeOrFresh":
     "\uC7AC\uAC1C \uB610\uB294 \uC0C8\uB85C \uC2DC\uC791?",
   "resume.resume": "\uC7AC\uAC1C",
@@ -93,8 +95,10 @@ export const ko: Messages = {
     "  PR\uC774 \uC774\uBBF8 \uC874\uC7AC\uD569\uB2C8\uB2E4 \u2014 5\uB2E8\uACC4(CI \uAC80\uC0AC)\uB85C \uAC74\uB108\uB701\uB2C8\uB2E4.",
   "boot.startingPipeline": (owner, repo, issue, resuming) =>
     `${owner}/${repo}#${issue} \uD30C\uC774\uD504\uB77C\uC778 \uC2DC\uC791${resuming ? " (\uC7AC\uAC1C)" : ""}`,
-  "boot.agentA": (model) => `  \uC5D0\uC774\uC804\uD2B8 A: ${model}`,
-  "boot.agentB": (model) => `  \uC5D0\uC774\uC804\uD2B8 B: ${model}`,
+  "boot.agentA": (model) =>
+    `  \uC5D0\uC774\uC804\uD2B8 A (\uC791\uC131\uC790): ${model}`,
+  "boot.agentB": (model) =>
+    `  \uC5D0\uC774\uC804\uD2B8 B (\uB9AC\uBDF0\uC5B4): ${model}`,
   "boot.mode": (mode) => `  \uBAA8\uB4DC: ${mode}`,
   "boot.resumingFromStage": (stage) =>
     `  ${stage}\uB2E8\uACC4\uBD80\uD130 \uC7AC\uAC1C`,

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -1625,8 +1625,8 @@ describe("runStartup — quick-start", () => {
 
     const logs = consoleSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(logs).toContain("Found saved configuration:");
-    expect(logs).toContain("Agent A: Claude Opus 4.6 (1M) / High");
-    expect(logs).toContain("Agent B: GPT-5.4 / Extra High");
+    expect(logs).toContain("Agent A (author): Claude Opus 4.6 (1M) / High");
+    expect(logs).toContain("Agent B (reviewer): GPT-5.4 / Extra High");
     expect(logs).toContain("Mode: auto");
     expect(logs).toContain("Language: English");
     expect(logs).toContain("Pipeline settings:");

--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -83,8 +83,8 @@ export function TokenBar({
 
   if (!visible || !hasData) return null;
 
-  const labelA = m["agent.labelA"];
-  const labelB = m["agent.labelB"];
+  const labelA = m["agent.labelARole"];
+  const labelB = m["agent.labelBRole"];
 
   const textA = m["tokenBar.agentUsage"](
     labelA,

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1576,10 +1576,10 @@ describe("TokenBar", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("Agent A");
+    expect(frame).toContain("Agent A (author)");
     expect(frame).toContain("12.3K in");
     expect(frame).toContain("5.1K out");
-    expect(frame).toContain("Agent B");
+    expect(frame).toContain("Agent B (reviewer)");
     expect(frame).toContain("8.7K in");
     expect(frame).toContain("3.2K out");
   });
@@ -1638,7 +1638,7 @@ describe("TokenBar", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("Agent A");
+    expect(frame).toContain("Agent A (author)");
     expect(frame).toContain("5.0K in");
   });
 });
@@ -1665,8 +1665,9 @@ describe("TokenBar width adaptation", () => {
     // Each box independently truncates its agent's text.
     expect(frame).toContain("\u2026");
     // Both agents appear since each has its own box.
-    expect(frame).toContain("Agent A");
-    expect(frame).toContain("Agent B");
+    // Role suffixes are truncated at this width, but the prefix survives.
+    expect(frame).toContain("Agent A (");
+    expect(frame).toContain("Agent B (");
   });
 
   test("truncates Korean (wide-char) content correctly", async () => {
@@ -1754,8 +1755,8 @@ describe("TokenBar layout prop", () => {
     const frame = lastFrame() ?? "";
     // Both agents should appear on the same line in row layout.
     const lines = frame.split("\n");
-    const agentALine = lines.find((l) => l.includes("Agent A"));
-    const agentBLine = lines.find((l) => l.includes("Agent B"));
+    const agentALine = lines.find((l) => l.includes("Agent A (author)"));
+    const agentBLine = lines.find((l) => l.includes("Agent B (reviewer)"));
     expect(agentALine).toBeDefined();
     expect(agentBLine).toBeDefined();
     // In row layout they share a line.
@@ -1781,8 +1782,8 @@ describe("TokenBar layout prop", () => {
     const frame = lastFrame() ?? "";
     // In column layout, each agent's text appears on a different line.
     const lines = frame.split("\n");
-    const agentAIdx = lines.findIndex((l) => l.includes("Agent A"));
-    const agentBIdx = lines.findIndex((l) => l.includes("Agent B"));
+    const agentAIdx = lines.findIndex((l) => l.includes("Agent A (author)"));
+    const agentBIdx = lines.findIndex((l) => l.includes("Agent B (reviewer)"));
     expect(agentAIdx).toBeGreaterThanOrEqual(0);
     expect(agentBIdx).toBeGreaterThanOrEqual(0);
     expect(agentAIdx).not.toBe(agentBIdx);


### PR DESCRIPTION
## Summary

- Append "(author)" / "(reviewer)" role labels to Agent A / Agent B lines in the quick-start, resume, and boot configuration displays
- Update the TokenBar to use role-labeled keys (`agent.labelARole` / `agent.labelBRole`) instead of plain labels
- Update English and Korean i18n strings and corresponding tests

Closes #144

## Test plan

- [x] Run `pnpm vitest run src/startup.test.ts` — quick-start test now expects `Agent A (author):` / `Agent B (reviewer):`
- [x] Launch the TUI and verify the TokenBar shows role labels (e.g. "A (author)", "B (reviewer)")
- [x] Trigger a resume flow and confirm the saved-config printout includes roles
- [x] Trigger a boot flow and confirm the startup printout includes roles
- [x] Switch locale to Korean and verify 작성자/리뷰어 appear in the same positions