### PR TITLE
Fix notification click opening Script Editor (#188)

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ InputArea (e.g., "Agent is blocked: push rejected").
 | Channel | Setting | Default | Behavior |
 | ------- | ------- | ------- | -------- |
 | Terminal bell | `notifications.bell` | `true` | Emits `BEL` (`\x07`) to stdout. Most terminals flash the tab or play a sound. |
-| Desktop | `notifications.desktop` | `false` | macOS: `osascript display notification`. Linux: `notify-send`. Silently ignored if the command is unavailable or no GUI session exists. |
+| Desktop | `notifications.desktop` | `false` | macOS: terminal-aware dispatch (cmux CLI, iTerm2 OSC 9, tmux DCS passthrough, osascript fallback). Linux: `notify-send`. Silently ignored if the command is unavailable or no GUI session exists. |
 
 Both channels can be toggled independently in
 `~/.agentcoop/config.json` or through the startup wizard

--- a/src/notify.test.ts
+++ b/src/notify.test.ts
@@ -9,7 +9,7 @@ import {
 } from "vitest";
 import type { NotificationSettings } from "./config.js";
 
-// Mock child_process.execFile before importing the module under test.
+// Mock child_process before importing the module under test.
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(),
 }));
@@ -20,24 +20,47 @@ vi.mock("./i18n/index.js", () => ({
 }));
 
 const { execFile } = await import("node:child_process");
-const { notifyInputWaiting, _emitBell, _sendDesktop } = await import(
-  "./notify.js"
-);
+const {
+  notifyInputWaiting,
+  _emitBell,
+  _sendDesktop,
+  _detectNotifier,
+  _sanitizeOscPayload,
+  _findTmuxOuterTerminal,
+  _probeTmuxPassthrough,
+} = await import("./notify.js");
+
+const ENV_KEYS = ["CMUX_SOCKET_PATH", "TMUX", "TERM_PROGRAM"] as const;
 
 describe("notifyInputWaiting", () => {
   let stdoutWriteSpy: MockInstance;
+  const savedEnv: Record<string, string | undefined> = {};
 
   beforeEach(() => {
     stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
     vi.mocked(execFile).mockReset();
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
   });
 
   afterEach(() => {
     stdoutWriteSpy.mockRestore();
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
   });
 
   test("fires bell when bell is enabled", () => {
-    const settings: NotificationSettings = { bell: true, desktop: false };
+    const settings: NotificationSettings = {
+      bell: true,
+      desktop: false,
+    };
     notifyInputWaiting(settings, "Ready?");
     expect(stdoutWriteSpy).toHaveBeenCalledWith("\x07");
     expect(execFile).not.toHaveBeenCalled();
@@ -47,7 +70,10 @@ describe("notifyInputWaiting", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
-      const settings: NotificationSettings = { bell: false, desktop: true };
+      const settings: NotificationSettings = {
+        bell: false,
+        desktop: true,
+      };
       notifyInputWaiting(settings, "Ready?");
       expect(stdoutWriteSpy).not.toHaveBeenCalled();
       expect(execFile).toHaveBeenCalledWith("osascript", [
@@ -55,7 +81,9 @@ describe("notifyInputWaiting", () => {
         'display notification "Ready?" with title "agentcoop"',
       ]);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+      });
     }
   });
 
@@ -63,26 +91,37 @@ describe("notifyInputWaiting", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "linux" });
     try {
-      const settings: NotificationSettings = { bell: false, desktop: true };
+      const settings: NotificationSettings = {
+        bell: false,
+        desktop: true,
+      };
       notifyInputWaiting(settings, "Ready?");
       expect(execFile).toHaveBeenCalledWith("notify-send", [
         "agentcoop",
         "Ready?",
       ]);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+      });
     }
   });
 
   test("fires both bell and desktop when both enabled", () => {
-    const settings: NotificationSettings = { bell: true, desktop: true };
+    const settings: NotificationSettings = {
+      bell: true,
+      desktop: true,
+    };
     notifyInputWaiting(settings, "Proceed?");
     expect(stdoutWriteSpy).toHaveBeenCalledWith("\x07");
     expect(execFile).toHaveBeenCalled();
   });
 
   test("fires nothing when both disabled", () => {
-    const settings: NotificationSettings = { bell: false, desktop: false };
+    const settings: NotificationSettings = {
+      bell: false,
+      desktop: false,
+    };
     notifyInputWaiting(settings, "Hello");
     expect(stdoutWriteSpy).not.toHaveBeenCalled();
     expect(execFile).not.toHaveBeenCalled();
@@ -96,26 +135,31 @@ describe("notifyInputWaiting", () => {
     expect(() => _emitBell()).not.toThrow();
   });
 
-  test("desktop notification silently handles execFile failure", () => {
+  test("desktop notification silently handles execFile failure", async () => {
     vi.mocked(execFile).mockImplementation(() => {
       throw new Error("command not found");
     });
-    // Should not throw.
-    expect(() => _sendDesktop("test message")).not.toThrow();
+    // Should not reject — outer try/catch swallows.
+    await _sendDesktop("test message");
   });
 
   test("escapes double quotes in desktop notification message (darwin)", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
-      const settings: NotificationSettings = { bell: false, desktop: true };
+      const settings: NotificationSettings = {
+        bell: false,
+        desktop: true,
+      };
       notifyInputWaiting(settings, 'Stage "Done" ready');
       expect(execFile).toHaveBeenCalledWith("osascript", [
         "-e",
         'display notification "Stage \\"Done\\" ready" with title "agentcoop"',
       ]);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+      });
     }
   });
 
