### PR TITLE
Show elapsed time in StatusBar (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ minimal human involvement.
 ├────────────────────────────────────────────┴────────────────────────────────┤
 │ A (Claude): 12.3K in / 5.1K out            │ B (Codex): 8.7K in / 3.2K out  │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│ owner/repo#42: Issue title                                                  │
+│ owner/repo#42: Issue title                              4m 12s (7m 30s)     │
 │ Base: abc1234  │  Stage 3: Self-check (round 2)  │  Layout: horizontal      │
 │ ●:Active [*]:Focused Tab:Switch pane ↑↓:Scroll Ctrl+L:Layout Ctrl+C:Quit    │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -33,8 +33,10 @@ minimal human involvement.
   scrolling) with `[*]`.
 - **TokenBar** — Per-agent token usage (input/output, with cached
   token counts when available).
-- **StatusBar** — Issue reference, base commit SHA, current pipeline
-  stage with loop count, and layout indicator.
+- **StatusBar** — Issue reference with elapsed time (active and
+  wall-clock), base commit SHA, current pipeline stage with loop
+  count, and layout indicator. Active time pauses while waiting
+  for user input.
 - **InputArea** — Shows "Pipeline running..." while agents work.
   When user input is needed (BLOCKED, loop budget, step-mode), it
   presents numbered choices or a free-text field.

