### PR TITLE
Broaden doc consistency check across stages (#183)

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -270,11 +270,23 @@ item, briefly note whether it passes or needs attention.
    service integrations correct and resilient?  Start all required
    services and run integration tests against them rather than skipping
    tests that need external services.
-5. **Documentation consistency** — Are comments, READMEs, and inline
-   docs consistent with the code changes?  If documentation or the
-   PR requires screenshots, verify they were actually captured by
-   starting the application, opening a browser, and taking real
-   screenshots — do not use placeholders.
+5. **Documentation consistency** — Are all forms of project
+   documentation consistent with the code changes?
+
+   If your changes affect documentation, update it accordingly —
+   code comments, inline API docs (JSDoc/TSDoc/docstrings), README
+   files, CHANGELOG entries, and any user-facing manuals, guides,
+   or tutorials the project maintains.  If the project uses a
+   documentation site generator (MkDocs/Sphinx/Docusaurus/mdBook/
+   etc.), update the corresponding source pages — not just the
+   README.  If the project keeps a CHANGELOG (e.g. Keep a Changelog
+   format), add an appropriate entry.
+
+   If a manual or documentation site page requires a screenshot,
+   capture a real one by starting the application and opening a
+   browser — do not use placeholders.  If your code changes
+   affect the visual output shown in existing manual screenshots,
+   retake them as part of the doc update.
 6. **Security** — Are there any security concerns (injection, auth,
    secrets exposure)?
 7. **Performance** — Are there obvious performance issues or regressions?
@@ -449,6 +461,21 @@ You are fixing CI failures for the following GitHub issue.
 
 Diagnose and fix the CI failures shown above.  After making your
 changes:
+
+If your changes affect documentation, update it accordingly —
+code comments, inline API docs (JSDoc/TSDoc/docstrings), README
+files, CHANGELOG entries, and any user-facing manuals, guides,
+or tutorials the project maintains.  If the project uses a
+documentation site generator (MkDocs/Sphinx/Docusaurus/mdBook/
+etc.), update the corresponding source pages — not just the
+README.  If the project keeps a CHANGELOG (e.g. Keep a Changelog
+format), add an appropriate entry.
+
+If a manual or documentation site page requires a screenshot,
+capture a real one by starting the application and opening a
+browser — do not use placeholders.  If your code changes
+affect the visual output shown in existing manual screenshots,
+retake them as part of the doc update.
 
 Before pushing, check whether the PR description still accurately
 reflects the current code changes.  Run
@@ -628,9 +655,20 @@ You are addressing review feedback for the following GitHub issue.
 3. Fix all agreed-upon items from the review.
 4. Post a response as a PR comment prefixed with
    `**[Author Round {n}]**` summarising what you changed.
-5. If your code changes affect the visual output shown in existing
-   screenshots, retake those screenshots by starting the application,
-   opening a browser, and capturing updated images.
+5. If your changes affect documentation, update it accordingly —
+   code comments, inline API docs (JSDoc/TSDoc/docstrings), README
+   files, CHANGELOG entries, and any user-facing manuals, guides,
+   or tutorials the project maintains.  If the project uses a
+   documentation site generator (MkDocs/Sphinx/Docusaurus/mdBook/
+   etc.), update the corresponding source pages — not just the
+   README.  If the project keeps a CHANGELOG (e.g. Keep a Changelog
+   format), add an appropriate entry.
+
+   If a manual or documentation site page requires a screenshot,
+   capture a real one by starting the application and opening a
+   browser — do not use placeholders.  If your code changes
+   affect the visual output shown in existing manual screenshots,
+   retake them as part of the doc update.
 6. Before pushing, check whether the PR description still accurately
    reflects the current code changes.  Run
    `gh pr view --json body --jq .body` to read the current

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -112,6 +112,12 @@ describe("buildCiFixPrompt", () => {
     expect(prompt).toContain("commit and push");
   });
 
+  test("includes doc consistency instructions", () => {
+    const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "error");
+    expect(prompt).toContain("CHANGELOG");
+    expect(prompt).toContain("MkDocs");
+  });
+
   test("includes user instruction when present", () => {
     const ctx = { ...BASE_CTX, userInstruction: "Ignore lint warnings" };
     const prompt = buildCiFixPrompt(ctx, makeOpts(), "error");

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -21,7 +21,11 @@ import {
 import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
-import { invokeOrResume, mapAgentError } from "./stage-util.js";
+import {
+  buildDocConsistencyInstructions,
+  invokeOrResume,
+  mapAgentError,
+} from "./stage-util.js";
 import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
 
 // ---- defaults --------------------------------------------------------------
@@ -91,6 +95,8 @@ export function buildCiFixPrompt(
     ``,
     `Diagnose and fix the CI failures shown above.  After making your`,
     `changes:`,
+    ``,
+    buildDocConsistencyInstructions(),
     ``,
     `${buildPrSyncInstructions(ctx.issueNumber)}`,
     ``,

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -151,21 +151,21 @@ describe("buildAuthorFixPrompt", () => {
     expect(prompt).toContain("Commit and push");
   });
 
-  test("instructs to retake screenshots when changes affect visuals", () => {
+  test("includes doc consistency instructions with screenshots", () => {
     const prompt = buildAuthorFixPrompt(BASE_CTX, makeOpts(), 1);
+    expect(prompt).toContain("CHANGELOG");
+    expect(prompt).toContain("MkDocs");
     expect(prompt).toContain("retake");
     expect(prompt).toContain("screenshots");
   });
 
-  test("step numbers are correctly ordered after screenshot step insertion", () => {
+  test("step numbers are correctly ordered", () => {
     const prompt = buildAuthorFixPrompt(BASE_CTX, makeOpts(), 1);
     // Verify the 7 steps appear in order. Extract step numbers.
     const stepNumbers = [...prompt.matchAll(/^(\d+)\.\s/gm)].map((m) =>
       Number(m[1]),
     );
     expect(stepNumbers).toEqual([1, 2, 3, 4, 5, 6, 7]);
-    // Step 5 is about screenshots, step 7 is commit-and-push.
-    expect(prompt).toContain("5. If your code changes affect");
     expect(prompt).toContain("7. Commit and push");
   });
 });

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -30,6 +30,7 @@ import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  buildDocConsistencyInstructions,
   drainToSink,
   invokeOrResume,
   mapAgentError,
@@ -147,9 +148,7 @@ export function buildAuthorFixPrompt(
     `3. Fix all agreed-upon items from the review.`,
     `4. Post a response as a PR comment prefixed with`,
     `   \`**[Author Round ${round}]**\` summarising what you changed.`,
-    `5. If your code changes affect the visual output shown in existing`,
-    `   screenshots, retake those screenshots by starting the application,`,
-    `   opening a browser, and capturing updated images.`,
+    `5. ${buildDocConsistencyInstructions("   ").trimStart()}`,
     `6. ${buildPrSyncInstructions(ctx.issueNumber)}`,
     `7. Commit and push your changes so a new CI run is triggered.`,
   ];

--- a/src/stage-selfcheck.test.ts
+++ b/src/stage-selfcheck.test.ts
@@ -98,6 +98,12 @@ describe("buildSelfCheckPrompt", () => {
     expect(prompt).toContain("do not use placeholders");
   });
 
+  test("documentation item includes doc consistency helper content", () => {
+    const prompt = buildSelfCheckPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("CHANGELOG");
+    expect(prompt).toContain("MkDocs");
+  });
+
   test("includes repo and issue context", () => {
     const prompt = buildSelfCheckPrompt(BASE_CTX, makeOpts());
     expect(prompt).toContain("Owner: org");

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -21,6 +21,7 @@ import {
 } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  buildDocConsistencyInstructions,
   invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
@@ -80,11 +81,10 @@ export function buildSelfCheckPrompt(
     `   service integrations correct and resilient?  Start all required`,
     `   services and run integration tests against them rather than skipping`,
     `   tests that need external services.`,
-    `5. **Documentation consistency** — Are comments, READMEs, and inline`,
-    `   docs consistent with the code changes?  If documentation or the`,
-    `   PR requires screenshots, verify they were actually captured by`,
-    `   starting the application, opening a browser, and taking real`,
-    `   screenshots — do not use placeholders.`,
+    `5. **Documentation consistency** — Are all forms of project`,
+    `   documentation consistent with the code changes?`,
+    ``,
+    buildDocConsistencyInstructions("   "),
     `6. **Security** — Are there any security concerns (injection, auth,`,
     `   secrets exposure)?`,
     `7. **Performance** — Are there obvious performance issues or regressions?`,

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import {
+  buildDocConsistencyInstructions,
   invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
@@ -1072,5 +1073,70 @@ describe("mapAgentError inactivity_timeout", () => {
     expect(result.message).toBe(
       "Agent process timed out due to inactivity during implementation.",
     );
+  });
+});
+
+// ---- buildDocConsistencyInstructions ---------------------------------------
+
+describe("buildDocConsistencyInstructions", () => {
+  const text = buildDocConsistencyInstructions();
+
+  test("mentions CHANGELOG", () => {
+    expect(text).toContain("CHANGELOG");
+  });
+
+  test("mentions documentation site generators", () => {
+    expect(text).toContain("MkDocs");
+    expect(text).toContain("Sphinx");
+    expect(text).toContain("Docusaurus");
+    expect(text).toContain("mdBook");
+    expect(text).toContain("documentation site generator");
+  });
+
+  test("instructs to update source pages, not just the README", () => {
+    expect(text).toContain("not just the");
+    expect(text).toContain("README");
+  });
+
+  test("mentions Keep a Changelog format", () => {
+    expect(text).toContain("Keep a Changelog");
+  });
+
+  test("mentions manuals", () => {
+    expect(text).toContain("manual");
+  });
+
+  test("mentions screenshots and placeholders", () => {
+    expect(text).toContain("screenshot");
+    expect(text).toContain("do not use placeholders");
+    expect(text).toContain("retake");
+  });
+
+  test("screenshot paragraph comes after doc paragraph", () => {
+    const paragraphs = text.split("\n\n");
+    expect(paragraphs.length).toBe(2);
+    expect(paragraphs[0]).toContain("CHANGELOG");
+    expect(paragraphs[1]).toContain("screenshot");
+  });
+
+  test("screenshot paragraph does not mention README or CHANGELOG", () => {
+    const paragraphs = text.split("\n\n");
+    const screenshotParagraph = paragraphs[1];
+    expect(screenshotParagraph).not.toContain("README");
+    expect(screenshotParagraph).not.toContain("CHANGELOG");
+  });
+
+  test("indent parameter prefixes every non-empty line", () => {
+    const indented = buildDocConsistencyInstructions("   ");
+    const lines = indented.split("\n");
+    for (const line of lines) {
+      if (line === "") continue;
+      expect(line).toMatch(/^ {3}\S/);
+    }
+  });
+
+  test("indent parameter preserves blank line between paragraphs", () => {
+    const indented = buildDocConsistencyInstructions("   ");
+    expect(indented).toContain("\n\n");
   });
 });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -337,6 +337,43 @@ export function mapResponseToResult(
 }
 
 /**
+ * Build instructions for keeping all forms of project documentation
+ * consistent with code changes.
+ *
+ * Included in prompts at any stage where the author agent may be
+ * modifying code: Stage 2 self-check, Stage 4 CI fix, and Stage 6
+ * review response.  Stage 7 post-squash CI fix reuses the Stage 4
+ * prompt and is covered transitively.
+ *
+ * The screenshot paragraph is scoped to manuals and documentation
+ * site pages only — README hero images and CHANGELOG entries do
+ * not typically embed behavior-tracking screenshots, so listing
+ * them in the screenshot clause would be noise.
+ */
+export function buildDocConsistencyInstructions(indent = ""): string {
+  const lines = [
+    `If your changes affect documentation, update it accordingly —`,
+    `code comments, inline API docs (JSDoc/TSDoc/docstrings), README`,
+    `files, CHANGELOG entries, and any user-facing manuals, guides,`,
+    `or tutorials the project maintains.  If the project uses a`,
+    `documentation site generator (MkDocs/Sphinx/Docusaurus/mdBook/`,
+    `etc.), update the corresponding source pages — not just the`,
+    `README.  If the project keeps a CHANGELOG (e.g. Keep a Changelog`,
+    `format), add an appropriate entry.`,
+    ``,
+    `If a manual or documentation site page requires a screenshot,`,
+    `capture a real one by starting the application and opening a`,
+    `browser — do not use placeholders.  If your code changes`,
+    `affect the visual output shown in existing manual screenshots,`,
+    `retake them as part of the doc update.`,
+  ];
+  if (!indent) return lines.join("\n");
+  return lines
+    .map((line) => (line === "" ? "" : `${indent}${line}`))
+    .join("\n");
+}
+
+/**
  * Map a fix-or-done / verify-or-done response to a `StageResult`.
  *
  * The step parser maps both FIXED and DONE to `"fixed"` status.  We


### PR DESCRIPTION
## Summary

- Add `buildDocConsistencyInstructions(indent?)` helper in `src/stage-util.ts` that enumerates all forms of project documentation: code comments, inline API docs, READMEs, CHANGELOGs, manuals/guides/tutorials, and documentation site pages (MkDocs/Sphinx/Docusaurus/mdBook/etc.)
- The optional `indent` parameter prefixes every non-empty line so the helper output stays nested under numbered list items in the rendered prompt
- Call the helper from Stage 2 self-check, Stage 4 CI fix, and Stage 6 author fix — Stage 7 post-squash CI fix reuses the Stage 4 prompt and is covered transitively
- Replace the narrow "comments, READMEs, and inline docs" wording in self-check item 5 and the screenshots-only step in the author fix prompt
- Mirror all prompt changes in `docs/pipeline.md`

Closes #183

## Test plan

- [x] `buildDocConsistencyInstructions` returns text containing CHANGELOG, MkDocs, Sphinx, Docusaurus, mdBook, "not just the README", "Keep a Changelog", "documentation site generator", "manual", "screenshot", "do not use placeholders", "retake"
- [x] Screenshot paragraph comes after doc paragraph (split on blank line) and does not mention README or CHANGELOG
- [x] `indent` parameter prefixes every non-empty line and preserves blank lines
- [x] Self-check prompt contains CHANGELOG and MkDocs (proves helper was inlined)
- [x] CI fix prompt contains CHANGELOG and MkDocs
- [x] Author fix prompt contains CHANGELOG, MkDocs, "retake", and "screenshots"
- [x] Step numbering in author fix prompt remains sequential (1–7)
- [x] Existing self-check screenshot test still passes with new wording
- [x] `docs/pipeline.md` matches the prompt changes in all three stages
- [x] Full test suite passes (1282 tests)
- [x] TypeScript type check passes
- [x] Biome lint passes