### PR TITLE
Clarify that AgentCoop prepares merge-ready PRs (#171)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ expand to three agents (one author and two reviewers).
 
 Break your project down into well-written issues, each scoped to a
 single PR. AgentCoop works through them — implementing, reviewing,
-and merging — so the software gets built with minimal human
-involvement.
+and preparing merge-ready PRs — so the software gets built with
+minimal human involvement.
 
 ## Terminal UI
 


### PR DESCRIPTION
## Summary

- Updated the introductory paragraph in README.md to clarify that AgentCoop prepares **merge-ready PRs** rather than performing the merge itself. A human still performs the actual merge.

Closes #171

## Test plan

- [x] Verify the README intro paragraph no longer says "and merging"
- [x] Verify the new wording ("and preparing merge-ready PRs") reads naturally and accurately describes AgentCoop's role