### PR TITLE
Improve README and pipeline.md clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ AgentCoop runs an 8-stage pipeline with two agents: Agent A (author
 5. **Test plan** — Agent A verifies the PR test plan
 6. **Review** — Agent B reviews; Agent A addresses feedback
    (multi-round)
-7. **Squash** — When the branch has multiple commits that should be
-   consolidated, Agent A squashes them into a single commit and
-   force-pushes. Skipped if the branch already has only one commit
-   or if the existing commits are already clean.
+7. **Squash** — Agent A consolidates branch commits into one or a
+   few meaningful commits and force-pushes. Skipped if the branch
+   already has only one commit or if the existing commits are
+   already clean.
 8. **Done** — Check for merge conflicts, optionally rebase, confirm
    merge with the user, and clean up resources
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -659,9 +659,9 @@ is asked whether to continue.
 ### Stage 7: Squash commits
 
 **Agent:** A\
-**Purpose:** Squash commits that need squashing into a single
-commit with a clear message. Skipped automatically if the branch
-has only one commit.
+**Purpose:** Consolidate branch commits into one or a few
+meaningful commits. Skipped automatically if the branch has only
+one commit.
 
 **Prompt:**
 
@@ -687,13 +687,14 @@ You are squashing commits for the following GitHub issue.
    If the description is outdated or inaccurate, update it using
    `gh pr edit --body "..."`.  Keep the issue reference
    (Closes #{number} or Part of #{number}) in the body.
-2. Squash all commits after the base commit `{baseSha}` into a single
-   commit.  Only commits introduced on this branch should be squashed —
-   do not include commits from the base branch.  Use
+2. Review the commits after the base commit `{baseSha}` and
+   consolidate them into one or a few meaningful commits.  Only
+   commits introduced on this branch should be touched — do not
+   include commits from the base branch.  Use
    `git reset --soft {baseSha}` followed by `git commit`, or an
    interactive rebase — whichever is simpler.
-3. Write a clear, concise commit message that summarises all changes
-   made for this issue.  Reference the issue number
+3. Write clear, concise commit messages that summarise the changes.
+   Reference the issue number in the primary commit
    (e.g. "Implement widget rendering (#42)").
 4. Force-push the branch (`git push --force-with-lease`).
 ```

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -1746,7 +1746,7 @@ describe("Stage 8 (Squash) baseSha integration", () => {
 
     await runPipeline(makePipelineOpts({ stages: [stage] }));
 
-    expect(capturedPrompt).toContain("Squash all commits on this branch");
+    expect(capturedPrompt).toContain("Review all commits on this branch");
     expect(capturedPrompt).not.toContain("git reset --soft");
   });
 });

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -106,7 +106,7 @@ describe("buildSquashPrompt", () => {
 
   test("includes squash and force-push instructions", () => {
     const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("Squash all commits");
+    expect(prompt).toContain("consolidate them into one");
     expect(prompt).toContain("Force-push the branch");
   });
 
@@ -137,7 +137,7 @@ describe("buildSquashPrompt", () => {
 
   test("falls back to generic squash when baseSha is absent", () => {
     const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("Squash all commits on this branch");
+    expect(prompt).toContain("Review all commits on this branch");
     expect(prompt).not.toContain("git reset --soft");
   });
 });

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -81,18 +81,20 @@ export function buildSquashPrompt(
     `1. ${buildPrSyncInstructions(ctx.issueNumber)}`,
     ...(ctx.baseSha
       ? [
-          `2. Squash all commits after the base commit \`${ctx.baseSha}\` into`,
-          `   a single commit.  Only commits introduced on this branch should`,
-          `   be squashed — do not include commits from the base branch.  Use`,
+          `2. Review the commits after the base commit \`${ctx.baseSha}\` and`,
+          `   consolidate them into one or a few meaningful commits.  Only`,
+          `   commits introduced on this branch should be touched — do not`,
+          `   include commits from the base branch.  Use`,
           `   \`git reset --soft ${ctx.baseSha}\` followed by \`git commit\`, or`,
           `   an interactive rebase — whichever is simpler.`,
         ]
       : [
-          `2. Squash all commits on this branch into a single commit.  Use an`,
-          `   interactive rebase or reset-based approach — whichever is simpler.`,
+          `2. Review all commits on this branch and consolidate them into one`,
+          `   or a few meaningful commits.  Use an interactive rebase or`,
+          `   reset-based approach — whichever is simpler.`,
         ]),
-    `3. Write a clear, concise commit message that summarises all changes`,
-    `   made for this issue.  Reference the issue number`,
+    `3. Write clear, concise commit messages that summarise the changes.`,
+    `   Reference the issue number in the primary commit`,
     `   (e.g. "Implement widget rendering (#42)").`,
     `4. Force-push the branch (\`git push --force-with-lease\`).`,
   ];


### PR DESCRIPTION
## Summary

- Clarify that the current implementation uses two agents (1 author + 1 reviewer), with plans for three agents (1 author + 2 reviewers) in the future
- Update Terminal UI example to match the actual TUI: real model names, role labels, and proper column alignment
- Add TUI screenshot to README
- Fix auto mode budget description — default varies by stage (5 for self-check/review, 3 for CI fix/test plan)
- Clarify squash stage: only squashes when needed, skipped for single-commit branches
- Add prerequisite about external services (e.g., Figma Desktop MCP) needing to be authenticated

Closes #164