### PR TITLE
Show CLI name and cached tokens in TokenBar (#147)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -178,6 +178,13 @@ export const en: Messages = {
 
   "tokenBar.agentUsage": (label, inputTokens, outputTokens) =>
     `${label}: ${inputTokens} in / ${outputTokens} out`,
+  "tokenBar.agentUsageCached": (
+    label,
+    inputTokens,
+    cachedTokens,
+    outputTokens,
+  ) =>
+    `${label}: ${inputTokens} in (${cachedTokens} cached) / ${outputTokens} out`,
   "tokenBar.noUsage": "No token data yet",
 
   // ---- input area --------------------------------------------------------
@@ -193,6 +200,8 @@ export const en: Messages = {
   "agentPane.linesBelow": (count) => `\u2193 ${count} more lines`,
   "agent.labelA": "Agent A",
   "agent.labelB": "Agent B",
+  "agent.labelShortA": "A",
+  "agent.labelShortB": "B",
   "agent.labelARole": "Agent A (author)",
   "agent.labelBRole": "Agent B (reviewer)",
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -206,6 +206,13 @@ export const ko: Messages = {
 
   "tokenBar.agentUsage": (label, inputTokens, outputTokens) =>
     `${label}: ${inputTokens} \uC785\uB825 / ${outputTokens} \uCD9C\uB825`,
+  "tokenBar.agentUsageCached": (
+    label,
+    inputTokens,
+    cachedTokens,
+    outputTokens,
+  ) =>
+    `${label}: ${inputTokens} \uC785\uB825 (${cachedTokens} \uCE90\uC2DC) / ${outputTokens} \uCD9C\uB825`,
   "tokenBar.noUsage": "\uD1A0\uD070 \uB370\uC774\uD130 \uC5C6\uC74C",
 
   // ---- input area --------------------------------------------------------
@@ -226,6 +233,8 @@ export const ko: Messages = {
     `\u2193 ${count}\uC904 \uB354 \uC788\uC74C`,
   "agent.labelA": "에이전트 A",
   "agent.labelB": "에이전트 B",
+  "agent.labelShortA": "A",
+  "agent.labelShortB": "B",
   "agent.labelARole": "에이전트 A (작성자)",
   "agent.labelBRole": "에이전트 B (리뷰어)",
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -181,6 +181,12 @@ export interface Messages {
     inputTokens: string,
     outputTokens: string,
   ) => string;
+  "tokenBar.agentUsageCached": (
+    label: string,
+    inputTokens: string,
+    cachedTokens: string,
+    outputTokens: string,
+  ) => string;
   "tokenBar.noUsage": string;
 
   // ---- input area (InputArea.tsx) ----------------------------------------
@@ -196,6 +202,8 @@ export interface Messages {
   "agentPane.linesBelow": (count: number) => string;
   "agent.labelA": string;
   "agent.labelB": string;
+  "agent.labelShortA": string;
+  "agent.labelShortB": string;
   "agent.labelARole": string;
   "agent.labelBRole": string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -786,6 +786,8 @@ try {
       },
       modelNameA: modelDisplayName(agentAConfig),
       modelNameB: modelDisplayName(agentBConfig),
+      cliTypeA: agentAConfig.cli,
+      cliTypeB: agentBConfig.cli,
     });
   });
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -191,6 +191,10 @@ export interface AppProps {
   modelNameA?: string;
   /** Short model identifier for Agent B (e.g., "gpt-5.4"). */
   modelNameB?: string;
+  /** CLI identifier for Agent A (e.g. "claude" or "codex"). */
+  cliTypeA?: string;
+  /** CLI identifier for Agent B (e.g. "claude" or "codex"). */
+  cliTypeB?: string;
   /**
    * Called when the user presses Ctrl+C so the caller can kill running
    * agent child processes before the pipeline unwinds.
@@ -205,6 +209,8 @@ export function App({
   onPromptReady,
   modelNameA,
   modelNameB,
+  cliTypeA,
+  cliTypeB,
   onCancel,
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
@@ -387,6 +393,8 @@ export function App({
         visible={flags.showTokenBar}
         contentWidth={tokenBarContentWidth}
         layout={effectiveLayout}
+        cliTypeA={cliTypeA}
+        cliTypeB={cliTypeB}
       />
       <StatusBar
         emitter={emitter}

--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -25,6 +25,18 @@ export function formatTokenCount(n: number): string {
   return `${m.toFixed(1)}M`;
 }
 
+/** Map a CLI identifier to a title-case display name. */
+export function cliDisplayName(cli: string): string {
+  switch (cli) {
+    case "claude":
+      return "Claude";
+    case "codex":
+      return "Codex";
+    default:
+      return cli;
+  }
+}
+
 interface TokenBarProps {
   emitter: PipelineEventEmitter;
   /** When false, the bar stays mounted (accumulating data) but renders nothing. */
@@ -39,6 +51,10 @@ interface TokenBarProps {
   contentWidth?: number;
   /** Layout direction – must match the agent pane layout. */
   layout?: "row" | "column";
+  /** CLI identifier for Agent A (e.g. "claude" or "codex"). */
+  cliTypeA?: string;
+  /** CLI identifier for Agent B (e.g. "claude" or "codex"). */
+  cliTypeB?: string;
 }
 
 export function TokenBar({
@@ -46,6 +62,8 @@ export function TokenBar({
   visible = true,
   contentWidth,
   layout = "row",
+  cliTypeA,
+  cliTypeB,
 }: TokenBarProps) {
   const [usageA, setUsageA] = useState<TokenUsage>({
     inputTokens: 0,
@@ -78,24 +96,38 @@ export function TokenBar({
   const hasData =
     usageA.inputTokens > 0 ||
     usageA.outputTokens > 0 ||
+    usageA.cachedInputTokens > 0 ||
     usageB.inputTokens > 0 ||
-    usageB.outputTokens > 0;
+    usageB.outputTokens > 0 ||
+    usageB.cachedInputTokens > 0;
 
   if (!visible || !hasData) return null;
 
-  const labelA = m["agent.labelARole"];
-  const labelB = m["agent.labelBRole"];
+  const labelA = cliTypeA
+    ? `${m["agent.labelShortA"]} (${cliDisplayName(cliTypeA)})`
+    : m["agent.labelARole"];
+  const labelB = cliTypeB
+    ? `${m["agent.labelShortB"]} (${cliDisplayName(cliTypeB)})`
+    : m["agent.labelBRole"];
 
-  const textA = m["tokenBar.agentUsage"](
-    labelA,
-    formatTokenCount(usageA.inputTokens),
-    formatTokenCount(usageA.outputTokens),
-  );
-  const textB = m["tokenBar.agentUsage"](
-    labelB,
-    formatTokenCount(usageB.inputTokens),
-    formatTokenCount(usageB.outputTokens),
-  );
+  function formatUsage(label: string, usage: TokenUsage): string {
+    if (usage.cachedInputTokens > 0) {
+      return m["tokenBar.agentUsageCached"](
+        label,
+        formatTokenCount(usage.inputTokens),
+        formatTokenCount(usage.cachedInputTokens),
+        formatTokenCount(usage.outputTokens),
+      );
+    }
+    return m["tokenBar.agentUsage"](
+      label,
+      formatTokenCount(usage.inputTokens),
+      formatTokenCount(usage.outputTokens),
+    );
+  }
+
+  const textA = formatUsage(labelA, usageA);
+  const textB = formatUsage(labelB, usageB);
 
   const displayA =
     contentWidth !== undefined

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -22,7 +22,7 @@ import {
 } from "./App.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { fitInfoSegments, StatusBar } from "./StatusBar.js";
-import { formatTokenCount, TokenBar } from "./TokenBar.js";
+import { cliDisplayName, formatTokenCount, TokenBar } from "./TokenBar.js";
 
 afterEach(() => {
   cleanup();
@@ -1787,6 +1787,122 @@ describe("TokenBar layout prop", () => {
     expect(agentAIdx).toBeGreaterThanOrEqual(0);
     expect(agentBIdx).toBeGreaterThanOrEqual(0);
     expect(agentAIdx).not.toBe(agentBIdx);
+  });
+});
+
+// ---- cliDisplayName ----------------------------------------------------------
+
+describe("cliDisplayName", () => {
+  test("maps claude to title case", () => {
+    expect(cliDisplayName("claude")).toBe("Claude");
+  });
+
+  test("maps codex to title case", () => {
+    expect(cliDisplayName("codex")).toBe("Codex");
+  });
+
+  test("returns unknown CLI names unchanged", () => {
+    expect(cliDisplayName("other")).toBe("other");
+  });
+});
+
+// ---- TokenBar CLI labels and cached tokens -----------------------------------
+
+describe("TokenBar CLI labels", () => {
+  test("uses CLI name labels when cliType props are provided", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} cliTypeA="claude" cliTypeB="codex" />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:usage", {
+      agent: "b",
+      usage: { inputTokens: 2000, outputTokens: 800, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("A (Claude)");
+    expect(frame).toContain("B (Codex)");
+    expect(frame).not.toContain("Agent A");
+    expect(frame).not.toContain("Agent B");
+    expect(frame).not.toContain("(author)");
+    expect(frame).not.toContain("(reviewer)");
+  });
+
+  test("falls back to role labels when cliType props are not provided", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<TokenBar emitter={emitter} />);
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Agent A (author)");
+  });
+});
+
+describe("TokenBar cached tokens", () => {
+  test("shows cached count when cachedInputTokens > 0", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} cliTypeA="claude" cliTypeB="codex" />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: {
+        inputTokens: 4100,
+        outputTokens: 6200,
+        cachedInputTokens: 40000,
+      },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("4.1K in");
+    expect(frame).toContain("40.0K cached");
+    expect(frame).toContain("6.2K out");
+  });
+
+  test("hides cached count when cachedInputTokens is 0", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} cliTypeA="claude" cliTypeB="codex" />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("cached");
+  });
+
+  test("renders when only cachedInputTokens is non-zero (cached-only edge case)", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} cliTypeA="claude" cliTypeB="codex" />,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 0, outputTokens: 0, cachedInputTokens: 5000 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("A (Claude)");
+    expect(frame).toContain("5.0K cached");
   });
 });
 


### PR DESCRIPTION
## Summary

- Display the CLI tool name (e.g. "Claude", "Codex") alongside the short agent label in the TokenBar: `A (Claude): 4.1K in (40K cached) / 6.2K out`
- Show cached input token counts in parentheses when `cachedInputTokens > 0`, hiding the cached portion when zero
- Fix `hasData` guard to include `cachedInputTokens` so the bar renders even in cached-only edge cases
- Add `tokenBar.agentUsageCached` message key with English and Korean translations

Closes #147

## Test plan

- [x] Verify TokenBar shows `A (Claude)` / `B (Codex)` labels when CLI types are provided
- [x] Verify TokenBar falls back to `Agent A (author)` / `Agent B (reviewer)` when CLI types are not provided
- [x] Verify cached token count appears in parentheses when `cachedInputTokens > 0`
- [x] Verify cached portion is hidden when `cachedInputTokens` is 0
- [x] Verify TokenBar renders when only `cachedInputTokens` is non-zero (cached-only edge case)
- [x] Verify AgentPane headers remain unchanged (`Agent A (author)` / `Agent B (reviewer)`)
- [x] Verify `cliDisplayName` maps `"claude"` → `"Claude"`, `"codex"` → `"Codex"`, and passes unknown names through unchanged
- [x] All existing and new tests pass (`pnpm vitest run`)
- [x] Biome lint and TypeScript type checks pass