### PR TITLE
Make AgentPane rendering size-aware (#154)

### DIFF
--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -7,19 +7,80 @@ import type {
   StageEnterEvent,
 } from "../pipeline-events.js";
 import {
+  type LineEntry,
   PROMPT_LINE_PREFIX,
   PROMPT_SEPARATOR_CHAR,
+  type PromptBlock,
   useAgentLines,
 } from "./useEventEmitter.js";
 
 /** Stage number at which Agent B becomes active. */
 const REVIEW_STAGE = 7;
 
+/** Maximum number of wrapped content rows in a rendered prompt block. */
+const MAX_PROMPT_ROWS = 12;
+
 /** Split a logical line into terminal rows of the given width. */
 export function splitIntoRows(line: string, width: number): string[] {
   if (width < 1) return [line];
   const wrapped = wrapAnsi(line, width, { hard: true, trim: false });
   return wrapped.split("\n");
+}
+
+/**
+ * Render a structured prompt block into terminal rows at the given
+ * width.  Separator length is derived from the width, and content
+ * lines are truncated by wrapped row count rather than source line
+ * count.
+ */
+export function renderPromptRows(block: PromptBlock, width: number): string[] {
+  if (width < 1) return [];
+
+  const label = block.stageName ? ` Prompt (${block.stageName}) ` : " Prompt ";
+
+  // Header: separator chars + label + separator chars, total ≤ width.
+  const availSep = Math.max(0, width - label.length);
+  const leftSep = Math.floor(availSep / 2);
+  const rightSep = availSep - leftSep;
+  const header =
+    PROMPT_SEPARATOR_CHAR.repeat(leftSep) +
+    label +
+    PROMPT_SEPARATOR_CHAR.repeat(rightSep);
+
+  const result: string[] = [];
+
+  // Header — normally one row, but wrap if the label exceeds the width.
+  for (const row of splitIntoRows(header, width)) {
+    result.push(row);
+  }
+
+  // Content lines with wrapped row budget.
+  const rawLines = block.prompt.split("\n");
+  let rowsUsed = 0;
+  let linesShown = 0;
+
+  for (const line of rawLines) {
+    const prefixed = `${PROMPT_LINE_PREFIX}${line}`;
+    const wrapped = splitIntoRows(prefixed, width);
+    if (rowsUsed + wrapped.length > MAX_PROMPT_ROWS) {
+      break;
+    }
+    result.push(...wrapped);
+    rowsUsed += wrapped.length;
+    linesShown++;
+  }
+
+  if (linesShown < rawLines.length) {
+    const notice = `${PROMPT_LINE_PREFIX}\u2026 (${rawLines.length - linesShown} more lines)`;
+    for (const row of splitIntoRows(notice, width)) {
+      result.push(row);
+    }
+  }
+
+  // Footer: separator chars filling the pane width.
+  result.push(PROMPT_SEPARATOR_CHAR.repeat(width));
+
+  return result;
 }
 
 /** A single terminal row tagged with display metadata. */
@@ -58,9 +119,9 @@ export function AgentPane({
   showSeparator = true,
 }: AgentPaneProps) {
   const { lines, pendingLine } = useAgentLines(emitter, agent);
-  const containerRef = useRef<DOMElement>(null);
-  const [visibleRows, setVisibleRows] = useState(20);
-  const [contentWidth, setContentWidth] = useState(80);
+  const contentRef = useRef<DOMElement>(null);
+  const [visibleRows, setVisibleRows] = useState(0);
+  const [contentWidth, setContentWidth] = useState(0);
   const [currentStage, setCurrentStage] = useState<number | null>(null);
   const [scrollOffset, setScrollOffset] = useState(0);
   const prevTotalRowsRef = useRef(0);
@@ -76,32 +137,37 @@ export function AgentPane({
     };
   }, [emitter]);
 
-  // Measure the content area after each render so we know
-  // exactly how many lines fit without relying on heuristics.
+  // Measure the inner content box after each render so visibleRows
+  // and contentWidth reflect the real scrollable area regardless of
+  // how many rows the header consumes.
   useEffect(() => {
-    if (containerRef.current) {
-      const { height, width } = measureElement(containerRef.current);
-      // Reserve rows: border (2) + label (1) + optional separator (1).
-      const overhead = showSeparator ? 4 : 3;
-      setVisibleRows(height > overhead ? height - overhead : 0);
-      // Subtract 4 for borderStyle="single" (2) + paddingX={1} (2).
-      setContentWidth(width > 4 ? width - 4 : 1);
+    if (contentRef.current) {
+      const { height, width } = measureElement(contentRef.current);
+      setVisibleRows(height);
+      setContentWidth(width);
     }
   });
 
-  const allLines = pendingLine ? [...lines, pendingLine] : lines;
+  const allLines: LineEntry[] = pendingLine ? [...lines, pendingLine] : lines;
 
-  // Build a flat array of terminal rows from logical lines so that
-  // scrolling operates at the row level, correctly handling wrapped
-  // lines that span multiple terminal rows.
+  // Build a flat array of terminal rows from logical lines and prompt
+  // blocks so that scrolling operates at the row level, correctly
+  // handling wrapped lines that span multiple terminal rows.
   const allRows: RowEntry[] = [];
   for (let i = 0; i < allLines.length; i++) {
-    const line = allLines[i];
-    const isPrompt =
-      line.startsWith(PROMPT_LINE_PREFIX) ||
-      line.startsWith(PROMPT_SEPARATOR_CHAR);
-    for (const row of splitIntoRows(line, contentWidth)) {
-      allRows.push({ text: row, isPrompt, lineIdx: i });
+    const entry = allLines[i];
+    if (typeof entry === "string") {
+      const isPrompt =
+        entry.startsWith(PROMPT_LINE_PREFIX) ||
+        entry.startsWith(PROMPT_SEPARATOR_CHAR);
+      for (const row of splitIntoRows(entry, contentWidth)) {
+        allRows.push({ text: row, isPrompt, lineIdx: i });
+      }
+    } else {
+      // PromptBlock: render size-aware with current content width.
+      for (const row of renderPromptRows(entry, contentWidth)) {
+        allRows.push({ text: row, isPrompt: true, lineIdx: i });
+      }
     }
   }
 
@@ -238,7 +304,6 @@ export function AgentPane({
 
   return (
     <Box
-      ref={containerRef}
       flexDirection="column"
       flexGrow={1}
       flexBasis={0}
@@ -252,21 +317,27 @@ export function AgentPane({
         {isActive ? " \u25CF" : ""}
         {isFocused ? " [*]" : ""}
       </Text>
-      {showSeparator && <Text dimColor>{"\u2500".repeat(contentWidth)}</Text>}
-      {placeholder !== undefined ? (
-        <Text dimColor>{placeholder}</Text>
-      ) : (
-        <>
-          {topIndicator && <Text dimColor>{topIndicator}</Text>}
-          {visibleRowEntries.map((row, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: rows are derived without stable IDs
-            <Text key={i} dimColor={row.isPrompt}>
-              {row.text}
-            </Text>
-          ))}
-          {bottomIndicator && <Text dimColor>{bottomIndicator}</Text>}
-        </>
+      {showSeparator && (
+        <Text dimColor>
+          {contentWidth > 0 ? "\u2500".repeat(contentWidth) : ""}
+        </Text>
       )}
+      <Box ref={contentRef} flexDirection="column" flexGrow={1}>
+        {placeholder !== undefined ? (
+          <Text dimColor>{placeholder}</Text>
+        ) : (
+          <>
+            {topIndicator && <Text dimColor>{topIndicator}</Text>}
+            {visibleRowEntries.map((row, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: rows are derived without stable IDs
+              <Text key={i} dimColor={row.isPrompt}>
+                {row.text}
+              </Text>
+            ))}
+            {bottomIndicator && <Text dimColor>{bottomIndicator}</Text>}
+          </>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -14,7 +14,7 @@ import {
   type AgentInvokeEvent,
   PipelineEventEmitter,
 } from "../pipeline-events.js";
-import { AgentPane, splitIntoRows } from "./AgentPane.js";
+import { AgentPane, renderPromptRows, splitIntoRows } from "./AgentPane.js";
 import {
   computeVisibilityFlags,
   inputAreaHeight,
@@ -23,6 +23,10 @@ import {
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { fitInfoSegments, StatusBar } from "./StatusBar.js";
 import { cliDisplayName, formatTokenCount, TokenBar } from "./TokenBar.js";
+import {
+  PROMPT_LINE_PREFIX,
+  PROMPT_SEPARATOR_CHAR,
+} from "./useEventEmitter.js";
 
 afterEach(() => {
   cleanup();
@@ -246,7 +250,10 @@ describe("AgentPane", () => {
     expect(frame).toContain("LATEST_TOKEN");
   });
 
-  test("shows 'pane too small' instead of log lines in a tiny pane", async () => {
+  test("no content leaks in a tiny pane", async () => {
+    // height=3 → border(2) + 1 inner row.  The label fills the inner
+    // row, so the content box has 0 measured height.  No log lines
+    // should leak through.
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
       <Box height={3}>
@@ -262,9 +269,8 @@ describe("AgentPane", () => {
     expect(frame).not.toContain("line1");
     expect(frame).not.toContain("line2");
     expect(frame).not.toContain("line3");
-    // Must not show the waiting placeholder — output exists.
+    // No waiting placeholder either.
     expect(frame).not.toContain("waiting for output");
-    expect(frame).toContain("pane too small");
   });
 
   test("Page Up reveals earlier lines and shows scroll indicator", async () => {
@@ -2322,11 +2328,15 @@ describe("AgentPane showSeparator", () => {
     expect(separatorLines).toHaveLength(0);
   });
 
-  test("shows separator by default", () => {
+  test("shows separator by default", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
       <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />,
     );
+
+    // Wait for the measurement effect to set contentWidth > 0 so the
+    // separator characters actually render.
+    await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame() ?? "";
     // Separator line has \u2500 inside the box (no corner chars).
@@ -2336,5 +2346,179 @@ describe("AgentPane showSeparator", () => {
         l.includes("\u2500") && !l.includes("\u250C") && !l.includes("\u2514"),
     );
     expect(separatorLines.length).toBeGreaterThan(0);
+  });
+});
+
+// ---- renderPromptRows --------------------------------------------------------
+
+describe("renderPromptRows", () => {
+  test("header and footer fit the given width", () => {
+    const rows = renderPromptRows({ kind: "prompt", prompt: "hello" }, 40);
+    const header = rows[0];
+    const footer = rows[rows.length - 1];
+
+    // Header contains label with separator padding.
+    expect(header).toContain("Prompt");
+    expect(header).toContain(PROMPT_SEPARATOR_CHAR);
+    expect(header).toHaveLength(40);
+
+    // Footer is all separator chars, exactly the width.
+    expect(footer).toBe(PROMPT_SEPARATOR_CHAR.repeat(40));
+  });
+
+  test("includes stage name in header", () => {
+    const rows = renderPromptRows(
+      { kind: "prompt", prompt: "do it", stageName: "Review" },
+      50,
+    );
+    expect(rows[0]).toContain("Prompt (Review)");
+  });
+
+  test("prefixes content lines", () => {
+    const rows = renderPromptRows(
+      { kind: "prompt", prompt: "line1\nline2" },
+      80,
+    );
+    expect(rows[1]).toBe(`${PROMPT_LINE_PREFIX}line1`);
+    expect(rows[2]).toBe(`${PROMPT_LINE_PREFIX}line2`);
+  });
+
+  test("truncates by wrapped row count, not source line count", () => {
+    // 10 lines of 50 chars each.  At width 20, each "▶ " + 50 chars
+    // wraps to ~3 rows, so 10 lines = ~30 content rows, well above
+    // the MAX_PROMPT_ROWS budget of 12.
+    const longLine = "x".repeat(50);
+    const prompt = Array.from({ length: 10 }, () => longLine).join("\n");
+    const rows = renderPromptRows({ kind: "prompt", prompt }, 20);
+
+    // The truncation notice ("… (N more lines)") may wrap across
+    // rows at narrow widths, so search the joined output.
+    const allText = rows.join("\n");
+    expect(allText).toContain("more lines");
+    // Not all 10 lines should have been rendered.
+    const prefixedRows = rows.filter((r) => r.startsWith(PROMPT_LINE_PREFIX));
+    expect(prefixedRows.length).toBeLessThan(10 * 3);
+  });
+
+  test("returns empty array for zero width", () => {
+    const rows = renderPromptRows({ kind: "prompt", prompt: "hello" }, 0);
+    expect(rows).toEqual([]);
+  });
+
+  test("narrow width produces single-row header", () => {
+    // Label " Prompt " is 9 chars.  At width 9, no separator chars fit
+    // but the header should still be one row.
+    const rows = renderPromptRows({ kind: "prompt", prompt: "hi" }, 9);
+    // Header should not wrap since label ≤ width.
+    expect(rows[0]).toContain("Prompt");
+    // Only 1 header + 1 content + 1 footer = 3 rows.
+    expect(rows).toHaveLength(3);
+  });
+});
+
+// ---- AgentPane size-aware rendering (regression) ----------------------------
+
+describe("AgentPane size-aware rendering", () => {
+  test("no overflow when label wraps in a narrow pane", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={20} height={10}>
+        <AgentPane
+          label="Very Long Agent Label That Wraps"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+        />
+      </Box>,
+    );
+
+    emitter.emit("agent:chunk", {
+      agent: "a",
+      chunk: "a\nb\nc\nd\ne\nf\ng\nh\n",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    const frameRows = frame.split("\n");
+    // Frame must fit within the container height.
+    expect(frameRows.length).toBeLessThanOrEqual(10);
+    // The label text must still be visible.
+    expect(frame).toContain("Very Long");
+  });
+
+  test("prompt block renders size-aware in narrow pane", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={30} height={12}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    emitter.emit("agent:prompt", { agent: "a", prompt: "Do the task" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // Prompt header must be visible.
+    expect(frame).toContain("Prompt");
+    // Prompt content must be visible.
+    expect(frame).toContain("Do the task");
+    // Frame must not exceed container height.
+    expect(frame.split("\n").length).toBeLessThanOrEqual(12);
+  });
+
+  test("prompt separator fits pane width instead of fixed 80 chars", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={25} height={10}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          showSeparator={false}
+        />
+      </Box>,
+    );
+
+    emitter.emit("agent:prompt", { agent: "a", prompt: "hi" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // The prompt separator should not wrap — it should fit in one row.
+    // Count separator-char rows (excluding border lines).
+    const rows = frame.split("\n");
+    const sepRows = rows.filter(
+      (r) =>
+        r.includes(PROMPT_SEPARATOR_CHAR) &&
+        !r.includes("\u250C") &&
+        !r.includes("\u2514"),
+    );
+    // Header + footer = at most 2 separator-containing rows.
+    expect(sepRows.length).toBeLessThanOrEqual(2);
+  });
+
+  test("visibleRows starts at 0 preventing first-render overflow", async () => {
+    // Render a pane with content already in the emitter before mount.
+    // The pane should not render speculative rows on the first frame.
+    const emitter = new PipelineEventEmitter();
+
+    // Emit many lines before rendering.
+    const chunk = Array.from({ length: 50 }, (_, i) => `pre${i}`)
+      .join("\n")
+      .concat("\n");
+    emitter.emit("agent:chunk", { agent: "a", chunk });
+
+    const { lastFrame } = render(
+      <Box height={8}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    // Allow effects to settle.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // The frame must fit within 8 rows.
+    expect(frame.split("\n").length).toBeLessThanOrEqual(8);
   });
 });

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -6,17 +6,14 @@
  */
 import { describe, expect, test } from "vitest";
 import { PipelineEventEmitter } from "../pipeline-events.js";
-import {
-  formatPromptForDisplay,
-  PROMPT_LINE_PREFIX,
-  PROMPT_SEPARATOR_CHAR,
-} from "./useEventEmitter.js";
+import type { LineEntry, PromptBlock } from "./useEventEmitter.js";
 
 // ---- line accumulation logic (mirrors useAgentLines) -------------------------
 
 /**
  * Simplified version of the hook's accumulation logic, extracted for
- * testability without React.
+ * testability without React.  Handles both chunk and prompt events,
+ * storing prompt events as structured PromptBlock objects.
  */
 function createLineAccumulator(
   emitter: PipelineEventEmitter,
@@ -24,24 +21,49 @@ function createLineAccumulator(
   maxLines = 500,
 ) {
   let buffer = "";
-  let lines: string[] = [];
+  let lines: LineEntry[] = [];
+  let stageName: string | undefined;
 
-  const handler = (ev: { agent: "a" | "b"; chunk: string }) => {
+  const chunkHandler = (ev: { agent: "a" | "b"; chunk: string }) => {
     if (ev.agent !== agent) return;
     buffer += ev.chunk;
     const parts = buffer.split("\n");
     buffer = parts.pop() ?? "";
     if (parts.length === 0) return;
-    const next = [...lines, ...parts];
+    const next: LineEntry[] = [...lines, ...parts];
     lines = next.length > maxLines ? next.slice(-maxLines) : next;
   };
 
-  emitter.on("agent:chunk", handler);
+  const promptHandler = (ev: { agent: "a" | "b"; prompt: string }) => {
+    if (ev.agent !== agent) return;
+    const block: PromptBlock = { kind: "prompt", prompt: ev.prompt, stageName };
+    if (buffer) {
+      const pending = buffer;
+      buffer = "";
+      const next: LineEntry[] = [...lines, pending, block];
+      lines = next.length > maxLines ? next.slice(-maxLines) : next;
+    } else {
+      const next: LineEntry[] = [...lines, block];
+      lines = next.length > maxLines ? next.slice(-maxLines) : next;
+    }
+  };
+
+  const stageHandler = (ev: { stageName: string }) => {
+    stageName = ev.stageName;
+  };
+
+  emitter.on("agent:chunk", chunkHandler);
+  emitter.on("agent:prompt", promptHandler);
+  emitter.on("stage:enter", stageHandler);
 
   return {
     getLines: () => lines,
     getBuffer: () => buffer,
-    cleanup: () => emitter.off("agent:chunk", handler),
+    cleanup: () => {
+      emitter.off("agent:chunk", chunkHandler);
+      emitter.off("agent:prompt", promptHandler);
+      emitter.off("stage:enter", stageHandler);
+    },
   };
 }
 
@@ -167,104 +189,74 @@ describe("line accumulation (useAgentLines logic)", () => {
   });
 });
 
-describe("formatPromptForDisplay", () => {
-  test("formats a short prompt with separator and prefix", () => {
-    const lines = formatPromptForDisplay("Hello\nWorld");
-
-    // First line is separator with "Prompt" label
-    expect(lines[0]).toContain("Prompt");
-    expect(lines[0]).toContain(PROMPT_SEPARATOR_CHAR);
-    // Content lines are prefixed
-    expect(lines[1]).toBe(`${PROMPT_LINE_PREFIX}Hello`);
-    expect(lines[2]).toBe(`${PROMPT_LINE_PREFIX}World`);
-    // Last line is closing separator
-    expect(lines[lines.length - 1]).toContain(PROMPT_SEPARATOR_CHAR);
-  });
-
-  test("footer length matches header length", () => {
-    const lines = formatPromptForDisplay("Hello");
-    const header = lines[0];
-    const footer = lines[lines.length - 1];
-
-    expect(footer).toBeDefined();
-    expect(footer).toHaveLength(header.length);
-    // Footer should be all separator chars
-    expect(footer).toBe(PROMPT_SEPARATOR_CHAR.repeat(header.length));
-  });
-
-  test("footer length matches header length with stage name", () => {
-    const lines = formatPromptForDisplay("Hello", "Create PR");
-    const header = lines[0];
-    const footer = lines[lines.length - 1];
-
-    expect(footer).toBeDefined();
-    expect(footer).toHaveLength(header.length);
-    expect(footer).toBe(PROMPT_SEPARATOR_CHAR.repeat(header.length));
-  });
-
-  test("includes stage name in header when provided", () => {
-    const lines = formatPromptForDisplay("Hello", "Self-check");
-
-    expect(lines[0]).toContain("Prompt (Self-check)");
-  });
-
-  test("omits stage name from header when not provided", () => {
-    const lines = formatPromptForDisplay("Hello");
-
-    expect(lines[0]).toContain(" Prompt ");
-    expect(lines[0]).not.toContain("(");
-  });
-
-  test("truncates long prompts to 8 lines with remainder count", () => {
-    const prompt = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
-    const lines = formatPromptForDisplay(prompt);
-
-    // 1 header + 8 content + 1 truncation notice + 1 footer = 11
-    expect(lines).toHaveLength(11);
-    // First content line
-    expect(lines[1]).toBe(`${PROMPT_LINE_PREFIX}line 0`);
-    // Last content line shown
-    expect(lines[8]).toBe(`${PROMPT_LINE_PREFIX}line 7`);
-    // Truncation indicator
-    expect(lines[9]).toContain("12 more lines");
-  });
-
-  test("does not truncate prompt with exactly 8 lines", () => {
-    const prompt = Array.from({ length: 8 }, (_, i) => `line ${i}`).join("\n");
-    const lines = formatPromptForDisplay(prompt);
-
-    // 1 header + 8 content + 1 footer = 10, no truncation line
-    expect(lines).toHaveLength(10);
-    expect(lines.join("\n")).not.toContain("more lines");
-  });
-
-  test("handles single-line prompt", () => {
-    const lines = formatPromptForDisplay("Do the thing");
-
-    expect(lines[1]).toBe(`${PROMPT_LINE_PREFIX}Do the thing`);
-    expect(lines).toHaveLength(3); // header + 1 line + footer
-  });
-});
-
 describe("agent:prompt integration with line accumulator", () => {
-  test("prompt lines are injected into the accumulator", () => {
+  test("prompt events are stored as structured PromptBlock objects", () => {
     const emitter = new PipelineEventEmitter();
     const acc = createLineAccumulator(emitter, "a");
 
-    // Simulate agent:prompt by manually injecting formatted lines
-    // (mirrors what the hook does).
     emitter.emit("agent:chunk", { agent: "a", chunk: "output\n" });
-
-    const formatted = formatPromptForDisplay("hello");
-    // Inject formatted lines as if the hook did it.
-    for (const line of formatted) {
-      emitter.emit("agent:chunk", { agent: "a", chunk: `${line}\n` });
-    }
+    emitter.emit("stage:enter", {
+      stageNumber: 1,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    emitter.emit("agent:prompt", { agent: "a", prompt: "hello" });
 
     const lines = acc.getLines();
     expect(lines[0]).toBe("output");
-    expect(lines[1]).toContain("Prompt");
-    expect(lines[2]).toBe(`${PROMPT_LINE_PREFIX}hello`);
+    expect(lines[1]).toEqual({
+      kind: "prompt",
+      prompt: "hello",
+      stageName: "Implement",
+    });
+
+    acc.cleanup();
+  });
+
+  test("prompt block flushes pending buffer first", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial" });
+    expect(acc.getBuffer()).toBe("partial");
+
+    emitter.emit("agent:prompt", { agent: "a", prompt: "question" });
+
+    const lines = acc.getLines();
+    expect(lines[0]).toBe("partial");
+    expect(lines[1]).toEqual({
+      kind: "prompt",
+      prompt: "question",
+      stageName: undefined,
+    });
+    expect(acc.getBuffer()).toBe("");
+
+    acc.cleanup();
+  });
+
+  test("prompt block without prior stage has undefined stageName", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:prompt", { agent: "a", prompt: "hi" });
+
+    const lines = acc.getLines();
+    expect(lines[0]).toEqual({
+      kind: "prompt",
+      prompt: "hi",
+      stageName: undefined,
+    });
+
+    acc.cleanup();
+  });
+
+  test("prompt events for other agents are ignored", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:prompt", { agent: "b", prompt: "not mine" });
+
+    expect(acc.getLines()).toEqual([]);
 
     acc.cleanup();
   });

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -1,15 +1,22 @@
 import { useEffect, useRef, useState } from "react";
 import type { PipelineEventEmitter } from "../pipeline-events.js";
 
+/** A structured prompt block stored for size-aware rendering. */
+export interface PromptBlock {
+  kind: "prompt";
+  prompt: string;
+  stageName?: string;
+}
+
+/** A line buffer entry: either a plain text line or a deferred prompt block. */
+export type LineEntry = string | PromptBlock;
+
 export interface AgentLinesResult {
-  /** Completed (newline-terminated) lines. */
-  lines: string[];
+  /** Completed (newline-terminated) lines and prompt blocks. */
+  lines: LineEntry[];
   /** Current unterminated fragment, or empty string if none. */
   pendingLine: string;
 }
-
-/** Maximum number of prompt lines shown before truncation. */
-const MAX_PROMPT_LINES = 8;
 
 /** Prefix applied to every displayed prompt line. */
 export const PROMPT_LINE_PREFIX = "\u25B6 ";
@@ -17,61 +24,21 @@ export const PROMPT_LINE_PREFIX = "\u25B6 ";
 /** Prefix for the prompt separator lines. */
 export const PROMPT_SEPARATOR_CHAR = "\u2504";
 
-/** Number of separator characters on each side of the header label. */
-const SEPARATOR_HALF_LENGTH = 36;
-
-/**
- * Format a prompt string for display in the agent pane.
- *
- * The prompt is truncated to `MAX_PROMPT_LINES` lines with an
- * indicator showing how many lines were omitted.  Each line is
- * prefixed with `▶ ` so the renderer can apply distinct styling.
- *
- * When `stageName` is provided the header includes it for context,
- * e.g. `┄┄ Prompt (Create PR) ┄┄`.  The footer is always computed
- * dynamically to match the header length.
- */
-export function formatPromptForDisplay(
-  prompt: string,
-  stageName?: string,
-): string[] {
-  const rawLines = prompt.split("\n");
-  const truncated = rawLines.length > MAX_PROMPT_LINES;
-  const shown = truncated ? rawLines.slice(0, MAX_PROMPT_LINES) : rawLines;
-
-  const label = stageName ? ` Prompt (${stageName}) ` : " Prompt ";
-  const halfSep = PROMPT_SEPARATOR_CHAR.repeat(SEPARATOR_HALF_LENGTH);
-  const header = `${halfSep}${label}${halfSep}`;
-
-  const result = [header, ...shown.map((l) => `${PROMPT_LINE_PREFIX}${l}`)];
-
-  if (truncated) {
-    result.push(
-      `${PROMPT_LINE_PREFIX}\u2026 (${rawLines.length - MAX_PROMPT_LINES} more lines)`,
-    );
-  }
-
-  result.push(PROMPT_SEPARATOR_CHAR.repeat(header.length));
-
-  return result;
-}
-
 /**
  * Accumulate string chunks emitted on `agent:chunk` for a given agent
  * into a line buffer.  Returns completed lines (capped at `maxLines`)
  * and the current unterminated fragment so the UI can display partial
  * output in real time.
  *
- * Also listens for `agent:prompt` events and injects formatted,
- * truncated prompt lines into the buffer so the user can see what
- * the agent was asked to do.
+ * Also listens for `agent:prompt` events and stores structured
+ * `PromptBlock` entries so the pane can render them size-aware.
  */
 export function useAgentLines(
   emitter: PipelineEventEmitter,
   agent: "a" | "b",
   maxLines = 500,
 ): AgentLinesResult {
-  const [lines, setLines] = useState<string[]>([]);
+  const [lines, setLines] = useState<LineEntry[]>([]);
   const [pendingLine, setPendingLine] = useState("");
   const bufferRef = useRef("");
   const stageNameRef = useRef<string | undefined>(undefined);
@@ -114,26 +81,31 @@ export function useAgentLines(
     };
   }, [emitter, agent, maxLines]);
 
-  // Listen for outgoing prompt events and inject formatted lines.
+  // Listen for outgoing prompt events and store structured blocks
+  // so the pane can render them size-aware at display time.
   useEffect(() => {
     const handler = (ev: { agent: "a" | "b"; prompt: string }) => {
       if (ev.agent !== agent) return;
 
-      const formatted = formatPromptForDisplay(ev.prompt, stageNameRef.current);
+      const block: PromptBlock = {
+        kind: "prompt",
+        prompt: ev.prompt,
+        stageName: stageNameRef.current,
+      };
 
-      // Flush any pending partial line before injecting prompt lines
-      // so the prompt appears on its own visual block.
+      // Flush any pending partial line before injecting the prompt
+      // block so it appears on its own visual block.
       if (bufferRef.current) {
         const pending = bufferRef.current;
         bufferRef.current = "";
         setPendingLine("");
         setLines((prev) => {
-          const next = [...prev, pending, ...formatted];
+          const next: LineEntry[] = [...prev, pending, block];
           return next.length > maxLines ? next.slice(-maxLines) : next;
         });
       } else {
         setLines((prev) => {
-          const next = [...prev, ...formatted];
+          const next: LineEntry[] = [...prev, block];
           return next.length > maxLines ? next.slice(-maxLines) : next;
         });
       }


### PR DESCRIPTION
## Summary

- Refactor AgentPane to measure an inner content box instead of subtracting assumed header overhead from the outer container, so `visibleRows` reflects the real scrollable area regardless of label wrapping
- Replace preformatted prompt-string injection with structured `PromptBlock` objects rendered at display time using the current content width and a wrapped-row budget
- Initialize `visibleRows` and `contentWidth` to 0 so the first frame never renders speculative content before the layout is measured

Closes #154

## Test plan

- [x] No vertical overflow when the agent label wraps in a narrow pane
- [x] No vertical overflow when prompt headers or prompt body lines wrap
- [x] No first-render overflow before the content area has been measured
- [x] Prompt separator length is derived from the current pane width, not a fixed constant
- [x] Prompt display remains stable after Ctrl+L layout changes or terminal resize
- [x] The pane never renders more rows than fit inside its content area
- [x] All existing tests pass (`pnpm vitest run`)
- [x] Biome lint and type checks pass