### PR TITLE
Notify user when pipeline is waiting for input (#148)

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -43,6 +43,7 @@ describe("loadConfig", () => {
         inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
+      notifications: { bell: true, desktop: false },
     });
     expect(existsSync(configPath())).toBe(true);
   });
@@ -60,6 +61,7 @@ describe("loadConfig", () => {
         inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
+      notifications: { bell: true, desktop: false },
     });
   });
 
@@ -448,6 +450,83 @@ describe("loadConfig", () => {
       autoResumeAttempts: 3,
     });
   });
+
+  // ---- notifications -------------------------------------------------------
+
+  test("default config includes notification defaults", () => {
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: true, desktop: false });
+  });
+
+  test("reads saved notification settings", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        notifications: { bell: false, desktop: true },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: false, desktop: true });
+  });
+
+  test("fills missing notification fields with defaults", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], notifications: { desktop: true } }),
+    );
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: true, desktop: true });
+  });
+
+  test("falls back to defaults for non-boolean notification values", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        notifications: { bell: "yes", desktop: 1 },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: true, desktop: false });
+  });
+
+  test("falls back to defaults when notifications is not an object", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], notifications: "on" }),
+    );
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: true, desktop: false });
+  });
+
+  test("notifications null falls back to defaults", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], notifications: null }),
+    );
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: true, desktop: false });
+  });
+
+  test("notifications array falls back to defaults", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], notifications: [true, false] }),
+    );
+    const config = loadConfig();
+    expect(config.notifications).toEqual({ bell: true, desktop: false });
+  });
+
+  test("notification defaults are isolated from mutations", () => {
+    const config1 = loadConfig();
+    (config1.notifications as Record<string, unknown>).bell = false;
+
+    rmSync(configPath());
+
+    const config2 = loadConfig();
+    expect(config2.notifications.bell).toBe(true);
+  });
 });
 
 describe("saveConfig", () => {
@@ -462,12 +541,15 @@ describe("saveConfig", () => {
     autoResumeAttempts: 3,
   };
 
+  const defaultNotif = { bell: true, desktop: false };
+
   test("creates directories and writes config", () => {
     const config = {
       owners: ["org1"],
       cloneBaseDir: "~/code",
       language: "ko" as const,
       pipelineSettings: { ...defaultPS },
+      notifications: { ...defaultNotif },
     };
     saveConfig(config);
     const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
@@ -480,6 +562,7 @@ describe("saveConfig", () => {
       cloneBaseDir: "~/x",
       language: "en",
       pipelineSettings: { ...defaultPS },
+      notifications: { ...defaultNotif },
     });
     const content = readFileSync(configPath(), "utf-8");
     expect(content.endsWith("\n")).toBe(true);
@@ -491,18 +574,21 @@ describe("saveConfig", () => {
       cloneBaseDir: "~/x",
       language: "en",
       pipelineSettings: { ...defaultPS },
+      notifications: { ...defaultNotif },
     });
     saveConfig({
       owners: ["b"],
       cloneBaseDir: "~/y",
       language: "ko",
       pipelineSettings: { ...defaultPS, reviewAutoRounds: 5 },
+      notifications: { bell: false, desktop: true },
     });
     const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
     expect(raw.owners).toEqual(["b"]);
     expect(raw.cloneBaseDir).toBe("~/y");
     expect(raw.language).toBe("ko");
     expect(raw.pipelineSettings.reviewAutoRounds).toBe(5);
+    expect(raw.notifications).toEqual({ bell: false, desktop: true });
   });
 
   test("roundtrips correctly with loadConfig", () => {
@@ -511,6 +597,7 @@ describe("saveConfig", () => {
       cloneBaseDir: "~/dev",
       language: "ko" as const,
       pipelineSettings: { ...defaultPS, inactivityTimeoutMinutes: 30 },
+      notifications: { bell: false, desktop: true },
     };
     saveConfig(original);
     const loaded = loadConfig();

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,11 +23,22 @@ export interface SavedAgentConfig {
   effortLevel?: string;
 }
 
+export interface NotificationSettings {
+  bell: boolean;
+  desktop: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_SETTINGS: NotificationSettings = {
+  bell: true,
+  desktop: false,
+};
+
 export interface Config {
   owners: string[];
   cloneBaseDir: string;
   language: "en" | "ko";
   pipelineSettings: PipelineSettings;
+  notifications: NotificationSettings;
   agentA?: SavedAgentConfig;
   agentB?: SavedAgentConfig;
   executionMode?: "auto" | "step";
@@ -38,6 +49,7 @@ const DEFAULT_CONFIG: Config = {
   cloneBaseDir: "~/projects",
   language: "en",
   pipelineSettings: { ...DEFAULT_PIPELINE_SETTINGS },
+  notifications: { ...DEFAULT_NOTIFICATION_SETTINGS },
 };
 
 export function configPath(): string {
@@ -63,6 +75,18 @@ function loadSavedAgentConfig(raw: unknown): SavedAgentConfig | undefined {
     contextWindow:
       typeof r.contextWindow === "string" ? r.contextWindow : undefined,
     effortLevel: typeof r.effortLevel === "string" ? r.effortLevel : undefined,
+  };
+}
+
+function loadNotificationSettings(raw: unknown): NotificationSettings {
+  const d = DEFAULT_NOTIFICATION_SETTINGS;
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return { ...d };
+  }
+  const r = raw as Record<string, unknown>;
+  return {
+    bell: typeof r.bell === "boolean" ? r.bell : d.bell,
+    desktop: typeof r.desktop === "boolean" ? r.desktop : d.desktop,
   };
 }
 
@@ -96,6 +120,7 @@ export function loadConfig(): Config {
       ...DEFAULT_CONFIG,
       owners: [...DEFAULT_CONFIG.owners],
       pipelineSettings: { ...DEFAULT_CONFIG.pipelineSettings },
+      notifications: { ...DEFAULT_CONFIG.notifications },
     };
   }
   const raw = JSON.parse(readFileSync(path, "utf-8"));
@@ -104,6 +129,7 @@ export function loadConfig(): Config {
       ...DEFAULT_CONFIG,
       owners: [...DEFAULT_CONFIG.owners],
       pipelineSettings: { ...DEFAULT_CONFIG.pipelineSettings },
+      notifications: { ...DEFAULT_CONFIG.notifications },
     };
   }
   const language = VALID_LANGUAGES.has(raw.language)
@@ -121,6 +147,7 @@ export function loadConfig(): Config {
         : DEFAULT_CONFIG.cloneBaseDir,
     language,
     pipelineSettings: loadPipelineSettings(raw.pipelineSettings),
+    notifications: loadNotificationSettings(raw.notifications),
     agentA: loadSavedAgentConfig(raw.agentA),
     agentB: loadSavedAgentConfig(raw.agentB),
     executionMode:

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -9,6 +9,7 @@ export const en: Messages = {
   "quickStart.mode": (exec) => `  Mode: ${exec}`,
   "quickStart.language": (lang) => `  Language: ${lang}`,
   "quickStart.pipelineSettings": "  Pipeline settings:",
+  "quickStart.notifications": "  Notifications:",
   "quickStart.usePrevious": "Use previous settings?",
 
   // ---- startup / config --------------------------------------------------
@@ -37,6 +38,9 @@ export const en: Messages = {
   "startup.settingSuffixMin": "min",
   "startup.adjustSettings": "Adjust any settings?",
   "startup.positiveInteger": "Enter a positive integer",
+  "startup.notificationBell": "Terminal bell",
+  "startup.notificationDesktop": "Desktop notification",
+  "startup.notificationSettings": "Notification settings:",
   "startup.saveChanges": "Save changes to config?",
   "startup.issueState": (state) => `  State: ${state}`,
   "startup.issueLabels": (labels) => `  Labels: ${labels}`,
@@ -264,6 +268,12 @@ export const en: Messages = {
   "cleanup.done": "Cleanup complete.",
   "prompt.yesCleanup": "Yes",
   "prompt.noSkipCleanup": "No",
+
+  // ---- worktree errors ---------------------------------------------------
+
+  // ---- notifications -------------------------------------------------------
+
+  "notification.title": "agentcoop",
 
   // ---- worktree errors ---------------------------------------------------
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -9,7 +9,9 @@ export const ko: Messages = {
   "quickStart.mode": (exec) => `  모드: ${exec}`,
   "quickStart.language": (lang) => `  언어: ${lang}`,
   "quickStart.pipelineSettings": "  파이프라인 설정:",
-  "quickStart.usePrevious": "이전 설정을 사용하시겠습니까?",
+  "quickStart.notifications": "  \uC54C\uB9BC:",
+  "quickStart.usePrevious":
+    "\uC774\uC804 \uC124\uC815\uC744 \uC0AC\uC6A9\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?",
 
   // ---- startup / config --------------------------------------------------
 
@@ -48,6 +50,9 @@ export const ko: Messages = {
     "\uC124\uC815\uC744 \uC870\uC815\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?",
   "startup.positiveInteger":
     "\uC591\uC758 \uC815\uC218\uB97C \uC785\uB825\uD558\uC138\uC694",
+  "startup.notificationBell": "\uD130\uBBF8\uB110 \uBCA8",
+  "startup.notificationDesktop": "\uB370\uC2A4\uD06C\uD1B1 \uC54C\uB9BC",
+  "startup.notificationSettings": "\uC54C\uB9BC \uC124\uC815:",
   "startup.saveChanges":
     "\uBCC0\uACBD \uC0AC\uD56D\uC744 \uC800\uC7A5\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?",
   "startup.issueState": (state) => `  \uC0C1\uD0DC: ${state}`,
@@ -304,6 +309,12 @@ export const ko: Messages = {
   "cleanup.done": "\uC815\uB9AC \uC644\uB8CC.",
   "prompt.yesCleanup": "\uC608",
   "prompt.noSkipCleanup": "\uC544\uB2C8\uC624",
+
+  // ---- worktree errors ---------------------------------------------------
+
+  // ---- notifications -------------------------------------------------------
+
+  "notification.title": "agentcoop",
 
   // ---- worktree errors ---------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -13,6 +13,7 @@ export interface Messages {
   "quickStart.mode": (exec: string) => string;
   "quickStart.language": (lang: string) => string;
   "quickStart.pipelineSettings": string;
+  "quickStart.notifications": string;
   "quickStart.usePrevious": string;
 
   // ---- startup / config (startup.ts) -------------------------------------
@@ -40,6 +41,9 @@ export interface Messages {
   "startup.settingSuffixMin": string;
   "startup.adjustSettings": string;
   "startup.positiveInteger": string;
+  "startup.notificationBell": string;
+  "startup.notificationDesktop": string;
+  "startup.notificationSettings": string;
   "startup.saveChanges": string;
   "startup.issueState": (state: string) => string;
   "startup.issueLabels": (labels: string) => string;
@@ -252,6 +256,12 @@ export interface Messages {
   "cleanup.done": string;
   "prompt.yesCleanup": string;
   "prompt.noSkipCleanup": string;
+
+  // ---- worktree errors ---------------------------------------------------
+
+  // ---- notifications -------------------------------------------------------
+
+  "notification.title": string;
 
   // ---- worktree errors ---------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
   stopDockerCompose,
 } from "./cleanup.js";
 import { createCodexAdapter } from "./codex-adapter.js";
-import type { PipelineSettings } from "./config.js";
+import type { NotificationSettings, PipelineSettings } from "./config.js";
 import { loadConfig } from "./config.js";
 import { getGitHubUsername, getIssue } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
@@ -65,6 +65,7 @@ interface RunParams {
   agentBConfig: AgentConfig;
   executionMode: "auto" | "step";
   pipelineSettings: PipelineSettings;
+  notifications: NotificationSettings;
   issueTitle: string;
   issueBody: string;
   startFromStage: number | undefined;
@@ -327,6 +328,7 @@ try {
         },
         executionMode: savedState.executionMode,
         pipelineSettings: target.config.pipelineSettings,
+        notifications: target.config.notifications,
         issueTitle: issue.title,
         issueBody: issue.body,
         startFromStage: savedState.currentStage,
@@ -360,11 +362,14 @@ try {
     const result = await runStartup(target);
     // Re-initialise i18n if the user changed language during startup.
     await initI18n(result.language);
+    // Reload config to pick up any notification changes made during startup.
+    const freshConfig = loadConfig();
     return {
       agentAConfig: result.agentA,
       agentBConfig: result.agentB,
       executionMode: result.executionMode,
       pipelineSettings: result.pipelineSettings,
+      notifications: freshConfig.notifications,
       issueTitle: result.issue.title,
       issueBody: result.issue.body,
       startFromStage: undefined,
@@ -378,6 +383,7 @@ try {
     agentBConfig,
     executionMode,
     pipelineSettings,
+    notifications,
     issueTitle,
     issueBody,
     startFromStage: rawStartFromStage,
@@ -788,6 +794,7 @@ try {
       modelNameB: modelDisplayName(agentBConfig),
       cliTypeA: agentAConfig.cli,
       cliTypeB: agentBConfig.cli,
+      notifications,
     });
   });
 

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -1,0 +1,148 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  type MockInstance,
+  test,
+  vi,
+} from "vitest";
+import type { NotificationSettings } from "./config.js";
+
+// Mock child_process.execFile before importing the module under test.
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(),
+}));
+
+// Mock i18n — provide a minimal catalog with notification.title.
+vi.mock("./i18n/index.js", () => ({
+  t: () => ({ "notification.title": "agentcoop" }),
+}));
+
+const { execFile } = await import("node:child_process");
+const { notifyInputWaiting, _emitBell, _sendDesktop } = await import(
+  "./notify.js"
+);
+
+describe("notifyInputWaiting", () => {
+  let stdoutWriteSpy: MockInstance;
+
+  beforeEach(() => {
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    vi.mocked(execFile).mockReset();
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+  });
+
+  test("fires bell when bell is enabled", () => {
+    const settings: NotificationSettings = { bell: true, desktop: false };
+    notifyInputWaiting(settings, "Ready?");
+    expect(stdoutWriteSpy).toHaveBeenCalledWith("\x07");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  test("fires desktop notification when desktop is enabled (darwin)", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const settings: NotificationSettings = { bell: false, desktop: true };
+      notifyInputWaiting(settings, "Ready?");
+      expect(stdoutWriteSpy).not.toHaveBeenCalled();
+      expect(execFile).toHaveBeenCalledWith("osascript", [
+        "-e",
+        'display notification "Ready?" with title "agentcoop"',
+      ]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  test("fires desktop notification when desktop is enabled (linux)", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux" });
+    try {
+      const settings: NotificationSettings = { bell: false, desktop: true };
+      notifyInputWaiting(settings, "Ready?");
+      expect(execFile).toHaveBeenCalledWith("notify-send", [
+        "agentcoop",
+        "Ready?",
+      ]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  test("fires both bell and desktop when both enabled", () => {
+    const settings: NotificationSettings = { bell: true, desktop: true };
+    notifyInputWaiting(settings, "Proceed?");
+    expect(stdoutWriteSpy).toHaveBeenCalledWith("\x07");
+    expect(execFile).toHaveBeenCalled();
+  });
+
+  test("fires nothing when both disabled", () => {
+    const settings: NotificationSettings = { bell: false, desktop: false };
+    notifyInputWaiting(settings, "Hello");
+    expect(stdoutWriteSpy).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  test("bell silently handles stdout write failure", () => {
+    stdoutWriteSpy.mockImplementation(() => {
+      throw new Error("stdout broken");
+    });
+    // Should not throw.
+    expect(() => _emitBell()).not.toThrow();
+  });
+
+  test("desktop notification silently handles execFile failure", () => {
+    vi.mocked(execFile).mockImplementation(() => {
+      throw new Error("command not found");
+    });
+    // Should not throw.
+    expect(() => _sendDesktop("test message")).not.toThrow();
+  });
+
+  test("escapes double quotes in desktop notification message (darwin)", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const settings: NotificationSettings = { bell: false, desktop: true };
+      notifyInputWaiting(settings, 'Stage "Done" ready');
+      expect(execFile).toHaveBeenCalledWith("osascript", [
+        "-e",
+        'display notification "Stage \\"Done\\" ready" with title "agentcoop"',
+      ]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  test("skips desktop notification on unsupported platform", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32" });
+    try {
+      const settings: NotificationSettings = { bell: false, desktop: true };
+      notifyInputWaiting(settings, "Ready?");
+      expect(execFile).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+
+  test("escapes backslashes in desktop notification message (darwin)", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    try {
+      const settings: NotificationSettings = { bell: false, desktop: true };
+      notifyInputWaiting(settings, "path\\to\\file");
+      expect(execFile).toHaveBeenCalledWith("osascript", [
+        "-e",
+        'display notification "path\\\\to\\\\file" with title "agentcoop"',
+      ]);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform });
+    }
+  });
+});

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -1,0 +1,54 @@
+import { execFile } from "node:child_process";
+import type { NotificationSettings } from "./config.js";
+import { t } from "./i18n/index.js";
+
+/**
+ * Send notifications to alert the user that the pipeline is waiting
+ * for input.  Fires bell and/or desktop notification based on settings.
+ * All errors are silently swallowed — notifications must never block
+ * or break the prompt flow.
+ */
+export function notifyInputWaiting(
+  settings: NotificationSettings,
+  message: string,
+): void {
+  if (settings.bell) {
+    emitBell();
+  }
+  if (settings.desktop) {
+    sendDesktopNotification(message);
+  }
+}
+
+/** Emit the BEL character (\x07) to stdout. */
+function emitBell(): void {
+  try {
+    process.stdout.write("\x07");
+  } catch {
+    // Ignore — stdout may be closed or not writable.
+  }
+}
+
+/** Send a desktop notification using platform-native commands. */
+function sendDesktopNotification(message: string): void {
+  try {
+    const title = t()["notification.title"];
+    if (process.platform === "darwin") {
+      execFile("osascript", [
+        "-e",
+        `display notification "${escapeAppleScript(message)}" with title "${escapeAppleScript(title)}"`,
+      ]);
+    } else if (process.platform === "linux") {
+      execFile("notify-send", [title, message]);
+    }
+  } catch {
+    // Silently ignore — command may not exist, no GUI session, etc.
+  }
+}
+
+/** Escape double quotes and backslashes for AppleScript string literals. */
+function escapeAppleScript(s: string): string {
+  return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+export { emitBell as _emitBell, sendDesktopNotification as _sendDesktop };

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -54,6 +54,7 @@ function defaultConfig(): Config {
       inactivityTimeoutMinutes: 15,
       autoResumeAttempts: 3,
     },
+    notifications: { bell: true, desktop: false },
   };
 }
 
@@ -82,7 +83,9 @@ function setupHappyPath() {
     .mockResolvedValueOnce("en"); // language
   mockSearch.mockResolvedValueOnce("agentcoop"); // repo
   mockInput.mockResolvedValueOnce("42"); // issue number
-  mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
+  mockCheckbox
+    .mockResolvedValueOnce([]) // no pipeline settings adjusted
+    .mockResolvedValueOnce(["bell"]); // notification settings (keep defaults)
   mockListRepositories.mockReturnValue([
     { name: "agentcoop", description: "Multi-agent CLI" },
   ]);
@@ -168,6 +171,7 @@ describe("runStartup — owner selection", () => {
         inactivityTimeoutMinutes: 15,
         autoResumeAttempts: 3,
       },
+      notifications: { bell: true, desktop: false },
     };
     mockLoadConfig.mockReturnValue(config);
     mockInput
@@ -183,7 +187,9 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("step") // execution mode
       .mockResolvedValueOnce("ko"); // language
-    mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
+    mockCheckbox
+      .mockResolvedValueOnce([]) // no pipeline settings adjusted
+      .mockResolvedValueOnce(["bell"]); // notification settings
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -236,7 +242,7 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
       .mockResolvedValueOnce("en"); // language
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -262,7 +268,7 @@ describe("runStartup — owner selection", () => {
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
       .mockResolvedValueOnce("en"); // language
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -542,7 +548,7 @@ describe("runStartup — model selection", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -674,7 +680,7 @@ describe("runStartup — language selection", () => {
       .mockResolvedValueOnce("ko"); // changed from "en" to "ko"
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -705,7 +711,7 @@ describe("runStartup — language selection", () => {
       .mockResolvedValueOnce("ko"); // same as config
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -756,7 +762,7 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -790,7 +796,7 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
       .mockResolvedValueOnce("en"); // same language
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockSearch.mockResolvedValueOnce("repo1");
     mockListRepositories.mockReturnValue([{ name: "repo1", description: "" }]);
     mockGetIssue.mockReturnValue(defaultIssue());
@@ -816,7 +822,7 @@ describe("runStartup — config dirty tracking", () => {
       .mockResolvedValueOnce("ko"); // changed
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -1029,7 +1035,7 @@ describe("runStartup — alternate selections", () => {
       .mockResolvedValueOnce("ko"); // language
     mockSearch.mockResolvedValueOnce("my-repo");
     mockInput.mockResolvedValueOnce("99");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "my-repo", description: "test" },
     ]);
@@ -1074,7 +1080,8 @@ describe("runStartup — pipeline settings", () => {
     setupHappyPath();
     mockCheckbox
       .mockReset()
-      .mockResolvedValueOnce(["selfCheckAutoIterations", "reviewAutoRounds"]);
+      .mockResolvedValueOnce(["selfCheckAutoIterations", "reviewAutoRounds"])
+      .mockResolvedValueOnce(["bell"]); // notification settings
     // input for the two selected settings
     mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
     mockInput.mockResolvedValueOnce("5"); // selfCheckAutoIterations
@@ -1092,7 +1099,10 @@ describe("runStartup — pipeline settings", () => {
 
   test("does not persist pipeline settings when user declines save", async () => {
     setupHappyPath();
-    mockCheckbox.mockReset().mockResolvedValueOnce(["autoResumeAttempts"]);
+    mockCheckbox
+      .mockReset()
+      .mockResolvedValueOnce(["autoResumeAttempts"])
+      .mockResolvedValueOnce(["bell"]); // notification settings
     mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
     mockInput.mockResolvedValueOnce("10"); // autoResumeAttempts
     mockConfirm.mockReset().mockResolvedValueOnce(false); // decline save
@@ -1108,7 +1118,7 @@ describe("runStartup — pipeline settings", () => {
     setupHappyPath();
     await runStartup();
 
-    expect(mockCheckbox).toHaveBeenCalledOnce();
+    expect(mockCheckbox).toHaveBeenCalledTimes(2);
     const opts = mockCheckbox.mock.calls[0][0];
     expect(opts.choices).toHaveLength(4);
     const values = opts.choices.map((c: { value: string }) => c.value);
@@ -1161,7 +1171,7 @@ describe("runStartup — pipeline settings", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -1181,7 +1191,10 @@ describe("runStartup — pipeline settings", () => {
 
   test("unchanged fields preserve original values after adjustment", async () => {
     setupHappyPath();
-    mockCheckbox.mockReset().mockResolvedValueOnce(["selfCheckAutoIterations"]);
+    mockCheckbox
+      .mockReset()
+      .mockResolvedValueOnce(["selfCheckAutoIterations"])
+      .mockResolvedValueOnce(["bell"]); // notification settings
     mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
     mockInput.mockResolvedValueOnce("10"); // selfCheckAutoIterations only
     mockConfirm.mockReset().mockResolvedValueOnce(false); // decline save
@@ -1196,7 +1209,10 @@ describe("runStartup — pipeline settings", () => {
 
   test("validates input rejects negative, zero, decimal, and empty values", async () => {
     setupHappyPath();
-    mockCheckbox.mockReset().mockResolvedValueOnce(["reviewAutoRounds"]);
+    mockCheckbox
+      .mockReset()
+      .mockResolvedValueOnce(["reviewAutoRounds"])
+      .mockResolvedValueOnce(["bell"]); // notification settings
 
     mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
     mockInput.mockImplementationOnce(
@@ -1231,7 +1247,8 @@ describe("runStartup — pipeline settings", () => {
         "reviewAutoRounds",
         "inactivityTimeoutMinutes",
         "autoResumeAttempts",
-      ]);
+      ])
+      .mockResolvedValueOnce(["bell"]); // notification settings
     mockInput.mockReset().mockResolvedValueOnce("42"); // issue number
     mockInput
       .mockResolvedValueOnce("5") // selfCheckAutoIterations
@@ -1277,7 +1294,9 @@ describe("runStartup — pipeline settings", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce(["selfCheckAutoIterations"]);
+    mockCheckbox
+      .mockResolvedValueOnce(["selfCheckAutoIterations"])
+      .mockResolvedValueOnce(["bell"]); // notification settings
     mockInput.mockResolvedValueOnce("99");
     mockConfirm
       .mockResolvedValueOnce(false) // decline save
@@ -1313,7 +1332,9 @@ describe("runStartup — pipeline settings", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce(["autoResumeAttempts"]);
+    mockCheckbox
+      .mockResolvedValueOnce(["autoResumeAttempts"])
+      .mockResolvedValueOnce(["bell"]); // notification settings
     mockInput.mockImplementationOnce(
       async (opts: { message: string; default: string }) => {
         expect(opts.default).toBe("7");
@@ -1419,7 +1440,7 @@ describe("runStartup with target parameter", () => {
       .mockResolvedValueOnce("high") // agent B effort
       .mockResolvedValueOnce("auto") // execution mode
       .mockResolvedValueOnce("en"); // language
-    mockCheckbox.mockResolvedValueOnce([]); // no settings adjusted
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]); // no settings adjusted
     mockConfirm.mockResolvedValueOnce(true); // confirm issue
     mockGetIssue.mockReturnValue(defaultIssue());
 
@@ -1507,7 +1528,7 @@ describe("runStartup — quick-start", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop"); // repo
     mockInput.mockResolvedValueOnce("42"); // issue number
-    mockCheckbox.mockResolvedValueOnce([]); // no pipeline settings adjusted
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]); // no pipeline settings adjusted
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -1556,7 +1577,7 @@ describe("runStartup — quick-start", () => {
       .mockResolvedValueOnce("en"); // language
     mockSearch.mockResolvedValueOnce("agentcoop");
     mockInput.mockResolvedValueOnce("42");
-    mockCheckbox.mockResolvedValueOnce([]);
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
     mockListRepositories.mockReturnValue([
       { name: "agentcoop", description: "" },
     ]);
@@ -1634,6 +1655,9 @@ describe("runStartup — quick-start", () => {
     expect(logs).toContain("Review auto rounds");
     expect(logs).toContain("Inactivity timeout");
     expect(logs).toContain("Auto-resume attempts");
+    expect(logs).toContain("Notifications:");
+    expect(logs).toContain("Terminal bell");
+    expect(logs).toContain("Desktop notification");
 
     consoleSpy.mockRestore();
   });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -1,5 +1,9 @@
 import { checkbox, confirm, input, search, select } from "@inquirer/prompts";
-import type { Config, PipelineSettings } from "./config.js";
+import type {
+  Config,
+  NotificationSettings,
+  PipelineSettings,
+} from "./config.js";
 import { loadConfig, saveConfig } from "./config.js";
 import type { Issue } from "./github.js";
 import { getIssue, listRepositories } from "./github.js";
@@ -172,6 +176,14 @@ export async function runStartup(
       const label = labels[key].padEnd(30);
       console.log(`    ${label} ${formatSettingValue(key, ps[key])}`);
     }
+    const notif = config.notifications;
+    console.log(m["quickStart.notifications"]);
+    console.log(
+      `    ${m["startup.notificationBell"].padEnd(30)} ${notif.bell ? "on" : "off"}`,
+    );
+    console.log(
+      `    ${m["startup.notificationDesktop"].padEnd(30)} ${notif.desktop ? "on" : "off"}`,
+    );
     console.log();
 
     const reuse = await confirm({
@@ -224,6 +236,14 @@ export async function runStartup(
     config.pipelineSettings = pipelineSettings;
   }
   configDirty ||= settingsDirty;
+
+  const { notifications, dirty: notifDirty } = await adjustNotificationSettings(
+    config.notifications,
+  );
+  if (notifDirty) {
+    config.notifications = notifications;
+  }
+  configDirty ||= notifDirty;
 
   const issue = getIssue(owner, repo, issueNumber);
   const confirmed = await confirmIssue(owner, repo, issue);
@@ -496,6 +516,36 @@ async function adjustPipelineSettings(
   });
 
   return { pipelineSettings: updated, dirty: save };
+}
+
+async function adjustNotificationSettings(
+  current: NotificationSettings,
+): Promise<{ notifications: NotificationSettings; dirty: boolean }> {
+  const m = t();
+  const selected = await checkbox<"bell" | "desktop">({
+    message: m["startup.notificationSettings"],
+    choices: [
+      {
+        name: m["startup.notificationBell"],
+        value: "bell" as const,
+        checked: current.bell,
+      },
+      {
+        name: m["startup.notificationDesktop"],
+        value: "desktop" as const,
+        checked: current.desktop,
+      },
+    ],
+  });
+
+  const updated: NotificationSettings = {
+    bell: selected.includes("bell"),
+    desktop: selected.includes("desktop"),
+  };
+
+  const dirty =
+    updated.bell !== current.bell || updated.desktop !== current.desktop;
+  return { notifications: updated, dirty };
 }
 
 async function confirmIssue(

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * App-level tests that verify dispatch() triggers notifications when
+ * entering the input-wait state.
+ */
+import { cleanup, render } from "ink-testing-library";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { initI18n } from "../i18n/index.js";
+import type { UserPrompt } from "../pipeline.js";
+import { PipelineEventEmitter } from "../pipeline-events.js";
+
+// Mock runPipeline so it never actually executes.
+vi.mock("../pipeline.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pipeline.js")>();
+  return {
+    ...actual,
+    runPipeline: vi.fn(async () => ({
+      success: true,
+      stoppedAt: undefined,
+      message: "",
+    })),
+  };
+});
+
+// Spy on notifyInputWaiting.
+const notifyInputWaitingSpy = vi.fn();
+vi.mock("../notify.js", () => ({
+  notifyInputWaiting: (...args: unknown[]) => notifyInputWaitingSpy(...args),
+}));
+
+const { App } = await import("./App.js");
+
+const minimalOptions = {
+  context: {
+    owner: "test",
+    repo: "repo",
+    issueNumber: 1,
+    baseSha: "abc",
+  },
+} as never;
+
+afterEach(() => {
+  cleanup();
+  notifyInputWaitingSpy.mockClear();
+});
+
+describe("App dispatch notifications", () => {
+  test("calls notifyInputWaiting when dispatch enters input-wait state", async () => {
+    initI18n("en");
+    const emitter = new PipelineEventEmitter();
+    let capturedPrompt: UserPrompt | undefined;
+
+    render(
+      <App
+        emitter={emitter}
+        pipelineOptions={minimalOptions}
+        onExit={vi.fn()}
+        onPromptReady={(prompt) => {
+          capturedPrompt = prompt;
+        }}
+        notifications={{ bell: true, desktop: false }}
+      />,
+    );
+
+    // Wait for the useEffect to run and call onPromptReady.
+    await vi.waitFor(() => {
+      expect(capturedPrompt).toBeDefined();
+    });
+
+    // Call a prompt method that dispatches an InputRequest.
+    // Don't await — dispatch returns a Promise that resolves on user submit,
+    // but notifyInputWaiting fires synchronously in the Promise constructor.
+    capturedPrompt?.confirmNextStage("CI check");
+
+    expect(notifyInputWaitingSpy).toHaveBeenCalledOnce();
+    expect(notifyInputWaitingSpy).toHaveBeenCalledWith(
+      { bell: true, desktop: false },
+      expect.stringContaining("CI check"),
+    );
+  });
+
+  test("does not call notifyInputWaiting when notifications prop is undefined", async () => {
+    initI18n("en");
+    const emitter = new PipelineEventEmitter();
+    let capturedPrompt: UserPrompt | undefined;
+
+    render(
+      <App
+        emitter={emitter}
+        pipelineOptions={minimalOptions}
+        onExit={vi.fn()}
+        onPromptReady={(prompt) => {
+          capturedPrompt = prompt;
+        }}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(capturedPrompt).toBeDefined();
+    });
+
+    capturedPrompt?.confirmNextStage("CI check");
+
+    expect(notifyInputWaitingSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,6 +1,8 @@
 import { Box, useInput, useStdout } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { NotificationSettings } from "../config.js";
 import { t } from "../i18n/index.js";
+import { notifyInputWaiting } from "../notify.js";
 import type {
   PipelineOptions,
   PipelineResult,
@@ -195,6 +197,8 @@ export interface AppProps {
   cliTypeA?: string;
   /** CLI identifier for Agent B (e.g. "claude" or "codex"). */
   cliTypeB?: string;
+  /** Notification settings (bell / desktop). */
+  notifications?: NotificationSettings;
   /**
    * Called when the user presses Ctrl+C so the caller can kill running
    * agent child processes before the pipeline unwinds.
@@ -211,6 +215,7 @@ export function App({
   modelNameB,
   cliTypeA,
   cliTypeB,
+  notifications,
   onCancel,
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
@@ -283,10 +288,16 @@ export function App({
         : terminalWidth - 4
       : undefined;
 
+  const notificationsRef = useRef(notifications);
+  notificationsRef.current = notifications;
+
   const dispatch = useCallback((request: InputRequest): Promise<string> => {
     return new Promise<string>((resolve) => {
       resolveRef.current = resolve;
       setInputRequest(request);
+      if (notificationsRef.current) {
+        notifyInputWaiting(notificationsRef.current, request.message);
+      }
     });
   }, []);
 


### PR DESCRIPTION
## Summary

- Add configurable notification system that alerts the user when the TUI enters a user-input wait state via `dispatch()` in `App.tsx`
- Terminal bell (`\a`) enabled by default; desktop notifications (`osascript` on macOS, `notify-send` on Linux) disabled by default
- Notifications are configured via `notifications` field in `~/.agentcoop/config.json` and the interactive startup flow
- All notification errors are silently swallowed — notifications never block the prompt flow

Closes #148

## Test plan

- [x] Bell notification fires when `dispatch` is called with `bell: true`
- [x] Desktop notification fires via `osascript` on macOS when `desktop: true`
- [x] Desktop notification fires via `notify-send` on Linux when `desktop: true`
- [x] Desktop notification silently skips on unsupported platforms (e.g. `win32`)
- [x] Both bell and desktop fire when both are enabled
- [x] No notification fires when both are disabled
- [x] `stdout.write` failure in bell does not throw
- [x] `execFile` failure (command not found, no GUI session) does not throw or block the prompt
- [x] AppleScript special characters (double quotes, backslashes) are properly escaped
- [x] App-level: `dispatch()` calls `notifyInputWaiting` when entering input-wait state
- [x] App-level: no notification fires when `notifications` prop is undefined
- [x] Config loads default notification settings (`bell: true`, `desktop: false`) when no config file exists
- [x] Config reads saved notification settings correctly
- [x] Config fills missing notification fields with defaults
- [x] Config falls back to defaults for non-boolean, null, or array values
- [x] Notification defaults are isolated from mutations across `loadConfig()` calls
- [x] Startup flow displays current notification settings in quick-start preview
- [x] Startup flow presents checkbox for notification settings and persists changes
- [x] `saveConfig` round-trips notification settings correctly
- [x] i18n strings added for notification config UI in both English and Korean
- [x] TypeScript type checks pass (`pnpm tsc --noEmit`)
- [x] Biome lint passes (`pnpm biome check`)
- [x] All tests pass (`pnpm vitest run` — 1245 tests)