### PR TITLE
Fix InputArea message/choices overlap (#181)

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -74,8 +74,9 @@ interface VisibilityBudgetOptions {
 /** Compute the height of the InputArea in terminal rows. */
 export function inputAreaHeight(request: InputRequest | null): number {
   if (!request) return 1;
-  if (request.choices) return 1 + request.choices.length;
-  return 2;
+  const messageLines = request.message.split("\n").length;
+  if (request.choices) return messageLines + request.choices.length;
+  return messageLines + 1;
 }
 
 /**

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -47,7 +47,10 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
   if (request.choices) {
     return (
       <Box flexDirection="column" paddingX={1}>
-        <Text>{request.message}</Text>
+        {request.message.split("\n").map((line, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: static message lines never reorder
+          <Text key={i}>{line || " "}</Text>
+        ))}
         {request.choices.map((c, i) => (
           <Text key={c.value}>
             {"  "}
@@ -64,7 +67,10 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
 
   return (
     <Box flexDirection="column" paddingX={1}>
-      <Text>{request.message}</Text>
+      {request.message.split("\n").map((line, i) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: static message lines never reorder
+        <Text key={i}>{line || " "}</Text>
+      ))}
       <Box>
         <Text bold color="cyan">
           {">"}{" "}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1244,6 +1244,49 @@ describe("InputArea", () => {
     expect(frame).toContain("Stop");
   });
 
+  test("renders multiline message as separate lines with choices", () => {
+    const request: InputRequest = {
+      message: "Pipeline completed.\n\nHas the PR been merged?",
+      choices: [
+        { label: "Yes, merged", value: "yes" },
+        { label: "No", value: "no" },
+      ],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    const mergedIdx = lines.findIndex((l) =>
+      l.includes("Has the PR been merged"),
+    );
+    const choiceIdx = lines.findIndex((l) => l.includes("Yes, merged"));
+    // The message's last line and the first choice must be on different rows.
+    expect(mergedIdx).toBeGreaterThanOrEqual(0);
+    expect(choiceIdx).toBeGreaterThanOrEqual(0);
+    expect(mergedIdx).toBeLessThan(choiceIdx);
+  });
+
+  test("renders multiline message as separate lines with text input", () => {
+    const request: InputRequest = {
+      message: "Summary:\n\nEnter your instruction:",
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    const summaryIdx = lines.findIndex((l) => l.includes("Summary:"));
+    const instructionIdx = lines.findIndex((l) =>
+      l.includes("Enter your instruction:"),
+    );
+    expect(summaryIdx).toBeGreaterThanOrEqual(0);
+    expect(instructionIdx).toBeGreaterThanOrEqual(0);
+    expect(summaryIdx).toBeLessThan(instructionIdx);
+  });
+
   test("renders text input when request has no choices", () => {
     const request: InputRequest = {
       message: "Enter your instruction:",
@@ -2322,6 +2365,19 @@ describe("inputAreaHeight", () => {
         ],
       }),
     ).toBe(3);
+  });
+
+  test("counts newlines in message for text input", () => {
+    expect(inputAreaHeight({ message: "Line1\n\nLine3" })).toBe(4);
+  });
+
+  test("counts newlines in message for choice request", () => {
+    expect(
+      inputAreaHeight({
+        message: "Summary\n\nChoose:",
+        choices: [{ label: "A", value: "a" }],
+      }),
+    ).toBe(4);
   });
 });
 


### PR DESCRIPTION
## Summary

- Split `request.message` on `\n` in `InputArea` and render each line as a separate `<Text>` element, preventing Ink's Yoga layout engine from miscalculating the height of multiline messages.
- Updated `inputAreaHeight()` in `App.tsx` to count newlines in the message so the visibility budget stays correct.
- Added tests for both the multiline rendering (choices and text-input variants) and the updated height calculation.

Closes #181

## Test plan

- [x] Prompt with embedded `\n` in the message (e.g. merge confirmation) renders each message line on its own row, with choices below
- [x] No "garbled" overlap between the last message line and the first choice
- [x] Text-input variant (no choices) also renders multiline messages correctly
- [x] `inputAreaHeight` returns the correct row count for messages containing newlines
- [x] All existing component tests continue to pass (`pnpm vitest run src/ui/components.test.tsx`)