--- a/src/index.ts
+++ b/src/index.ts
@@ -771,6 +771,7 @@ try {
 
   const emitter = new PipelineEventEmitter();
 
+  const startedAt = Date.now();
   const pipelineResult = await new Promise<PipelineResult>((resolve) => {
     const { unmount } = renderApp({
       emitter,
@@ -782,6 +783,7 @@ try {
       onPromptReady: (prompt) => {
         tuiPrompt = prompt;
       },
+      startedAt,
       onCancel: () => {
         // Kill all tracked agent child processes so the pipeline
         // can unwind quickly.  We read `.child` at kill-time so

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -243,6 +243,8 @@ export interface AppProps {
    * agent child processes before the pipeline unwinds.
    */
   onCancel?: () => void;
+  /** Timestamp (ms) when agentcoop started, for wall-clock elapsed time. */
+  startedAt?: number;
 }
 
 export function App({
@@ -256,6 +258,7 @@ export function App({
   cliTypeB,
   notifications,
   onCancel,
+  startedAt,
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
     useTerminalDimensions();
@@ -477,6 +480,8 @@ export function App({
         layout={effectiveLayout}
         showKeyHints={flags.showKeyHints}
         contentWidth={borderedContentWidth}
+        paused={inputRequest !== null}
+        startedAt={startedAt}
       />
       <InputArea request={inputRequest} onSubmit={handleSubmit} />
     </Box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -1,5 +1,5 @@
 import { Box, Text } from "ink";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import stringWidth from "string-width";
 import { t } from "../i18n/index.js";
 import type {
@@ -28,6 +28,62 @@ interface StatusBarProps {
   showKeyHints?: boolean;
   /** Content width budget for the info line (terminal width minus border and padding). */
   contentWidth?: number;
+  /** Whether the active timer is paused (e.g. waiting for user input). */
+  paused?: boolean;
+  /** Timestamp (ms) when agentcoop started, for wall-clock elapsed time. */
+  startedAt?: number;
+}
+
+// ---- Elapsed time helpers ----------------------------------------------------
+
+/**
+ * Format a duration in seconds as a human-readable string.
+ * Examples: "0s", "45s", "1m 30s", "1h 5m 0s".
+ */
+export function formatElapsed(totalSeconds: number): string {
+  const s = Math.floor(totalSeconds);
+  if (s < 60) return `${s}s`;
+  const hours = Math.floor(s / 3600);
+  const minutes = Math.floor((s % 3600) / 60);
+  const seconds = s % 60;
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Hook that tracks active and wall-clock elapsed time, updating every second.
+ * Active time pauses when `paused` is true.
+ */
+function useElapsedTime(
+  paused: boolean,
+  startedAt: number | undefined,
+): { activeSeconds: number; wallSeconds: number } {
+  const [, setTick] = useState(0);
+  const activeRef = useRef(0);
+  const lastTickRef = useRef(Date.now());
+
+  useEffect(() => {
+    // When transitioning to paused, accumulate the partial interval
+    // since the last tick so sub-second active time is not lost.
+    if (paused) {
+      activeRef.current += (Date.now() - lastTickRef.current) / 1000;
+    }
+    lastTickRef.current = Date.now();
+    const id = setInterval(() => {
+      const now = Date.now();
+      if (!paused) {
+        activeRef.current += (now - lastTickRef.current) / 1000;
+      }
+      lastTickRef.current = now;
+      setTick((t) => t + 1);
+    }, 1000);
+    return () => clearInterval(id);
+  }, [paused]);
+
+  const wallSeconds =
+    startedAt !== undefined ? (Date.now() - startedAt) / 1000 : 0;
+
+  return { activeSeconds: activeRef.current, wallSeconds };
 }
 
 // ---- Segment fitting helpers -------------------------------------------------
@@ -136,6 +192,8 @@ export function StatusBar({
   layout,
   showKeyHints = true,
   contentWidth,
+  paused = false,
+  startedAt,
 }: StatusBarProps) {
   const [stage, setStage] = useState<StageEnterEvent | null>(null);
   const [lastOutcome, setLastOutcome] = useState<string | null>(null);
@@ -199,11 +257,36 @@ export function StatusBar({
       ? m["statusBar.completed"](selfCheckCount, reviewCount)
       : "";
 
-  // Line 1: Issue reference + title (independent of other segments).
+  // Elapsed time display.
+  const { activeSeconds, wallSeconds } = useElapsedTime(paused, startedAt);
+  const activeText = formatElapsed(activeSeconds);
+  const wallText = `(${formatElapsed(wallSeconds)})`;
+
+  // Line 1: Issue reference + title, with elapsed time right-aligned.
+  // When space is tight, drop wall-clock time first, then active time.
   const issueLineText = issueTitle ? `${issueRef}: ${issueTitle}` : issueRef;
+
+  let elapsedText = "";
+  let issueBudget: number | undefined = contentWidth;
+  if (startedAt !== undefined && contentWidth !== undefined) {
+    const fullElapsed = `${activeText} ${wallText}`;
+    const activeOnly = activeText;
+    // Need at least 2 chars for truncated title + 2 for gap.
+    const minTitleWidth = 2;
+    const gap = 2; // space between title and elapsed
+    if (contentWidth >= minTitleWidth + gap + stringWidth(fullElapsed)) {
+      elapsedText = fullElapsed;
+    } else if (contentWidth >= minTitleWidth + gap + stringWidth(activeOnly)) {
+      elapsedText = activeOnly;
+    }
+    if (elapsedText) {
+      issueBudget = contentWidth - gap - stringWidth(elapsedText);
+    }
+  }
+
   const issueLine =
-    contentWidth !== undefined
-      ? truncateWithEllipsis(issueLineText, contentWidth)
+    issueBudget !== undefined
+      ? truncateWithEllipsis(issueLineText, issueBudget)
       : issueLineText;
 
   // Line 2: Pipeline status segments with drop priorities.
@@ -239,9 +322,12 @@ export function StatusBar({
       height={contentWidth !== undefined ? (showKeyHints ? 5 : 4) : undefined}
       overflow="hidden"
     >
-      <Text bold color="cyan">
-        {issueLine}
-      </Text>
+      <Box justifyContent="space-between">
+        <Text bold color="cyan">
+          {issueLine}
+        </Text>
+        {elapsedText !== "" && <Text dimColor>{elapsedText}</Text>}
+      </Box>
       <Box>
         {pipelineDisplay.map((seg, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: stable render-local array

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -6,9 +6,9 @@
  */
 import { Box, Text, useInput, useStdout } from "ink";
 import { cleanup, render } from "ink-testing-library";
-import { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import stringWidth from "string-width";
-import { afterEach, describe, expect, test } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import { initI18n } from "../i18n/index.js";
 import {
   type AgentInvokeEvent,
@@ -21,7 +21,7 @@ import {
   useTerminalHeight,
 } from "./App.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
-import { fitInfoSegments, StatusBar } from "./StatusBar.js";
+import { fitInfoSegments, formatElapsed, StatusBar } from "./StatusBar.js";
 import { cliDisplayName, formatTokenCount, TokenBar } from "./TokenBar.js";
 import {
   PROMPT_LINE_PREFIX,
@@ -2519,6 +2519,200 @@ describe("StatusBar width adaptation", () => {
     expect(frame).toContain("Stage 2: Implement");
     // Layout indicator should be dropped due to narrow width.
     expect(frame).not.toContain("Layout:");
+  });
+});
+
+// ---- formatElapsed -----------------------------------------------------------
+
+describe("formatElapsed", () => {
+  test("formats seconds only", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(45)).toBe("45s");
+    expect(formatElapsed(59)).toBe("59s");
+  });
+
+  test("formats minutes and seconds", () => {
+    expect(formatElapsed(60)).toBe("1m 0s");
+    expect(formatElapsed(90)).toBe("1m 30s");
+    expect(formatElapsed(3599)).toBe("59m 59s");
+  });
+
+  test("formats hours, minutes, and seconds", () => {
+    expect(formatElapsed(3600)).toBe("1h 0m 0s");
+    expect(formatElapsed(3661)).toBe("1h 1m 1s");
+    expect(formatElapsed(7530)).toBe("2h 5m 30s");
+  });
+
+  test("floors fractional seconds", () => {
+    expect(formatElapsed(4.7)).toBe("4s");
+    expect(formatElapsed(90.9)).toBe("1m 30s");
+  });
+});
+
+// ---- StatusBar elapsed time --------------------------------------------------
+
+describe("StatusBar elapsed time", () => {
+  test("shows elapsed time when startedAt is provided", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={80}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={42}
+          issueTitle="Fix the widget"
+          contentWidth={76}
+          startedAt={Date.now() - 5000}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Should show the issue ref and some elapsed time indicator.
+    expect(frame).toContain("aicers/agentcoop#42");
+    // Wall-clock time should appear in parentheses.
+    expect(frame).toMatch(/\(\d+s\)/);
+  });
+
+  test("hides elapsed time when startedAt is not provided", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={42}
+        issueTitle="Fix the widget"
+        contentWidth={76}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("aicers/agentcoop#42: Fix the widget");
+    // No elapsed time should appear.
+    expect(frame).not.toMatch(/\d+s/);
+  });
+
+  test("drops wall-clock time first when space is tight", () => {
+    const emitter = new PipelineEventEmitter();
+    // At t=0: activeText="0s" (2), wallText="(0s)" (4), fullElapsed="0s (0s)" (7).
+    // Full needs: minTitle(2) + gap(2) + 7 = 11.
+    // Active only needs: minTitle(2) + gap(2) + 2 = 6.
+    // contentWidth=9: 9 < 11 → full dropped, 9 >= 6 → active shown.
+    // issueBudget = 9 - 2 - 2 = 5.
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="o"
+        repo="r"
+        issueNumber={1}
+        issueTitle="Fix"
+        contentWidth={9}
+        startedAt={Date.now()}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Active time should be visible.
+    expect(frame).toMatch(/\d+s/);
+    // Wall-clock (in parentheses) should be dropped.
+    expect(frame).not.toMatch(/\(\d+s\)/);
+  });
+
+  test("drops all elapsed time when space is extremely tight", () => {
+    const emitter = new PipelineEventEmitter();
+    // At t=0: activeOnly "0s" (2) needs minTitle(2)+gap(2)+2=6.
+    // contentWidth=5: 5 < 6 → all elapsed dropped.
+    // issueBudget = 5 → "o/r#…".
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="o"
+        repo="r"
+        issueNumber={1}
+        issueTitle="Fix"
+        contentWidth={5}
+        startedAt={Date.now()}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("o/r#");
+    // Title should be truncated.
+    expect(frame).toContain("\u2026");
+    // No elapsed time should appear.
+    expect(frame).not.toMatch(/\d+s/);
+  });
+
+  test("pausing mid-second does not lose partial interval", async () => {
+    vi.useFakeTimers();
+    try {
+      const start = Date.now();
+      const emitter = new PipelineEventEmitter();
+      const props = {
+        emitter,
+        owner: "aicers",
+        repo: "agentcoop",
+        issueNumber: 42,
+        issueTitle: "Fix the widget",
+        contentWidth: 76,
+        startedAt: start,
+      };
+
+      const { lastFrame, rerender } = render(
+        <Box width={80}>
+          <StatusBar {...props} paused={false} />
+        </Box>,
+      );
+
+      // Two pause/resume cycles, each losing 600ms without the fix.
+      // Cycle 1: 1600ms active → tick at 1000ms + 600ms partial.
+      await React.act(() => vi.advanceTimersByTimeAsync(1600));
+      await React.act(() => {
+        rerender(
+          <Box width={80}>
+            <StatusBar {...props} paused={true} />
+          </Box>,
+        );
+      });
+      await React.act(() => vi.advanceTimersByTimeAsync(400));
+
+      // Cycle 2: resume → 1600ms active → tick at 1000ms + 600ms partial.
+      await React.act(() => {
+        rerender(
+          <Box width={80}>
+            <StatusBar {...props} paused={false} />
+          </Box>,
+        );
+      });
+      await React.act(() => vi.advanceTimersByTimeAsync(1600));
+      await React.act(() => {
+        rerender(
+          <Box width={80}>
+            <StatusBar {...props} paused={true} />
+          </Box>,
+        );
+      });
+      await React.act(() => vi.advanceTimersByTimeAsync(400));
+
+      // Final resume + 1s to trigger a render with updated active time.
+      await React.act(() => {
+        rerender(
+          <Box width={80}>
+            <StatusBar {...props} paused={false} />
+          </Box>,
+        );
+      });
+      await React.act(() => vi.advanceTimersByTimeAsync(1000));
+
+      const frame = lastFrame() ?? "";
+      // With fix: 1.0+0.6+1.0+0.6+1.0 = 4.2s → "4s", wall = 5.0s → "(5s)".
+      // Without fix: 1.0+0+1.0+0+1.0 = 3.0s → "3s" — regression detected.
+      expect(frame).toMatch(/4s\s+\(5s\)/);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Add active and wall-clock elapsed timers to StatusBar Line 1, right-aligned via a `justifyContent: "space-between"` flex container.
- Active time pauses while the pipeline is blocked on user input (`inputRequest !== null` in App.tsx, passed as `paused` prop).
- Wall-clock time is measured from the `renderApp` call in `index.ts` via a `startedAt` timestamp prop.
- When space is tight, wall-clock time (parenthesized) drops first, then active time.
- Update the Terminal UI section in README.md to reflect the new display.

Closes #177

## Test plan

- [x] `formatElapsed` correctly formats seconds, minutes+seconds, and hours+minutes+seconds
- [x] `formatElapsed` floors fractional seconds
- [x] Elapsed time appears when `startedAt` is provided
- [x] Elapsed time is hidden when `startedAt` is not provided
- [x] Wall-clock time (parenthesized) drops first when space is tight
- [x] All elapsed time drops when space is extremely tight
- [x] Active timer pauses when `paused` is true (waiting for user input)
- [x] Pausing mid-second does not discard partial-interval active time
- [x] Timer updates every second via `setInterval`
- [x] Line 1 uses flex layout with `justifyContent: "space-between"` for right-alignment
- [x] Issue title truncates to make room for elapsed time