@@ -123,11 +167,16 @@ describe("notifyInputWaiting", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "win32" });
     try {
-      const settings: NotificationSettings = { bell: false, desktop: true };
+      const settings: NotificationSettings = {
+        bell: false,
+        desktop: true,
+      };
       notifyInputWaiting(settings, "Ready?");
       expect(execFile).not.toHaveBeenCalled();
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+      });
     }
   });
 
@@ -135,14 +184,361 @@ describe("notifyInputWaiting", () => {
     const originalPlatform = process.platform;
     Object.defineProperty(process, "platform", { value: "darwin" });
     try {
-      const settings: NotificationSettings = { bell: false, desktop: true };
+      const settings: NotificationSettings = {
+        bell: false,
+        desktop: true,
+      };
       notifyInputWaiting(settings, "path\\to\\file");
       expect(execFile).toHaveBeenCalledWith("osascript", [
         "-e",
         'display notification "path\\\\to\\\\file" with title "agentcoop"',
       ]);
     } finally {
-      Object.defineProperty(process, "platform", { value: originalPlatform });
+      Object.defineProperty(process, "platform", {
+        value: originalPlatform,
+      });
     }
   });
 });
+
+describe("detectNotifier", () => {
+  test("returns notify-send on linux", () => {
+    expect(_detectNotifier({}, "linux")).toBe("notify-send");
+  });
+
+  test("returns none on unsupported platform", () => {
+    expect(_detectNotifier({}, "win32")).toBe("none");
+  });
+
+  test("returns cmux when CMUX_SOCKET_PATH is set", () => {
+    expect(
+      _detectNotifier({ CMUX_SOCKET_PATH: "/tmp/cmux.sock" }, "darwin"),
+    ).toBe("cmux");
+  });
+
+  test("returns tmux when TMUX is set", () => {
+    expect(
+      _detectNotifier({ TMUX: "/tmp/tmux-1000/default,1234,0" }, "darwin"),
+    ).toBe("tmux");
+  });
+
+  test("returns iterm when TERM_PROGRAM is iTerm.app", () => {
+    expect(_detectNotifier({ TERM_PROGRAM: "iTerm.app" }, "darwin")).toBe(
+      "iterm",
+    );
+  });
+
+  test("returns apple-terminal when TERM_PROGRAM is Apple_Terminal", () => {
+    expect(_detectNotifier({ TERM_PROGRAM: "Apple_Terminal" }, "darwin")).toBe(
+      "apple-terminal",
+    );
+  });
+
+  test("returns osascript as fallback on darwin", () => {
+    expect(_detectNotifier({}, "darwin")).toBe("osascript");
+  });
+
+  test("CMUX_SOCKET_PATH takes priority over TMUX", () => {
+    expect(
+      _detectNotifier(
+        {
+          CMUX_SOCKET_PATH: "/tmp/cmux.sock",
+          TMUX: "/tmp/tmux",
+        },
+        "darwin",
+      ),
+    ).toBe("cmux");
+  });
+
+  test("TMUX takes priority over TERM_PROGRAM", () => {
+    expect(
+      _detectNotifier(
+        { TMUX: "/tmp/tmux", TERM_PROGRAM: "iTerm.app" },
+        "darwin",
+      ),
+    ).toBe("tmux");
+  });
+
+  test("ignores terminal env vars on linux", () => {
+    expect(
+      _detectNotifier(
+        { TERM_PROGRAM: "iTerm.app", TMUX: "/tmp/tmux" },
+        "linux",
+      ),
+    ).toBe("notify-send");
+  });
+});
+
+describe("sanitizeOscPayload", () => {
+  test("strips BEL character", () => {
+    expect(_sanitizeOscPayload("hello\x07world")).toBe("helloworld");
+  });
+
+  test("strips ESC character", () => {
+    expect(_sanitizeOscPayload("hello\x1bworld")).toBe("helloworld");
+  });
+
+  test("strips ST character", () => {
+    expect(_sanitizeOscPayload("hello\x9cworld")).toBe("helloworld");
+  });
+
+  test("strips semicolons", () => {
+    expect(_sanitizeOscPayload("hello;world")).toBe("helloworld");
+  });
+
+  test("leaves normal text unchanged", () => {
+    expect(_sanitizeOscPayload("Hello World 123!")).toBe("Hello World 123!");
+  });
+
+  test("strips multiple special characters at once", () => {
+    expect(_sanitizeOscPayload("a\x07b\x1bc\x9cd;e")).toBe("abcde");
+  });
+});
+
+describe("findTmuxOuterTerminal", () => {
+  test("finds iTerm in ancestor chain", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("1234\n"); // tmux display-message
+    run.mockResolvedValueOnce("1233 bash\n"); // ps for 1234
+    run.mockResolvedValueOnce("1232 iTerm2\n"); // ps for 1233
+    expect(await _findTmuxOuterTerminal(run)).toBe("iterm");
+  });
+
+  test("finds cmux in ancestor chain", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("1234\n");
+    run.mockResolvedValueOnce("1233 cmux\n");
+    expect(await _findTmuxOuterTerminal(run)).toBe("cmux");
+  });
+
+  test("finds Apple Terminal in ancestor chain", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("1234\n");
+    run.mockResolvedValueOnce("1233 Terminal\n");
+    expect(await _findTmuxOuterTerminal(run)).toBe("apple-terminal");
+  });
+
+  test("returns undefined when PID 1 is reached", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("1234\n");
+    run.mockResolvedValueOnce("1 bash\n");
+    expect(await _findTmuxOuterTerminal(run)).toBeUndefined();
+  });
+
+  test("returns undefined when tmux display-message fails", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockRejectedValue(new Error("not connected"));
+    expect(await _findTmuxOuterTerminal(run)).toBeUndefined();
+  });
+
+  test("returns undefined when max depth reached", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("1000\n"); // tmux display-message
+    for (let i = 0; i < 5; i++) {
+      run.mockResolvedValueOnce(`${999 - i} bash\n`);
+    }
+    expect(await _findTmuxOuterTerminal(run)).toBeUndefined();
+  });
+
+  test("returns undefined for empty client pid", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("\n");
+    expect(await _findTmuxOuterTerminal(run)).toBeUndefined();
+  });
+
+  test("returns undefined for client pid 0", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("0\n");
+    expect(await _findTmuxOuterTerminal(run)).toBeUndefined();
+  });
+});
+
+describe("probeTmuxPassthrough", () => {
+  test("returns true for 'on'", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("on\n");
+    expect(await _probeTmuxPassthrough(run)).toBe(true);
+  });
+
+  test("returns true for 'all'", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("all\n");
+    expect(await _probeTmuxPassthrough(run)).toBe(true);
+  });
+
+  test("returns false for 'off'", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("off\n");
+    expect(await _probeTmuxPassthrough(run)).toBe(false);
+  });
+
+  test("returns false for empty value", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("\n");
+    expect(await _probeTmuxPassthrough(run)).toBe(false);
+  });
+
+  test("returns false on error", async () => {
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockRejectedValue(new Error("no tmux"));
+    expect(await _probeTmuxPassthrough(run)).toBe(false);
+  });
+});
+
+describe("desktop notification dispatch", () => {
+  let stdoutWriteSpy: MockInstance;
+  let originalPlatform: string;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    vi.mocked(execFile).mockReset();
+    originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "darwin" });
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    stdoutWriteSpy.mockRestore();
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+    });
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
+
+  test("cmux: calls cmux notify CLI", async () => {
+    process.env.CMUX_SOCKET_PATH = "/tmp/cmux.sock";
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("");
+    await _sendDesktop("Hello", run);
+    expect(run).toHaveBeenCalledWith("cmux", [
+      "notify",
+      "--title",
+      "agentcoop",
+      "--body",
+      "Hello",
+    ]);
+  });
+
+  test("cmux: falls back to OSC 777 when CLI unavailable", async () => {
+    process.env.CMUX_SOCKET_PATH = "/tmp/cmux.sock";
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockRejectedValueOnce(new Error("command not found"));
+    await _sendDesktop("Hello", run);
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      "\x1b]777;notify;agentcoop;Hello\x07",
+    );
+  });
+
+  test("iterm: sends OSC 9 escape sequence", async () => {
+    process.env.TERM_PROGRAM = "iTerm.app";
+    await _sendDesktop("Hello");
+    expect(stdoutWriteSpy).toHaveBeenCalledWith("\x1b]9;Hello\x07");
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  test("iterm: sanitizes OSC 9 payload", async () => {
+    process.env.TERM_PROGRAM = "iTerm.app";
+    await _sendDesktop("Hello\x07World");
+    expect(stdoutWriteSpy).toHaveBeenCalledWith("\x1b]9;HelloWorld\x07");
+  });
+
+  test("tmux+iterm: sends DCS-wrapped OSC 9 when passthrough enabled", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    const run = vi.fn<ExecRunnerFn>();
+    run
+      .mockResolvedValueOnce("5678\n") // tmux display-message
+      .mockResolvedValueOnce("5677 iTerm2\n") // ps — found iTerm
+      .mockResolvedValueOnce("on\n"); // tmux show allow-passthrough
+    await _sendDesktop("Hello", run);
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(
+      "\x1bPtmux;\x1b\x1b]9;Hello\x07\x1b\\",
+    );
+  });
+
+  test("tmux+iterm: falls back to osascript when passthrough disabled", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    const run = vi.fn<ExecRunnerFn>();
+    run
+      .mockResolvedValueOnce("5678\n") // tmux display-message
+      .mockResolvedValueOnce("5677 iTerm2\n") // ps
+      .mockResolvedValueOnce("off\n"); // tmux show allow-passthrough
+    await _sendDesktop("Hello", run);
+    expect(execFile).toHaveBeenCalledWith("osascript", [
+      "-e",
+      'display notification "Hello" with title "agentcoop"',
+    ]);
+  });
+
+  test("tmux+unknown: falls back to osascript", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockResolvedValueOnce("5678\n").mockResolvedValueOnce("1 bash\n"); // ppid is 1
+    await _sendDesktop("Hello", run);
+    expect(execFile).toHaveBeenCalledWith("osascript", [
+      "-e",
+      'display notification "Hello" with title "agentcoop"',
+    ]);
+  });
+
+  test("tmux+cmux: calls cmux notify CLI", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    const run = vi.fn<ExecRunnerFn>();
+    run
+      .mockResolvedValueOnce("5678\n") // tmux display-message
+      .mockResolvedValueOnce("5677 cmux\n") // ps — found cmux
+      .mockResolvedValueOnce(""); // cmux notify CLI
+    await _sendDesktop("Hello", run);
+    expect(run).toHaveBeenCalledWith("cmux", [
+      "notify",
+      "--title",
+      "agentcoop",
+      "--body",
+      "Hello",
+    ]);
+  });
+
+  test("tmux+apple-terminal: falls back to osascript", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    const run = vi.fn<ExecRunnerFn>();
+    run
+      .mockResolvedValueOnce("5678\n") // tmux display-message
+      .mockResolvedValueOnce("5677 Terminal\n"); // ps — found Apple Terminal
+    await _sendDesktop("Hello", run);
+    expect(execFile).toHaveBeenCalledWith("osascript", [
+      "-e",
+      'display notification "Hello" with title "agentcoop"',
+    ]);
+  });
+
+  test("tmux display-message failure: falls back to osascript", async () => {
+    process.env.TMUX = "/tmp/tmux-1000/default,1234,0";
+    const run = vi.fn<ExecRunnerFn>();
+    run.mockRejectedValue(new Error("no clients"));
+    await _sendDesktop("Hello", run);
+    expect(execFile).toHaveBeenCalledWith("osascript", [
+      "-e",
+      'display notification "Hello" with title "agentcoop"',
+    ]);
+  });
+
+  test("iterm: silently handles stdout.write failure", async () => {
+    process.env.TERM_PROGRAM = "iTerm.app";
+    stdoutWriteSpy.mockImplementation(() => {
+      throw new Error("stdout broken");
+    });
+    // Should not reject — outer try/catch swallows.
+    await _sendDesktop("Hello");
+  });
+});
+
+type ExecRunnerFn = (cmd: string, args: readonly string[]) => Promise<string>;

