### PR TITLE
Improve Done stage rebase flow: debug logging and stage name display (#191)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -92,6 +92,7 @@ export const en: Messages = {
   "stage.ciCheck": "CI check",
   "stage.testPlan": "Test plan verification",
   "stage.squash": "Squash commits",
+  "stage.rebase": "Rebase",
   "stage.review": "Review",
   "stage.done": "Done",
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -116,6 +116,7 @@ export const ko: Messages = {
   "stage.ciCheck": "CI \uAC80\uC0AC",
   "stage.testPlan": "\uD14C\uC2A4\uD2B8 \uACC4\uD68D \uAC80\uC99D",
   "stage.squash": "\uCEE4\uBC0B \uC2A4\uCFFC\uC2DC",
+  "stage.rebase": "\uB9AC\uBCA0\uC774\uC2A4",
   "stage.review": "\uB9AC\uBDF0",
   "stage.done": "\uC644\uB8CC",
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -93,6 +93,7 @@ export interface Messages {
   "stage.ciCheck": string;
   "stage.testPlan": string;
   "stage.squash": string;
+  "stage.rebase": string;
   "stage.review": string;
   "stage.done": string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,7 +555,10 @@ try {
       }
     | undefined;
 
+  const emitter = new PipelineEventEmitter();
+
   const doneStage = createDoneStageHandler({
+    events: emitter,
     checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
     prompt: {
       confirmMerge: async (msg) => {
@@ -769,8 +772,6 @@ try {
   };
   process.on("SIGINT", sigintHandler);
 
-  const emitter = new PipelineEventEmitter();
-
   const startedAt = Date.now();
   const pipelineResult = await new Promise<PipelineResult>((resolve) => {
     const { unmount } = renderApp({
@@ -805,6 +806,9 @@ try {
   // (allows Ctrl+C to kill during cleanup prompts).
   process.off("SIGINT", sigintHandler);
 
+  console.error(
+    `[done-stage-debug] pipelineResult: success=${pipelineResult.success} stoppedAt=${pipelineResult.stoppedAt} cancelled=${pipelineResult.cancelled} message=${pipelineResult.message}`,
+  );
   console.log();
   console.log(pipelineResult.message);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -807,7 +807,7 @@ try {
   process.off("SIGINT", sigintHandler);
 
   console.error(
-    `[done-stage-debug] pipelineResult: success=${pipelineResult.success} stoppedAt=${pipelineResult.stoppedAt} cancelled=${pipelineResult.cancelled} message=${pipelineResult.message}`,
+    `[done-stage-debug] pipelineResult: ${JSON.stringify(pipelineResult)}`,
   );
   console.log();
   console.log(pipelineResult.message);

--- a/src/pipeline-events.test.ts
+++ b/src/pipeline-events.test.ts
@@ -7,6 +7,7 @@ import {
   PipelineEventEmitter,
   type StageEnterEvent,
   type StageExitEvent,
+  type StageNameOverrideEvent,
 } from "./pipeline-events.js";
 
 describe("PipelineEventEmitter", () => {
@@ -104,6 +105,17 @@ describe("PipelineEventEmitter", () => {
       usage: { inputTokens: 100, outputTokens: 50, cachedInputTokens: 10 },
     };
     emitter.emit("agent:usage", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives stage:name-override events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("stage:name-override", handler);
+
+    const event: StageNameOverrideEvent = { stageName: "Rebase" };
+    emitter.emit("stage:name-override", event);
 
     expect(handler).toHaveBeenCalledWith(event);
   });

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -17,6 +17,10 @@ export interface StageExitEvent {
   outcome: string;
 }
 
+export interface StageNameOverrideEvent {
+  stageName: string;
+}
+
 export interface AgentInvokeEvent {
   agent: "a" | "b";
   type: "invoke" | "resume";
@@ -38,6 +42,7 @@ interface PipelineEventMap {
   "agent:usage": [AgentUsageEvent];
   "stage:enter": [StageEnterEvent];
   "stage:exit": [StageExitEvent];
+  "stage:name-override": [StageNameOverrideEvent];
   "agent:invoke": [AgentInvokeEvent];
 }
 

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -19,6 +19,7 @@ import {
   PipelineEventEmitter,
   type StageEnterEvent,
   type StageExitEvent,
+  type StageNameOverrideEvent,
 } from "./pipeline-events.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
@@ -1468,6 +1469,158 @@ describe("createDoneStageHandler", () => {
     // CI polling still happens after the manual resolve re-check.
     expect(opts.pollCiAndFix).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
+  });
+
+  // ---- stage:name-override events ------------------------------------------
+
+  test("handleConflicting rebase emits Rebase then Done on success", async () => {
+    const emitter = new PipelineEventEmitter();
+    const names: string[] = [];
+    emitter.on("stage:name-override", (ev: StageNameOverrideEvent) => {
+      names.push(ev.stageName);
+    });
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      events: emitter,
+      checkMergeable,
+      prompt: { handleConflict: vi.fn().mockResolvedValue("agent_rebase") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    // "Rebase" emitted before rebase, "Done" restored after CI poll.
+    expect(names).toEqual(["Rebase", "Done"]);
+  });
+
+  test("handleConflicting rebase emits Rebase then Done on failure", async () => {
+    const emitter = new PipelineEventEmitter();
+    const names: string[] = [];
+    emitter.on("stage:name-override", (ev: StageNameOverrideEvent) => {
+      names.push(ev.stageName);
+    });
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("CONFLICTING")
+      .mockResolvedValueOnce("MERGEABLE");
+    const opts = makeDoneOpts({
+      events: emitter,
+      checkMergeable,
+      rebaseOntoMain: vi
+        .fn()
+        .mockResolvedValue({ success: false, message: "conflict" }),
+      prompt: { handleConflict: vi.fn().mockResolvedValue("agent_rebase") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    // "Rebase" emitted before rebase, "Done" restored on failure.
+    expect(names[0]).toBe("Rebase");
+    expect(names[1]).toBe("Done");
+  });
+
+  test("askMerge inner rebase emits Rebase then Done", async () => {
+    const emitter = new PipelineEventEmitter();
+    const names: string[] = [];
+    emitter.on("stage:name-override", (ev: StageNameOverrideEvent) => {
+      names.push(ev.stageName);
+    });
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE") // initial → askMerge
+      .mockResolvedValueOnce("CONFLICTING"); // inside askMerge
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("merged");
+    const opts = makeDoneOpts({
+      events: emitter,
+      checkMergeable,
+      prompt: { confirmMerge },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    // "Rebase" emitted inside askMerge, "Done" restored after CI poll.
+    expect(names).toEqual(["Rebase", "Done"]);
+  });
+
+  test("handleConflicting rebase emits Done on abort", async () => {
+    const controller = new AbortController();
+    const emitter = new PipelineEventEmitter();
+    const names: string[] = [];
+    emitter.on("stage:name-override", (ev: StageNameOverrideEvent) => {
+      names.push(ev.stageName);
+    });
+    const opts = makeDoneOpts({
+      events: emitter,
+      checkMergeable: vi.fn().mockResolvedValue("CONFLICTING"),
+      rebaseOntoMain: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return { success: true, message: "" };
+      }),
+      prompt: { handleConflict: vi.fn().mockResolvedValue("agent_rebase") },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+      signal: controller.signal,
+    };
+    await stage.handler(ctx);
+    expect(names).toEqual(["Rebase", "Done"]);
+  });
+
+  test("askMerge inner rebase emits Done on abort", async () => {
+    const controller = new AbortController();
+    const emitter = new PipelineEventEmitter();
+    const names: string[] = [];
+    emitter.on("stage:name-override", (ev: StageNameOverrideEvent) => {
+      names.push(ev.stageName);
+    });
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE")
+      .mockResolvedValueOnce("CONFLICTING");
+    const confirmMerge = vi.fn().mockResolvedValue("check_conflicts");
+    const opts = makeDoneOpts({
+      events: emitter,
+      checkMergeable,
+      rebaseOntoMain: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return { success: true, message: "" };
+      }),
+      prompt: { confirmMerge },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+      signal: controller.signal,
+    };
+    await stage.handler(ctx);
+    expect(names).toEqual(["Rebase", "Done"]);
   });
 
   // ---- askMerge "check_conflicts" sub-path --------------------------------

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1025,7 +1025,7 @@ export function createDoneStageHandler(
         const ciResult = await options.pollCiAndFix(ctx);
         emitStageName(doneName);
         console.error(
-          `[done-stage-debug] afterResolution ciResult: passed=${ciResult.passed} message=${ciResult.message}`,
+          `[done-stage-debug] afterResolution ciResult: ${JSON.stringify(ciResult)}`,
         );
         if (ctx.signal?.aborted) {
           return { outcome: "completed", message: "" };

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -802,6 +802,8 @@ export interface RebaseResult {
 
 /** Options for {@link createDoneStageHandler}. */
 export interface DoneStageOptions {
+  /** Pipeline event emitter for stage name overrides (e.g. "Rebase"). */
+  events?: PipelineEventEmitter;
   /**
    * Check whether the PR has merge conflicts with the base branch.
    * Returns the resolved mergeable state (with retries for UNKNOWN).
@@ -857,6 +859,12 @@ export function createDoneStageHandler(
 ): StageDefinition {
   // Agent rebase is limited to 1 attempt across all loop-backs.
   let rebaseAttempted = false;
+
+  const doneName = t()["stage.done"];
+  const rebaseName = t()["stage.rebase"];
+  const emitStageName = (name: string) => {
+    options.events?.emit("stage:name-override", { stageName: name });
+  };
 
   return {
     name: t()["stage.done"],
@@ -946,11 +954,14 @@ export function createDoneStageHandler(
 
         if (choice === "agent_rebase") {
           rebaseAttempted = true;
+          emitStageName(rebaseName);
           const rebaseResult = await options.rebaseOntoMain(ctx);
           if (ctx.signal?.aborted) {
+            emitStageName(doneName);
             return { outcome: "completed", message: "" };
           }
           if (!rebaseResult.success) {
+            emitStageName(doneName);
             // Agent could not resolve — notify and fall back to manual.
             await options.prompt.waitForManualResolve(
               m["pipeline.rebaseFailed"],
@@ -986,11 +997,13 @@ export function createDoneStageHandler(
           return { outcome: "completed", message: "" };
         }
         if (state === "CONFLICTING") {
+          emitStageName(doneName);
           // Still conflicting — return undefined so the top-level loop
           // re-enters mergeableLoop → handleConflicting.
           return undefined;
         }
         if (state === "UNKNOWN") {
+          emitStageName(doneName);
           // checkMergeable already exhausted its retry budget.  Show the
           // unknown-state prompt immediately instead of re-running the
           // full backoff cycle a second time.
@@ -1010,6 +1023,10 @@ export function createDoneStageHandler(
 
         // MERGEABLE — poll CI after resolution.
         const ciResult = await options.pollCiAndFix(ctx);
+        emitStageName(doneName);
+        console.error(
+          `[done-stage-debug] afterResolution ciResult: passed=${ciResult.passed} message=${ciResult.message}`,
+        );
         if (ctx.signal?.aborted) {
           return { outcome: "completed", message: "" };
         }
@@ -1093,16 +1110,20 @@ export function createDoneStageHandler(
           break; // back to confirmMerge
         }
         rebaseAttempted = true;
+        emitStageName(rebaseName);
         const rebaseResult = await options.rebaseOntoMain(ctx);
         if (ctx.signal?.aborted) {
+          emitStageName(doneName);
           return { outcome: "completed", message: "" };
         }
         if (!rebaseResult.success) {
+          emitStageName(doneName);
           break; // rebase failed — back to confirmMerge
         }
 
         // Rebase succeeded — poll CI and surface the result.
         const ciResult = await options.pollCiAndFix(ctx);
+        emitStageName(doneName);
         if (ctx.signal?.aborted) {
           return { outcome: "completed", message: "" };
         }

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -6,6 +6,7 @@ import type {
   PipelineEventEmitter,
   StageEnterEvent,
   StageExitEvent,
+  StageNameOverrideEvent,
 } from "../pipeline-events.js";
 
 /** Stage number for the self-check stage. */
@@ -213,11 +214,16 @@ export function StatusBar({
         setReviewCount((c) => c + 1);
       }
     };
+    const onNameOverride = (ev: StageNameOverrideEvent) => {
+      setStage((prev) => (prev ? { ...prev, stageName: ev.stageName } : prev));
+    };
     emitter.on("stage:enter", onEnter);
     emitter.on("stage:exit", onExit);
+    emitter.on("stage:name-override", onNameOverride);
     return () => {
       emitter.off("stage:enter", onEnter);
       emitter.off("stage:exit", onExit);
+      emitter.off("stage:name-override", onNameOverride);
     };
   }, [emitter]);
 

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1211,6 +1211,38 @@ describe("StatusBar", () => {
     expect(frame).toContain("aicers/agentcoop#42:");
     expect(frame).toContain("\u2026");
   });
+
+  test("stage:name-override changes displayed name then restores on next override", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+      />,
+    );
+
+    emitter.emit("stage:enter", {
+      stageNumber: 9,
+      stageName: "Done",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("Stage 9: Done");
+
+    // Override to "Rebase"
+    emitter.emit("stage:name-override", { stageName: "Rebase" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("Stage 9: Rebase");
+    expect(lastFrame()).not.toContain("Stage 9: Done");
+
+    // Restore to "Done"
+    emitter.emit("stage:name-override", { stageName: "Done" });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("Stage 9: Done");
+    expect(lastFrame()).not.toContain("Stage 9: Rebase");
+  });
 });
 
 // ---- InputArea ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `[done-stage-debug]` diagnostic logging at two key points to capture the actual values during the rebase → CI → merge flow: after `pollCiAndFix` returns in `afterResolution`, and at the `index.ts` exit path before the final `console.log(pipelineResult.message)`.
- Add a `stage:name-override` event so the TUI StatusBar displays "Rebase" while a rebase operation is in progress, covering both the `handleConflicting` rebase path and the `askMerge` inner rebase path. The display reverts to "Done" on success, failure, or cancellation.
- Route the rebase stage label through the i18n translation path (`stage.rebase` key) so it renders correctly in all supported languages (e.g. "리베이스" in Korean instead of mixed-language "Rebase").
- Add a StatusBar component test verifying that `stage:name-override` events change and restore the rendered stage name.

Closes #191

## Test plan

- [x] Verify `[done-stage-debug] afterResolution ciResult:` log line appears in stderr after a rebase triggers CI polling
- [x] Verify `[done-stage-debug] pipelineResult:` log line appears in stderr when the pipeline exits
- [x] Verify StatusBar shows "Rebase" when agent rebase starts via the conflict prompt (`handleConflicting` path)
- [x] Verify StatusBar shows "Rebase" when agent rebase starts via the merge prompt (`askMerge` inner rebase path)
- [x] Verify StatusBar reverts to "Done" after rebase + CI polling completes successfully
- [x] Verify StatusBar reverts to "Done" when rebase fails
- [x] Verify StatusBar reverts to "Done" on Ctrl+C cancellation
- [x] Verify `pnpm vitest run` passes (pipeline-events, pipeline, and components test suites cover the new event, name-override emissions, and StatusBar rendering)
- [x] Verify `pnpm tsc --noEmit` and `pnpm biome check` pass