### PR TITLE
Fix AgentPane overflow (#160)

### DIFF
--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -322,7 +322,13 @@ export function AgentPane({
           {contentWidth > 0 ? "\u2500".repeat(contentWidth) : ""}
         </Text>
       )}
-      <Box ref={contentRef} flexDirection="column" flexGrow={1}>
+      <Box
+        ref={contentRef}
+        flexDirection="column"
+        flexGrow={1}
+        flexShrink={1}
+        overflow="hidden"
+      >
         {placeholder !== undefined ? (
           <Text dimColor>{placeholder}</Text>
         ) : (

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -13,7 +13,7 @@ import type {
   AgentInvokeEvent,
   PipelineEventEmitter,
 } from "../pipeline-events.js";
-import { AgentPane } from "./AgentPane.js";
+import { AgentPane, splitIntoRows } from "./AgentPane.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
 import { TokenBar } from "./TokenBar.js";
@@ -66,6 +66,11 @@ export interface VisibilityFlags {
   allowColumnLayout: boolean;
 }
 
+interface VisibilityBudgetOptions {
+  terminalWidth?: number;
+  paneHeaderTexts?: readonly string[];
+}
+
 /** Compute the height of the InputArea in terminal rows. */
 export function inputAreaHeight(request: InputRequest | null): number {
   if (!request) return 1;
@@ -82,11 +87,43 @@ function computeFlagsForLayout(
   inputHeight: number,
   hasTokenData: boolean,
   layout: "row" | "column",
+  options: VisibilityBudgetOptions = {},
 ): VisibilityFlags {
   let showTokenBar = hasTokenData;
   let showKeyHints = true;
   let showPaneSeparator = true;
   let allowColumnLayout = true;
+
+  function paneContentWidth(): number | undefined {
+    if (options.terminalWidth === undefined) {
+      return undefined;
+    }
+
+    const paneWidth =
+      layout === "row"
+        ? Math.floor(options.terminalWidth / 2)
+        : options.terminalWidth;
+
+    return Math.max(1, paneWidth - 4);
+  }
+
+  function paneHeaderRows(): number {
+    const width = paneContentWidth();
+    if (
+      width === undefined ||
+      !options.paneHeaderTexts ||
+      options.paneHeaderTexts.length === 0
+    ) {
+      return 1;
+    }
+
+    return Math.max(
+      1,
+      ...options.paneHeaderTexts.map(
+        (text) => splitIntoRows(text, width).length,
+      ),
+    );
+  }
 
   function paneContentRows(
     tokenBar: boolean,
@@ -100,8 +137,7 @@ function computeFlagsForLayout(
     const tokenBarHeight = tokenBar ? (layout === "column" ? 6 : 3) : 0;
     const bottomChrome = inputHeight + statusBarHeight + tokenBarHeight;
     const paneArea = terminalHeight - bottomChrome;
-    // AgentPane overhead: border (2) + label (1) + optional separator (1).
-    const paneOverhead = separator ? 4 : 3;
+    const paneOverhead = 2 + paneHeaderRows() + (separator ? 1 : 0);
     if (layout === "column") {
       return Math.floor(paneArea / 2) - paneOverhead;
     }
@@ -157,12 +193,14 @@ export function computeVisibilityFlags(
   inputHeight: number,
   hasTokenData: boolean,
   preferredLayout: "row" | "column",
+  options: VisibilityBudgetOptions = {},
 ): VisibilityFlags {
   const flags = computeFlagsForLayout(
     terminalHeight,
     inputHeight,
     hasTokenData,
     preferredLayout,
+    options,
   );
 
   // When column is forced to row, recompute for the effective (row) layout
@@ -173,6 +211,7 @@ export function computeVisibilityFlags(
       inputHeight,
       hasTokenData,
       "row",
+      options,
     );
     rowFlags.allowColumnLayout = false;
     return rowFlags;
@@ -220,6 +259,7 @@ export function App({
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
     useTerminalDimensions();
+  const messages = t();
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
   const resolveRef = useRef<((value: string) => void) | null>(null);
   const [focusedPane, setFocusedPane] = useState<"a" | "b">("a");
@@ -251,6 +291,15 @@ export function App({
 
   // Compute visibility flags based on terminal dimensions.
   const inputHeight = inputAreaHeight(inputRequest);
+  const labelA = messages["agent.labelARole"];
+  const labelB = messages["agent.labelBRole"];
+  const paneHeaderTexts = useMemo(
+    () => [
+      `${modelNameA ? `${labelA} \u2014 ${modelNameA}` : labelA} \u25CF [*]`,
+      `${modelNameB ? `${labelB} \u2014 ${modelNameB}` : labelB} \u25CF [*]`,
+    ],
+    [labelA, labelB, modelNameA, modelNameB],
+  );
   const flags = useMemo<VisibilityFlags>(() => {
     if (terminalHeight === undefined) {
       return {
@@ -265,8 +314,19 @@ export function App({
       inputHeight,
       hasTokenData,
       preferredLayout,
+      {
+        terminalWidth,
+        paneHeaderTexts,
+      },
     );
-  }, [terminalHeight, inputHeight, hasTokenData, preferredLayout]);
+  }, [
+    terminalHeight,
+    inputHeight,
+    hasTokenData,
+    preferredLayout,
+    terminalWidth,
+    paneHeaderTexts,
+  ]);
 
   const effectiveLayout =
     preferredLayout === "column" && !flags.allowColumnLayout
@@ -375,7 +435,7 @@ export function App({
       {/* Agent panes: side by side (row) or stacked (column) */}
       <Box flexDirection={effectiveLayout} flexGrow={1}>
         <AgentPane
-          label={t()["agent.labelARole"]}
+          label={labelA}
           modelName={modelNameA}
           agent="a"
           emitter={emitter}
@@ -386,7 +446,7 @@ export function App({
           showSeparator={flags.showPaneSeparator}
         />
         <AgentPane
-          label={t()["agent.labelBRole"]}
+          label={labelB}
           modelName={modelNameB}
           agent="b"
           emitter={emitter}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1606,6 +1606,117 @@ describe("viewport height constraint", () => {
     // Pane B must remain at the bottom (unaffected by pane A scroll).
     expect(after).toContain("B20");
   });
+
+  test("full app layout stays within viewport with bottom chrome", async () => {
+    await initI18n("en");
+
+    const emitter = new PipelineEventEmitter();
+    const viewportWidth = 80;
+    const viewportHeight = 16;
+    const labelA = "Agent A (author)";
+    const labelB = "Agent B (reviewer)";
+    const flags = computeVisibilityFlags(viewportHeight, 1, true, "row", {
+      terminalWidth: viewportWidth,
+      paneHeaderTexts: [`${labelA} \u25CF [*]`, `${labelB} \u25CF [*]`],
+    });
+
+    expect(flags.showTokenBar).toBe(true);
+    expect(flags.showKeyHints).toBe(true);
+    expect(flags.showPaneSeparator).toBe(true);
+
+    const { lastFrame } = render(
+      <Box flexDirection="column" width={viewportWidth} height={viewportHeight}>
+        <Box flexDirection="row" flexGrow={1}>
+          <AgentPane
+            label={labelA}
+            agent="a"
+            emitter={emitter}
+            color="blue"
+            isFocused
+            showSeparator={flags.showPaneSeparator}
+          />
+          <AgentPane
+            label={labelB}
+            agent="b"
+            emitter={emitter}
+            color="green"
+            showSeparator={flags.showPaneSeparator}
+          />
+        </Box>
+        <TokenBar
+          emitter={emitter}
+          visible={flags.showTokenBar}
+          contentWidth={Math.floor(viewportWidth / 2) - 4}
+          layout="row"
+          cliTypeA="claude"
+          cliTypeB="codex"
+        />
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={160}
+          issueTitle="Fix AgentPane overflow"
+          baseSha="abcdef1234567890"
+          layout="row"
+          showKeyHints={flags.showKeyHints}
+          contentWidth={viewportWidth - 4}
+        />
+        <InputArea request={null} onSubmit={() => {}} />
+      </Box>,
+    );
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 12_300, outputTokens: 5_100, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:usage", {
+      agent: "b",
+      usage: { inputTokens: 8_700, outputTokens: 3_200, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:prompt", {
+      agent: "a",
+      prompt: [
+        "Investigate the overflow in the real app layout.",
+        "Keep the prompt block visible and clipped to the pane viewport.",
+      ].join("\n"),
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const promptFrame = lastFrame() ?? "";
+    expect(promptFrame).toContain("Keep the prompt block visible");
+
+    emitter.emit("agent:chunk", {
+      agent: "a",
+      chunk: [
+        "First streamed line after the prompt block stays visible.",
+        "This follow-up line is intentionally long so it wraps across multiple rows within the pane content area and exercises clipping.",
+        "Another wrapped status line arrives afterwards and should still stay inside the pane border without pushing the frame past the viewport height.",
+        "Final short line.",
+      ]
+        .join("\n")
+        .concat("\n"),
+    });
+    emitter.emit("agent:chunk", {
+      agent: "b",
+      chunk: [
+        "Reviewer output line one.",
+        "Reviewer output line two is also long enough to wrap and compete for vertical space in the split layout.",
+      ]
+        .join("\n")
+        .concat("\n"),
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Final short line.");
+    expect(frame.split("\n").length).toBeLessThanOrEqual(viewportHeight);
+  });
 });
 
 // ---- formatTokenCount -------------------------------------------------------
@@ -2077,6 +2188,20 @@ describe("computeVisibilityFlags", () => {
     const flags = computeVisibilityFlags(22, 1, true, "column");
     expect(flags.showTokenBar).toBe(false);
     expect(flags.allowColumnLayout).toBe(true);
+  });
+
+  test("budgets extra header rows when pane headers wrap", () => {
+    const flags = computeVisibilityFlags(16, 1, true, "row", {
+      terminalWidth: 40,
+      paneHeaderTexts: [
+        "Very Long Agent Label \u25CF [*]",
+        "Very Long Agent Label \u25CF [*]",
+      ],
+    });
+
+    expect(flags.showTokenBar).toBe(false);
+    expect(flags.showKeyHints).toBe(true);
+    expect(flags.showPaneSeparator).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- Constrain `AgentPane`'s measured content box with `flexShrink={1}` and `overflow="hidden"` so `measureElement(contentRef)` reflects the clipped viewport used for rendering.
- Make `computeVisibilityFlags()` budget pane overhead from real wrapped header rows instead of a fixed single-line header heuristic.
- Add regression coverage for the full horizontal app composition with `TokenBar`, three-line `StatusBar`, `InputArea`, prompt output, and wrapped streamed logs.

Closes #160

## Test plan
- [x] Verify the full horizontal app layout stays within the viewport when `TokenBar`, `StatusBar`, and `InputArea` are all visible.
- [x] Verify `measureElement(contentRef)` tracks the clipped `AgentPane` content viewport instead of a content-expanded height.
- [x] Verify `AgentPane` stays stable when prompt output is followed by multiple wrapped log lines.
- [x] Verify the regression test reproducing the previously failing layout passes.
- [x] Verify CI checks pass locally with `pnpm check` and `pnpm test`.
