### PR TITLE
Show issue title in StatusBar (#151)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -715,6 +715,7 @@ try {
       owner,
       repo,
       issueNumber,
+      issueTitle,
       branch: wt.branch,
       worktreePath: wt.path,
       baseSha: savedState?.baseSha ?? wt.baseSha,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -89,6 +89,8 @@ export interface StageContext {
   owner: string;
   repo: string;
   issueNumber: number;
+  /** Title of the GitHub issue (used for display in the StatusBar). */
+  issueTitle?: string;
   branch: string;
   worktreePath: string;
   /**

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -401,6 +401,7 @@ export function App({
         owner={pipelineOptions.context.owner}
         repo={pipelineOptions.context.repo}
         issueNumber={pipelineOptions.context.issueNumber}
+        issueTitle={pipelineOptions.context.issueTitle}
         baseSha={pipelineOptions.context.baseSha}
         layout={effectiveLayout}
         showKeyHints={flags.showKeyHints}

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -18,6 +18,8 @@ interface StatusBarProps {
   owner: string;
   repo: string;
   issueNumber: number;
+  /** Title of the GitHub issue, shown after the issue reference. */
+  issueTitle?: string;
   /** Full SHA of the base commit; displayed abbreviated in the bar. */
   baseSha?: string;
   /** Current pane layout direction. */
@@ -129,6 +131,7 @@ export function StatusBar({
   owner,
   repo,
   issueNumber,
+  issueTitle,
   baseSha,
   layout,
   showKeyHints = true,
@@ -195,7 +198,7 @@ export function StatusBar({
     outcomeKey && outcomeKey in m ? (m[outcomeKey] as string) : lastOutcome;
   const outcomeText = outcomeLabel ? m["statusBar.last"](outcomeLabel) : "";
 
-  const issueLabel = `${owner}/${repo}#${issueNumber}`;
+  const issueRef = `${owner}/${repo}#${issueNumber}`;
   const baseText = baseSha ? m["statusBar.base"](baseSha.slice(0, 7)) : "";
   const layoutText = layout
     ? m["statusBar.layout"](
@@ -212,8 +215,16 @@ export function StatusBar({
   // Build segments in display order with drop priorities.
   // Priority 0 = required (never dropped); higher = dropped sooner.
   // Drop order: layout (4) → completed (3) → outcome (2) → base (1).
+  // The issue segment uses only the reference (owner/repo#N); the title
+  // is appended afterwards using leftover space so that truncation never
+  // clips the reference itself (see issue #151 review).
   const segments: InfoSegment[] = [
-    { text: issueLabel, bold: true, color: "cyan", dropPriority: 0 },
+    {
+      text: issueTitle ? `${issueRef}: ${issueTitle}` : issueRef,
+      bold: true,
+      color: "cyan",
+      dropPriority: 0,
+    },
   ];
   if (baseText) {
     segments.push({ text: baseText, dropPriority: 1 });
@@ -229,10 +240,34 @@ export function StatusBar({
     segments.push({ text: layoutText, dropPriority: 4 });
   }
 
-  const display =
-    contentWidth !== undefined
-      ? fitInfoSegments(segments, contentWidth)
-      : segments;
+  let display: InfoSegment[];
+  if (contentWidth !== undefined) {
+    // Fit segments using only the reference for the issue segment, so
+    // that fitInfoSegments never truncates the reference portion.
+    const refSegments = segments.map((seg, i) =>
+      i === 0 ? { ...seg, text: issueRef } : seg,
+    );
+    display = fitInfoSegments(refSegments, contentWidth);
+
+    // Append the issue title to the first segment using leftover space.
+    if (issueTitle && display.length > 0) {
+      const used = segmentsWidth(display);
+      const available = contentWidth - used;
+      if (available >= 2) {
+        const titleWithSep = `: ${issueTitle}`;
+        display = display.map((seg, i) =>
+          i === 0
+            ? {
+                ...seg,
+                text: seg.text + truncateWithEllipsis(titleWithSep, available),
+              }
+            : seg,
+        );
+      }
+    }
+  } else {
+    display = segments;
+  }
 
   return (
     <Box

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1123,6 +1123,84 @@ describe("StatusBar", () => {
     expect(frame).toContain("Tab:Switch pane");
     expect(frame).toContain("Ctrl+C:Quit");
   });
+
+  test("shows issue title after issue reference when provided", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={42}
+        issueTitle="Fix the widget"
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("aicers/agentcoop#42: Fix the widget");
+  });
+
+  test("omits title separator when issueTitle is not provided", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={42}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("aicers/agentcoop#42");
+    expect(frame).not.toContain("aicers/agentcoop#42:");
+  });
+
+  test("truncates long issue title with ellipsis under tight width", () => {
+    const emitter = new PipelineEventEmitter();
+    // ref (19) + sep (5) + stage (15) = 39, leaving 16 cols for the title.
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={42}
+        issueTitle="This is a very long issue title that should be truncated"
+        contentWidth={55}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    // The title portion should be truncated with an ellipsis.
+    expect(frame).toContain("\u2026");
+    // The full title should NOT appear since 55 columns is too narrow.
+    expect(frame).not.toContain(
+      "This is a very long issue title that should be truncated",
+    );
+    // The issue reference must always remain fully visible (#151 review).
+    expect(frame).toContain("aicers/agentcoop#42:");
+  });
+
+  test("shows truncated title suffix at boundary width", () => {
+    const emitter = new PipelineEventEmitter();
+    // ref (19) + sep (5) + stage (16) = 40, so contentWidth=42 leaves
+    // only 2 columns for the title suffix — just enough for `:…`.
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={42}
+        issueTitle="Bug fix"
+        contentWidth={42}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Even with very little leftover space the title suffix must appear.
+    expect(frame).toContain("aicers/agentcoop#42:");
+    expect(frame).toContain("\u2026");
+  });
 });
 
 // ---- InputArea ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Thread the `issueTitle` field from `RunParams` through `StageContext` into the `StatusBar` component
- When present, display the title after the issue reference (e.g. `owner/repo#42: Fix the widget`)
- Truncation preserves the full issue reference: `fitInfoSegments` sizes segments using only the reference, then the title is appended into leftover space via `truncateWithEllipsis` so the `owner/repo#N` prefix is never clipped

Closes #151

## Test plan

- [x] Launch with an issue that has a short title — verify it appears in full after the issue reference
- [x] Launch with an issue that has a long title — verify it is truncated with an ellipsis and stays on one line
- [x] Launch without an issue title (e.g. resumed state with no title saved) — verify the StatusBar shows only `owner/repo#N` with no trailing colon
- [x] Resize the terminal to a narrow width — verify truncation adapts and the bar does not wrap
- [x] Under constrained width, the full `owner/repo#42:` prefix remains visible while the title is truncated
- [x] At boundary width (only 2–3 columns of leftover space), a truncated title suffix still appears
- [x] `pnpm vitest run src/ui/components.test.tsx` passes (4 tests covering the above scenarios)