--- a/src/notify.ts
+++ b/src/notify.ts
@@ -16,7 +16,7 @@ export function notifyInputWaiting(
     emitBell();
   }
   if (settings.desktop) {
-    sendDesktopNotification(message);
+    sendDesktopNotification(message).catch(() => {});
   }
 }
 
@@ -29,17 +29,171 @@ function emitBell(): void {
   }
 }
 
+type Notifier =
+  | "cmux"
+  | "tmux"
+  | "iterm"
+  | "apple-terminal"
+  | "osascript"
+  | "notify-send"
+  | "none";
+
+/** Async shell runner used by tmux helpers and cmux CLI. */
+type ExecRunner = (cmd: string, args: readonly string[]) => Promise<string>;
+
+function defaultExecRunner(
+  cmd: string,
+  args: readonly string[],
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      cmd,
+      [...args],
+      { encoding: "utf8", timeout: 5000 },
+      (error, stdout) => {
+        if (error) reject(error);
+        else resolve(stdout);
+      },
+    );
+  });
+}
+
+/**
+ * Detect the appropriate notifier based on environment variables and
+ * platform.  Returns an intermediate "tmux" value when further
+ * process-tree resolution is needed.
+ */
+function detectNotifier(
+  env: Record<string, string | undefined>,
+  platform: string = process.platform,
+): Notifier {
+  if (platform === "linux") return "notify-send";
+  if (platform !== "darwin") return "none";
+  if (env.CMUX_SOCKET_PATH) return "cmux";
+  if (env.TMUX) return "tmux";
+  if (env.TERM_PROGRAM === "iTerm.app") return "iterm";
+  if (env.TERM_PROGRAM === "Apple_Terminal") return "apple-terminal";
+  return "osascript";
+}
+
+/**
+ * Sanitize text for embedding in OSC escape sequences.
+ * Strips BEL, ESC, ST, and semicolons to prevent sequence
+ * truncation or misparsing.
+ */
+function sanitizeOscPayload(text: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping terminal control chars is the purpose of this function
+  return text.replace(/[\x07\x1b\x9c;]/g, "");
+}
+
+/**
+ * Walk the tmux process tree from the attached client upward
+ * (max 5 levels) to identify the outer terminal emulator.
+ */
+async function findTmuxOuterTerminal(
+  run: ExecRunner = defaultExecRunner,
+): Promise<"cmux" | "iterm" | "apple-terminal" | undefined> {
+  try {
+    const clientPid = (
+      await run("tmux", ["display-message", "-p", "#{client_pid}"])
+    ).trim();
+    if (!clientPid || clientPid === "0") return undefined;
+
+    let pid = clientPid;
+    for (let i = 0; i < 5; i++) {
+      const line = (await run("ps", ["-p", pid, "-o", "ppid=,comm="])).trim();
+      const match = line.match(/^(\d+)\s+(.+)$/);
+      if (!match) return undefined;
+
+      const ppid = match[1];
+      const name = (match[2].split("/").pop() ?? "").trim();
+
+      if (/cmux/i.test(name)) return "cmux";
+      if (/iterm/i.test(name)) return "iterm";
+      if (name === "Terminal") return "apple-terminal";
+
+      if (ppid === "0" || ppid === "1" || ppid === pid) return undefined;
+      pid = ppid;
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Probe the tmux `allow-passthrough` global setting.
+ * Returns true if passthrough is enabled ("on" or "all").
+ */
+async function probeTmuxPassthrough(
+  run: ExecRunner = defaultExecRunner,
+): Promise<boolean> {
+  try {
+    const value = (
+      await run("tmux", ["show", "-gv", "allow-passthrough"])
+    ).trim();
+    return value === "on" || value === "all";
+  } catch {
+    return false;
+  }
+}
+
 /** Send a desktop notification using platform-native commands. */
-function sendDesktopNotification(message: string): void {
+async function sendDesktopNotification(
+  message: string,
+  run: ExecRunner = defaultExecRunner,
+): Promise<void> {
   try {
     const title = t()["notification.title"];
-    if (process.platform === "darwin") {
-      execFile("osascript", [
-        "-e",
-        `display notification "${escapeAppleScript(message)}" with title "${escapeAppleScript(title)}"`,
-      ]);
-    } else if (process.platform === "linux") {
+    let notifier = detectNotifier(process.env);
+
+    if (notifier === "none") return;
+
+    if (notifier === "notify-send") {
       execFile("notify-send", [title, message]);
+      return;
+    }
+
+    // macOS — resolve tmux to a concrete notifier
+    if (notifier === "tmux") {
+      const outer = await findTmuxOuterTerminal(run);
+      if (outer === "cmux") {
+        notifier = "cmux";
+      } else if (outer === "iterm") {
+        if (await probeTmuxPassthrough(run)) {
+          const sanitized = sanitizeOscPayload(message);
+          process.stdout.write(`\x1bPtmux;\x1b\x1b]9;${sanitized}\x07\x1b\\`);
+          return;
+        }
+        notifier = "osascript";
+      } else {
+        notifier = "osascript";
+      }
+    }
+
+    switch (notifier) {
+      case "cmux": {
+        try {
+          await run("cmux", ["notify", "--title", title, "--body", message]);
+        } catch {
+          // Binary unavailable — fall back to OSC 777
+          const oscTitle = sanitizeOscPayload(title);
+          const oscBody = sanitizeOscPayload(message);
+          process.stdout.write(`\x1b]777;notify;${oscTitle};${oscBody}\x07`);
+        }
+        break;
+      }
+      case "iterm":
+        process.stdout.write(`\x1b]9;${sanitizeOscPayload(message)}\x07`);
+        break;
+      case "apple-terminal":
+      case "osascript":
+        execFile("osascript", [
+          "-e",
+          `display notification "${escapeAppleScript(message)}" with title "${escapeAppleScript(title)}"`,
+        ]);
+        break;
     }
   } catch {
     // Silently ignore — command may not exist, no GUI session, etc.
@@ -51,4 +205,11 @@ function escapeAppleScript(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
 
-export { emitBell as _emitBell, sendDesktopNotification as _sendDesktop };
+export {
+  detectNotifier as _detectNotifier,
+  emitBell as _emitBell,
+  findTmuxOuterTerminal as _findTmuxOuterTerminal,
+  probeTmuxPassthrough as _probeTmuxPassthrough,
+  sanitizeOscPayload as _sanitizeOscPayload,
+  sendDesktopNotification as _sendDesktop,
+};


### PR DESCRIPTION
## Summary

- Replace the single `osascript` notification path with terminal-aware dispatch that routes through cmux CLI, iTerm2 OSC 9, or tmux DCS passthrough depending on the detected terminal emulator
- Walk the tmux process tree to identify the outer terminal (cmux, iTerm, Apple Terminal) and choose the best notification channel
- Sanitize notification payloads for OSC escape sequences (strip BEL, ESC, ST, semicolons)
- Fall back to `display notification` via osascript for Apple Terminal and unknown terminals (known limitation documented in issue)
- All process-tree probes and cmux CLI calls are fully async (`execFile` with callback-based promises) — notification dispatch never blocks the event loop or the TUI prompt flow

Closes #188

## Not addressed

- **Apple Terminal click attribution**: There is no known way to send a macOS notification attributed to Terminal.app. Apple Terminal users still get the Script Editor behavior when clicking notifications. The recommended workaround is `bell: true, desktop: false` in notification config.

## Test plan

- [x] Verify `detectNotifier` returns correct notifier for each env var combination
- [x] Verify `sanitizeOscPayload` strips BEL, ESC, ST, and semicolons
- [x] Verify `findTmuxOuterTerminal` walks process tree and identifies cmux, iTerm, Apple Terminal
- [x] Verify `findTmuxOuterTerminal` handles edge cases (PID 1, empty PID, max depth, errors)
- [x] Verify `probeTmuxPassthrough` returns true for `on`/`all`, false for `off`/empty/error
- [x] Verify cmux path calls `cmux notify` CLI and falls back to OSC 777
- [x] Verify iTerm path sends OSC 9 and sanitizes payload
- [x] Verify tmux+iTerm sends DCS-wrapped OSC 9 when passthrough enabled, falls back to osascript when disabled
- [x] Verify tmux+cmux calls `cmux notify` CLI
- [x] Verify tmux+Apple Terminal and tmux failures fall back to osascript
- [x] Verify Linux path still uses `notify-send` unchanged
- [x] Verify all notification failures are silently swallowed
- [x] Run full test suite: all 1327 tests pass