### PR TITLE
Split StatusBar into three lines (#156)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -93,8 +93,8 @@ function computeFlagsForLayout(
     keyHints: boolean,
     separator: boolean,
   ): number {
-    // StatusBar: border (2) + info line (1) + optional key hints (1).
-    const statusBarHeight = keyHints ? 4 : 3;
+    // StatusBar: border (2) + issue line (1) + pipeline line (1) + optional key hints (1).
+    const statusBarHeight = keyHints ? 5 : 4;
     // TokenBar is split into two boxes.  In row layout they sit side by
     // side (3 rows), in column layout they stack (6 rows).
     const tokenBarHeight = tokenBar ? (layout === "column" ? 6 : 3) : 0;

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -199,62 +199,35 @@ export function StatusBar({
       ? m["statusBar.completed"](selfCheckCount, reviewCount)
       : "";
 
-  // Build segments in display order with drop priorities.
+  // Line 1: Issue reference + title (independent of other segments).
+  const issueLineText = issueTitle ? `${issueRef}: ${issueTitle}` : issueRef;
+  const issueLine =
+    contentWidth !== undefined
+      ? truncateWithEllipsis(issueLineText, contentWidth)
+      : issueLineText;
+
+  // Line 2: Pipeline status segments with drop priorities.
   // Priority 0 = required (never dropped); higher = dropped sooner.
   // Drop order: layout (4) → completed (3) → outcome (2) → base (1).
-  // The issue segment uses only the reference (owner/repo#N); the title
-  // is appended afterwards using leftover space so that truncation never
-  // clips the reference itself (see issue #151 review).
-  const segments: InfoSegment[] = [
-    {
-      text: issueTitle ? `${issueRef}: ${issueTitle}` : issueRef,
-      bold: true,
-      color: "cyan",
-      dropPriority: 0,
-    },
-  ];
+  const pipelineSegments: InfoSegment[] = [];
   if (baseText) {
-    segments.push({ text: baseText, dropPriority: 1 });
+    pipelineSegments.push({ text: baseText, dropPriority: 1 });
   }
-  segments.push({ text: stageText, bold: true, dropPriority: 0 });
+  pipelineSegments.push({ text: stageText, bold: true, dropPriority: 0 });
   if (outcomeText) {
-    segments.push({ text: outcomeText, dropPriority: 2 });
+    pipelineSegments.push({ text: outcomeText, dropPriority: 2 });
   }
   if (completedText) {
-    segments.push({ text: completedText, dropPriority: 3 });
+    pipelineSegments.push({ text: completedText, dropPriority: 3 });
   }
   if (layoutText) {
-    segments.push({ text: layoutText, dropPriority: 4 });
+    pipelineSegments.push({ text: layoutText, dropPriority: 4 });
   }
 
-  let display: InfoSegment[];
-  if (contentWidth !== undefined) {
-    // Fit segments using only the reference for the issue segment, so
-    // that fitInfoSegments never truncates the reference portion.
-    const refSegments = segments.map((seg, i) =>
-      i === 0 ? { ...seg, text: issueRef } : seg,
-    );
-    display = fitInfoSegments(refSegments, contentWidth);
-
-    // Append the issue title to the first segment using leftover space.
-    if (issueTitle && display.length > 0) {
-      const used = segmentsWidth(display);
-      const available = contentWidth - used;
-      if (available >= 2) {
-        const titleWithSep = `: ${issueTitle}`;
-        display = display.map((seg, i) =>
-          i === 0
-            ? {
-                ...seg,
-                text: seg.text + truncateWithEllipsis(titleWithSep, available),
-              }
-            : seg,
-        );
-      }
-    }
-  } else {
-    display = segments;
-  }
+  const pipelineDisplay =
+    contentWidth !== undefined
+      ? fitInfoSegments(pipelineSegments, contentWidth)
+      : pipelineSegments;
 
   return (
     <Box
@@ -263,11 +236,14 @@ export function StatusBar({
       paddingX={1}
       flexDirection="column"
       flexShrink={0}
-      height={contentWidth !== undefined ? (showKeyHints ? 4 : 3) : undefined}
+      height={contentWidth !== undefined ? (showKeyHints ? 5 : 4) : undefined}
       overflow="hidden"
     >
+      <Text bold color="cyan">
+        {issueLine}
+      </Text>
       <Box>
-        {display.map((seg, i) => (
+        {pipelineDisplay.map((seg, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: stable render-local array
           <Text key={i} bold={seg.bold} color={seg.color}>
             {i > 0 ? SEP : ""}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1160,7 +1160,9 @@ describe("StatusBar", () => {
 
   test("truncates long issue title with ellipsis under tight width", () => {
     const emitter = new PipelineEventEmitter();
-    // ref (19) + sep (5) + stage (15) = 39, leaving 16 cols for the title.
+    // Issue line uses the full contentWidth independently.
+    // "aicers/agentcoop#42: This is a very long issue title..." = 75 chars
+    // At contentWidth=35, the issue line is truncated with ellipsis.
     const { lastFrame } = render(
       <StatusBar
         emitter={emitter}
@@ -1168,25 +1170,25 @@ describe("StatusBar", () => {
         repo="agentcoop"
         issueNumber={42}
         issueTitle="This is a very long issue title that should be truncated"
-        contentWidth={55}
+        contentWidth={35}
       />,
     );
 
     const frame = lastFrame() ?? "";
     // The title portion should be truncated with an ellipsis.
     expect(frame).toContain("\u2026");
-    // The full title should NOT appear since 55 columns is too narrow.
+    // The full title should NOT appear since 35 columns is too narrow.
     expect(frame).not.toContain(
       "This is a very long issue title that should be truncated",
     );
-    // The issue reference must always remain fully visible (#151 review).
+    // The issue reference must always remain fully visible.
     expect(frame).toContain("aicers/agentcoop#42:");
   });
 
   test("shows truncated title suffix at boundary width", () => {
     const emitter = new PipelineEventEmitter();
-    // ref (19) + sep (5) + stage (16) = 40, so contentWidth=42 leaves
-    // only 2 columns for the title suffix — just enough for `:…`.
+    // "aicers/agentcoop#42: Bug fix" = 28 chars.
+    // At contentWidth=22, only 22 cols for the issue line → truncated.
     const { lastFrame } = render(
       <StatusBar
         emitter={emitter}
@@ -1194,7 +1196,7 @@ describe("StatusBar", () => {
         repo="agentcoop"
         issueNumber={42}
         issueTitle="Bug fix"
-        contentWidth={42}
+        contentWidth={22}
       />,
     );
 
@@ -1998,9 +2000,9 @@ describe("computeVisibilityFlags", () => {
   });
 
   test("hides token bar first when space is tight", () => {
-    // Row: paneContent = 14 - 1(input) - 4(status) - 3(token) - 4(overhead) = 2 < 3
-    // Without token: 14 - 1 - 4 - 0 - 4 = 5 >= 3
-    const flags = computeVisibilityFlags(14, 1, true, "row");
+    // Row: paneContent = 15 - 1(input) - 5(status) - 3(token) - 4(overhead) = 2 < 3
+    // Without token: 15 - 1 - 5 - 0 - 4 = 5 >= 3
+    const flags = computeVisibilityFlags(15, 1, true, "row");
     expect(flags.showTokenBar).toBe(false);
     expect(flags.showKeyHints).toBe(true);
     expect(flags.showPaneSeparator).toBe(true);
@@ -2008,18 +2010,18 @@ describe("computeVisibilityFlags", () => {
 
   test("hides key hints after token bar", () => {
     // No token data, token bar already hidden.
-    // paneContent = 11 - 1 - 4 - 0 - 4 = 2 < 3 → hide hints
-    // Without hints: 11 - 1 - 3 - 0 - 4 = 3 >= 3
-    const flags = computeVisibilityFlags(11, 1, false, "row");
+    // paneContent = 12 - 1 - 5 - 0 - 4 = 2 < 3 → hide hints
+    // Without hints: 12 - 1 - 4 - 0 - 4 = 3 >= 3
+    const flags = computeVisibilityFlags(12, 1, false, "row");
     expect(flags.showTokenBar).toBe(false);
     expect(flags.showKeyHints).toBe(false);
     expect(flags.showPaneSeparator).toBe(true);
   });
 
   test("hides separator after key hints", () => {
-    // paneContent = 10 - 1 - 3 - 0 - 4 = 2 < 3 → hide separator
-    // Without separator: 10 - 1 - 3 - 0 - 3 = 3 >= 3
-    const flags = computeVisibilityFlags(10, 1, false, "row");
+    // paneContent = 11 - 1 - 4 - 0 - 4 = 2 < 3 → hide separator
+    // Without separator: 11 - 1 - 4 - 0 - 3 = 3 >= 3
+    const flags = computeVisibilityFlags(11, 1, false, "row");
     expect(flags.showTokenBar).toBe(false);
     expect(flags.showKeyHints).toBe(false);
     expect(flags.showPaneSeparator).toBe(false);
@@ -2028,8 +2030,8 @@ describe("computeVisibilityFlags", () => {
   test("forces row layout when column panes are too small", () => {
     // Column layout can't fit MIN_PANE_CONTENT even with all hidden.
     // After forcing row, flags are recomputed for row mode.
-    // Row: paneContent = 12 - 1 - 4 - 0 - 4 = 3 >= 3 → hints and sep shown
-    const flags = computeVisibilityFlags(12, 1, false, "column");
+    // Row: paneContent = 13 - 1 - 5 - 0 - 4 = 3 >= 3 → hints and sep shown
+    const flags = computeVisibilityFlags(13, 1, false, "column");
     expect(flags.allowColumnLayout).toBe(false);
     expect(flags.showKeyHints).toBe(true);
     expect(flags.showPaneSeparator).toBe(true);
@@ -2265,6 +2267,8 @@ describe("StatusBar width adaptation", () => {
 
   test("drops layout indicator first when contentWidth is narrow", async () => {
     const emitter = new PipelineEventEmitter();
+    // Pipeline line: "Stage 2: Implement" (18) + sep (5) + "Layout: horizontal" (19) = 42.
+    // At contentWidth=30, layout (dropPriority 4) is dropped first.
     const { lastFrame } = render(
       <StatusBar
         emitter={emitter}
@@ -2272,7 +2276,7 @@ describe("StatusBar width adaptation", () => {
         repo="agentcoop"
         issueNumber={49}
         layout="row"
-        contentWidth={50}
+        contentWidth={30}
       />,
     );
 


### PR DESCRIPTION
## Summary

- Reorganize the StatusBar from a single content line into three distinct lines: issue reference + title, pipeline status segments, and key hints.
- Line 1 uses the full `contentWidth` for the issue ref/title (truncated with ellipsis), independent of other segments.
- Line 2 reuses the existing `fitInfoSegments` drop-priority logic for pipeline status (base SHA, stage, outcome, completed, layout).
- Update `statusBarHeight` in `computeVisibilityFlags` to account for the extra row (from 3/4 to 4/5).

Closes #156

## Test plan

- [x] Verify the StatusBar renders three lines: issue line, pipeline status, key hints
- [x] Verify long issue titles are truncated with ellipsis on Line 1
- [x] Verify pipeline segments (base, stage, outcome, completed, layout) appear on Line 2 with correct drop-priority fitting
- [x] Verify key hints line still toggles via `showKeyHints`
- [x] Verify `computeVisibilityFlags` height calculations are correct (progressive hiding still works)
- [x] Verify column/row layout switching still works correctly
- [x] Verify narrow terminal widths gracefully drop optional segments on Line 2