### PR TITLE
Fix AgentPane header disappearing on overflow (#163)

### DIFF
--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -312,15 +312,19 @@ export function AgentPane({
       paddingX={1}
       overflow="hidden"
     >
-      <Text bold color={borderCol}>
-        {modelName ? `${label} \u2014 ${modelName}` : label}
-        {isActive ? " \u25CF" : ""}
-        {isFocused ? " [*]" : ""}
-      </Text>
-      {showSeparator && (
-        <Text dimColor>
-          {contentWidth > 0 ? "\u2500".repeat(contentWidth) : ""}
+      <Box flexShrink={0}>
+        <Text bold color={borderCol}>
+          {modelName ? `${label} \u2014 ${modelName}` : label}
+          {isActive ? " \u25CF" : ""}
+          {isFocused ? " [*]" : ""}
         </Text>
+      </Box>
+      {showSeparator && (
+        <Box flexShrink={0}>
+          <Text dimColor>
+            {contentWidth > 0 ? "\u2500".repeat(contentWidth) : ""}
+          </Text>
+        </Box>
       )}
       <Box
         ref={contentRef}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1717,6 +1717,102 @@ describe("viewport height constraint", () => {
     expect(frame).toContain("Final short line.");
     expect(frame.split("\n").length).toBeLessThanOrEqual(viewportHeight);
   });
+
+  test("header and separator remain visible when content overflows pane", async () => {
+    await initI18n("en");
+
+    const emitter = new PipelineEventEmitter();
+    const viewportWidth = 80;
+    const viewportHeight = 16;
+    const labelA = "Agent A (author)";
+    const labelB = "Agent B (reviewer)";
+    const modelA = "GPT-5.4 / Extra High";
+    const flags = computeVisibilityFlags(viewportHeight, 1, true, "row", {
+      terminalWidth: viewportWidth,
+      paneHeaderTexts: [
+        `${labelA} \u2014 ${modelA} \u25CF [*]`,
+        `${labelB} \u25CF [*]`,
+      ],
+    });
+
+    const { lastFrame } = render(
+      <Box flexDirection="column" width={viewportWidth} height={viewportHeight}>
+        <Box flexDirection="row" flexGrow={1}>
+          <AgentPane
+            label={labelA}
+            modelName={modelA}
+            agent="a"
+            emitter={emitter}
+            color="blue"
+            isFocused
+            isActive
+            showSeparator={flags.showPaneSeparator}
+          />
+          <AgentPane
+            label={labelB}
+            agent="b"
+            emitter={emitter}
+            color="green"
+            showSeparator={flags.showPaneSeparator}
+          />
+        </Box>
+        <TokenBar
+          emitter={emitter}
+          visible={flags.showTokenBar}
+          contentWidth={Math.floor(viewportWidth / 2) - 4}
+          layout="row"
+          cliTypeA="claude"
+          cliTypeB="codex"
+        />
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={163}
+          issueTitle="AgentPane header disappears when content overflows"
+          baseSha="abcdef1234567890"
+          layout="row"
+          showKeyHints={flags.showKeyHints}
+          contentWidth={viewportWidth - 4}
+        />
+        <InputArea request={null} onSubmit={() => {}} />
+      </Box>,
+    );
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+
+    // Emit enough lines to overflow the pane content area.
+    const overflowLines = Array.from(
+      { length: 30 },
+      (_, i) => `Output line ${i + 1}`,
+    );
+    emitter.emit("agent:chunk", {
+      agent: "a",
+      chunk: overflowLines.join("\n").concat("\n"),
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+
+    // Header must still be visible despite content overflow.
+    // The label and model name may wrap across lines in narrow panes,
+    // so check for key fragments rather than the full combined string.
+    expect(frame).toContain(labelA);
+    expect(frame).toContain("GPT-5.4");
+
+    // Separator must be present when enabled.
+    if (flags.showPaneSeparator) {
+      expect(frame).toContain("\u2500");
+    }
+
+    // Frame must not exceed viewport height.
+    expect(lines.length).toBeLessThanOrEqual(viewportHeight);
+  });
 });
 
 // ---- formatTokenCount -------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wrapped the header and separator `<Text>` elements in `<Box flexShrink={0}>` so Ink's flex layout cannot collapse them when the content area grows.
- Added a full app layout regression test that renders `AgentPane` alongside `TokenBar`, `StatusBar`, and `InputArea` with overflowing content.

Closes #163

## Test plan

- [x] Header row remains visible when content fills the pane
- [x] Separator stays visible when enabled, regardless of content length
- [x] Full app layout regression test confirms header visibility with AgentPane + TokenBar + StatusBar + InputArea rendered together
- [x] Rendered frame height does not exceed viewport height in full app layout