### PR TITLE
Standardize verdict handling across pipeline stages (#193)

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -10,7 +10,7 @@ the [README](../README.md).
 - [Pipeline overview](#pipeline-overview)
 - [Prompt design principles](#prompt-design-principles)
   - [Self-contained context](#self-contained-context)
-  - [Explicit completion keywords](#explicit-completion-keywords)
+  - [Two-step verdict pattern](#two-step-verdict-pattern)
   - [No confirmation requests](#no-confirmation-requests)
   - [Service-aware instructions](#service-aware-instructions)
   - [PR body as living documentation](#pr-body-as-living-documentation)
@@ -52,21 +52,52 @@ never need to search for context — it is handed to them. This
 avoids wasted tokens on exploration and reduces the chance of the
 agent working against the wrong branch or issue.
 
-### Explicit completion keywords
+### Two-step verdict pattern
 
-Each stage ends with a strict keyword contract. The orchestrator
-parses the agent's final response for a specific keyword to
-determine the next action. This eliminates ambiguity — the
-orchestrator does not try to infer intent from free-form text.
+Every stage that needs to determine an outcome follows a consistent
+two-step pattern:
 
-| Step type | Keywords | Proceed | Loop/Retry |
-| --------- | -------- | ------- | ---------- |
-| Implementation | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` -> user chooses |
-| Loops (self-check, test plan) | `FIXED` / `DONE` | `DONE` | `FIXED` -> repeat |
-| One-shot (PR, squash) | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` -> user chooses |
-| Review approval | `APPROVED` / `NOT_APPROVED` | `APPROVED` | `NOT_APPROVED` -> repeat |
-| Issue sync | `ISSUE_NO_CHANGES` / `ISSUE_UPDATED` / `ISSUE_COMMENTED` | any | best-effort |
-| PR finalization | `PR_FINALIZED` | `PR_FINALIZED` | missing -> clarification |
+1. **Work step** — the agent performs its task and responds freely.
+   This response is **not** parsed for keywords.
+2. **Verdict follow-up** — a dedicated follow-up prompt asks for
+   **only** the verdict keyword.  The keyword is parsed from this
+   constrained response.
+
+Each verdict call site declares its valid keywords and passes them
+to a strict verdict parser (`parseVerdictKeyword`).  The parser
+requires the response to be essentially just the keyword — it
+rejects responses with extra commentary, multiple valid keywords,
+or out-of-scope keywords.  When the parser rejects a response, a
+single clarification retry is attempted listing only the valid
+keywords for that substep.
+
+The canonical verdict prompt template:
+
+```text
+<Context sentence about what just happened.>
+Respond with exactly one of the following keywords:
+
+- KEYWORD_A — <when to use>
+- KEYWORD_B — <when to use>
+
+Do not include any other commentary — just the keyword.
+```
+
+#### Keyword contracts per substep
+
+| Substep | Valid keywords | Proceed | Loop/Retry |
+| ------- | -------------- | ------- | ---------- |
+| Implementation check | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
+| Self-check verdict | `FIXED` / `DONE` | `DONE` | `FIXED` → repeat |
+| Test plan verdict | `FIXED` / `DONE` | `DONE` | `FIXED` → repeat |
+| PR creation check | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
+| Squash check | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
+| Reviewer verdict | `APPROVED` / `NOT_APPROVED` | `APPROVED` | `NOT_APPROVED` → repeat |
+| Author completion | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
+| Unresolved summary | `NONE` / `COMPLETED` | either | — |
+| PR finalization | `PR_FINALIZED` | `PR_FINALIZED` | missing → clarification → PR body consistency check → blocked |
+| Issue sync | `ISSUE_NO_CHANGES` / `ISSUE_UPDATED` / `ISSUE_COMMENTED` | any | clarification retry; best-effort |
+| Rebase verdict | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → manual |
 
 ### No confirmation requests
 
@@ -143,19 +174,42 @@ at arbitrary times.
 
 ### Ambiguous response clarification
 
-When an agent's response does not end with a recognized status
-keyword, the orchestrator sends a fixed clarification prompt
-rather than re-running the stage (which could be side-effectful).
-The same template is used in two contexts:
+When a verdict follow-up does not contain a recognized keyword, the
+orchestrator sends a **substep-scoped** clarification prompt listing
+only the keywords valid for that specific substep.  This is used in
+two contexts:
 
-- **Within-stage session resume** (Create PR, Squash) — the
-  orchestrator resumes the existing agent session with the
-  clarification prompt.
-- **Pipeline loop injection** — the prompt is set as
-  `userInstruction` and appears as `## Additional feedback`
-  on the next iteration.
+- **Within-stage session resume** (all stages with verdict
+  follow-ups) — the orchestrator resumes the existing agent
+  session with the scoped clarification prompt.  If the retry
+  also returns an ambiguous response, the stage uses a
+  **conservative fallback** instead of bubbling
+  `needs_clarification` to the pipeline engine (which would
+  re-run side-effectful work steps or route the clarification
+  to the wrong agent in multi-agent stages).  The fallback
+  depends on the substep's keyword contract:
+  - *FIXED / DONE* loops (self-check, test-plan): `not_approved`
+    — the pipeline loops the stage again.
+  - *COMPLETED / BLOCKED* substeps (implement, author
+    completion, create-pr, squash): `blocked` — the user is
+    asked how to proceed.
+- **Pipeline loop injection** — used only when the ambiguous
+  verdict comes from the agent that receives `userInstruction`
+  on the next iteration (e.g. the reviewer verdict in the
+  review stage).  `StageResult.validVerdicts` carries the
+  keyword set from the stage handler to the pipeline engine.
 
-The clarification prompt:
+When `validVerdicts` is provided, the clarification prompt:
+
+```text
+Your previous response did not contain a clear verdict keyword.
+Respond with exactly one of the following keywords: KEYWORD_A, KEYWORD_B
+
+Do not include any other commentary — just the keyword.
+```
+
+When no `validVerdicts` are set (legacy fallback), all six keywords
+are listed:
 
 ```text
 Your previous response did not end with a clear status keyword.
@@ -296,18 +350,28 @@ item, briefly note whether it passes or needs attention.
    them.  Do not refactor unrelated existing code.
 ```
 
-**Fix-or-done prompt:**
+**Fix-or-done work prompt:**
 
 ```text
 Based on your self-check above, decide what to do next.
 
-- If you found issues that need fixing, fix them now and end your
-  response with the keyword FIXED.
-- If everything looks good and no changes are needed, end your
-  response with the keyword DONE.
+- If you found issues that need fixing, fix them now.
+- If everything looks good and no changes are needed, you are done.
 ```
 
-**Loop behavior:** `FIXED` -> repeat self-check. `DONE` -> run
+**Fix-or-done verdict follow-up:**
+
+```text
+You have finished the self-check pass.
+Respond with exactly one of the following keywords:
+
+- FIXED — if you found and fixed issues
+- DONE — if everything looks good and no changes were needed
+
+Do not include any other commentary — just the keyword.
+```
+
+**Loop behavior:** `FIXED` → repeat self-check. `DONE` → run
 issue sync, then proceed. Default auto-budget: 5 iterations
 (configurable via `selfCheckAutoIterations`). When the budget is
 exhausted, the user is asked whether to continue.
@@ -342,23 +406,27 @@ implementation against the original issue description below.
    `gh issue comment {number} --repo {owner}/{repo} --body "..."`
    Do NOT modify the issue description for major changes.
 5. If there are no discrepancies, do nothing.
-
-## Response format
-
-End your response with one of the following:
-
-- If no changes were needed:
-  `ISSUE_NO_CHANGES`
-- If you updated the issue (minor):
-  `ISSUE_UPDATED: <brief description of what changed>`
-- If you added a comment (major):
-  `ISSUE_COMMENTED: <brief description of the discrepancy>`
-
-You may include both ISSUE_UPDATED and ISSUE_COMMENTED if there
-were both minor and major discrepancies.
 ```
 
-Issue sync is best-effort — if it fails, the pipeline continues.
+**Issue sync verdict follow-up:**
+
+```text
+Report what issue sync actions you performed.
+Respond with one or more of the following on separate lines:
+
+- ISSUE_NO_CHANGES — if no changes were needed
+- ISSUE_UPDATED: <brief description> — if you updated the issue
+- ISSUE_COMMENTED: <brief description> — if you added a comment
+
+Do not include any other commentary.
+```
+
+The verdict response is strictly parsed: every non-blank line must
+match one of the recognised keyword patterns.  If the response
+contains extra commentary, missing colons, or unrecognised lines,
+a single clarification retry is attempted.  Issue sync is
+best-effort — if the verdict is still malformed after the retry,
+or if any step fails, the pipeline continues.
 
 ---
 
@@ -410,15 +478,17 @@ result and respond with exactly one of the following keywords:
 - COMPLETED — if the pull request was created successfully
 - BLOCKED — if you could not create the PR and need user intervention
 
-If BLOCKED, add a brief reason on the next line explaining what
-went wrong (e.g. auth failure, push rejected, PR already exists).
+Do not include any other commentary — just the keyword.
 ```
 
 **Ambiguous response handling:** If the completion check response
 does not clearly match `COMPLETED` or `BLOCKED`, the orchestrator
 resumes the same session with a clarification prompt (rather than
 re-running the PR creation step, which would be side-effectful).
-If clarification also fails, the response is shown to the user.
+If clarification also fails, the handler performs a post-condition
+check using `findPrNumber` to verify whether a PR was actually
+created.  If the PR exists, the stage completes; otherwise it
+reports `BLOCKED`.
 
 **Outcome handling:** PR creation is a required step
 (`requiresArtifact: true`). If `BLOCKED`, only **Instruct** and
@@ -555,7 +625,7 @@ You are verifying the test plan for the following GitHub issue.
 6. Make sure CI is still passing after any changes.
 ```
 
-**Self-check prompt:**
+**Self-check work prompt:**
 
 ```text
 Based on your verification above, evaluate the current state.
@@ -566,14 +636,23 @@ Based on your verification above, evaluate the current state.
   recursively) when applicable.
 - Is CI still passing?
 
-If you found and fixed issues during verification, end your
-response with the keyword FIXED.
-
-If everything is verified and passing with no changes needed,
-end your response with the keyword DONE.
+If you found issues during verification, fix them now.
+If everything is verified and passing, you are done.
 ```
 
-**Loop behavior:** `FIXED` -> repeat the verification loop.
+**Test plan verdict follow-up:**
+
+```text
+You have finished the test plan verification pass.
+Respond with exactly one of the following keywords:
+
+- FIXED — if you found and fixed issues
+- DONE — if everything is verified and passing with no changes needed
+
+Do not include any other commentary — just the keyword.
+```
+
+**Loop behavior:** `FIXED` → repeat the verification loop.
 `DONE` -> proceed to review. Default auto-budget: 3 iterations.
 
 ---
@@ -641,9 +720,18 @@ You are reviewing a pull request for the following GitHub issue.
    `**[Reviewer Round {n}]**`. Be specific. Cite file paths and
    line numbers when they help; for broader concerns, explain
    the concern at the appropriate level.
-4. End your response with one of these keywords:
-   - APPROVED — if the changes are ready to merge
-   - NOT_APPROVED — if changes are needed
+```
+
+**Reviewer verdict follow-up** (sent after the review comment):
+
+```text
+You have posted your review comment.
+Respond with exactly one of the following keywords:
+
+- APPROVED — if the changes are ready to merge
+- NOT_APPROVED — if changes are needed
+
+Do not include any other commentary — just the keyword.
 ```
 
 #### Review prompt — Agent B (round 2+)
@@ -665,47 +753,17 @@ step:
      or does not address the concern, keep the item open.
    - Only carry forward items that remain genuinely unresolved.
 3. Review the updated diff against the issue.
-   Your job is an
-   independent judgment on whether this is the right change
-   and whether it is built well — not a mechanical checklist.
-   Read the code, form an opinion, and explain it with
-   concrete references where they help anchor the point.
-
-   Common review angles include:
-   - Whether the approach actually solves the issue, and
-     whether any requirement appears to be dropped, only
-     partially implemented, or implemented in a surprising way.
-   - Correctness on edge cases and failure paths, not just the
-     happy path.
-   - Design quality: readability, appropriate abstractions,
-     avoiding over-engineering, unrelated drive-by changes,
-     dead code, or stray debug output.
-   - Test presence and meaningfulness — especially whether the
-     tests exercise the new behaviour in a way that would have
-     failed before the change. You do NOT need to run the test
-     suite or re-check CI; assume those are already handled and
-     focus on whether the tests are the right tests.
-   - Error handling, security (input validation, injection,
-     secrets, permissions), and obvious performance issues.
-   - Documentation or comments that now appear out of sync with
-     the code.
-   - PR hygiene if it appears off: issue linkage (`Closes #N`
-     vs. `Part of #N` with `## Not addressed` when partial) and
-     a `## Test plan` checklist.
-
-   The list above is guidance, not a limit. If something feels
-   off for any other reason — architectural, stylistic, product,
-   or subtle — raise it.
+   [same review angles block as round 1]
 4. Post your follow-up review as a PR comment prefixed with
    `**[Reviewer Round {n}]**`. Include any still-unresolved
    prior items and any new findings from this round. Be
    specific. Cite file paths and line numbers when they help;
    for broader concerns, explain the concern at the
    appropriate level.
-5. End your response with one of these keywords:
-   - APPROVED — if the changes are ready to merge
-   - NOT_APPROVED — if changes are needed
 ```
+
+The same reviewer verdict follow-up is sent after the round 2+
+review comment.
 
 #### Author fix prompt — Agent A (round N)
 
@@ -775,16 +833,31 @@ next review round begins.
 When the review loop ends (either because B approves or the
 auto-budget is exhausted), B is asked:
 
+**Work step:**
+
 ```text
 The review loop has ended.  Please check whether there are any
 unresolved items from this review cycle.
 
 - If there are unresolved items, post a PR comment prefixed with
   `**[Reviewer Unresolved Round {n}]**` listing each unresolved item.
-  Then end your response with COMPLETED.
-- If there are no unresolved items, respond with exactly: NONE
+- If there are no unresolved items, simply confirm that there is
+  nothing left to address.
 ```
 
+**Verdict follow-up:**
+
+```text
+Respond with exactly one of the following keywords:
+
+- NONE — if there are no unresolved items
+- COMPLETED — if you posted the unresolved items comment
+
+Do not include any other commentary — just the keyword.
+```
+
+If the verdict is ambiguous or contains an out-of-scope keyword,
+the orchestrator retries once with a scoped clarification prompt.
 If B posts an unresolved summary, the orchestrator shows it to
 the user before asking whether to continue (at budget limit) or
 before reporting completion (on approval).
@@ -822,11 +895,28 @@ state of the implementation.
    were not implemented and why.
 4. If the reference or "## Not addressed" section needs to change,
    update the PR body using `gh pr edit --body "..."`.
-5. End your response with PR_FINALIZED.
+```
+
+**PR finalization verdict follow-up:**
+
+```text
+You have finished verifying the PR body.
+Respond with exactly one of the following keywords:
+
+- PR_FINALIZED — if the PR body is now accurate
+
+Do not include any other commentary — just the keyword.
 ```
 
 Agent A must respond with `PR_FINALIZED` for the stage to
-complete.
+complete. If the verdict is ambiguous after the clarification
+retry, the handler verifies the PR body directly for
+consistency: `Closes #N` must not have a contradictory
+`## Not addressed` section, and `Part of #N` must include one.
+If the body is consistent the stage proceeds as completed;
+otherwise it returns `blocked` so the user can intervene. This
+avoids relying on the squash stage to catch a bad body, since
+squash short-circuits on single-commit branches.
 
 **Loop behavior:** Default auto-budget: 5 rounds (configurable
 via `reviewAutoRounds`). When the budget is exhausted, the user
@@ -887,12 +977,14 @@ and respond with exactly one of the following keywords:
 - COMPLETED — if the commits were squashed and force-pushed
 - BLOCKED — if you could not squash and need user intervention
 
-If BLOCKED, add a brief reason on the next line explaining what
-went wrong.
+Do not include any other commentary — just the keyword.
 ```
 
 **Ambiguous response handling:** Same internal clarification
-retry pattern as stage 3 (Create PR).
+retry pattern as stage 3 (Create PR).  If clarification also fails,
+the handler re-checks the branch commit count to verify whether the
+squash actually happened.  If the count decreased, the stage
+completes; otherwise it reports `BLOCKED`.
 
 **Post-squash CI:** After a successful squash and force-push, the
 orchestrator polls CI and invokes Agent A to fix failures if
@@ -1036,10 +1128,18 @@ You are rebasing a feature branch onto the latest main.
 IMPORTANT: If you cannot resolve conflicts cleanly or if the
 build/tests fail after resolution, do NOT push. Instead, abort
 the rebase (`git rebase --abort`) and report failure.
+```
 
-When you are done, end your response with exactly one of:
-- COMPLETED — if the rebase succeeded and was force-pushed.
-- BLOCKED — if you could not resolve conflicts or tests failed.
+**Verdict follow-up:**
+
+```text
+You have finished the rebase attempt.
+Respond with exactly one of the following keywords:
+
+- COMPLETED — if the rebase succeeded and was force-pushed
+- BLOCKED — if you could not resolve conflicts or tests failed
+
+Do not include any other commentary — just the keyword.
 ```
 
 **Rebase constraints and rationale:**

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -225,6 +225,8 @@ export const en: Messages = {
     `${base}\n\nUnresolved items:\n${summary}`,
   "review.fixesApplied": (round) =>
     `Round ${round} fixes applied, CI passed. Proceeding to next review round.`,
+  "review.finalizationUnverified": (issueNumber) =>
+    `PR finalization verdict was ambiguous and the PR body does not reference issue #${issueNumber}. Manual verification required.`,
 
   // ---- stage-util errors -------------------------------------------------
 

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -89,6 +89,7 @@ describe("catalogs are complete", () => {
       "review.approved": [2],
       "review.unresolvedItems": ["Review approved.", "item 1"],
       "review.fixesApplied": [1],
+      "review.finalizationUnverified": [42],
       "worktree.alreadyExists": ["/tmp/wt"],
     };
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -259,6 +259,8 @@ export const ko: Messages = {
     `${base}\n\n미해결 항목:\n${summary}`,
   "review.fixesApplied": (round) =>
     `${round}라운드 수정 적용 완료, CI 통과. 다음 리뷰 라운드로 진행합니다.`,
+  "review.finalizationUnverified": (issueNumber) =>
+    `PR 마무리 판정이 모호하고 PR 본문에 이슈 #${issueNumber} 참조가 없습니다. 수동 확인이 필요합니다.`,
 
   // ---- stage-util errors -------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -219,6 +219,7 @@ export interface Messages {
   "review.approved": (round: number) => string;
   "review.unresolvedItems": (base: string, summary: string) => string;
   "review.fixesApplied": (round: number) => string;
+  "review.finalizationUnverified": (issueNumber: number) => string;
 
   // ---- stage-util errors -------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import type {
 import { createDoneStageHandler } from "./pipeline.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
 import { checkMergeable, findPrNumber } from "./pr.js";
+import { createRebaseHandler } from "./rebase.js";
 import {
   deleteRunState,
   loadRunState,
@@ -44,10 +45,8 @@ import { createReviewStageHandler } from "./stage-review.js";
 import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
 import { createSquashStageHandler } from "./stage-squash.js";
 import { createTestPlanStageHandler } from "./stage-testplan.js";
-import { drainToSink } from "./stage-util.js";
 import type { AgentConfig } from "./startup.js";
 import { modelDisplayName, runStartup, selectTarget } from "./startup.js";
-import { parseStepStatus } from "./step-parser.js";
 import { renderApp } from "./ui/render-app.js";
 import {
   bootstrapRepo,
@@ -577,64 +576,7 @@ try {
         if (tuiPrompt) return tuiPrompt.waitForManualResolve(msg);
       },
     },
-    rebaseOntoMain: async (ctx) => {
-      const rebasePrompt = [
-        `You are rebasing a feature branch onto the latest main.`,
-        ``,
-        `## Repository`,
-        `- Owner: ${ctx.owner}`,
-        `- Repo: ${ctx.repo}`,
-        `- Branch: ${ctx.branch}`,
-        `- Worktree: ${ctx.worktreePath}`,
-        ``,
-        `## Instructions`,
-        ``,
-        `1. Run \`git fetch origin ${defaultBranch}\` to get the latest main.`,
-        `2. Run \`git rebase origin/${defaultBranch}\` to rebase onto main.`,
-        `3. Resolve any merge conflicts that arise.`,
-        `4. After resolving conflicts, verify the result locally:`,
-        `   - Build the project to ensure it compiles.`,
-        `   - Run the full test suite to ensure nothing is broken.`,
-        `5. Only if the build and all tests pass, force-push the branch:`,
-        `   \`git push --force-with-lease\``,
-        `6. After a successful force-push, post a brief PR comment noting`,
-        `   which main commit the branch was rebased onto and a short`,
-        `   summary of resolved conflicts. Use:`,
-        `   \`gh pr comment --body "<your summary>"\``,
-        `   If no PR exists or the comment fails, continue without failing.`,
-        ``,
-        `IMPORTANT: If you cannot resolve conflicts cleanly or if the`,
-        `build/tests fail after resolution, do NOT push. Instead, abort`,
-        `the rebase (\`git rebase --abort\`) and report failure.`,
-        ``,
-        `When you are done, end your response with exactly one of:`,
-        `- COMPLETED — if the rebase succeeded and was force-pushed.`,
-        `- BLOCKED — if you could not resolve conflicts or tests failed.`,
-      ].join("\n");
-
-      ctx.promptSinks?.a?.(rebasePrompt);
-      const stream = agentA.invoke(rebasePrompt, {
-        cwd: ctx.worktreePath,
-        onUsage: ctx.usageSinks?.a,
-      });
-      if (ctx.streamSinks?.a) {
-        drainToSink(stream, ctx.streamSinks.a);
-      }
-      const result = await stream.result;
-
-      if (result.sessionId) {
-        ctx.onSessionId?.("a", result.sessionId);
-      }
-
-      if (result.status === "error") {
-        return { success: false, message: result.responseText };
-      }
-
-      const parsed = parseStepStatus(result.responseText);
-      const success =
-        parsed.status === "completed" || parsed.status === "fixed";
-      return { success, message: result.responseText };
-    },
+    rebaseOntoMain: createRebaseHandler(agentA, defaultBranch),
     pollCiAndFix: async (ctx) => {
       return pollCiAndFix({
         ctx,

--- a/src/issue-sync.test.ts
+++ b/src/issue-sync.test.ts
@@ -1,7 +1,9 @@
 import { beforeAll, describe, expect, test } from "vitest";
 import { initI18n } from "./i18n/index.js";
 import {
+  buildIssueSyncClarificationPrompt,
   buildIssueSyncPrompt,
+  buildIssueSyncVerdictPrompt,
   buildPrSyncInstructions,
   formatIssueSyncSummary,
   parseIssueSyncResponse,
@@ -47,15 +49,11 @@ describe("buildIssueSyncPrompt", () => {
     expect(prompt).toContain("gh issue comment 42 --repo org/repo");
   });
 
-  test("mentions ISSUE_NO_CHANGES keyword", () => {
+  test("does not include response-format keywords (moved to verdict prompt)", () => {
     const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
-    expect(prompt).toContain("ISSUE_NO_CHANGES");
-  });
-
-  test("mentions ISSUE_UPDATED and ISSUE_COMMENTED keywords", () => {
-    const prompt = buildIssueSyncPrompt(BASE_CTX, opts);
-    expect(prompt).toContain("ISSUE_UPDATED");
-    expect(prompt).toContain("ISSUE_COMMENTED");
+    expect(prompt).not.toContain("ISSUE_NO_CHANGES");
+    expect(prompt).not.toContain("ISSUE_UPDATED");
+    expect(prompt).not.toContain("ISSUE_COMMENTED");
   });
 
   test("distinguishes minor and major discrepancies", () => {
@@ -65,62 +63,111 @@ describe("buildIssueSyncPrompt", () => {
   });
 });
 
+// ---- buildIssueSyncVerdictPrompt -----------------------------------------
+
+describe("buildIssueSyncVerdictPrompt", () => {
+  test("mentions ISSUE_NO_CHANGES keyword", () => {
+    const prompt = buildIssueSyncVerdictPrompt();
+    expect(prompt).toContain("ISSUE_NO_CHANGES");
+  });
+
+  test("mentions ISSUE_UPDATED and ISSUE_COMMENTED keywords", () => {
+    const prompt = buildIssueSyncVerdictPrompt();
+    expect(prompt).toContain("ISSUE_UPDATED");
+    expect(prompt).toContain("ISSUE_COMMENTED");
+  });
+
+  test("asks for no other commentary", () => {
+    const prompt = buildIssueSyncVerdictPrompt();
+    expect(prompt).toContain("Do not include any other commentary");
+  });
+});
+
 // ---- parseIssueSyncResponse ----------------------------------------------
 
 describe("parseIssueSyncResponse", () => {
-  test("returns empty array for ISSUE_NO_CHANGES", () => {
-    const result = parseIssueSyncResponse(
-      "Everything matches.\n\nISSUE_NO_CHANGES",
-    );
-    expect(result).toEqual([]);
+  test("returns valid with no changes for ISSUE_NO_CHANGES", () => {
+    const result = parseIssueSyncResponse("ISSUE_NO_CHANGES");
+    expect(result).toEqual({ changes: [], valid: true });
   });
 
   test("parses a single ISSUE_UPDATED line", () => {
-    const result = parseIssueSyncResponse(
-      "Updated the description.\n\nISSUE_UPDATED: corrected file path",
-    );
-    expect(result).toEqual([
-      { type: "minor", description: "corrected file path" },
-    ]);
+    const result = parseIssueSyncResponse("ISSUE_UPDATED: corrected file path");
+    expect(result).toEqual({
+      changes: [{ type: "minor", description: "corrected file path" }],
+      valid: true,
+    });
   });
 
   test("parses a single ISSUE_COMMENTED line", () => {
     const result = parseIssueSyncResponse(
-      "Left a comment.\n\nISSUE_COMMENTED: uses WebSocket instead of polling",
+      "ISSUE_COMMENTED: uses WebSocket instead of polling",
     );
-    expect(result).toEqual([
-      { type: "major", description: "uses WebSocket instead of polling" },
-    ]);
+    expect(result).toEqual({
+      changes: [
+        { type: "major", description: "uses WebSocket instead of polling" },
+      ],
+      valid: true,
+    });
   });
 
   test("parses both ISSUE_UPDATED and ISSUE_COMMENTED", () => {
     const text = [
-      "Made some changes.",
       "ISSUE_UPDATED: fixed typo in description",
       "ISSUE_COMMENTED: scope expanded to include API changes",
     ].join("\n");
     const result = parseIssueSyncResponse(text);
-    expect(result).toEqual([
-      { type: "minor", description: "fixed typo in description" },
-      { type: "major", description: "scope expanded to include API changes" },
-    ]);
+    expect(result).toEqual({
+      changes: [
+        { type: "minor", description: "fixed typo in description" },
+        { type: "major", description: "scope expanded to include API changes" },
+      ],
+      valid: true,
+    });
   });
 
-  test("returns empty array for unrecognised response", () => {
+  test("rejects unrecognised response as invalid", () => {
     const result = parseIssueSyncResponse(
       "I looked at the issue and it seems fine.",
     );
-    expect(result).toEqual([]);
+    expect(result).toEqual({ changes: [], valid: false });
+  });
+
+  test("rejects response with extra commentary before keywords", () => {
+    const result = parseIssueSyncResponse(
+      "Everything matches.\n\nISSUE_NO_CHANGES",
+    );
+    expect(result).toEqual({ changes: [], valid: false });
+  });
+
+  test("rejects ISSUE_UPDATED without colon as invalid", () => {
+    const result = parseIssueSyncResponse("ISSUE_UPDATED fixed title");
+    expect(result).toEqual({ changes: [], valid: false });
+  });
+
+  test("rejects mixed commentary and keywords", () => {
+    const text = [
+      "Made some changes.",
+      "ISSUE_UPDATED: fixed typo in description",
+    ].join("\n");
+    const result = parseIssueSyncResponse(text);
+    expect(result).toEqual({ changes: [], valid: false });
   });
 
   test("is case-insensitive", () => {
     const result = parseIssueSyncResponse("issue_updated: fixed path");
-    expect(result).toEqual([{ type: "minor", description: "fixed path" }]);
+    expect(result).toEqual({
+      changes: [{ type: "minor", description: "fixed path" }],
+      valid: true,
+    });
   });
 
   test("trims description whitespace", () => {
     const result = parseIssueSyncResponse("ISSUE_UPDATED:   extra spaces  ");
-    expect(result).toEqual([{ type: "minor", description: "extra spaces" }]);
+    expect(result).toEqual({
+      changes: [{ type: "minor", description: "extra spaces" }],
+      valid: true,
+    });
   });
 
   test("handles multiple ISSUE_UPDATED lines", () => {
@@ -129,9 +176,64 @@ describe("parseIssueSyncResponse", () => {
       "ISSUE_UPDATED: clarified wording in step 3",
     ].join("\n");
     const result = parseIssueSyncResponse(text);
-    expect(result).toHaveLength(2);
-    expect(result[0].type).toBe("minor");
-    expect(result[1].type).toBe("minor");
+    expect(result.valid).toBe(true);
+    expect(result.changes).toHaveLength(2);
+    expect(result.changes[0].type).toBe("minor");
+    expect(result.changes[1].type).toBe("minor");
+  });
+
+  test("allows blank lines between keywords", () => {
+    const text = "ISSUE_UPDATED: fixed path\n\nISSUE_COMMENTED: scope changed";
+    const result = parseIssueSyncResponse(text);
+    expect(result.valid).toBe(true);
+    expect(result.changes).toHaveLength(2);
+  });
+
+  test("strips optional leading bullet markers", () => {
+    const text = "- ISSUE_UPDATED: fixed path";
+    const result = parseIssueSyncResponse(text);
+    expect(result).toEqual({
+      changes: [{ type: "minor", description: "fixed path" }],
+      valid: true,
+    });
+  });
+
+  test("returns invalid for empty response", () => {
+    const result = parseIssueSyncResponse("");
+    expect(result).toEqual({ changes: [], valid: false });
+  });
+
+  test("rejects ISSUE_NO_CHANGES mixed with ISSUE_UPDATED", () => {
+    const text = "ISSUE_NO_CHANGES\nISSUE_UPDATED: fixed typo";
+    const result = parseIssueSyncResponse(text);
+    expect(result).toEqual({ changes: [], valid: false });
+  });
+
+  test("rejects ISSUE_NO_CHANGES mixed with ISSUE_COMMENTED", () => {
+    const text = "ISSUE_COMMENTED: scope changed\nISSUE_NO_CHANGES";
+    const result = parseIssueSyncResponse(text);
+    expect(result).toEqual({ changes: [], valid: false });
+  });
+});
+
+// ---- buildIssueSyncClarificationPrompt ------------------------------------
+
+describe("buildIssueSyncClarificationPrompt", () => {
+  test("mentions all three keyword patterns", () => {
+    const prompt = buildIssueSyncClarificationPrompt();
+    expect(prompt).toContain("ISSUE_NO_CHANGES");
+    expect(prompt).toContain("ISSUE_UPDATED");
+    expect(prompt).toContain("ISSUE_COMMENTED");
+  });
+
+  test("asks for no other commentary", () => {
+    const prompt = buildIssueSyncClarificationPrompt();
+    expect(prompt).toContain("Do not include any other commentary");
+  });
+
+  test("mentions the previous response was malformed", () => {
+    const prompt = buildIssueSyncClarificationPrompt();
+    expect(prompt).toContain("did not follow the expected format");
   });
 });
 

--- a/src/issue-sync.ts
+++ b/src/issue-sync.ts
@@ -21,6 +21,12 @@ export interface IssueChange {
   description: string;
 }
 
+export interface IssueSyncParseResult {
+  changes: IssueChange[];
+  /** True when every non-blank line matched a recognised keyword pattern. */
+  valid: boolean;
+}
+
 export type IssueSyncStatus = "completed" | "skipped" | "failed";
 
 // ---- issue sync prompt ---------------------------------------------------
@@ -55,20 +61,23 @@ export function buildIssueSyncPrompt(
     `   \`gh issue comment ${ctx.issueNumber} --repo ${ctx.owner}/${ctx.repo} --body "..."\``,
     `   Do NOT modify the issue description for major changes.`,
     `5. If there are no discrepancies, do nothing.`,
+  ].join("\n");
+}
+
+/**
+ * Verdict follow-up prompt for issue sync — asks the agent to report
+ * what actions were taken, separate from the work response.
+ */
+export function buildIssueSyncVerdictPrompt(): string {
+  return [
+    `Report what issue sync actions you performed.`,
+    `Respond with one or more of the following on separate lines:`,
     ``,
-    `## Response format`,
+    `- ISSUE_NO_CHANGES — if no changes were needed`,
+    `- ISSUE_UPDATED: <brief description> — if you updated the issue`,
+    `- ISSUE_COMMENTED: <brief description> — if you added a comment`,
     ``,
-    `End your response with one of the following:`,
-    ``,
-    `- If no changes were needed:`,
-    `  \`ISSUE_NO_CHANGES\``,
-    `- If you updated the issue (minor):`,
-    `  \`ISSUE_UPDATED: <brief description of what changed>\``,
-    `- If you added a comment (major):`,
-    `  \`ISSUE_COMMENTED: <brief description of the discrepancy>\``,
-    ``,
-    `You may include both ISSUE_UPDATED and ISSUE_COMMENTED if there`,
-    `were both minor and major discrepancies.`,
+    `Do not include any other commentary.`,
   ].join("\n");
 }
 
@@ -77,30 +86,77 @@ export function buildIssueSyncPrompt(
 /**
  * Parse the agent's issue sync response into a list of changes.
  *
- * Recognised line formats (case-insensitive):
+ * Strict parser — every non-blank line must match one of the
+ * recognised patterns (case-insensitive, optional leading bullet):
  *   ISSUE_NO_CHANGES
  *   ISSUE_UPDATED: <description>
  *   ISSUE_COMMENTED: <description>
+ *
+ * Returns `{ valid: false }` when the response contains
+ * unrecognised lines or no recognised lines at all, so the caller
+ * can trigger a clarification retry.
  */
-export function parseIssueSyncResponse(responseText: string): IssueChange[] {
+export function parseIssueSyncResponse(
+  responseText: string,
+): IssueSyncParseResult {
   const changes: IssueChange[] = [];
+  let hasRecognised = false;
+  let hasNoChanges = false;
 
   for (const line of responseText.split("\n")) {
     const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
 
-    const updatedMatch = trimmed.match(/^ISSUE_UPDATED:\s*(.+)$/i);
+    // Strip optional leading bullet marker (- or *).
+    const stripped = trimmed.replace(/^[-*]\s+/, "");
+
+    if (/^ISSUE_NO_CHANGES$/i.test(stripped)) {
+      hasRecognised = true;
+      hasNoChanges = true;
+      continue;
+    }
+
+    const updatedMatch = stripped.match(/^ISSUE_UPDATED:\s*(.+)$/i);
     if (updatedMatch) {
+      hasRecognised = true;
       changes.push({ type: "minor", description: updatedMatch[1].trim() });
       continue;
     }
 
-    const commentedMatch = trimmed.match(/^ISSUE_COMMENTED:\s*(.+)$/i);
+    const commentedMatch = stripped.match(/^ISSUE_COMMENTED:\s*(.+)$/i);
     if (commentedMatch) {
+      hasRecognised = true;
       changes.push({ type: "major", description: commentedMatch[1].trim() });
+      continue;
     }
+
+    // Unrecognised non-blank line — response is malformed.
+    return { changes: [], valid: false };
   }
 
-  return changes;
+  // ISSUE_NO_CHANGES contradicts ISSUE_UPDATED / ISSUE_COMMENTED.
+  if (hasNoChanges && changes.length > 0) {
+    return { changes: [], valid: false };
+  }
+
+  // At least one keyword must have been found.
+  return { changes, valid: hasRecognised };
+}
+
+/**
+ * Clarification prompt for a malformed issue sync verdict response.
+ */
+export function buildIssueSyncClarificationPrompt(): string {
+  return [
+    `Your previous response did not follow the expected format.`,
+    `Respond with one or more of the following on separate lines:`,
+    ``,
+    `- ISSUE_NO_CHANGES — if no changes were needed`,
+    `- ISSUE_UPDATED: <brief description> — if you updated the issue`,
+    `- ISSUE_COMMENTED: <brief description> — if you added a comment`,
+    ``,
+    `Do not include any other commentary.`,
+  ].join("\n");
 }
 
 // ---- PR description sync prompt ------------------------------------------

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -646,6 +646,33 @@ describe("runPipeline — needs_clarification handling", () => {
     expect(receivedInstruction).toBe(buildClarificationPrompt("vague"));
   });
 
+  test("auto-clarification uses validVerdicts to scope the prompt", async () => {
+    let receivedInstruction: string | undefined;
+    const scopedKeywords = ["APPROVED", "NOT_APPROVED"] as const;
+    const stages = [
+      makeStage(1, async (ctx) => {
+        if (ctx.iteration === 0) {
+          return {
+            outcome: "needs_clarification",
+            message: "vague",
+            validVerdicts: scopedKeywords,
+          } satisfies StageResult;
+        }
+        receivedInstruction = ctx.userInstruction;
+        return { outcome: "completed", message: "done" };
+      }),
+    ];
+    await runPipeline(makePipelineOpts({ stages }));
+    const expected = buildClarificationPrompt("vague", scopedKeywords);
+    expect(receivedInstruction).toBe(expected);
+    // The scoped prompt must mention the valid keywords.
+    expect(receivedInstruction).toContain("APPROVED");
+    expect(receivedInstruction).toContain("NOT_APPROVED");
+    // It must NOT mention keywords outside the scoped set.
+    expect(receivedInstruction).not.toContain("COMPLETED");
+    expect(receivedInstruction).not.toContain("BLOCKED");
+  });
+
   test("handleAmbiguous not called on first ambiguous (auto-retry first)", async () => {
     const prompt = makePrompt();
     let callCount = 0;

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -45,6 +45,12 @@ export interface StageResult {
   outcome: StageOutcome;
   /** Free-form message shown to the user or forwarded to the next stage. */
   message: string;
+  /**
+   * Valid keywords for clarification — set when outcome is
+   * `needs_clarification` so the pipeline engine can build a correctly
+   * scoped clarification prompt without knowing stage internals.
+   */
+  validVerdicts?: readonly string[];
 }
 
 /**
@@ -733,7 +739,10 @@ async function runStage(
       if (!clarificationAttempted) {
         // First ambiguous response: auto-retry with a clarification prompt.
         clarificationAttempted = true;
-        userInstruction = buildClarificationPrompt(result.message);
+        userInstruction = buildClarificationPrompt(
+          result.message,
+          result.validVerdicts,
+        );
       } else {
         // Clarification already tried once — fall back to user.
         clarificationAttempted = false;

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -5,9 +5,8 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
-const { checkMergeable, findPrNumber, queryMergeableState } = await import(
-  "./pr.js"
-);
+const { checkMergeable, findPrNumber, getPrBody, queryMergeableState } =
+  await import("./pr.js");
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -69,6 +68,43 @@ describe("findPrNumber", () => {
   test("returns undefined on malformed JSON output", () => {
     mockExecFileSync.mockReturnValue("not json at all");
     expect(findPrNumber("org", "repo", "issue-5")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPrBody
+// ---------------------------------------------------------------------------
+describe("getPrBody", () => {
+  test("returns trimmed PR body text", () => {
+    mockExecFileSync.mockReturnValue("  Some PR body\n");
+    expect(getPrBody("org", "repo", "branch")).toBe("Some PR body");
+  });
+
+  test("calls gh with correct arguments", () => {
+    mockExecFileSync.mockReturnValue("body");
+    getPrBody("aicers", "agentcoop", "issue-42");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "pr",
+        "view",
+        "--repo",
+        "aicers/agentcoop",
+        "issue-42",
+        "--json",
+        "body",
+        "--jq",
+        ".body",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("returns undefined when gh command fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("gh: not authenticated");
+    });
+    expect(getPrBody("org", "repo", "branch")).toBeUndefined();
   });
 });
 

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -42,6 +42,40 @@ export function findPrNumber(
   return prs.length > 0 ? prs[0].number : undefined;
 }
 
+// ---- PR body -----------------------------------------------------------------
+
+/**
+ * Read the body of the PR associated with `branch` in `owner/repo`.
+ *
+ * Returns the body text, or `undefined` if the PR does not exist or
+ * the command fails.
+ */
+export function getPrBody(
+  owner: string,
+  repo: string,
+  branch: string,
+): string | undefined {
+  try {
+    return execFileSync(
+      "gh",
+      [
+        "pr",
+        "view",
+        "--repo",
+        `${owner}/${repo}`,
+        branch,
+        "--json",
+        "body",
+        "--jq",
+        ".body",
+      ],
+      { encoding: "utf-8" },
+    ).trim();
+  } catch {
+    return undefined;
+  }
+}
+
 // ---- mergeable state ---------------------------------------------------------
 
 /**

--- a/src/rebase.test.ts
+++ b/src/rebase.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import type { StageContext } from "./pipeline.js";
+import {
+  buildRebasePrompt,
+  buildRebaseVerdictPrompt,
+  createRebaseHandler,
+  REBASE_KEYWORDS,
+} from "./rebase.js";
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
+  return {
+    sessionId: "sess-1",
+    responseText: "COMPLETED",
+    status: "success",
+    errorType: undefined,
+    stderrText: "",
+    ...overrides,
+  };
+}
+
+function makeStream(result: AgentResult): AgentStream {
+  return {
+    [Symbol.asyncIterator]() {
+      return { next: async () => ({ done: true, value: "" }) };
+    },
+    result: Promise.resolve(result),
+    child: {} as AgentStream["child"],
+  };
+}
+
+const BASE_CTX: StageContext = {
+  owner: "org",
+  repo: "repo",
+  issueNumber: 42,
+  branch: "issue-42",
+  worktreePath: "/tmp/wt",
+  iteration: 0,
+  lastAutoIteration: false,
+  userInstruction: undefined,
+};
+
+// ---- prompt builders -------------------------------------------------------
+
+describe("buildRebasePrompt", () => {
+  test("includes repository context", () => {
+    const prompt = buildRebasePrompt(BASE_CTX, "main");
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("Branch: issue-42");
+  });
+
+  test("references the default branch", () => {
+    const prompt = buildRebasePrompt(BASE_CTX, "develop");
+    expect(prompt).toContain("git fetch origin develop");
+    expect(prompt).toContain("git rebase origin/develop");
+  });
+});
+
+describe("buildRebaseVerdictPrompt", () => {
+  test("mentions COMPLETED and BLOCKED", () => {
+    const prompt = buildRebaseVerdictPrompt();
+    expect(prompt).toContain("COMPLETED");
+    expect(prompt).toContain("BLOCKED");
+  });
+
+  test("does not contain work instructions", () => {
+    const prompt = buildRebaseVerdictPrompt();
+    expect(prompt).not.toContain("git fetch");
+    expect(prompt).not.toContain("git rebase");
+  });
+});
+
+// ---- createRebaseHandler ---------------------------------------------------
+
+describe("createRebaseHandler", () => {
+  test("COMPLETED → success: true", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "rebased OK" })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe("rebased OK");
+  });
+
+  test("BLOCKED → success: false", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "could not resolve" })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "BLOCKED" }))),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(false);
+  });
+
+  test("ambiguous verdict → clarification retry → COMPLETED", async () => {
+    let resumeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCall++;
+        if (resumeCall === 1) {
+          return makeStream(makeResult({ responseText: "I think it worked" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(true);
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("out-of-scope DONE → clarification retry → BLOCKED", async () => {
+    let resumeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCall++;
+        if (resumeCall === 1) {
+          return makeStream(makeResult({ responseText: "DONE" }));
+        }
+        return makeStream(makeResult({ responseText: "BLOCKED" }));
+      }),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(false);
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("out-of-scope APPROVED → clarification retry → COMPLETED", async () => {
+    let resumeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCall++;
+        if (resumeCall === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(true);
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("FIXED is out-of-scope and not treated as success", async () => {
+    let resumeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCall++;
+        if (resumeCall === 1) {
+          // FIXED triggers clarification (out-of-scope)
+          return makeStream(makeResult({ responseText: "FIXED" }));
+        }
+        // After clarification, still returns FIXED
+        return makeStream(makeResult({ responseText: "FIXED" }));
+      }),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    // FIXED maps to "fixed" status, not "completed" → success: false
+    expect(result.success).toBe(false);
+  });
+
+  test("agent work step error → success: false", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            responseText: "crash",
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("crash");
+    expect(agent.resume).not.toHaveBeenCalled();
+  });
+
+  test("verdict follow-up error → success: false", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            responseText: "verdict crash",
+          }),
+        ),
+      ),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe("verdict crash");
+  });
+
+  test("clarification retry error → success: false", async () => {
+    let resumeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi.fn().mockImplementation(() => {
+        resumeCall++;
+        if (resumeCall === 1) {
+          return makeStream(makeResult({ responseText: "I think it worked" }));
+        }
+        return makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            responseText: "crash",
+          }),
+        );
+      }),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    const result = await handler(BASE_CTX);
+
+    expect(result.success).toBe(false);
+  });
+
+  test("reports session ID via onSessionId", async () => {
+    const onSessionId = vi.fn();
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-42", responseText: "rebased" }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    await handler({ ...BASE_CTX, onSessionId });
+
+    expect(onSessionId).toHaveBeenCalledWith("a", "sess-42");
+  });
+
+  test("sinks receive prompts", async () => {
+    const promptSink = vi.fn();
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "rebased" }))),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const handler = createRebaseHandler(agent, "main");
+    await handler({ ...BASE_CTX, promptSinks: { a: promptSink } });
+
+    // Work prompt + verdict prompt
+    expect(promptSink).toHaveBeenCalledTimes(2);
+    expect(promptSink.mock.calls[0][0]).toContain("git rebase");
+    expect(promptSink.mock.calls[1][0]).toContain("COMPLETED");
+  });
+});
+
+describe("REBASE_KEYWORDS", () => {
+  test("contains only COMPLETED and BLOCKED", () => {
+    expect([...REBASE_KEYWORDS]).toEqual(["COMPLETED", "BLOCKED"]);
+  });
+});

--- a/src/rebase.ts
+++ b/src/rebase.ts
@@ -1,0 +1,158 @@
+/**
+ * Rebase handler — invokes an agent to rebase a feature branch onto
+ * the latest main and reports the result via a verdict follow-up.
+ *
+ * Two-step flow:
+ *   1. Work step — agent performs the rebase.
+ *   2. Verdict follow-up — agent reports COMPLETED or BLOCKED.
+ *
+ * Includes substep-scoped keyword validation and a single
+ * clarification retry on ambiguous or out-of-scope responses.
+ *
+ * Extracted from `index.ts` for testability.
+ */
+
+import type { AgentAdapter } from "./agent.js";
+import type { StageContext } from "./pipeline.js";
+import { drainToSink, sendFollowUp } from "./stage-util.js";
+import {
+  buildClarificationPrompt,
+  parseVerdictKeyword,
+} from "./step-parser.js";
+
+export const REBASE_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
+
+export interface RebaseResult {
+  success: boolean;
+  message: string;
+}
+
+export function buildRebasePrompt(
+  ctx: StageContext,
+  defaultBranch: string,
+): string {
+  return [
+    `You are rebasing a feature branch onto the latest main.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    `- Worktree: ${ctx.worktreePath}`,
+    ``,
+    `## Instructions`,
+    ``,
+    `1. Run \`git fetch origin ${defaultBranch}\` to get the latest main.`,
+    `2. Run \`git rebase origin/${defaultBranch}\` to rebase onto main.`,
+    `3. Resolve any merge conflicts that arise.`,
+    `4. After resolving conflicts, verify the result locally:`,
+    `   - Build the project to ensure it compiles.`,
+    `   - Run the full test suite to ensure nothing is broken.`,
+    `5. Only if the build and all tests pass, force-push the branch:`,
+    `   \`git push --force-with-lease\``,
+    `6. After a successful force-push, post a brief PR comment noting`,
+    `   which main commit the branch was rebased onto and a short`,
+    `   summary of resolved conflicts. Use:`,
+    `   \`gh pr comment --body "<your summary>"\``,
+    `   If no PR exists or the comment fails, continue without failing.`,
+    ``,
+    `IMPORTANT: If you cannot resolve conflicts cleanly or if the`,
+    `build/tests fail after resolution, do NOT push. Instead, abort`,
+    `the rebase (\`git rebase --abort\`) and report failure.`,
+  ].join("\n");
+}
+
+export function buildRebaseVerdictPrompt(): string {
+  return [
+    `You have finished the rebase attempt.`,
+    `Respond with exactly one of the following keywords:`,
+    ``,
+    `- COMPLETED — if the rebase succeeded and was force-pushed`,
+    `- BLOCKED — if you could not resolve conflicts or tests failed`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
+  ].join("\n");
+}
+
+/**
+ * Create a rebase handler that invokes the given agent.
+ */
+export function createRebaseHandler(
+  agent: AgentAdapter,
+  defaultBranch: string,
+): (ctx: StageContext) => Promise<RebaseResult> {
+  return async (ctx) => {
+    const rebasePrompt = buildRebasePrompt(ctx, defaultBranch);
+    ctx.promptSinks?.a?.(rebasePrompt);
+    const stream = agent.invoke(rebasePrompt, {
+      cwd: ctx.worktreePath,
+      onUsage: ctx.usageSinks?.a,
+    });
+    if (ctx.streamSinks?.a) {
+      drainToSink(stream, ctx.streamSinks.a);
+    }
+    const result = await stream.result;
+
+    if (result.sessionId) {
+      ctx.onSessionId?.("a", result.sessionId);
+    }
+
+    if (result.status === "error") {
+      return { success: false, message: result.responseText };
+    }
+
+    // Verdict follow-up: ask for exactly COMPLETED or BLOCKED.
+    const verdictPrompt = buildRebaseVerdictPrompt();
+    ctx.promptSinks?.a?.(verdictPrompt);
+    let verdictResult = await sendFollowUp(
+      agent,
+      result.sessionId,
+      verdictPrompt,
+      ctx.worktreePath,
+      ctx.streamSinks?.a,
+      undefined,
+      ctx.usageSinks?.a,
+    );
+
+    if (verdictResult.status === "error") {
+      return { success: false, message: verdictResult.responseText };
+    }
+
+    let verdict = parseVerdictKeyword(
+      verdictResult.responseText,
+      REBASE_KEYWORDS,
+    );
+
+    // Clarification retry if ambiguous, extra commentary, or
+    // multiple valid keywords.
+    if (verdict.keyword === undefined) {
+      const clarifyPrompt = buildClarificationPrompt(
+        verdictResult.responseText,
+        REBASE_KEYWORDS,
+      );
+      ctx.promptSinks?.a?.(clarifyPrompt);
+      const retryResult = await sendFollowUp(
+        agent,
+        verdictResult.sessionId ?? result.sessionId,
+        clarifyPrompt,
+        ctx.worktreePath,
+        ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
+      );
+
+      if (retryResult.status === "error") {
+        return { success: false, message: retryResult.responseText };
+      }
+
+      verdictResult = retryResult;
+      verdict = parseVerdictKeyword(
+        verdictResult.responseText,
+        REBASE_KEYWORDS,
+      );
+    }
+
+    const success = verdict.keyword?.toUpperCase() === "COMPLETED";
+    return { success, message: result.responseText };
+  };
+}

--- a/src/stage-createpr.test.ts
+++ b/src/stage-createpr.test.ts
@@ -127,10 +127,10 @@ describe("buildPrCompletionCheckPrompt", () => {
     expect(prompt).toContain("exactly one");
   });
 
-  test("asks for a brief reason when BLOCKED", () => {
+  test("asks for just the keyword with no other commentary", () => {
     const prompt = buildPrCompletionCheckPrompt();
     expect(prompt).toContain("BLOCKED");
-    expect(prompt).toContain("brief reason");
+    expect(prompt).toContain("Do not include any other commentary");
   });
 });
 
@@ -190,10 +190,11 @@ describe("createCreatePrStageHandler", () => {
     expect(result.outcome).toBe("completed");
   });
 
-  test("returns completed on DONE", async () => {
+  test("proceeds as completed on DONE (not in valid keywords) when PR exists", async () => {
     const checkResult = makeResult({ responseText: "DONE" });
     const agent = makeAgent(makeResult(), checkResult);
-    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const findPrNumber = vi.fn().mockReturnValue(99);
+    const stage = createCreatePrStageHandler(makeOpts({ agent, findPrNumber }));
     const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("completed");
   });
@@ -211,23 +212,22 @@ describe("createCreatePrStageHandler", () => {
       sessionId: "sess-pr",
       responseText: "Push failed: permission denied to push to main.",
     });
-    const checkResult = makeResult({
-      responseText: "BLOCKED\nCannot push to the remote.",
-    });
+    const checkResult = makeResult({ responseText: "BLOCKED" });
     const agent = makeAgent(prResult, checkResult);
     const stage = createCreatePrStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("blocked");
     expect(result.message).toContain("permission denied");
-    expect(result.message).toContain("Cannot push to the remote");
+    expect(result.message).toContain("BLOCKED");
   });
 
-  test("returns not_approved on NOT_APPROVED", async () => {
+  test("proceeds as completed on NOT_APPROVED (not in valid keywords) when PR exists", async () => {
     const checkResult = makeResult({ responseText: "NOT_APPROVED" });
     const agent = makeAgent(makeResult(), checkResult);
-    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const findPrNumber = vi.fn().mockReturnValue(99);
+    const stage = createCreatePrStageHandler(makeOpts({ agent, findPrNumber }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("not_approved");
+    expect(result.outcome).toBe("completed");
   });
 
   test("ambiguous check → internal clarification → completed", async () => {
@@ -256,7 +256,7 @@ describe("createCreatePrStageHandler", () => {
     expect(agent.resume).toHaveBeenCalledTimes(2);
   });
 
-  test("ambiguous check → internal clarification also ambiguous → needs_clarification", async () => {
+  test("ambiguous check → clarification also ambiguous → completed when PR exists", async () => {
     const prResult = makeResult({ sessionId: "sess-pr" });
     const ambiguousCheck = makeResult({
       sessionId: "sess-check",
@@ -274,30 +274,72 @@ describe("createCreatePrStageHandler", () => {
         .mockReturnValueOnce(makeStream(stillAmbiguous)),
     };
 
-    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const findPrNumber = vi.fn().mockReturnValue(99);
+    const stage = createCreatePrStageHandler(makeOpts({ agent, findPrNumber }));
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
+    expect(result.outcome).toBe("completed");
+    expect(findPrNumber).toHaveBeenCalledWith("org", "repo", "issue-42");
   });
 
-  test("ambiguous check without sessionId skips internal clarification", async () => {
+  test("ambiguous check → clarification also ambiguous → blocked when no PR exists", async () => {
+    const prResult = makeResult({
+      sessionId: "sess-pr",
+      responseText: "I tried to create the PR.",
+    });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "I think it worked.",
+    });
+    const stillAmbiguous = makeResult({
+      responseText: "I think so maybe.",
+    });
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(prResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(stillAmbiguous)),
+    };
+
+    const findPrNumber = vi.fn().mockReturnValue(undefined);
+    const stage = createCreatePrStageHandler(makeOpts({ agent, findPrNumber }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("I tried to create the PR.");
+  });
+
+  test("ambiguous check without sessionId retries via fallback session", async () => {
     const prResult = makeResult({ sessionId: "sess-pr" });
     const ambiguousCheck = makeResult({
       sessionId: undefined,
       responseText: "I think it worked.",
     });
 
+    let resumeCall = 0;
+    const resumeResults = [
+      // 1st resume: ambiguous completion check (no sessionId)
+      makeStream(ambiguousCheck),
+      // 2nd resume: clarification retry via fallback session
+      makeStream(makeResult({ responseText: "COMPLETED" })),
+    ];
+
     const agent: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(makeStream(prResult)),
-      resume: vi.fn().mockReturnValueOnce(makeStream(ambiguousCheck)),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
     };
 
     const stage = createCreatePrStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
-    // Only one resume call (completion check), no clarification attempt
-    expect(agent.resume).toHaveBeenCalledTimes(1);
+    // Clarification retry succeeds via fallback to "sess-pr".
+    expect(result.outcome).toBe("completed");
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect((agent.resume as ReturnType<typeof vi.fn>).mock.calls[1][0]).toBe(
+      "sess-pr",
+    );
   });
 
   // -- error handling --------------------------------------------------------
@@ -341,7 +383,8 @@ describe("createCreatePrStageHandler", () => {
       responseText: "PR #99 created successfully.\n\nCOMPLETED",
     });
     const agent = makeAgent(makeResult(), checkResult);
-    const stage = createCreatePrStageHandler(makeOpts({ agent }));
+    const findPrNumber = vi.fn().mockReturnValue(99);
+    const stage = createCreatePrStageHandler(makeOpts({ agent, findPrNumber }));
     const result = await stage.handler(BASE_CTX);
     expect(result.message).toBe("PR #99 created successfully.\n\nCOMPLETED");
   });

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -10,8 +10,10 @@
  * If the completion check response is ambiguous, the handler retries
  * by resuming the same session with a clarification prompt.  This
  * avoids re-entering the handler (which would re-run the side-effectful
- * PR creation step).  If clarification also fails, the ambiguous
- * result is returned to the engine for user intervention.
+ * PR creation step).  If clarification also fails, the handler
+ * performs a post-condition check (`findPrNumber`) to verify whether
+ * a PR was actually created.  If the PR exists, the stage completes;
+ * otherwise it reports BLOCKED.
  *
  * `requiresArtifact` is set to `true` so the engine suppresses the
  * "Proceed" option when the agent reports BLOCKED — only Instruct and
@@ -21,6 +23,7 @@
 import type { AgentAdapter } from "./agent.js";
 import { t } from "./i18n/index.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
+import { findPrNumber as defaultFindPrNumber } from "./pr.js";
 import {
   invokeOrResume,
   mapAgentError,
@@ -33,6 +36,12 @@ export interface CreatePrStageOptions {
   agent: AgentAdapter;
   issueTitle: string;
   issueBody: string;
+  /** Injected for testability. Defaults to `pr.findPrNumber`. */
+  findPrNumber?: (
+    owner: string,
+    repo: string,
+    branch: string,
+  ) => number | undefined;
 }
 
 export function buildCreatePrPrompt(
@@ -78,6 +87,8 @@ export function buildCreatePrPrompt(
   return lines.join("\n");
 }
 
+export const PR_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
+
 export function buildPrCompletionCheckPrompt(): string {
   return [
     `You have finished your PR creation attempt.  Please evaluate the`,
@@ -86,8 +97,7 @@ export function buildPrCompletionCheckPrompt(): string {
     `- COMPLETED — if the pull request was created successfully`,
     `- BLOCKED — if you could not create the PR and need user intervention`,
     ``,
-    `If BLOCKED, add a brief reason on the next line explaining what`,
-    `went wrong (e.g. auth failure, push rejected, PR already exists).`,
+    `Do not include any other commentary — just the keyword.`,
   ].join("\n");
 }
 
@@ -140,16 +150,21 @@ export function createCreatePrStageHandler(
         return mapAgentError(checkResult, "during PR completion check");
       }
 
-      let result = mapResponseToResult(checkResult.responseText);
+      let result = mapResponseToResult(
+        checkResult.responseText,
+        undefined,
+        PR_CHECK_KEYWORDS,
+      );
 
-      if (result.outcome === "needs_clarification" && checkResult.sessionId) {
+      if (result.outcome === "needs_clarification") {
         const clarifyPrompt = buildClarificationPrompt(
           checkResult.responseText,
+          PR_CHECK_KEYWORDS,
         );
         ctx.promptSinks?.a?.(clarifyPrompt);
         const retryResult = await sendFollowUp(
           opts.agent,
-          checkResult.sessionId,
+          checkResult.sessionId ?? prResult.sessionId,
           clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
@@ -165,7 +180,29 @@ export function createCreatePrStageHandler(
         }
 
         checkResult = retryResult;
-        result = mapResponseToResult(retryResult.responseText);
+        result = mapResponseToResult(
+          retryResult.responseText,
+          undefined,
+          PR_CHECK_KEYWORDS,
+        );
+      }
+
+      // If still ambiguous after the in-session retry, verify
+      // the PR actually exists before proceeding.
+      if (result.outcome === "needs_clarification") {
+        const prNumber = (opts.findPrNumber ?? defaultFindPrNumber)(
+          ctx.owner,
+          ctx.repo,
+          ctx.branch,
+        );
+        if (prNumber != null) {
+          result = { outcome: "completed", message: result.message };
+        } else {
+          result = {
+            outcome: "blocked",
+            message: `${prResult.responseText}\n\n---\n\n${checkResult.responseText}`,
+          };
+        }
       }
 
       // When blocked, combine the step 1 diagnostic text with the

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -222,7 +222,7 @@ describe("Stage 2 (Implement) through pipeline", () => {
     expect(callCount).toBe(2);
   });
 
-  test("NOT_APPROVED on check → pipeline loops → COMPLETED", async () => {
+  test("NOT_APPROVED on check → blocked (user intervention)", async () => {
     let callCount = 0;
     const agent: AgentAdapter = {
       invoke: vi.fn().mockImplementation(() => {
@@ -231,36 +231,42 @@ describe("Stage 2 (Implement) through pipeline", () => {
           makeResult({ sessionId: `s${callCount}`, responseText: "impl" }),
         );
       }),
-      resume: vi.fn().mockImplementation(() => {
-        if (callCount === 1) {
-          return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
-        }
-        return makeStream(makeResult({ responseText: "COMPLETED" }));
-      }),
+      // NOT_APPROVED is out-of-scope for implement — both the check
+      // and the internal clarification retry return it, so the handler
+      // falls back to "blocked" to surface the ambiguity to the user.
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
+    const prompt = makePrompt();
     const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
-    const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
+    const result = await runPipeline(
+      makePipelineOpts({ stages: [stage], prompt }),
+    );
 
-    expect(result.success).toBe(true);
-    expect(callCount).toBe(2);
+    expect(result.success).toBe(false);
+    expect(prompt.handleBlocked).toHaveBeenCalled();
+    expect(callCount).toBe(1);
   });
 
   test("ambiguous check → auto-clarification → completed", async () => {
-    let callCount = 0;
     const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => {
-        callCount++;
-        return makeStream(
-          makeResult({ sessionId: `s${callCount}`, responseText: "impl" }),
-        );
-      }),
-      resume: vi.fn().mockImplementation(() => {
-        if (callCount === 1) {
-          return makeStream(makeResult({ responseText: "maybe done?" }));
-        }
-        return makeStream(makeResult({ responseText: "COMPLETED" }));
-      }),
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ sessionId: "s1", responseText: "impl" })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "maybe done?" })),
+        )
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "COMPLETED" })),
+        ),
     };
 
     const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
@@ -283,10 +289,10 @@ describe("Stage 3 (Self-check) through pipeline", () => {
       sessionId: "s1",
       responseText: "Review.",
     });
-    const fixResult = makeResult({ responseText: "All good.\n\nDONE" });
+    const doneResult = makeResult({ responseText: "DONE" });
     const agent: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
-      resume: vi.fn().mockReturnValue(makeStream(fixResult)),
+      resume: vi.fn().mockReturnValue(makeStream(doneResult)),
     };
 
     const stage = createSelfCheckStageHandler({ agent, ...ISSUE_CTX });
@@ -308,15 +314,21 @@ describe("Stage 3 (Self-check) through pipeline", () => {
           }),
         );
       }),
-      resume: vi.fn().mockImplementation(() => {
+      resume: vi.fn().mockImplementation((_s: string, prompt: string) => {
         resumeCalls++;
-        if (resumeCalls < 3) {
+        if (prompt.includes("Report what issue sync")) {
+          return makeStream(makeResult({ responseText: "ISSUE_NO_CHANGES" }));
+        }
+        // 3-step flow: odd = work, even = verdict per iteration.
+        if (resumeCalls % 2 === 1) {
+          return makeStream(makeResult({ responseText: "Applied fixes." }));
+        }
+        if (resumeCalls < 5) {
+          // Even calls 2,4 = verdict FIXED
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
-        // resumeCalls 3 = DONE, resumeCalls 4 = issue sync follow-up
-        return makeStream(
-          makeResult({ responseText: "ISSUE_NO_CHANGES\n\nDONE" }),
-        );
+        // Even calls >= 5: verdict DONE or issue sync work
+        return makeStream(makeResult({ responseText: "DONE" }));
       }),
     };
 
@@ -325,7 +337,7 @@ describe("Stage 3 (Self-check) through pipeline", () => {
 
     expect(result.success).toBe(true);
     expect(invokeCalls).toBe(3); // 3 self-check rounds
-    expect(resumeCalls).toBe(4); // 3 fix-or-done + 1 issue sync
+    expect(resumeCalls).toBe(8); // 3x(work+verdict) + issue sync + issue sync verdict
   });
 
   test("FIXED 3x → budget exhausted → user approves → DONE", async () => {
@@ -338,15 +350,21 @@ describe("Stage 3 (Self-check) through pipeline", () => {
           makeResult({ sessionId: `s${invokeCalls}`, responseText: "rev" }),
         );
       }),
-      resume: vi.fn().mockImplementation(() => {
+      resume: vi.fn().mockImplementation((_s: string, prompt: string) => {
         resumeCalls++;
-        if (resumeCalls <= 3) {
+        if (prompt.includes("Report what issue sync")) {
+          return makeStream(makeResult({ responseText: "ISSUE_NO_CHANGES" }));
+        }
+        // 3-step flow: odd = work, even = verdict.
+        if (resumeCalls % 2 === 1) {
+          return makeStream(makeResult({ responseText: "Applied fixes." }));
+        }
+        if (resumeCalls <= 6) {
+          // Even calls 2,4,6 = verdict FIXED (3 rounds)
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
-        // resumeCalls 4 = DONE, resumeCalls 5 = issue sync follow-up
-        return makeStream(
-          makeResult({ responseText: "ISSUE_NO_CHANGES\n\nDONE" }),
-        );
+        // Even calls > 6: verdict DONE or issue sync work
+        return makeStream(makeResult({ responseText: "DONE" }));
       }),
     };
     const prompt = makePrompt({
@@ -488,7 +506,7 @@ describe("Stage 3 (Self-check) through pipeline", () => {
     expect(prompt.handleAmbiguous).not.toHaveBeenCalled();
   });
 
-  test("blocked during fix → user instructs → completes next round", async () => {
+  test("error during fix → user retries → completes next round", async () => {
     let invokeCalls = 0;
     let resumeCalls = 0;
     const agent: AgentAdapter = {
@@ -504,16 +522,22 @@ describe("Stage 3 (Self-check) through pipeline", () => {
       resume: vi.fn().mockImplementation(() => {
         resumeCalls++;
         if (resumeCalls === 1) {
-          return makeStream(makeResult({ responseText: "BLOCKED" }));
+          // Work step returns agent error on first round.
+          return makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "timeout",
+              responseText: "",
+            }),
+          );
         }
+        // Subsequent rounds: work + verdict + sync all succeed.
         return makeStream(makeResult({ responseText: "DONE" }));
       }),
     };
     const prompt = makePrompt({
-      handleBlocked: vi.fn().mockResolvedValueOnce({
-        action: "instruct",
-        instruction: "skip the flaky test",
-      }),
+      handleError: vi.fn().mockResolvedValueOnce({ action: "retry" }),
     });
 
     const stage = createSelfCheckStageHandler({ agent, ...ISSUE_CTX });
@@ -628,12 +652,14 @@ describe("Stage 4 (Create PR) through pipeline", () => {
           makeResult({ sessionId: `s${callCount}`, responseText: "pr" }),
         );
       }),
-      resume: vi.fn().mockImplementation(() => {
-        if (callCount === 1) {
-          return makeStream(makeResult({ responseText: "I think it worked?" }));
-        }
-        return makeStream(makeResult({ responseText: "COMPLETED" }));
-      }),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "I think it worked?" })),
+        )
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "COMPLETED" })),
+        ),
     };
     const prompt = makePrompt();
 
@@ -1030,10 +1056,10 @@ describe("Stage 6 (Test plan verification) through pipeline", () => {
       sessionId: "s1",
       responseText: "Verified.",
     });
-    const checkResult = makeResult({ responseText: "All good.\n\nDONE" });
+    const doneResult = makeResult({ responseText: "DONE" });
     const agent: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(makeStream(verifyResult)),
-      resume: vi.fn().mockReturnValue(makeStream(checkResult)),
+      resume: vi.fn().mockReturnValue(makeStream(doneResult)),
     };
 
     const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
@@ -1057,7 +1083,11 @@ describe("Stage 6 (Test plan verification) through pipeline", () => {
       }),
       resume: vi.fn().mockImplementation(() => {
         resumeCalls++;
-        if (resumeCalls < 3) {
+        // 3-step flow: odd = work, even = verdict.
+        if (resumeCalls % 2 === 1) {
+          return makeStream(makeResult({ responseText: "Checked items." }));
+        }
+        if (resumeCalls < 5) {
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
         return makeStream(makeResult({ responseText: "DONE" }));
@@ -1069,7 +1099,7 @@ describe("Stage 6 (Test plan verification) through pipeline", () => {
 
     expect(result.success).toBe(true);
     expect(invokeCalls).toBe(3);
-    expect(resumeCalls).toBe(3);
+    expect(resumeCalls).toBe(6); // 3x(work+verdict)
   });
 
   test("FIXED 3x → budget exhausted → user approves → DONE", async () => {
@@ -1084,7 +1114,11 @@ describe("Stage 6 (Test plan verification) through pipeline", () => {
       }),
       resume: vi.fn().mockImplementation(() => {
         resumeCalls++;
-        if (resumeCalls <= 3) {
+        // 3-step flow: odd = work, even = verdict.
+        if (resumeCalls % 2 === 1) {
+          return makeStream(makeResult({ responseText: "Checked items." }));
+        }
+        if (resumeCalls <= 6) {
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
         return makeStream(makeResult({ responseText: "DONE" }));
@@ -1199,7 +1233,7 @@ describe("Stage 6 (Test plan verification) through pipeline", () => {
     expect(prompt.handleAmbiguous).not.toHaveBeenCalled();
   });
 
-  test("blocked during self-check → user instructs → completes next round", async () => {
+  test("error during self-check → user retries → completes next round", async () => {
     let invokeCalls = 0;
     let resumeCalls = 0;
     const agent: AgentAdapter = {
@@ -1215,16 +1249,22 @@ describe("Stage 6 (Test plan verification) through pipeline", () => {
       resume: vi.fn().mockImplementation(() => {
         resumeCalls++;
         if (resumeCalls === 1) {
-          return makeStream(makeResult({ responseText: "BLOCKED" }));
+          // Work step returns agent error on first round.
+          return makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "timeout",
+              responseText: "",
+            }),
+          );
         }
+        // Subsequent rounds: work + verdict both succeed with DONE.
         return makeStream(makeResult({ responseText: "DONE" }));
       }),
     };
     const prompt = makePrompt({
-      handleBlocked: vi.fn().mockResolvedValueOnce({
-        action: "instruct",
-        instruction: "skip the flaky check",
-      }),
+      handleError: vi.fn().mockResolvedValueOnce({ action: "retry" }),
     });
 
     const stage = createTestPlanStageHandler({ agent, ...ISSUE_CTX });
@@ -1318,7 +1358,7 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
       return makeCiStatus("pass");
     });
 
-    let tpResumeCalls = 0;
+    let tpVerdictCalls = 0;
     const agent: AgentAdapter = {
       invoke: vi.fn().mockImplementation((prompt: string) => {
         if (prompt.includes("creating a pull request")) {
@@ -1335,12 +1375,16 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
         if (prompt.includes("PR creation attempt")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
-        // Test plan self-check
-        tpResumeCalls++;
-        if (tpResumeCalls === 1) {
-          return makeStream(makeResult({ responseText: "FIXED" }));
+        // Test plan verdict follow-up (3-step: work + verdict)
+        if (prompt.includes("finished the test plan verification pass")) {
+          tpVerdictCalls++;
+          if (tpVerdictCalls === 1) {
+            return makeStream(makeResult({ responseText: "FIXED" }));
+          }
+          return makeStream(makeResult({ responseText: "DONE" }));
         }
-        return makeStream(makeResult({ responseText: "DONE" }));
+        // Test plan self-check work prompt
+        return makeStream(makeResult({ responseText: "Checked items." }));
       }),
     };
 
@@ -1366,7 +1410,7 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
     expect(result.success).toBe(true);
     // CI polled twice: once on initial pass-through, once on restart
     expect(ciPollCount).toBe(2);
-    expect(tpResumeCalls).toBe(2);
+    expect(tpVerdictCalls).toBe(2);
   });
 
   test("test plan FIXED 3x → restart budget exhausted → user declines", async () => {
@@ -1456,8 +1500,11 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
           implResumeCalls++;
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
-        // Fix-or-done
+        // Self-check: work, verdict, issue sync, issue sync verdict
         scResumeCalls++;
+        if (prompt.includes("Report what issue sync")) {
+          return makeStream(makeResult({ responseText: "ISSUE_NO_CHANGES" }));
+        }
         return makeStream(makeResult({ responseText: "DONE" }));
       }),
     };
@@ -1479,8 +1526,8 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
     expect(implInvokeCalls).toBe(1);
     expect(implResumeCalls).toBe(1);
     expect(scInvokeCalls).toBe(1);
-    // 1 fix-or-done + 1 issue sync follow-up
-    expect(scResumeCalls).toBe(2);
+    // 1 work + 1 verdict + 1 issue sync + 1 issue sync verdict
+    expect(scResumeCalls).toBe(4);
   });
 
   test("implement completes → self-check FIXED twice then DONE", async () => {
@@ -1501,14 +1548,20 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
         if (prompt.includes("evaluate the")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
+        // 3-step self-check: odd = work, even = verdict.
         scResumeCalls++;
-        if (scResumeCalls <= 2) {
+        if (prompt.includes("Report what issue sync")) {
+          return makeStream(makeResult({ responseText: "ISSUE_NO_CHANGES" }));
+        }
+        if (scResumeCalls % 2 === 1) {
+          return makeStream(makeResult({ responseText: "Applied fixes." }));
+        }
+        if (scResumeCalls <= 4) {
+          // Verdict calls 2,4 = FIXED
           return makeStream(makeResult({ responseText: "FIXED" }));
         }
-        // scResumeCalls 3 = DONE, 4 = issue sync follow-up
-        return makeStream(
-          makeResult({ responseText: "ISSUE_NO_CHANGES\n\nDONE" }),
-        );
+        // Even calls > 4: verdict DONE or issue sync work
+        return makeStream(makeResult({ responseText: "DONE" }));
       }),
     };
 
@@ -1526,8 +1579,8 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
     );
 
     expect(result.success).toBe(true);
-    // 2 FIXED + 1 DONE + 1 issue sync follow-up
-    expect(scResumeCalls).toBe(4);
+    // 2 FIXED + 1 DONE: 3x(work+verdict) + issue sync + issue sync verdict
+    expect(scResumeCalls).toBe(8);
   });
 
   test("step mode asks before each stage", async () => {
@@ -1760,25 +1813,36 @@ describe("Stage 7 (Review) through pipeline", () => {
         makeStream(
           makeResult({
             sessionId: "sa-fin",
-            responseText: "PR_FINALIZED",
-          }),
-        ),
-      ),
-      resume: vi.fn(),
-    };
-
-    const agentB: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            sessionId: "sb",
-            responseText: "Looks good.\n\nAPPROVED",
+            responseText: "PR body verified.",
           }),
         ),
       ),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
+    };
+
+    let bResumeCalls = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sb",
+            responseText: "Looks good.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCalls++;
+        if (bResumeCalls === 1) {
+          // Verdict follow-up
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        // Unresolved summary + unresolved verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const stage = createReviewStageHandler({
@@ -1801,43 +1865,47 @@ describe("Stage 7 (Review) through pipeline", () => {
 
   test("NOT_APPROVED → fix → CI pass → loops → APPROVED: completes", async () => {
     let bInvokeCalls = 0;
+    let bResumeCalls = 0;
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockImplementation(() => {
         bInvokeCalls++;
-        if (bInvokeCalls === 1) {
-          return makeStream(
-            makeResult({
-              sessionId: "sb1",
-              responseText: "NOT_APPROVED",
-            }),
-          );
-        }
         return makeStream(
           makeResult({
-            sessionId: "sb2",
-            responseText: "APPROVED",
+            sessionId: `sb${bInvokeCalls}`,
+            responseText: "Review posted.",
           }),
         );
       }),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCalls++;
+        if (bResumeCalls === 1) {
+          // Round 1 verdict: NOT_APPROVED
+          return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
+        }
+        if (bResumeCalls === 2) {
+          // Round 2 verdict: APPROVED
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        // Unresolved summary + verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const agentA: AgentAdapter = {
-      invoke: vi.fn().mockImplementation((prompt: string) =>
+      invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
             sessionId: "sa1",
-            responseText: prompt.includes("PR_FINALIZED")
-              ? "PR_FINALIZED"
-              : "Fixed.",
+            responseText: "Fixed.",
           }),
         ),
       ),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        if (prompt.includes("PR_FINALIZED")) {
+          return makeStream(makeResult({ responseText: "PR_FINALIZED" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
     };
 
     const stage = createReviewStageHandler({
@@ -1864,13 +1932,18 @@ describe("Stage 7 (Review) through pipeline", () => {
         makeStream(
           makeResult({
             sessionId: "sb",
-            responseText: "NOT_APPROVED",
+            responseText: "Review posted.",
           }),
         ),
       ),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        // Verdict follow-up → NOT_APPROVED
+        if (prompt.includes("posted your review")) {
+          return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
+        }
+        // Unresolved summary + verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const agentA: AgentAdapter = {
@@ -1919,40 +1992,41 @@ describe("Stage 7 (Review) through pipeline", () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockImplementation(() => {
         bInvokeCalls++;
-        if (bInvokeCalls <= 3) {
-          return makeStream(
-            makeResult({
-              sessionId: `sb${bInvokeCalls}`,
-              responseText: "NOT_APPROVED",
-            }),
-          );
-        }
         return makeStream(
           makeResult({
             sessionId: `sb${bInvokeCalls}`,
-            responseText: "APPROVED",
+            responseText: "Review posted.",
           }),
         );
       }),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        // Verdict follow-up
+        if (prompt.includes("posted your review")) {
+          if (bInvokeCalls <= 3) {
+            return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
+          }
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        // Unresolved summary + verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const agentA: AgentAdapter = {
-      invoke: vi.fn().mockImplementation((prompt: string) =>
+      invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
             sessionId: "sa",
-            responseText: prompt.includes("PR_FINALIZED")
-              ? "PR_FINALIZED"
-              : "Fixed.",
+            responseText: "Fixed.",
           }),
         ),
       ),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        if (prompt.includes("PR_FINALIZED")) {
+          return makeStream(makeResult({ responseText: "PR_FINALIZED" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
     };
 
     const prompt = makePrompt({
@@ -1991,18 +2065,27 @@ describe("Stage 7 (Review) through pipeline", () => {
         return makeStream(
           makeResult({
             sessionId: `sb${bInvokeCalls}`,
-            responseText: "NOT_APPROVED",
+            responseText: "Review posted.",
           }),
         );
       }),
-      resume: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            responseText:
-              "**[Reviewer Unresolved Round 3]**\n- Missing error handling in parser",
-          }),
-        ),
-      ),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        // Review verdict follow-up
+        if (prompt.includes("posted your review")) {
+          return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
+        }
+        // Unresolved summary work step (contains "review cycle")
+        if (prompt.includes("review cycle")) {
+          return makeStream(
+            makeResult({
+              responseText:
+                "**[Reviewer Unresolved Round 3]**\n- Missing error handling in parser",
+            }),
+          );
+        }
+        // Unresolved verdict follow-up or clarification
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
     };
 
     const agentA: AgentAdapter = {
@@ -2045,14 +2128,10 @@ describe("Stage 7 (Review) through pipeline", () => {
     expect(result.success).toBe(false);
     expect(prompt.confirmContinueLoop).toHaveBeenCalled();
 
-    // Agent B should be resumed for unresolved summary only on round 3
-    // (the last auto-iteration). Rounds 1-2 should not trigger resume.
-    expect(agentB.resume).toHaveBeenCalledTimes(1);
-    expect(agentB.resume).toHaveBeenCalledWith(
-      "sb3",
-      expect.stringContaining("unresolved"),
-      { cwd: "/tmp/wt" },
-    );
+    // Agent B resumed: 3 verdict follow-ups + unresolved summary +
+    // unresolved verdict on round 3 (lastAutoIteration).
+    // Rounds 1-2 only have verdict follow-up, round 3 adds unresolved.
+    expect(agentB.resume).toHaveBeenCalledTimes(5);
 
     // The unresolved summary must reach the user via confirmContinueLoop.
     expect(prompt.confirmContinueLoop).toHaveBeenCalledWith(
@@ -2067,40 +2146,53 @@ describe("Stage 7 (Review) through pipeline", () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockImplementation(() => {
         bInvokeCalls++;
-        if (bInvokeCalls <= 2) {
-          return makeStream(
-            makeResult({
-              sessionId: `sb${bInvokeCalls}`,
-              responseText: "NOT_APPROVED",
-            }),
-          );
-        }
         return makeStream(
           makeResult({
             sessionId: `sb${bInvokeCalls}`,
-            responseText: "APPROVED",
+            responseText: "Review posted.",
           }),
         );
       }),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        // Verdict follow-up — return a session ID that advances
+        // beyond the invoke session, so we can verify the
+        // unresolved summary resumes the verdict session.
+        if (prompt.includes("posted your review")) {
+          if (bInvokeCalls <= 2) {
+            return makeStream(
+              makeResult({
+                sessionId: `sb${bInvokeCalls}-v`,
+                responseText: "NOT_APPROVED",
+              }),
+            );
+          }
+          return makeStream(
+            makeResult({
+              sessionId: `sb${bInvokeCalls}-v`,
+              responseText: "APPROVED",
+            }),
+          );
+        }
+        // Unresolved summary + verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const agentA: AgentAdapter = {
-      invoke: vi.fn().mockImplementation((prompt: string) =>
+      invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
             sessionId: "sa",
-            responseText: prompt.includes("PR_FINALIZED")
-              ? "PR_FINALIZED"
-              : "Fixed.",
+            responseText: "Fixed.",
           }),
         ),
       ),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+      resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
+        if (prompt.includes("PR_FINALIZED")) {
+          return makeStream(makeResult({ responseText: "PR_FINALIZED" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
     };
 
     const stage = {
@@ -2122,11 +2214,14 @@ describe("Stage 7 (Review) through pipeline", () => {
     const result = await runPipeline(makePipelineOpts({ stages: [stage] }));
     expect(result.success).toBe(true);
 
-    // Agent B resumed once: for the APPROVED unresolved summary (round 3).
-    // Rounds 1-2 (NOT_APPROVED, not lastAutoIteration) should NOT trigger resume.
-    expect(agentB.resume).toHaveBeenCalledTimes(1);
+    // Agent B resumed: 2 verdict follow-ups (NOT_APPROVED, rounds 1-2) +
+    // 1 verdict follow-up (APPROVED, round 3) + unresolved summary + verdict.
+    // Rounds 1-2 do NOT trigger unresolved summary (not lastAutoIteration).
+    expect(agentB.resume).toHaveBeenCalledTimes(5);
+    // The unresolved summary call should use the verdict session ID
+    // ("sb3-v"), not the initial review invoke session ("sb3").
     expect(agentB.resume).toHaveBeenCalledWith(
-      "sb3",
+      "sb3-v",
       expect.stringContaining("unresolved"),
       { cwd: "/tmp/wt" },
     );
@@ -2138,11 +2233,15 @@ describe("Stage 7 (Review) through pipeline", () => {
         makeStream(
           makeResult({
             sessionId: "sb",
-            responseText: "NOT_APPROVED",
+            responseText: "Review posted.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const getCiStatus = vi
@@ -2213,25 +2312,34 @@ describe("Stages 7+8 (Review + Squash) through pipeline", () => {
         makeStream(
           makeResult({
             sessionId: "sa-fin",
-            responseText: "PR_FINALIZED",
-          }),
-        ),
-      ),
-      resume: vi.fn(),
-    };
-
-    const agentB: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            sessionId: "sb",
-            responseText: "APPROVED",
+            responseText: "PR body verified.",
           }),
         ),
       ),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
+    };
+
+    let bResumeCalls = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sb",
+            responseText: "Looks good.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCalls++;
+        if (bResumeCalls === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
@@ -2284,18 +2392,23 @@ describe("Stages 7+8 (Review + Squash) through pipeline", () => {
         .mockReturnValue(makeStream(makeResult({ responseText: "BLOCKED" }))),
     };
 
+    let bResumeCalls = 0;
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
             sessionId: "sb",
-            responseText: "Looks good.\n\nAPPROVED",
+            responseText: "Looks good.",
           }),
         ),
       ),
-      resume: vi
-        .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCalls++;
+        if (bResumeCalls === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const prompt = makePrompt({
@@ -2321,11 +2434,15 @@ describe("Stages 7+8 (Review + Squash) through pipeline", () => {
         makeStream(
           makeResult({
             sessionId: "sa-fin",
-            responseText: "PR_FINALIZED",
+            responseText: "PR body verified.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
     };
 
     const reviewStage = createReviewStageHandler({
@@ -2414,7 +2531,9 @@ describe("Pipeline event emitter integration", () => {
     const implResult = makeResult({ sessionId: "s1", responseText: "ok" });
     const implCheck = makeResult({ responseText: "COMPLETED" });
     const selfResult = makeResult({ sessionId: "s2", responseText: "ok" });
-    const selfCheck = makeResult({ responseText: "DONE" });
+    const selfWork = makeResult({ responseText: "All good." });
+    const selfDone = makeResult({ responseText: "DONE" });
+    const syncVerdict = makeResult({ responseText: "ISSUE_NO_CHANGES" });
 
     const agent: AgentAdapter = {
       invoke: vi
@@ -2424,7 +2543,11 @@ describe("Pipeline event emitter integration", () => {
       resume: vi
         .fn()
         .mockReturnValueOnce(makeStream(implCheck))
-        .mockReturnValueOnce(makeStream(selfCheck)),
+        // Self-check: work + verdict + issue sync + issue sync verdict
+        .mockReturnValueOnce(makeStream(selfWork))
+        .mockReturnValueOnce(makeStream(selfDone))
+        .mockReturnValueOnce(makeStream(selfDone))
+        .mockReturnValueOnce(makeStream(syncVerdict)),
     };
 
     const emitter = new PipelineEventEmitter();
@@ -2464,29 +2587,39 @@ describe("Pipeline event emitter integration", () => {
   test("review stage emits chunks for agent B on sink b", async () => {
     const reviewResult = makeResult({
       sessionId: "sb1",
-      responseText: "APPROVED",
+      responseText: "Looks good.",
     });
-    // Unresolved summary response.
-    const summaryResult = makeResult({ responseText: "NONE" });
 
     const agentA: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
             sessionId: "sa-fin",
-            responseText: "PR_FINALIZED",
+            responseText: "PR body verified.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
     };
+
+    let bResumeCalls = 0;
     const agentB: AgentAdapter = {
       invoke: vi
         .fn()
         .mockReturnValue(
           makeStreamWithChunks(reviewResult, ["review-b1", "review-b2"]),
         ),
-      resume: vi.fn().mockReturnValue(makeStream(summaryResult)),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCalls++;
+        if (bResumeCalls === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
     };
 
     const emitter = new PipelineEventEmitter();
@@ -2515,11 +2648,12 @@ describe("Pipeline event emitter integration", () => {
     const implCheck = makeResult({ responseText: "COMPLETED" });
 
     const selfResult1 = makeResult({ sessionId: "s2", responseText: "ok" });
-    const selfCheck1 = makeResult({ responseText: "FIXED" });
+    const selfWork = makeResult({ responseText: "Applied fixes." });
+    const selfFixed = makeResult({ responseText: "FIXED" });
     const selfResult2 = makeResult({ sessionId: "s3", responseText: "ok" });
-    const selfCheck2 = makeResult({ responseText: "FIXED" });
     const selfResult3 = makeResult({ sessionId: "s4", responseText: "ok" });
-    const selfCheck3 = makeResult({ responseText: "DONE" });
+    const selfDoneResult = makeResult({ responseText: "DONE" });
+    const syncVerdictResult = makeResult({ responseText: "ISSUE_NO_CHANGES" });
 
     const agent: AgentAdapter = {
       invoke: vi
@@ -2530,10 +2664,19 @@ describe("Pipeline event emitter integration", () => {
         .mockReturnValueOnce(makeStream(selfResult3)),
       resume: vi
         .fn()
+        // Stage 2: completion check
         .mockReturnValueOnce(makeStream(implCheck))
-        .mockReturnValueOnce(makeStream(selfCheck1))
-        .mockReturnValueOnce(makeStream(selfCheck2))
-        .mockReturnValueOnce(makeStream(selfCheck3)),
+        // Stage 3, iteration 0: work + verdict FIXED
+        .mockReturnValueOnce(makeStream(selfWork))
+        .mockReturnValueOnce(makeStream(selfFixed))
+        // Stage 3, iteration 1: work + verdict FIXED
+        .mockReturnValueOnce(makeStream(selfWork))
+        .mockReturnValueOnce(makeStream(selfFixed))
+        // Stage 3, iteration 2: work + verdict DONE + issue sync + verdict
+        .mockReturnValueOnce(makeStream(selfWork))
+        .mockReturnValueOnce(makeStream(selfDoneResult))
+        .mockReturnValueOnce(makeStream(selfDoneResult))
+        .mockReturnValueOnce(makeStream(syncVerdictResult)),
     };
 
     const emitter = new PipelineEventEmitter();
@@ -2573,7 +2716,9 @@ describe("Pipeline event emitter integration", () => {
     const implResult = makeResult({ sessionId: "s1", responseText: "ok" });
     const implCheck = makeResult({ responseText: "COMPLETED" });
     const selfResult = makeResult({ sessionId: "s2", responseText: "ok" });
-    const selfCheck = makeResult({ responseText: "DONE" });
+    const selfWork = makeResult({ responseText: "All good." });
+    const selfDoneEvt = makeResult({ responseText: "DONE" });
+    const syncVerdictEvt = makeResult({ responseText: "ISSUE_NO_CHANGES" });
 
     const agent: AgentAdapter = {
       invoke: vi
@@ -2583,7 +2728,11 @@ describe("Pipeline event emitter integration", () => {
       resume: vi
         .fn()
         .mockReturnValueOnce(makeStream(implCheck))
-        .mockReturnValueOnce(makeStream(selfCheck)),
+        // Self-check: work + verdict + issue sync + issue sync verdict
+        .mockReturnValueOnce(makeStream(selfWork))
+        .mockReturnValueOnce(makeStream(selfDoneEvt))
+        .mockReturnValueOnce(makeStream(selfDoneEvt))
+        .mockReturnValueOnce(makeStream(syncVerdictEvt)),
     };
 
     const emitter = new PipelineEventEmitter();

--- a/src/stage-implement.test.ts
+++ b/src/stage-implement.test.ts
@@ -172,12 +172,12 @@ describe("createImplementStageHandler", () => {
     expect(result.outcome).toBe("completed");
   });
 
-  test("returns completed on DONE", async () => {
+  test("returns blocked on DONE (not in valid keywords)", async () => {
     const checkResult = makeResult({ responseText: "DONE" });
     const agent = makeAgent(makeResult(), checkResult);
     const stage = createImplementStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("completed");
+    expect(result.outcome).toBe("blocked");
   });
 
   test("returns blocked on BLOCKED", async () => {
@@ -188,20 +188,140 @@ describe("createImplementStageHandler", () => {
     expect(result.outcome).toBe("blocked");
   });
 
-  test("returns not_approved on NOT_APPROVED", async () => {
+  test("returns blocked on NOT_APPROVED (not in valid keywords)", async () => {
     const checkResult = makeResult({ responseText: "NOT_APPROVED" });
     const agent = makeAgent(makeResult(), checkResult);
     const stage = createImplementStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("not_approved");
+    expect(result.outcome).toBe("blocked");
   });
 
-  test("returns needs_clarification on ambiguous check response", async () => {
+  test("returns blocked on ambiguous check response", async () => {
     const checkResult = makeResult({ responseText: "I think it works." });
     const agent = makeAgent(makeResult(), checkResult);
     const stage = createImplementStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("needs_clarification");
+    expect(result.outcome).toBe("blocked");
+  });
+
+  // -- internal clarification retry ------------------------------------------
+
+  test("ambiguous check → internal clarification → completed", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "I think it works",
+    });
+    const clarifiedCheck = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(clarifiedCheck)),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // (completion check + clarification)
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("out-of-scope DONE → internal clarification → BLOCKED", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const outOfScope = makeResult({
+      sessionId: "sess-check",
+      responseText: "DONE",
+    });
+    const clarifiedCheck = makeResult({ responseText: "BLOCKED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(outOfScope))
+        .mockReturnValueOnce(makeStream(clarifiedCheck)),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("ambiguous check → clarification also ambiguous → returns blocked", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "Looks OK",
+    });
+    const stillAmbiguous = makeResult({ responseText: "It is OK" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(stillAmbiguous)),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+  });
+
+  test("clarification retry error → returns error", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "I think so",
+    });
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "clarify crash",
+      responseText: "",
+    });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(errorResult)),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("clarify crash");
+  });
+
+  test("ambiguous check without sessionId retries via fallback session", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const noSession = makeResult({
+      sessionId: undefined,
+      responseText: "I think it works",
+    });
+    let resumeCall = 0;
+    const resumeResults = [
+      // 1st resume: ambiguous completion check (no sessionId)
+      makeStream(noSession),
+      // 2nd resume: clarification retry via fallback session
+      makeStream(makeResult({ responseText: "COMPLETED" })),
+    ];
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+    };
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    // Clarification retry succeeds via fallback to "sess-impl".
+    expect(result.outcome).toBe("completed");
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect((agent.resume as ReturnType<typeof vi.fn>).mock.calls[1][0]).toBe(
+      "sess-impl",
+    );
   });
 
   // -- error handling --------------------------------------------------------

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -17,6 +17,7 @@ import {
   mapResponseToResult,
   sendFollowUp,
 } from "./stage-util.js";
+import { buildClarificationPrompt } from "./step-parser.js";
 
 export interface ImplementStageOptions {
   agent: AgentAdapter;
@@ -62,6 +63,8 @@ export function buildImplementPrompt(
 
   return lines.join("\n");
 }
+
+export const IMPLEMENT_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
 
 export function buildCompletionCheckPrompt(): string {
   return [
@@ -120,7 +123,49 @@ export function createImplementStageHandler(
         return mapAgentError(checkResult, "during completion check");
       }
 
-      return mapResponseToResult(checkResult.responseText);
+      let result = mapResponseToResult(
+        checkResult.responseText,
+        undefined,
+        IMPLEMENT_CHECK_KEYWORDS,
+      );
+
+      // Internal clarification retry (same pattern as stage 4 / stage 8).
+      if (result.outcome === "needs_clarification") {
+        const clarifyPrompt = buildClarificationPrompt(
+          checkResult.responseText,
+          IMPLEMENT_CHECK_KEYWORDS,
+        );
+        ctx.promptSinks?.a?.(clarifyPrompt);
+        const retryResult = await sendFollowUp(
+          opts.agent,
+          checkResult.sessionId ?? implResult.sessionId,
+          clarifyPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+
+        if (retryResult.status === "error") {
+          return mapAgentError(retryResult, "during completion clarification");
+        }
+
+        result = mapResponseToResult(
+          retryResult.responseText,
+          undefined,
+          IMPLEMENT_CHECK_KEYWORDS,
+        );
+      }
+
+      // If still ambiguous after the in-session retry, surface a
+      // blocked condition so the user can decide how to proceed.
+      // Treating ambiguity as "completed" could mask a real BLOCKED
+      // and send the pipeline into self-check on an unfinished branch.
+      if (result.outcome === "needs_clarification") {
+        result = { outcome: "blocked", message: result.message };
+      }
+
+      return result;
     },
   };
 }

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -6,7 +6,9 @@ import {
   buildAuthorCompletionCheckPrompt,
   buildAuthorFixPrompt,
   buildPrFinalizationPrompt,
+  buildPrFinalizationVerdictPrompt,
   buildReviewPrompt,
+  buildReviewVerdictPrompt,
   buildUnresolvedSummaryPrompt,
   createReviewStageHandler,
   type ReviewStageOptions,
@@ -70,13 +72,15 @@ function makeOpts(
       makeStream(
         makeResult({
           sessionId: "sess-a",
-          responseText: "PR_FINALIZED",
+          responseText: "I verified the PR body.",
         }),
       ),
     ),
     resume: vi
       .fn()
-      .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+      .mockReturnValue(
+        makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+      ),
   };
 
   const agentB: AgentAdapter = {
@@ -84,12 +88,19 @@ function makeOpts(
       makeStream(
         makeResult({
           sessionId: "sess-b",
-          responseText: "Looks good.\n\nAPPROVED",
+          responseText: "Looks good.",
         }),
       ),
     ),
     resume: vi
       .fn()
+      // 1st resume: review verdict
+      .mockReturnValueOnce(makeStream(makeResult({ responseText: "APPROVED" })))
+      // 2nd resume: unresolved summary
+      .mockReturnValueOnce(
+        makeStream(makeResult({ responseText: "Summary text" })),
+      )
+      // 3rd resume: unresolved verdict
       .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
   };
 
@@ -124,8 +135,14 @@ describe("buildReviewPrompt", () => {
     expect(prompt).toContain("[Reviewer Round 2]");
   });
 
-  test("mentions APPROVED and NOT_APPROVED", () => {
+  test("review prompt no longer contains verdict keywords", () => {
     const prompt = buildReviewPrompt(BASE_CTX, makeOpts(), 1);
+    expect(prompt).not.toContain("APPROVED");
+    expect(prompt).not.toContain("NOT_APPROVED");
+  });
+
+  test("verdict prompt mentions APPROVED and NOT_APPROVED", () => {
+    const prompt = buildReviewVerdictPrompt();
     expect(prompt).toContain("APPROVED");
     expect(prompt).toContain("NOT_APPROVED");
   });
@@ -245,10 +262,13 @@ describe("buildAuthorCompletionCheckPrompt", () => {
 });
 
 describe("buildUnresolvedSummaryPrompt", () => {
-  test("includes round number and NONE keyword", () => {
+  test("includes round number and does not contain verdict keywords", () => {
     const prompt = buildUnresolvedSummaryPrompt(3);
     expect(prompt).toContain("[Reviewer Unresolved Round 3]");
-    expect(prompt).toContain("NONE");
+    // Work prompt must not contain verdict keywords — those belong
+    // in the dedicated verdict follow-up.
+    expect(prompt).not.toContain("NONE");
+    expect(prompt).not.toContain("COMPLETED");
   });
 });
 
@@ -273,8 +293,13 @@ describe("buildPrFinalizationPrompt", () => {
     expect(prompt).toContain("gh pr edit --body");
   });
 
-  test("ends with PR_FINALIZED keyword", () => {
+  test("finalization prompt no longer contains PR_FINALIZED", () => {
     const prompt = buildPrFinalizationPrompt(BASE_CTX, makeOpts());
+    expect(prompt).not.toContain("PR_FINALIZED");
+  });
+
+  test("finalization verdict prompt mentions PR_FINALIZED", () => {
+    const prompt = buildPrFinalizationVerdictPrompt();
     expect(prompt).toContain("PR_FINALIZED");
   });
 });
@@ -305,12 +330,10 @@ describe("createReviewStageHandler", () => {
     const stage = createReviewStageHandler(opts);
     await stage.handler(BASE_CTX);
 
-    // Agent B should have been resumed with the unresolved summary prompt.
-    expect(opts.agentB.resume).toHaveBeenCalledWith(
-      "sess-b",
-      expect.stringContaining("unresolved"),
-      { cwd: "/tmp/wt" },
-    );
+    // 1st resume: review verdict, 2nd resume: unresolved summary.
+    const calls = (opts.agentB.resume as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    expect(calls[1][1]).toContain("unresolved");
   });
 
   // -- not approved path ------------------------------------------------------
@@ -321,16 +344,33 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-b",
-            responseText: "Needs changes.\n\nNOT_APPROVED",
+            responseText: "Needs changes.",
+          }),
+        ),
+      ),
+      // 1st resume: review verdict (NOT_APPROVED)
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Fixed.",
           }),
         ),
       ),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
     };
 
-    const opts = makeOpts({ agentB });
+    const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
@@ -346,11 +386,16 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-b",
-            responseText: "Issues found.\n\nNOT_APPROVED",
+            responseText: "Issues found.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict (NOT_APPROVED)
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const opts = makeOpts({ agentB });
@@ -388,7 +433,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const agentA: AgentAdapter = {
@@ -425,7 +475,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const getCiStatus = vi
@@ -501,7 +556,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const agentA: AgentAdapter = {
@@ -537,7 +597,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const agentA: AgentAdapter = {
@@ -578,7 +643,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const agentA: AgentAdapter = {
@@ -609,7 +679,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     let resumeCall = 0;
@@ -643,8 +718,8 @@ describe("createReviewStageHandler", () => {
     expect(result.outcome).toBe("not_approved");
     expect(agentA.resume).toHaveBeenCalledTimes(2);
 
-    // The retry prompt must be the stage-specific completion check
-    // (COMPLETED/BLOCKED only), not the generic clarification prompt.
+    // The retry prompt uses buildClarificationPrompt with
+    // AUTHOR_CHECK_KEYWORDS (COMPLETED/BLOCKED), not the generic one.
     const retryPrompt = (agentA.resume as ReturnType<typeof vi.fn>).mock
       .calls[1][1] as string;
     expect(retryPrompt).toContain("COMPLETED");
@@ -652,7 +727,7 @@ describe("createReviewStageHandler", () => {
     expect(retryPrompt).not.toContain("NOT_APPROVED");
   });
 
-  test("ambiguous author check without sessionId skips internal clarification", async () => {
+  test("ambiguous author check without sessionId retries via fallback session", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -662,13 +737,26 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const ambiguousCheck = makeResult({
       sessionId: undefined,
       responseText: "I addressed the feedback.",
     });
+
+    let aResumeCall = 0;
+    const aResumeResults = [
+      // 1st resume: ambiguous completion check (no sessionId)
+      makeStream(ambiguousCheck),
+      // 2nd resume: clarification retry via fallback session
+      makeStream(makeResult({ responseText: "COMPLETED" })),
+    ];
 
     const agentA: AgentAdapter = {
       invoke: vi
@@ -678,18 +766,23 @@ describe("createReviewStageHandler", () => {
             makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
           ),
         ),
-      resume: vi.fn().mockReturnValueOnce(makeStream(ambiguousCheck)),
+      resume: vi.fn().mockImplementation(() => aResumeResults[aResumeCall++]),
     };
 
     const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
-    expect(agentA.resume).toHaveBeenCalledTimes(1);
+    // Clarification retry succeeds via fallback to "sess-a".
+    expect(result.outcome).toBe("not_approved");
+    expect(agentA.resume).toHaveBeenCalledTimes(2);
+    // The retry used the invoke session as fallback.
+    expect((agentA.resume as ReturnType<typeof vi.fn>).mock.calls[1][0]).toBe(
+      "sess-a",
+    );
   });
 
-  test("returns needs_clarification when author check stays ambiguous after retry", async () => {
+  test("returns blocked when author check stays ambiguous after retry", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -699,7 +792,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     let resumeCall = 0;
@@ -728,7 +826,9 @@ describe("createReviewStageHandler", () => {
     const stage = createReviewStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
+    // Surfaces a blocked condition so the user can decide how to
+    // proceed, rather than polling stale CI on an unchanged head.
+    expect(result.outcome).toBe("blocked");
   });
 
   test("returns error when author clarification retry fails", async () => {
@@ -741,7 +841,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     let resumeCall = 0;
@@ -783,7 +888,7 @@ describe("createReviewStageHandler", () => {
 
   // -- ambiguous review response -----------------------------------------------
 
-  test("returns needs_clarification on ambiguous review response", async () => {
+  test("returns needs_clarification on ambiguous review verdict", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -793,7 +898,15 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: ambiguous verdict, 2nd resume: still ambiguous after clarification
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b2",
+            responseText: "I think it looks fine.",
+          }),
+        ),
+      ),
     };
 
     const opts = makeOpts({ agentB });
@@ -801,6 +914,254 @@ describe("createReviewStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("ambiguous review verdict → clarification retry → APPROVED completes", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Looks good.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          // 1st resume: ambiguous verdict
+          return makeStream(
+            makeResult({
+              sessionId: "sess-b2",
+              responseText: "I think it is fine.",
+            }),
+          );
+        }
+        if (bResumeCall === 2) {
+          // 2nd resume: clarification → APPROVED
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 3) {
+          // 3rd resume: unresolved summary
+          return makeStream(
+            makeResult({ responseText: "No unresolved items." }),
+          );
+        }
+        // 4th resume: unresolved verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
+    };
+
+    const opts = makeOpts({ agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // Clarification retry was attempted (3rd call = clarification, not unresolved)
+    expect(agentB.resume).toHaveBeenCalledTimes(4);
+  });
+
+  test("ambiguous review verdict → clarification retry → NOT_APPROVED triggers fix loop", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Needs work.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          // 1st resume: ambiguous verdict
+          return makeStream(
+            makeResult({ sessionId: "sess-b2", responseText: "Hmm not sure" }),
+          );
+        }
+        // 2nd resume: clarification → NOT_APPROVED
+        return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
+      }),
+    };
+
+    // Agent A must handle the fix loop after NOT_APPROVED.
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Fixed the issues.",
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+
+    const opts = makeOpts({ agentA, agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("out-of-scope keyword in review verdict triggers clarification → APPROVED", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Looks good.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          // 1st resume: out-of-scope keyword COMPLETED
+          return makeStream(
+            makeResult({ sessionId: "sess-b2", responseText: "COMPLETED" }),
+          );
+        }
+        if (bResumeCall === 2) {
+          // 2nd resume: clarification → APPROVED
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 3) {
+          // 3rd resume: unresolved summary
+          return makeStream(
+            makeResult({ responseText: "Nothing unresolved." }),
+          );
+        }
+        // 4th resume: unresolved verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
+    };
+
+    const opts = makeOpts({ agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(agentB.resume).toHaveBeenCalledTimes(4);
+  });
+
+  test("returns error when review verdict clarification retry fails", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Looks good.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          // 1st resume: ambiguous verdict
+          return makeStream(
+            makeResult({ sessionId: "sess-b2", responseText: "I think so" }),
+          );
+        }
+        // 2nd resume: clarification error
+        return makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            stderrText: "crash",
+            responseText: "",
+          }),
+        );
+      }),
+    };
+
+    const opts = makeOpts({ agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("review verdict clarification");
+  });
+
+  // -- PR finalization clarification paths ----------------------------------------
+
+  test("ambiguous finalization verdict → clarification → PR_FINALIZED completes", async () => {
+    let aResumeCall = 0;
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "I verified the PR body.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        aResumeCall++;
+        if (aResumeCall === 1) {
+          // 1st resume: ambiguous verdict
+          return makeStream(
+            makeResult({
+              sessionId: "sess-a2",
+              responseText: "Done updating.",
+            }),
+          );
+        }
+        // 2nd resume: clarification → PR_FINALIZED
+        return makeStream(makeResult({ responseText: "PR_FINALIZED" }));
+      }),
+    };
+
+    const opts = makeOpts({ agentA });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("returns error when finalization clarification retry fails", async () => {
+    let aResumeCall = 0;
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "I verified the PR body.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        aResumeCall++;
+        if (aResumeCall === 1) {
+          // 1st resume: ambiguous verdict
+          return makeStream(
+            makeResult({ sessionId: "sess-a2", responseText: "Updated it." }),
+          );
+        }
+        // 2nd resume: clarification error
+        return makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            stderrText: "crash",
+            responseText: "",
+          }),
+        );
+      }),
+    };
+
+    const opts = makeOpts({ agentA });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("PR finalization clarification");
   });
 
   // -- unresolved summary paths -------------------------------------------------
@@ -811,20 +1172,27 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-b",
-            responseText: "APPROVED",
+            responseText: "Looks good.",
           }),
         ),
       ),
-      resume: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            status: "error",
-            errorType: "execution_error",
-            stderrText: "crash",
-            responseText: "",
-          }),
+      resume: vi
+        .fn()
+        // 1st resume: review verdict (APPROVED)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "APPROVED" })),
+        )
+        // 2nd resume: unresolved summary (error)
+        .mockReturnValue(
+          makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "crash",
+              responseText: "",
+            }),
+          ),
         ),
-      ),
     };
 
     const opts = makeOpts({ agentB });
@@ -841,18 +1209,27 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-b",
-            responseText: "APPROVED",
+            responseText: "Looks good.",
           }),
         ),
       ),
-      resume: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            responseText:
-              "**[Reviewer Unresolved Round 1]**\n- Error handling in module X\n- Missing test for edge case Y",
-          }),
-        ),
-      ),
+      resume: vi
+        .fn()
+        // 1st resume: review verdict (APPROVED)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "APPROVED" })),
+        )
+        // 2nd resume: unresolved summary (items found)
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              responseText:
+                "**[Reviewer Unresolved Round 1]**\n- Error handling in module X\n- Missing test for edge case Y",
+            }),
+          ),
+        )
+        // 3rd resume: unresolved verdict (COMPLETED — items were posted)
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
     };
 
     const opts = makeOpts({ agentB });
@@ -874,7 +1251,272 @@ describe("createReviewStageHandler", () => {
     expect(result.message).toContain("Review approved at round 1.");
   });
 
-  test("invokes fresh when sessionId is undefined for unresolved summary", async () => {
+  test("retries with clarification when unresolved verdict is ambiguous", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Review posted.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          // 1st resume: review verdict
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 2) {
+          // 2nd resume: unresolved summary (work step)
+          return makeStream(
+            makeResult({
+              responseText:
+                "**[Reviewer Unresolved Round 1]**\n- Item X needs attention",
+            }),
+          );
+        }
+        if (bResumeCall === 3) {
+          // 3rd resume: unresolved verdict — ambiguous response
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 4) {
+          // 4th resume: clarification retry — correct verdict
+          return makeStream(makeResult({ responseText: "COMPLETED" }));
+        }
+        return makeStream(makeResult({ responseText: "COMPLETED" }));
+      }),
+    };
+
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR finalized." })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
+    };
+
+    const opts = makeOpts({ agentB, agentA });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("Unresolved items:");
+    expect(result.message).toContain("Item X needs attention");
+    // Agent B should be resumed 4 times: review verdict, unresolved
+    // summary, ambiguous verdict, clarification retry.
+    expect(agentB.resume).toHaveBeenCalledTimes(4);
+  });
+
+  test("treats out-of-scope unresolved verdict as ambiguous and retries", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Review posted.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 2) {
+          // unresolved summary work step
+          return makeStream(
+            makeResult({ responseText: "Nothing unresolved." }),
+          );
+        }
+        if (bResumeCall === 3) {
+          // unresolved verdict — out-of-scope keyword
+          return makeStream(makeResult({ responseText: "NONE and COMPLETED" }));
+        }
+        // clarification retry — correct verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
+    };
+
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR finalized." })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
+    };
+
+    const opts = makeOpts({ agentB, agentA });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).not.toContain("Unresolved items:");
+    // Clarification retry was needed: 4 resume calls.
+    expect(agentB.resume).toHaveBeenCalledTimes(4);
+  });
+
+  test("returns error when unresolved verdict clarification retry fails", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Review posted.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 2) {
+          return makeStream(
+            makeResult({ responseText: "Nothing unresolved." }),
+          );
+        }
+        if (bResumeCall === 3) {
+          // ambiguous verdict
+          return makeStream(makeResult({ responseText: "I think NONE" }));
+        }
+        // clarification retry — error
+        return makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            responseText: "agent crashed",
+          }),
+        );
+      }),
+    };
+
+    const opts = makeOpts({ agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("unresolved summary clarification");
+  });
+
+  test("includes summary text when unresolved verdict stays ambiguous after retry", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b",
+            responseText: "Review posted.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          return makeStream(makeResult({ responseText: "APPROVED" }));
+        }
+        if (bResumeCall === 2) {
+          // unresolved summary work step
+          return makeStream(
+            makeResult({
+              responseText:
+                "**[Reviewer Unresolved Round 1]**\n- Item still open",
+            }),
+          );
+        }
+        if (bResumeCall === 3) {
+          // unresolved verdict — ambiguous
+          return makeStream(
+            makeResult({ responseText: "I'm not sure, maybe COMPLETED" }),
+          );
+        }
+        // clarification retry — still ambiguous
+        return makeStream(
+          makeResult({ responseText: "Well, it could be either one" }),
+        );
+      }),
+    };
+
+    const opts = makeOpts({ agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    // Conservatively includes the summary text and proceeds to PR
+    // finalization (default agentA mock handles it).
+    expect(result.outcome).toBe("completed");
+    expect(agentB.resume).toHaveBeenCalledTimes(4);
+  });
+
+  test("uses verdict session ID for unresolved summary when verdict advances session", async () => {
+    let bResumeCall = 0;
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b-initial",
+            responseText: "Review posted.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => {
+        bResumeCall++;
+        if (bResumeCall === 1) {
+          // 1st resume: review verdict — returns a NEW session ID
+          return makeStream(
+            makeResult({
+              sessionId: "sess-b-after-verdict",
+              responseText: "APPROVED",
+            }),
+          );
+        }
+        if (bResumeCall === 2) {
+          // 2nd resume: unresolved summary work step
+          return makeStream(
+            makeResult({ responseText: "Nothing unresolved." }),
+          );
+        }
+        // 3rd resume: unresolved verdict
+        return makeStream(makeResult({ responseText: "NONE" }));
+      }),
+    };
+
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR finalized." })),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
+    };
+
+    const opts = makeOpts({ agentB, agentA });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    // The unresolved summary (2nd resume) must use the session ID
+    // returned by the verdict step, not the initial invoke session.
+    const calls = (agentB.resume as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[1][0]).toBe("sess-b-after-verdict");
+  });
+
+  test("throws when B returns no sessionId (verdict follow-up needs session)", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -889,12 +1531,7 @@ describe("createReviewStageHandler", () => {
 
     const opts = makeOpts({ agentB });
     const stage = createReviewStageHandler(opts);
-    const result = await stage.handler(BASE_CTX);
-
-    expect(result.outcome).toBe("completed");
-    // invoke called twice: once for review, once for unresolved summary
-    expect(agentB.invoke).toHaveBeenCalledTimes(2);
-    expect(agentB.resume).not.toHaveBeenCalled();
+    await expect(stage.handler(BASE_CTX)).rejects.toThrow("no session ID");
   });
 
   // -- PR finalization on approval ---------------------------------------------
@@ -933,42 +1570,239 @@ describe("createReviewStageHandler", () => {
     expect(result.message).toContain("PR finalization");
   });
 
-  test("returns needs_clarification when finalization lacks PR_FINALIZED", async () => {
+  test("proceeds as completed when finalization verdict is ambiguous but PR body has issue reference", async () => {
     const agentA: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
+            sessionId: "sess-a",
             responseText: "I could not update the PR body.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      // Verdict follow-up also lacks PR_FINALIZED, and clarification retry too.
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "I still could not finalize.",
+          }),
+        ),
+      ),
     };
 
-    const opts = makeOpts({ agentA });
+    const getPrBody = vi.fn().mockReturnValue("Closes #42");
+    const opts = makeOpts({ agentA, getPrBody });
     const stage = createReviewStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
+    // Closes #N with no "## Not addressed" — consistent, safe to proceed.
+    expect(result.outcome).toBe("completed");
+    expect(getPrBody).toHaveBeenCalledWith("org", "repo", "issue-42");
   });
 
-  test("returns needs_clarification when finalization replies APPROVED without PR_FINALIZED", async () => {
+  test("returns blocked when finalization verdict is ambiguous and PR body lacks issue reference", async () => {
     const agentA: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
+            sessionId: "sess-a",
+            responseText: "I could not update the PR body.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "I still could not finalize.",
+          }),
+        ),
+      ),
+    };
+
+    const getPrBody = vi.fn().mockReturnValue("Some PR body without ref");
+    const opts = makeOpts({ agentA, getPrBody });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("#42");
+  });
+
+  test("returns blocked when finalization verdict replies APPROVED and PR body lacks issue reference", async () => {
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Done.",
+          }),
+        ),
+      ),
+      // Verdict follow-up says APPROVED (wrong keyword), clarification retry too.
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
             responseText: "APPROVED",
           }),
         ),
       ),
-      resume: vi.fn(),
     };
 
-    const opts = makeOpts({ agentA });
+    const getPrBody = vi.fn().mockReturnValue("No issue ref here");
+    const opts = makeOpts({ agentA, getPrBody });
     const stage = createReviewStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("proceeds as completed when finalization verdict replies APPROVED but PR body has Part of ref", async () => {
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Done.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "APPROVED",
+          }),
+        ),
+      ),
+    };
+
+    const getPrBody = vi
+      .fn()
+      .mockReturnValue("Part of #42\n\n## Not addressed\n- item");
+    const opts = makeOpts({ agentA, getPrBody });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("blocks when Part of ref is present but ## Not addressed section is missing", async () => {
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Done.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "APPROVED",
+          }),
+        ),
+      ),
+    };
+
+    const getPrBody = vi.fn().mockReturnValue("Part of #42");
+    const opts = makeOpts({ agentA, getPrBody });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("blocks when Closes ref is present alongside contradictory ## Not addressed section", async () => {
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Done.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "APPROVED",
+          }),
+        ),
+      ),
+    };
+
+    const getPrBody = vi
+      .fn()
+      .mockReturnValue("Closes #42\n\n## Not addressed\n- item");
+    const opts = makeOpts({ agentA, getPrBody });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("blocks when both Closes and Part of refs are present without ## Not addressed", async () => {
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Done.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "APPROVED",
+          }),
+        ),
+      ),
+    };
+
+    const getPrBody = vi.fn().mockReturnValue("Closes #42\nPart of #42");
+    const opts = makeOpts({ agentA, getPrBody });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+  });
+
+  test("blocks when both Closes and Part of refs are present with ## Not addressed", async () => {
+    const agentA: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a",
+            responseText: "Done.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-a2",
+            responseText: "APPROVED",
+          }),
+        ),
+      ),
+    };
+
+    const getPrBody = vi
+      .fn()
+      .mockReturnValue("Closes #42\nPart of #42\n\n## Not addressed\n- item");
+    const opts = makeOpts({ agentA, getPrBody });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
   });
 
   test("reports Agent A session ID after PR finalization", async () => {
@@ -978,11 +1812,16 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-a-fin",
-            responseText: "PR_FINALIZED",
+            responseText: "I verified the PR body.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      // Verdict follow-up: PR_FINALIZED
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
     };
 
     const opts = makeOpts({ agentA });
@@ -1016,7 +1855,7 @@ describe("createReviewStageHandler", () => {
 
   // -- ambiguous does not invoke Agent A --------------------------------------
 
-  test("does not invoke Agent A when review is ambiguous", async () => {
+  test("does not invoke Agent A when review verdict is ambiguous", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -1026,7 +1865,15 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: ambiguous verdict, 2nd: still ambiguous after clarification
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b2",
+            responseText: "I think it is fine.",
+          }),
+        ),
+      ),
     };
 
     const opts = makeOpts({ agentB });
@@ -1048,12 +1895,30 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
     };
 
     const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
     const getHeadSha = vi.fn().mockReturnValue("deadbeef");
-    const opts = makeOpts({ agentB, getCiStatus, getHeadSha });
+    const opts = makeOpts({ agentA, agentB, getCiStatus, getHeadSha });
     const stage = createReviewStageHandler(opts);
     await stage.handler(BASE_CTX);
 
@@ -1078,7 +1943,25 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
     };
 
     const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pending"));
@@ -1090,6 +1973,7 @@ describe("createReviewStageHandler", () => {
     vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
 
     const opts = makeOpts({
+      agentA,
       agentB,
       getCiStatus,
       delay,
@@ -1115,21 +1999,43 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-b",
-            responseText: "Needs changes.\n\nNOT_APPROVED",
+            responseText: "Needs changes.",
           }),
         ),
       ),
-      resume: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            responseText:
-              "**[Reviewer Unresolved Round 1]**\n- Missing validation in handler",
-          }),
-        ),
-      ),
+      resume: vi
+        .fn()
+        // 1st resume: review verdict (NOT_APPROVED)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        )
+        // 2nd resume: unresolved summary (items found)
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              responseText:
+                "**[Reviewer Unresolved Round 1]**\n- Missing validation in handler",
+            }),
+          ),
+        )
+        // 3rd resume: unresolved verdict (COMPLETED)
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
     };
 
-    const opts = makeOpts({ agentB });
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+
+    const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
     const ctx = { ...BASE_CTX, lastAutoIteration: true };
     const result = await stage.handler(ctx);
@@ -1137,11 +2043,9 @@ describe("createReviewStageHandler", () => {
     expect(result.outcome).toBe("not_approved");
     expect(result.message).toContain("Unresolved items:");
     expect(result.message).toContain("Missing validation in handler");
-    expect(agentB.resume).toHaveBeenCalledWith(
-      "sess-b",
-      expect.stringContaining("unresolved"),
-      { cwd: "/tmp/wt" },
-    );
+    // 2nd resume call should be the unresolved summary prompt.
+    const calls = (agentB.resume as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[1][1]).toContain("unresolved");
   });
 
   test("skips unresolved summary on NOT_APPROVED when lastAutoIteration is false", async () => {
@@ -1150,21 +2054,39 @@ describe("createReviewStageHandler", () => {
         makeStream(
           makeResult({
             sessionId: "sess-b",
-            responseText: "Needs changes.\n\nNOT_APPROVED",
+            responseText: "Needs changes.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict (NOT_APPROVED)
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
-    const opts = makeOpts({ agentB });
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+
+    const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("not_approved");
     expect(result.message).not.toContain("Unresolved items:");
-    // Agent B resume should not be called (no unresolved summary request).
-    expect(agentB.resume).not.toHaveBeenCalled();
+    // Agent B resume is called once for the verdict, but not for unresolved summary.
+    expect(agentB.resume).toHaveBeenCalledTimes(1);
   });
 
   test("returns error when unresolved summary fails on lastAutoIteration", async () => {
@@ -1177,19 +2099,39 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn().mockReturnValue(
-        makeStream(
-          makeResult({
-            status: "error",
-            errorType: "execution_error",
-            stderrText: "crash",
-            responseText: "",
-          }),
+      resume: vi
+        .fn()
+        // 1st resume: review verdict (NOT_APPROVED)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        )
+        // 2nd resume: unresolved summary (error)
+        .mockReturnValue(
+          makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "crash",
+              responseText: "",
+            }),
+          ),
         ),
-      ),
     };
 
-    const opts = makeOpts({ agentB });
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+
+    const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
     const ctx = { ...BASE_CTX, lastAutoIteration: true };
     const result = await stage.handler(ctx);
@@ -1210,10 +2152,32 @@ describe("createReviewStageHandler", () => {
       ),
       resume: vi
         .fn()
+        // 1st resume: review verdict (NOT_APPROVED)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        )
+        // 2nd resume: unresolved summary (some text)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "Nothing unresolved." })),
+        )
+        // 3rd resume: unresolved verdict (NONE)
         .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
     };
 
-    const opts = makeOpts({ agentB });
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+
+    const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
     const ctx = { ...BASE_CTX, lastAutoIteration: true };
     const result = await stage.handler(ctx);
@@ -1222,31 +2186,23 @@ describe("createReviewStageHandler", () => {
     expect(result.message).not.toContain("Unresolved items:");
   });
 
-  test("invokes fresh when sessionId is undefined for unresolved summary on lastAutoIteration", async () => {
+  test("throws when B returns no sessionId on lastAutoIteration (verdict follow-up needs session)", async () => {
     const agentB: AgentAdapter = {
-      invoke: vi
-        .fn()
-        .mockReturnValueOnce(
-          makeStream(
-            makeResult({
-              sessionId: undefined,
-              responseText: "NOT_APPROVED",
-            }),
-          ),
-        )
-        .mockReturnValueOnce(makeStream(makeResult({ responseText: "NONE" }))),
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: undefined,
+            responseText: "NOT_APPROVED",
+          }),
+        ),
+      ),
       resume: vi.fn(),
     };
 
     const opts = makeOpts({ agentB });
     const stage = createReviewStageHandler(opts);
     const ctx = { ...BASE_CTX, lastAutoIteration: true };
-    const result = await stage.handler(ctx);
-
-    expect(result.outcome).toBe("not_approved");
-    // invoke called twice: once for review, once for unresolved summary (fresh)
-    expect(agentB.invoke).toHaveBeenCalledTimes(2);
-    expect(agentB.resume).not.toHaveBeenCalled();
+    await expect(stage.handler(ctx)).rejects.toThrow("no session ID");
   });
 
   // -- CI passes after fix on second attempt ----------------------------------
@@ -1261,7 +2217,12 @@ describe("createReviewStageHandler", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
 
     const getCiStatus = vi
@@ -1309,11 +2270,20 @@ describe("onSessionId", () => {
         .fn()
         .mockReturnValue(
           makeStream(
-            makeResult({ sessionId: "sess-b-1", responseText: "APPROVED" }),
+            makeResult({ sessionId: "sess-b-1", responseText: "Looks good." }),
           ),
         ),
       resume: vi
         .fn()
+        // 1st resume: review verdict (APPROVED)
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "APPROVED" })),
+        )
+        // 2nd resume: unresolved summary
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "Nothing." })),
+        )
+        // 3rd resume: unresolved verdict (NONE)
         .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
     };
     const agentA: AgentAdapter = {
@@ -1321,11 +2291,16 @@ describe("onSessionId", () => {
         makeStream(
           makeResult({
             sessionId: "sess-a-fin",
-            responseText: "PR_FINALIZED",
+            responseText: "I verified the PR body.",
           }),
         ),
       ),
-      resume: vi.fn(),
+      // Verdict follow-up: PR_FINALIZED
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "PR_FINALIZED" })),
+        ),
     };
     const opts = makeOpts({ agentA, agentB });
     const stage = createReviewStageHandler(opts);
@@ -1348,14 +2323,19 @@ describe("onSessionId", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // 1st resume: review verdict
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
     };
     const agentA: AgentAdapter = {
       invoke: vi
         .fn()
         .mockReturnValue(
           makeStream(
-            makeResult({ sessionId: "sess-a-1", responseText: "COMPLETED" }),
+            makeResult({ sessionId: "sess-a-1", responseText: "Fixed." }),
           ),
         ),
       resume: vi

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -2,14 +2,17 @@
  * Stage 7 — Review loop.
  *
  * Multi-agent flow per iteration:
- *   1. Agent B posts a review prefixed with `[Reviewer Round {n}]`,
- *      ending with APPROVED or NOT_APPROVED.
- *   2. If APPROVED — Agent B summarises unresolved items (or NONE),
- *      and the stage completes.
- *   3. If NOT_APPROVED:
+ *   1. Agent B posts a review prefixed with `[Reviewer Round {n}]`.
+ *   2. A dedicated verdict follow-up asks Agent B for exactly
+ *      APPROVED or NOT_APPROVED — the review text is **not** parsed
+ *      for keywords.
+ *   3. If APPROVED — Agent B summarises unresolved items (or NONE),
+ *      Agent A performs PR finalization (verdict: PR_FINALIZED), and
+ *      the stage completes.
+ *   4. If NOT_APPROVED:
  *      a. Agent A reads the review, fixes issues, and posts a response
  *         prefixed with `[Author Round {n}]`.
- *      b. Completion check on Agent A.
+ *      b. Completion check on Agent A (verdict: COMPLETED / BLOCKED).
  *      c. Internal CI poll + fix loop.
  *      d. Returns `"not_approved"` so the pipeline engine loops for
  *         the next review round.
@@ -29,6 +32,7 @@ import { pollCiAndFix } from "./ci-poll.js";
 import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
+import { getPrBody as defaultGetPrBody } from "./pr.js";
 import {
   buildDocConsistencyInstructions,
   drainToSink,
@@ -40,7 +44,11 @@ import {
   sendFollowUp,
   type UsageSink,
 } from "./stage-util.js";
-import { parseStepStatus } from "./step-parser.js";
+import {
+  buildClarificationPrompt,
+  parseStepStatus,
+  parseVerdictKeyword,
+} from "./step-parser.js";
 
 // ---- public types ------------------------------------------------------------
 
@@ -62,6 +70,12 @@ export interface ReviewStageOptions {
   maxFixAttempts?: number;
   /** Injected for testability. */
   delay?: (ms: number) => Promise<void>;
+  /** Injected for testability. Defaults to `pr.getPrBody`. */
+  getPrBody?: (
+    owner: string,
+    repo: string,
+    branch: string,
+  ) => string | undefined;
 }
 
 // ---- prompt builders ---------------------------------------------------------
@@ -152,7 +166,6 @@ export function buildReviewPrompt(
       `   specific. Cite file paths and line numbers when they help;`,
       `   for broader concerns, explain the concern at the`,
       `   appropriate level.`,
-      `5. End your response with one of these keywords:`,
     );
   } else {
     lines.push(
@@ -162,20 +175,56 @@ export function buildReviewPrompt(
       `   \`**[Reviewer Round ${round}]**\`. Be specific. Cite file paths and`,
       `   line numbers when they help; for broader concerns, explain`,
       `   the concern at the appropriate level.`,
-      `4. End your response with one of these keywords:`,
     );
   }
-
-  lines.push(
-    `   - APPROVED — if the changes are ready to merge`,
-    `   - NOT_APPROVED — if changes are needed`,
-  );
 
   if (ctx.userInstruction) {
     lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
   }
 
   return lines.join("\n");
+}
+
+export const REVIEW_VERDICT_KEYWORDS = ["APPROVED", "NOT_APPROVED"] as const;
+
+export function buildReviewVerdictPrompt(): string {
+  return [
+    `You have posted your review comment.`,
+    `Respond with exactly one of the following keywords:`,
+    ``,
+    `- APPROVED — if the changes are ready to merge`,
+    `- NOT_APPROVED — if changes are needed`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
+  ].join("\n");
+}
+
+export const AUTHOR_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
+
+export const UNRESOLVED_KEYWORDS = ["NONE", "COMPLETED"] as const;
+
+export function buildUnresolvedVerdictPrompt(): string {
+  return [
+    `Respond with exactly one of the following keywords:`,
+    ``,
+    `- NONE — if there are no unresolved items`,
+    `- COMPLETED — if you posted the unresolved items comment`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
+  ].join("\n");
+}
+
+export const PR_FINALIZATION_KEYWORDS = ["PR_FINALIZED"] as const;
+
+export function buildPrFinalizationVerdictPrompt(): string {
+  return [
+    `You have finished verifying the PR body.`,
+    `Respond with exactly one of the following keywords:`,
+    ``,
+    `- PR_FINALIZED — if the PR body is now accurate`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
+  ].join("\n");
 }
 
 export function buildAuthorFixPrompt(
@@ -219,6 +268,8 @@ export function buildAuthorCompletionCheckPrompt(): string {
     ``,
     `- COMPLETED — if all feedback was addressed and changes were pushed`,
     `- BLOCKED — if you cannot proceed and need user intervention`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
   ].join("\n");
 }
 
@@ -229,8 +280,8 @@ export function buildUnresolvedSummaryPrompt(round: number): string {
     ``,
     `- If there are unresolved items, post a PR comment prefixed with`,
     `  \`**[Reviewer Unresolved Round ${round}]**\` listing each unresolved item.`,
-    `  Then end your response with COMPLETED.`,
-    `- If there are no unresolved items, respond with exactly: NONE`,
+    `- If there are no unresolved items, simply confirm that there is`,
+    `  nothing left to address.`,
   ].join("\n");
 }
 
@@ -266,8 +317,17 @@ export function buildPrFinalizationPrompt(
     `   were not implemented and why.`,
     `4. If the reference or "## Not addressed" section needs to change,`,
     `   update the PR body using \`gh pr edit --body "..."\`.`,
-    `5. End your response with PR_FINALIZED.`,
   ].join("\n");
+}
+
+/**
+ * Check whether the response is exactly the PR_FINALIZED keyword.
+ * Uses the strict verdict parser to reject extra commentary.
+ */
+function hasFinalizationKeyword(text: string): boolean {
+  return (
+    parseVerdictKeyword(text, PR_FINALIZATION_KEYWORDS).keyword !== undefined
+  );
 }
 
 // ---- handler -----------------------------------------------------------------
@@ -302,14 +362,68 @@ export function createReviewStageHandler(
         return mapAgentError(reviewResult, "during review");
       }
 
-      // Parse review verdict.
-      const reviewParsed = parseStepStatus(reviewResult.responseText);
+      // Verdict follow-up: ask B for exactly APPROVED / NOT_APPROVED.
+      const verdictPrompt = buildReviewVerdictPrompt();
+      ctx.promptSinks?.b?.(verdictPrompt);
+      let verdictResult = await sendFollowUp(
+        opts.agentB,
+        reviewResult.sessionId,
+        verdictPrompt,
+        ctx.worktreePath,
+        ctx.streamSinks?.b,
+        undefined,
+        ctx.usageSinks?.b,
+      );
+
+      if (verdictResult.status === "error") {
+        return mapAgentError(verdictResult, "during review verdict");
+      }
+
+      let reviewVerdict = parseVerdictKeyword(
+        verdictResult.responseText,
+        REVIEW_VERDICT_KEYWORDS,
+      );
+
+      // Clarification retry if ambiguous, extra commentary, or
+      // multiple valid keywords.
+      if (reviewVerdict.keyword === undefined) {
+        const clarifyPrompt = buildClarificationPrompt(
+          verdictResult.responseText,
+          REVIEW_VERDICT_KEYWORDS,
+        );
+        ctx.promptSinks?.b?.(clarifyPrompt);
+        const retryResult = await sendFollowUp(
+          opts.agentB,
+          verdictResult.sessionId ?? reviewResult.sessionId,
+          clarifyPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.b,
+          undefined,
+          ctx.usageSinks?.b,
+        );
+
+        if (retryResult.status === "error") {
+          return mapAgentError(
+            retryResult,
+            "during review verdict clarification",
+          );
+        }
+
+        verdictResult = retryResult;
+        reviewVerdict = parseVerdictKeyword(
+          verdictResult.responseText,
+          REVIEW_VERDICT_KEYWORDS,
+        );
+      }
 
       // Step 2: If approved — ask B for unresolved summary, then complete.
+      const reviewParsed = reviewVerdict.keyword
+        ? parseStepStatus(reviewVerdict.keyword)
+        : { status: "ambiguous" as const, keyword: undefined };
       if (reviewParsed.status === "approved") {
         const { error, summary } = await handleUnresolvedSummary(
           opts,
-          reviewResult.sessionId,
+          verdictResult.sessionId ?? reviewResult.sessionId,
           round,
           ctx.worktreePath,
           ctx.streamSinks?.b,
@@ -340,11 +454,94 @@ export function createReviewStageHandler(
           return mapAgentError(finalizeResult, "during PR finalization");
         }
 
-        if (!finalizeResult.responseText.includes("PR_FINALIZED")) {
-          return {
-            outcome: "needs_clarification",
-            message: finalizeResult.responseText,
-          };
+        // Verdict follow-up: ask A for exactly PR_FINALIZED.
+        const finalVerdictPrompt = buildPrFinalizationVerdictPrompt();
+        ctx.promptSinks?.a?.(finalVerdictPrompt);
+        let finalVerdictResult = await sendFollowUp(
+          opts.agentA,
+          finalizeResult.sessionId,
+          finalVerdictPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+
+        if (finalVerdictResult.status === "error") {
+          return mapAgentError(
+            finalVerdictResult,
+            "during PR finalization verdict",
+          );
+        }
+
+        if (!hasFinalizationKeyword(finalVerdictResult.responseText)) {
+          // Clarification retry.
+          const clarifyPrompt = buildClarificationPrompt(
+            finalVerdictResult.responseText,
+            PR_FINALIZATION_KEYWORDS,
+          );
+          ctx.promptSinks?.a?.(clarifyPrompt);
+          const retryResult = await sendFollowUp(
+            opts.agentA,
+            finalVerdictResult.sessionId ?? finalizeResult.sessionId,
+            clarifyPrompt,
+            ctx.worktreePath,
+            ctx.streamSinks?.a,
+            undefined,
+            ctx.usageSinks?.a,
+          );
+
+          if (retryResult.status === "error") {
+            return mapAgentError(
+              retryResult,
+              "during PR finalization clarification",
+            );
+          }
+
+          finalVerdictResult = retryResult;
+        }
+
+        // If the keyword is still missing after the in-session retry,
+        // verify the PR body directly.  The squash stage short-circuits
+        // on single-commit branches, so we cannot rely on a later stage
+        // to catch a missing issue reference.
+        //
+        // The finalization contract requires an accurate PR body: the
+        // correct issue reference (Closes vs Part of) AND, when partial,
+        // a "## Not addressed" section.  A bare issue reference is not
+        // sufficient — we verify that "Closes" and "Part of" each pair
+        // with the expected companion state:
+        //   - Closes #N  → no "## Not addressed" (contradictory otherwise)
+        //   - Part of #N → "## Not addressed" must be present
+        if (!hasFinalizationKeyword(finalVerdictResult.responseText)) {
+          const getPrBody = opts.getPrBody ?? defaultGetPrBody;
+          const body = getPrBody(ctx.owner, ctx.repo, ctx.branch);
+
+          const closesRef =
+            body !== undefined &&
+            new RegExp(`Closes\\s+#${ctx.issueNumber}\\b`, "i").test(body);
+          const partOfRef =
+            body !== undefined &&
+            new RegExp(`Part of\\s+#${ctx.issueNumber}\\b`, "i").test(body);
+          const hasNotAddressed =
+            body !== undefined && /^## Not addressed/im.test(body);
+
+          // The body must contain exactly one reference form.  Both
+          // present is self-contradictory (closes implies full fix,
+          // "Part of" implies partial).  Then validate the companion:
+          //   - Closes #N  → no "## Not addressed" section
+          //   - Part of #N → "## Not addressed" must be present
+          const exclusiveRef = closesRef !== partOfRef;
+          const bodyValid =
+            exclusiveRef &&
+            ((closesRef && !hasNotAddressed) || (partOfRef && hasNotAddressed));
+
+          if (!bodyValid) {
+            return {
+              outcome: "blocked",
+              message: t()["review.finalizationUnverified"](ctx.issueNumber),
+            };
+          }
         }
 
         const m = t();
@@ -358,7 +555,11 @@ export function createReviewStageHandler(
 
       // Treat anything other than not_approved as ambiguous → needs_clarification.
       if (reviewParsed.status !== "not_approved") {
-        return mapResponseToResult(reviewResult.responseText);
+        return {
+          outcome: "needs_clarification",
+          message: verdictResult.responseText,
+          validVerdicts: REVIEW_VERDICT_KEYWORDS,
+        };
       }
 
       // Step 3: NOT_APPROVED — Agent A fixes (resume if saved session).
@@ -400,17 +601,21 @@ export function createReviewStageHandler(
         return mapAgentError(checkResult, "during author completion check");
       }
 
-      let checkMapped = mapResponseToResult(checkResult.responseText);
+      let checkMapped = mapResponseToResult(
+        checkResult.responseText,
+        undefined,
+        AUTHOR_CHECK_KEYWORDS,
+      );
 
-      if (
-        checkMapped.outcome === "needs_clarification" &&
-        checkResult.sessionId
-      ) {
-        const retryPrompt = buildAuthorCompletionCheckPrompt();
+      if (checkMapped.outcome === "needs_clarification") {
+        const retryPrompt = buildClarificationPrompt(
+          checkResult.responseText,
+          AUTHOR_CHECK_KEYWORDS,
+        );
         ctx.promptSinks?.a?.(retryPrompt);
         const retryResult = await sendFollowUp(
           opts.agentA,
-          checkResult.sessionId,
+          checkResult.sessionId ?? fixResult.sessionId,
           retryPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
@@ -426,17 +631,27 @@ export function createReviewStageHandler(
         }
 
         checkResult = retryResult;
-        checkMapped = mapResponseToResult(retryResult.responseText);
+        checkMapped = mapResponseToResult(
+          retryResult.responseText,
+          undefined,
+          AUTHOR_CHECK_KEYWORDS,
+        );
       }
 
-      if (checkMapped.outcome === "blocked") {
+      if (
+        checkMapped.outcome === "blocked" ||
+        checkMapped.outcome === "needs_clarification"
+      ) {
+        // Surface a blocked condition so the user can decide how to
+        // proceed.  Treating an ambiguous author-completion verdict as
+        // progress would poll stale CI on an unchanged head when the
+        // agent actually meant BLOCKED.
         return {
           outcome: "blocked",
           message: `${fixResult.responseText}\n\n---\n\n${checkResult.responseText}`,
         };
       }
 
-      // If still ambiguous or unexpected, bubble up to the engine.
       if (
         checkMapped.outcome !== "completed" &&
         checkMapped.outcome !== "fixed" &&
@@ -472,7 +687,7 @@ export function createReviewStageHandler(
       if (ctx.lastAutoIteration) {
         const { error, summary } = await handleUnresolvedSummary(
           opts,
-          reviewResult.sessionId,
+          verdictResult.sessionId ?? reviewResult.sessionId,
           round,
           ctx.worktreePath,
           ctx.streamSinks?.b,
@@ -544,11 +759,106 @@ async function handleUnresolvedSummary(
     };
   }
 
-  // Check whether Agent B said NONE.
-  const upper = result.responseText.trim().toUpperCase();
-  if (upper === "NONE" || upper.endsWith("NONE")) {
+  const summaryText = result.responseText;
+
+  // Verdict follow-up: ask for exactly NONE or COMPLETED.
+  const verdictPrompt = buildUnresolvedVerdictPrompt();
+  promptSink?.(verdictPrompt);
+  let verdictResult: AgentResult;
+  const verdictSessionId = result.sessionId ?? sessionId;
+
+  if (verdictSessionId) {
+    verdictResult = await sendFollowUp(
+      opts.agentB,
+      verdictSessionId,
+      verdictPrompt,
+      cwd,
+      sink,
+      undefined,
+      usageSink,
+    );
+  } else {
+    const stream = opts.agentB.invoke(verdictPrompt, {
+      cwd,
+      onUsage: usageSink,
+    });
+    if (sink) drainToSink(stream, sink);
+    verdictResult = await stream.result;
+  }
+
+  if (verdictResult.status === "error") {
+    return {
+      error: mapAgentError(verdictResult, "during unresolved summary verdict"),
+      summary: undefined,
+    };
+  }
+
+  // Check whether Agent B said NONE or COMPLETED using the strict parser.
+  let verdict = parseVerdictKeyword(
+    verdictResult.responseText,
+    UNRESOLVED_KEYWORDS,
+  );
+
+  // Clarification retry if the verdict is ambiguous or out-of-scope.
+  if (verdict.keyword === undefined) {
+    const clarifyPrompt = buildClarificationPrompt(
+      verdictResult.responseText,
+      UNRESOLVED_KEYWORDS,
+    );
+    promptSink?.(clarifyPrompt);
+
+    const verdictSessionId2 = verdictResult.sessionId ?? sessionId;
+    let retryResult: AgentResult;
+
+    if (verdictSessionId2) {
+      retryResult = await sendFollowUp(
+        opts.agentB,
+        verdictSessionId2,
+        clarifyPrompt,
+        cwd,
+        sink,
+        undefined,
+        usageSink,
+      );
+    } else {
+      const stream = opts.agentB.invoke(clarifyPrompt, {
+        cwd,
+        onUsage: usageSink,
+      });
+      if (sink) drainToSink(stream, sink);
+      retryResult = await stream.result;
+    }
+
+    if (retryResult.status === "error") {
+      return {
+        error: mapAgentError(
+          retryResult,
+          "during unresolved summary clarification",
+        ),
+        summary: undefined,
+      };
+    }
+
+    verdictResult = retryResult;
+    verdict = parseVerdictKeyword(
+      retryResult.responseText,
+      UNRESOLVED_KEYWORDS,
+    );
+  }
+
+  if (verdict.keyword?.toUpperCase() === "NONE") {
     return { error: undefined, summary: undefined };
   }
 
-  return { error: undefined, summary: result.responseText };
+  if (verdict.keyword?.toUpperCase() === "COMPLETED") {
+    return { error: undefined, summary: summaryText };
+  }
+
+  // Still ambiguous after retry — conservatively include the summary
+  // text rather than bubbling to the pipeline engine.  The engine
+  // would inject A-side clarification into Agent B's review prompt,
+  // which cannot resolve an Agent-B unresolved-summary verdict.
+  // Including the summary is the safe default: it surfaces unresolved
+  // items to the user instead of silently dropping them.
+  return { error: undefined, summary: summaryText };
 }

--- a/src/stage-selfcheck.test.ts
+++ b/src/stage-selfcheck.test.ts
@@ -3,8 +3,10 @@ import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import type { StageContext } from "./pipeline.js";
 import {
   buildFixOrDonePrompt,
+  buildFixOrDoneVerdictPrompt,
   buildSelfCheckPrompt,
   createSelfCheckStageHandler,
+  FIX_OR_DONE_KEYWORDS,
   type SelfCheckStageOptions,
 } from "./stage-selfcheck.js";
 
@@ -13,7 +15,7 @@ import {
 function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
   return {
     sessionId: "sess-1",
-    responseText: "All checks pass.\n\nDONE",
+    responseText: "All checks pass.",
     status: "success",
     errorType: undefined,
     stderrText: "",
@@ -31,12 +33,22 @@ function makeStream(result: AgentResult): AgentStream {
   };
 }
 
+/**
+ * Create a mock agent that returns the given results in sequence.
+ * The first call to `invoke` returns `invokeResult`.
+ * Subsequent calls to `resume` return from `resumeResults` in order.
+ */
 function makeAgent(
-  checkResult: AgentResult,
-  fixResult?: AgentResult,
+  invokeResult: AgentResult,
+  ...resumeResults: AgentResult[]
 ): AgentAdapter {
-  const invoke = vi.fn().mockReturnValue(makeStream(checkResult));
-  const resume = vi.fn().mockReturnValue(makeStream(fixResult ?? checkResult));
+  const invoke = vi.fn().mockReturnValue(makeStream(invokeResult));
+  let resumeCall = 0;
+  const resume = vi.fn().mockImplementation(() => {
+    const r = resumeResults[resumeCall] ?? invokeResult;
+    resumeCall++;
+    return makeStream(r);
+  });
   return { invoke, resume };
 }
 
@@ -55,7 +67,11 @@ function makeOpts(
   overrides: Partial<SelfCheckStageOptions> = {},
 ): SelfCheckStageOptions {
   return {
-    agent: makeAgent(makeResult()),
+    agent: makeAgent(
+      makeResult(),
+      makeResult(),
+      makeResult({ responseText: "DONE" }),
+    ),
     issueTitle: "Fix the widget",
     issueBody: "The widget is broken.",
     ...overrides,
@@ -129,10 +145,32 @@ describe("buildSelfCheckPrompt", () => {
 // ---- buildFixOrDonePrompt --------------------------------------------------
 
 describe("buildFixOrDonePrompt", () => {
-  test("mentions FIXED and DONE keywords", () => {
+  test("mentions fix and done actions without verdict keywords", () => {
     const prompt = buildFixOrDonePrompt();
+    expect(prompt).toContain("fix them now");
+    expect(prompt).toContain("you are done");
+    // Should NOT contain the verdict keywords — those are in the verdict prompt
+    expect(prompt).not.toContain("FIXED");
+    expect(prompt).not.toContain("DONE");
+  });
+});
+
+// ---- buildFixOrDoneVerdictPrompt -------------------------------------------
+
+describe("buildFixOrDoneVerdictPrompt", () => {
+  test("mentions FIXED and DONE keywords", () => {
+    const prompt = buildFixOrDoneVerdictPrompt();
     expect(prompt).toContain("FIXED");
     expect(prompt).toContain("DONE");
+  });
+});
+
+// ---- FIX_OR_DONE_KEYWORDS --------------------------------------------------
+
+describe("FIX_OR_DONE_KEYWORDS", () => {
+  test("contains FIXED and DONE", () => {
+    expect(FIX_OR_DONE_KEYWORDS).toContain("FIXED");
+    expect(FIX_OR_DONE_KEYWORDS).toContain("DONE");
   });
 });
 
@@ -145,15 +183,23 @@ describe("createSelfCheckStageHandler", () => {
     expect(stage.name).toBe("Self-check");
   });
 
-  // -- two-step flow ---------------------------------------------------------
+  // -- three-step flow -------------------------------------------------------
 
-  test("invokes agent for self-check then resumes for fix-or-done", async () => {
+  test("invokes agent for self-check then resumes for fix-or-done and verdict", async () => {
     const checkResult = makeResult({
       sessionId: "sess-check",
       responseText: "Review done.",
     });
-    const fixResult = makeResult({ responseText: "All good.\n\nDONE" });
-    const agent = makeAgent(checkResult, fixResult);
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.",
+    });
+    // Use FIXED to avoid triggering issue sync (which would add more resume calls).
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "FIXED",
+    });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const stage = createSelfCheckStageHandler(makeOpts({ agent }));
 
     await stage.handler(BASE_CTX);
@@ -161,8 +207,17 @@ describe("createSelfCheckStageHandler", () => {
     expect(agent.invoke).toHaveBeenCalledWith(expect.any(String), {
       cwd: "/tmp/wt",
     });
-    expect(agent.resume).toHaveBeenCalledWith(
+    // Two resume calls: fix-or-done work + verdict
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(agent.resume).toHaveBeenNthCalledWith(
+      1,
       "sess-check",
+      expect.any(String),
+      { cwd: "/tmp/wt" },
+    );
+    expect(agent.resume).toHaveBeenNthCalledWith(
+      2,
+      "sess-fix",
       expect.any(String),
       { cwd: "/tmp/wt" },
     );
@@ -176,64 +231,198 @@ describe("createSelfCheckStageHandler", () => {
     await expect(stage.handler(BASE_CTX)).rejects.toThrow("no session ID");
   });
 
-  // -- outcome mapping: DONE vs FIXED ---------------------------------------
+  // -- outcome mapping: DONE vs FIXED ----------------------------------------
 
-  test("returns completed when agent says DONE", async () => {
+  test("returns completed when verdict says DONE", async () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
-      responseText: "Everything is fine.\n\nDONE",
+      sessionId: "sess-fix",
+      responseText: "Everything is fine.",
     });
-    const agent = makeAgent(checkResult, fixResult);
+    const verdictResult = makeResult({ responseText: "DONE" });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const stage = createSelfCheckStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("completed");
   });
 
-  test("returns not_approved when agent says FIXED (triggers loop)", async () => {
-    const checkResult = makeResult({ sessionId: "sess-1" });
-    const fixResult = makeResult({ responseText: "Fixed the test.\n\nFIXED" });
-    const agent = makeAgent(checkResult, fixResult);
-    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
-    const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("not_approved");
-  });
-
-  test("returns completed when agent says COMPLETED", async () => {
-    const checkResult = makeResult({ sessionId: "sess-1" });
-    const fixResult = makeResult({ responseText: "All set.\n\nCOMPLETED" });
-    const agent = makeAgent(checkResult, fixResult);
-    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
-    const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("completed");
-  });
-
-  test("returns blocked when agent says BLOCKED", async () => {
-    const checkResult = makeResult({ sessionId: "sess-1" });
-    const fixResult = makeResult({ responseText: "Cannot fix.\n\nBLOCKED" });
-    const agent = makeAgent(checkResult, fixResult);
-    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
-    const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("blocked");
-  });
-
-  test("returns not_approved on NOT_APPROVED", async () => {
+  test("returns not_approved when verdict says FIXED (triggers loop)", async () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
-      responseText: "Not right.\n\nNOT_APPROVED",
+      sessionId: "sess-fix",
+      responseText: "Fixed the test.",
     });
-    const agent = makeAgent(checkResult, fixResult);
+    const verdictResult = makeResult({ responseText: "FIXED" });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const stage = createSelfCheckStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("not_approved");
   });
 
-  test("returns needs_clarification on ambiguous fix response", async () => {
+  test("out-of-scope keyword COMPLETED → clarification retry → fallback to not_approved", async () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
-    const fixResult = makeResult({ responseText: "I looked at things." });
-    const agent = makeAgent(checkResult, fixResult);
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All set.",
+    });
+    const verdictResult = makeResult({ responseText: "COMPLETED" });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const stage = createSelfCheckStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("needs_clarification");
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("out-of-scope keyword BLOCKED → clarification retry → fallback to not_approved", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Cannot fix.",
+    });
+    const verdictResult = makeResult({ responseText: "BLOCKED" });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("out-of-scope keyword NOT_APPROVED → clarification retry → fallback to not_approved", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Not right.",
+    });
+    const verdictResult = makeResult({ responseText: "NOT_APPROVED" });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("ambiguous verdict response → clarification retry → fallback to not_approved", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "I looked at things.",
+    });
+    const verdictResult = makeResult({ responseText: "I looked at things." });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  // -- internal clarification retry ------------------------------------------
+
+  test("ambiguous verdict → internal clarification → DONE", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Checked.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "I think it looks good",
+    });
+    const clarifiedResult = makeResult({
+      sessionId: "sess-clarified",
+      responseText: "DONE",
+    });
+    const syncWorkResult = makeResult({
+      sessionId: "sess-sync",
+      responseText: "Compared.",
+    });
+    const syncVerdictResult = makeResult({
+      responseText: "ISSUE_NO_CHANGES",
+    });
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      clarifiedResult,
+      syncWorkResult,
+      syncVerdictResult,
+    );
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // (fix-or-done + verdict + clarification + issue sync + sync verdict)
+    expect(agent.resume).toHaveBeenCalledTimes(5);
+  });
+
+  test("out-of-scope COMPLETED → internal clarification → FIXED", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Fixed things.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "COMPLETED",
+    });
+    const clarifiedResult = makeResult({ responseText: "FIXED" });
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      clarifiedResult,
+    );
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("not_approved");
+    expect(agent.resume).toHaveBeenCalledTimes(3);
+  });
+
+  test("ambiguous verdict → clarification also ambiguous → fallback to not_approved", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Checked.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "Looks fine",
+    });
+    const stillAmbiguous = makeResult({ responseText: "It is fine" });
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      stillAmbiguous,
+    );
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    // Falls back to not_approved so the pipeline loops the self-check
+    // again rather than advancing past an uncertain verdict.
+    expect(result.outcome).toBe("not_approved");
+    // 3 verdict-related resumes only — issue sync does not run.
+    expect(agent.resume).toHaveBeenCalledTimes(3);
+  });
+
+  test("clarification retry error → returns error", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Checked.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "I think so",
+    });
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "clarify crash",
+      responseText: "",
+    });
+    const agent = makeAgent(checkResult, fixResult, verdictResult, errorResult);
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("clarify crash");
   });
 
   // -- error handling --------------------------------------------------------
@@ -286,16 +475,40 @@ describe("createSelfCheckStageHandler", () => {
     expect(result.message).toContain("during fix");
   });
 
-  // -- message preservation --------------------------------------------------
-
-  test("preserves fix response text in message", async () => {
-    const text = "Fixed several issues.\n\nFIXED";
+  test("returns error when verdict follow-up fails", async () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
-    const fixResult = makeResult({ responseText: text });
-    const agent = makeAgent(checkResult, fixResult);
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Did some work.",
+    });
+    const verdictResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "verdict crash",
+      responseText: "",
+    });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const stage = createSelfCheckStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.message).toBe(text);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("verdict crash");
+    expect(result.message).toContain("during fix verdict");
+  });
+
+  // -- message preservation --------------------------------------------------
+
+  test("preserves verdict response text in message", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "Fixed several issues.",
+    });
+    const verdictResult = makeResult({ responseText: "FIXED" });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
+    const stage = createSelfCheckStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.message).toBe("FIXED");
   });
 
   // -- issue sync step -------------------------------------------------------
@@ -304,20 +517,27 @@ describe("createSelfCheckStageHandler", () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "All good.\n\nDONE",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
     });
     const syncResult = makeResult({
-      responseText: "Everything matches.\n\nISSUE_NO_CHANGES",
+      sessionId: "sess-sync",
+      responseText: "Compared implementation.",
+    });
+    const syncVerdictResult = makeResult({
+      responseText: "ISSUE_NO_CHANGES",
     });
 
-    let resumeCall = 0;
-    const resumeResults = [fixResult, syncResult];
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
-      resume: vi
-        .fn()
-        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
-    };
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+    );
     const onIssueSyncStatus = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueSyncStatus }),
@@ -331,17 +551,62 @@ describe("createSelfCheckStageHandler", () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "All good.\n\nDONE",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
     });
 
     let resumeCall = 0;
+    const resumeResults = [fixResult, verdictResult];
     const agent: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
       resume: vi.fn().mockImplementation(() => {
-        if (resumeCall++ === 0) return makeStream(fixResult);
+        if (resumeCall < resumeResults.length) {
+          return makeStream(resumeResults[resumeCall++]);
+        }
+        resumeCall++;
         throw new Error("network error");
       }),
     };
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueSyncStatus }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("failed");
+  });
+
+  test("reports failed sync status when sync verdict follow-up returns error", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
+    });
+    const syncResult = makeResult({
+      sessionId: "sess-sync",
+      responseText: "Compared implementation.",
+    });
+    const syncVerdictResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      responseText: "",
+    });
+
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+    );
     const onIssueSyncStatus = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueSyncStatus }),
@@ -356,21 +621,27 @@ describe("createSelfCheckStageHandler", () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "All good.\n\nDONE",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
     });
     const syncResult = makeResult({
-      responseText:
-        "Compared implementation.\n\nISSUE_UPDATED: corrected file path",
+      sessionId: "sess-sync",
+      responseText: "Compared implementation.",
+    });
+    const syncVerdictResult = makeResult({
+      responseText: "ISSUE_UPDATED: corrected file path",
     });
 
-    let resumeCall = 0;
-    const resumeResults = [fixResult, syncResult];
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
-      resume: vi
-        .fn()
-        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
-    };
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+    );
     const onIssueChange = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueChange }),
@@ -378,7 +649,8 @@ describe("createSelfCheckStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("completed");
-    expect(agent.resume).toHaveBeenCalledTimes(2);
+    // 4 resume calls: fix work, verdict, sync work, sync verdict
+    expect(agent.resume).toHaveBeenCalledTimes(4);
     expect(onIssueChange).toHaveBeenCalledWith({
       type: "minor",
       description: "corrected file path",
@@ -389,20 +661,27 @@ describe("createSelfCheckStageHandler", () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "All good.\n\nDONE",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
     });
     const syncResult = makeResult({
+      sessionId: "sess-sync",
+      responseText: "Synced.",
+    });
+    const syncVerdictResult = makeResult({
       responseText: "ISSUE_COMMENTED: uses WebSocket instead of polling",
     });
 
-    let resumeCall = 0;
-    const resumeResults = [fixResult, syncResult];
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
-      resume: vi
-        .fn()
-        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
-    };
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+    );
     const onIssueChange = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueChange }),
@@ -415,13 +694,17 @@ describe("createSelfCheckStageHandler", () => {
     });
   });
 
-  test("skips issue sync when fix response is FIXED (not DONE)", async () => {
+  test("skips issue sync when verdict response is FIXED (not DONE)", async () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "Fixed.\n\nFIXED",
+      responseText: "Fixed.",
     });
-    const agent = makeAgent(checkResult, fixResult);
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "FIXED",
+    });
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const onIssueChange = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueChange }),
@@ -429,8 +712,8 @@ describe("createSelfCheckStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("not_approved");
-    // Only one resume call (fix-or-done), no issue sync
-    expect(agent.resume).toHaveBeenCalledTimes(1);
+    // Two resume calls: fix-or-done work + verdict, no issue sync
+    expect(agent.resume).toHaveBeenCalledTimes(2);
     expect(onIssueChange).not.toHaveBeenCalled();
   });
 
@@ -438,20 +721,27 @@ describe("createSelfCheckStageHandler", () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "All good.\n\nDONE",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
     });
     const syncResult = makeResult({
-      responseText: "Everything matches.\n\nISSUE_NO_CHANGES",
+      sessionId: "sess-sync",
+      responseText: "Everything matches.",
+    });
+    const syncVerdictResult = makeResult({
+      responseText: "ISSUE_NO_CHANGES",
     });
 
-    let resumeCall = 0;
-    const resumeResults = [fixResult, syncResult];
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
-      resume: vi
-        .fn()
-        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
-    };
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+    );
     const onIssueChange = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueChange }),
@@ -465,7 +755,11 @@ describe("createSelfCheckStageHandler", () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
       sessionId: "sess-fix",
-      responseText: "All good.\n\nDONE",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
     });
     const syncResult = makeResult({
       status: "error",
@@ -473,14 +767,7 @@ describe("createSelfCheckStageHandler", () => {
       responseText: "",
     });
 
-    let resumeCall = 0;
-    const resumeResults = [fixResult, syncResult];
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockReturnValue(makeStream(checkResult)),
-      resume: vi
-        .fn()
-        .mockImplementation(() => makeStream(resumeResults[resumeCall++])),
-    };
+    const agent = makeAgent(checkResult, fixResult, verdictResult, syncResult);
     const onIssueSyncStatus = vi.fn();
     const stage = createSelfCheckStageHandler(
       makeOpts({ agent, onIssueSyncStatus }),
@@ -492,14 +779,151 @@ describe("createSelfCheckStageHandler", () => {
     expect(onIssueSyncStatus).toHaveBeenCalledWith("failed");
   });
 
-  test("skips issue sync when fix response has no session ID and reports skipped status", async () => {
+  // -- issue sync clarification retry ----------------------------------------
+
+  test("malformed sync verdict → clarification → completed", async () => {
     const checkResult = makeResult({ sessionId: "sess-1" });
     const fixResult = makeResult({
-      sessionId: undefined,
-      responseText: "All good.\n\nDONE",
+      sessionId: "sess-fix",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
+    });
+    const syncResult = makeResult({
+      sessionId: "sess-sync",
+      responseText: "Compared implementation.",
+    });
+    // Malformed: extra commentary mixed in.
+    const syncVerdictResult = makeResult({
+      sessionId: "sess-syncv",
+      responseText: "I updated the issue\nISSUE_UPDATED: fixed path",
+    });
+    // Clarification retry returns clean response.
+    const clarifiedResult = makeResult({
+      responseText: "ISSUE_UPDATED: fixed path",
     });
 
-    const agent = makeAgent(checkResult, fixResult);
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+      clarifiedResult,
+    );
+    const onIssueChange = vi.fn();
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange, onIssueSyncStatus }),
+    );
+    await stage.handler(BASE_CTX);
+
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("completed");
+    expect(onIssueChange).toHaveBeenCalledWith({
+      type: "minor",
+      description: "fixed path",
+    });
+  });
+
+  test("malformed sync verdict → clarification also malformed → failed", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
+    });
+    const syncResult = makeResult({
+      sessionId: "sess-sync",
+      responseText: "Compared implementation.",
+    });
+    const syncVerdictResult = makeResult({
+      sessionId: "sess-syncv",
+      responseText: "ISSUE_UPDATED fixed title",
+    });
+    // Clarification also malformed.
+    const clarifiedResult = makeResult({
+      responseText: "I already updated it",
+    });
+
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+      clarifiedResult,
+    );
+    const onIssueChange = vi.fn();
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueChange, onIssueSyncStatus }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("failed");
+    expect(onIssueChange).not.toHaveBeenCalled();
+  });
+
+  test("malformed sync verdict → clarification error → failed", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
+    });
+    const syncResult = makeResult({
+      sessionId: "sess-sync",
+      responseText: "Compared implementation.",
+    });
+    const syncVerdictResult = makeResult({
+      sessionId: "sess-syncv",
+      responseText: "Sure, I did the sync",
+    });
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      responseText: "",
+    });
+
+    const agent = makeAgent(
+      checkResult,
+      fixResult,
+      verdictResult,
+      syncResult,
+      syncVerdictResult,
+      errorResult,
+    );
+    const onIssueSyncStatus = vi.fn();
+    const stage = createSelfCheckStageHandler(
+      makeOpts({ agent, onIssueSyncStatus }),
+    );
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(onIssueSyncStatus).toHaveBeenCalledWith("failed");
+  });
+
+  test("skips issue sync when verdict response has no session ID and reports skipped status", async () => {
+    const checkResult = makeResult({ sessionId: "sess-1" });
+    const fixResult = makeResult({
+      sessionId: "sess-fix",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: undefined,
+      responseText: "DONE",
+    });
+
+    const agent = makeAgent(checkResult, fixResult, verdictResult);
     const onIssueChange = vi.fn();
     const onIssueSyncStatus = vi.fn();
     const stage = createSelfCheckStageHandler(

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -1,12 +1,13 @@
 /**
  * Stage 3 — Self-check loop.
  *
- * Two-step flow per iteration:
+ * Three-step flow per iteration:
  *   1. Send a self-check prompt to Agent A covering 8 review items.
- *   2. Resume the session with a fix-or-done prompt.
+ *   2. Resume the session with a fix-or-done work prompt — the agent
+ *      performs fixes if needed but does **not** embed a verdict keyword.
+ *   3. A dedicated verdict follow-up asks for exactly FIXED or DONE.
  *
- * The agent responds with FIXED (loop again) or DONE (proceed).  The
- * pipeline engine's built-in loop control manages the 3-automatic /
+ * The pipeline engine's built-in loop control manages the 3-automatic /
  * 4th-asks-user budget — the handler returns `"not_approved"` on FIXED
  * so the engine loops.
  */
@@ -14,7 +15,9 @@
 import type { AgentAdapter } from "./agent.js";
 import { t } from "./i18n/index.js";
 import {
+  buildIssueSyncClarificationPrompt,
   buildIssueSyncPrompt,
+  buildIssueSyncVerdictPrompt,
   type IssueChange,
   type IssueSyncStatus,
   parseIssueSyncResponse,
@@ -27,6 +30,7 @@ import {
   mapFixOrDoneResponse,
   sendFollowUp,
 } from "./stage-util.js";
+import { buildClarificationPrompt } from "./step-parser.js";
 
 export interface SelfCheckStageOptions {
   agent: AgentAdapter;
@@ -105,10 +109,22 @@ export function buildFixOrDonePrompt(): string {
   return [
     `Based on your self-check above, decide what to do next.`,
     ``,
-    `- If you found issues that need fixing, fix them now and end your`,
-    `  response with the keyword FIXED.`,
-    `- If everything looks good and no changes are needed, end your`,
-    `  response with the keyword DONE.`,
+    `- If you found issues that need fixing, fix them now.`,
+    `- If everything looks good and no changes are needed, you are done.`,
+  ].join("\n");
+}
+
+export const FIX_OR_DONE_KEYWORDS = ["FIXED", "DONE"] as const;
+
+export function buildFixOrDoneVerdictPrompt(): string {
+  return [
+    `You have finished the self-check pass.`,
+    `Respond with exactly one of the following keywords:`,
+    ``,
+    `- FIXED — if you found and fixed issues`,
+    `- DONE — if everything looks good and no changes were needed`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
   ].join("\n");
 }
 
@@ -140,7 +156,7 @@ export function createSelfCheckStageHandler(
         return mapAgentError(checkResult, "during self-check");
       }
 
-      // Step 2: Send fix-or-done prompt (resume the same session).
+      // Step 2: Send fix-or-done work prompt (resume the same session).
       const fixPrompt = buildFixOrDonePrompt();
       ctx.promptSinks?.a?.(fixPrompt);
       const fixResult = await sendFollowUp(
@@ -157,16 +173,74 @@ export function createSelfCheckStageHandler(
         return mapAgentError(fixResult, "during fix");
       }
 
-      const result = mapFixOrDoneResponse(fixResult.responseText);
+      // Step 3: Verdict follow-up — ask for exactly FIXED or DONE.
+      const verdictPrompt = buildFixOrDoneVerdictPrompt();
+      ctx.promptSinks?.a?.(verdictPrompt);
+      const verdictResult = await sendFollowUp(
+        opts.agent,
+        fixResult.sessionId,
+        verdictPrompt,
+        ctx.worktreePath,
+        ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
+      );
 
-      // Step 3: Issue description sync (only when self-check is done).
-      if (result.outcome === "completed" && fixResult.sessionId) {
+      if (verdictResult.status === "error") {
+        return mapAgentError(verdictResult, "during fix verdict");
+      }
+
+      let verdictCheckResult = verdictResult;
+      let result = mapFixOrDoneResponse(
+        verdictCheckResult.responseText,
+        FIX_OR_DONE_KEYWORDS,
+      );
+
+      // Internal clarification retry (same pattern as other stages).
+      if (result.outcome === "needs_clarification") {
+        const clarifyPrompt = buildClarificationPrompt(
+          verdictCheckResult.responseText,
+          FIX_OR_DONE_KEYWORDS,
+        );
+        ctx.promptSinks?.a?.(clarifyPrompt);
+        const retryResult = await sendFollowUp(
+          opts.agent,
+          verdictCheckResult.sessionId ?? fixResult.sessionId,
+          clarifyPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+
+        if (retryResult.status === "error") {
+          return mapAgentError(retryResult, "during fix verdict clarification");
+        }
+
+        verdictCheckResult = retryResult;
+        result = mapFixOrDoneResponse(
+          retryResult.responseText,
+          FIX_OR_DONE_KEYWORDS,
+        );
+      }
+
+      // If still ambiguous after the in-session retry, fall back to
+      // not_approved so the pipeline loops the self-check again.
+      // Treating ambiguity as "completed" would skip the re-check
+      // loop when the agent actually said FIXED, and would trigger
+      // issue sync even though the verdict is uncertain.
+      if (result.outcome === "needs_clarification") {
+        result = { outcome: "not_approved", message: result.message };
+      }
+
+      // Step 4: Issue description sync (only when self-check is done).
+      if (result.outcome === "completed" && verdictCheckResult.sessionId) {
         try {
           const syncPrompt = buildIssueSyncPrompt(ctx, opts);
           ctx.promptSinks?.a?.(syncPrompt);
           const syncResult = await sendFollowUp(
             opts.agent,
-            fixResult.sessionId,
+            verdictCheckResult.sessionId,
             syncPrompt,
             ctx.worktreePath,
             ctx.streamSinks?.a,
@@ -175,11 +249,60 @@ export function createSelfCheckStageHandler(
           );
 
           if (syncResult.status === "success") {
-            const changes = parseIssueSyncResponse(syncResult.responseText);
-            for (const change of changes) {
-              opts.onIssueChange?.(change);
+            // Verdict follow-up: ask for sync status report.
+            const syncVerdictPrompt = buildIssueSyncVerdictPrompt();
+            ctx.promptSinks?.a?.(syncVerdictPrompt);
+            const syncVerdictResult = await sendFollowUp(
+              opts.agent,
+              syncResult.sessionId ?? verdictCheckResult.sessionId,
+              syncVerdictPrompt,
+              ctx.worktreePath,
+              ctx.streamSinks?.a,
+              undefined,
+              ctx.usageSinks?.a,
+            );
+
+            if (syncVerdictResult.status === "success") {
+              let parseResult = parseIssueSyncResponse(
+                syncVerdictResult.responseText,
+              );
+
+              // Clarification retry if the response was malformed.
+              if (!parseResult.valid) {
+                const clarifyPrompt = buildIssueSyncClarificationPrompt();
+                ctx.promptSinks?.a?.(clarifyPrompt);
+                const retryResult = await sendFollowUp(
+                  opts.agent,
+                  syncVerdictResult.sessionId ??
+                    syncResult.sessionId ??
+                    verdictCheckResult.sessionId,
+                  clarifyPrompt,
+                  ctx.worktreePath,
+                  ctx.streamSinks?.a,
+                  undefined,
+                  ctx.usageSinks?.a,
+                );
+
+                if (retryResult.status === "success") {
+                  parseResult = parseIssueSyncResponse(
+                    retryResult.responseText,
+                  );
+                }
+                // If retry failed or still invalid, fall through
+                // to the valid check below.
+              }
+
+              if (parseResult.valid) {
+                for (const change of parseResult.changes) {
+                  opts.onIssueChange?.(change);
+                }
+                opts.onIssueSyncStatus?.("completed");
+              } else {
+                opts.onIssueSyncStatus?.("failed");
+              }
+            } else {
+              opts.onIssueSyncStatus?.("failed");
             }
-            opts.onIssueSyncStatus?.("completed");
           } else {
             opts.onIssueSyncStatus?.("failed");
           }

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -230,7 +230,7 @@ describe("createSquashStageHandler", () => {
       resume: vi.fn().mockReturnValue(
         makeStream(
           makeResult({
-            responseText: "Cannot squash.\n\nBLOCKED",
+            responseText: "BLOCKED",
           }),
         ),
       ),
@@ -241,7 +241,7 @@ describe("createSquashStageHandler", () => {
 
     expect(result.outcome).toBe("blocked");
     expect(result.message).toContain("Tried to squash");
-    expect(result.message).toContain("Cannot squash");
+    expect(result.message).toContain("BLOCKED");
   });
 
   // -- CI fails after squash -------------------------------------------------
@@ -427,25 +427,38 @@ describe("createSquashStageHandler", () => {
     expect(agent.resume).toHaveBeenCalledTimes(2);
   });
 
-  test("ambiguous check without sessionId skips internal clarification", async () => {
+  test("ambiguous check without sessionId retries via fallback session", async () => {
     const ambiguousCheck = makeResult({
       sessionId: undefined,
       responseText: "I squashed the commits.",
     });
 
+    let resumeCall = 0;
+    const resumeResults = [
+      // 1st resume: ambiguous completion check (no sessionId)
+      makeStream(ambiguousCheck),
+      // 2nd resume: clarification retry via fallback session
+      makeStream(makeResult({ responseText: "COMPLETED" })),
+    ];
+
     const agent: AgentAdapter = {
       invoke: vi
         .fn()
         .mockReturnValue(makeStream(makeResult({ sessionId: "sess-squash" }))),
-      resume: vi.fn().mockReturnValueOnce(makeStream(ambiguousCheck)),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
     };
 
     const opts = makeOpts({ agent });
     const stage = createSquashStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
-    expect(agent.resume).toHaveBeenCalledTimes(1);
+    // Clarification retry succeeds via fallback to "sess-squash".
+    expect(result.outcome).toBe("completed");
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    // The retry used the invoke session as fallback.
+    expect((agent.resume as ReturnType<typeof vi.fn>).mock.calls[1][0]).toBe(
+      "sess-squash",
+    );
   });
 
   // -- CI pending then pass ---------------------------------------------------
@@ -537,7 +550,7 @@ describe("createSquashStageHandler", () => {
 
   // -- non-terminal non-blocked completion outcome ----------------------------
 
-  test("returns needs_clarification when clarification also ambiguous", async () => {
+  test("proceeds as completed when clarification also ambiguous but commit count decreased", async () => {
     let resumeCall = 0;
     const resumeResults = [
       makeStream(
@@ -563,11 +576,51 @@ describe("createSquashStageHandler", () => {
       resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
     };
 
-    const opts = makeOpts({ agent });
+    const countBranchCommits = vi
+      .fn()
+      .mockReturnValueOnce(2) // initial check: > 1, proceed
+      .mockReturnValueOnce(1); // post-condition: decreased, completed
+    const opts = makeOpts({ agent, countBranchCommits });
     const stage = createSquashStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(result.outcome).toBe("needs_clarification");
+    expect(result.outcome).toBe("completed");
+    expect(countBranchCommits).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns blocked when clarification also ambiguous and commit count unchanged", async () => {
+    let resumeCall = 0;
+    const resumeResults = [
+      makeStream(
+        makeResult({
+          sessionId: "sess-2",
+          responseText: "I squashed the commits.",
+        }),
+      ),
+      makeStream(
+        makeResult({ responseText: "I finished the squash process." }),
+      ),
+    ];
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: "Squashed.",
+          }),
+        ),
+      ),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+    };
+
+    const countBranchCommits = vi.fn().mockReturnValue(2); // unchanged
+    const opts = makeOpts({ agent, countBranchCommits });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("Squashed.");
   });
 
   // -- getHeadSha forwarding ----------------------------------------------------

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -107,6 +107,8 @@ export function buildSquashPrompt(
   return lines.join("\n");
 }
 
+export const SQUASH_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
+
 export function buildSquashCompletionCheckPrompt(): string {
   return [
     `You have finished your squash attempt.  Please evaluate the result`,
@@ -115,8 +117,7 @@ export function buildSquashCompletionCheckPrompt(): string {
     `- COMPLETED — if the commits were squashed and force-pushed`,
     `- BLOCKED — if you could not squash and need user intervention`,
     ``,
-    `If BLOCKED, add a brief reason on the next line explaining what`,
-    `went wrong.`,
+    `Do not include any other commentary — just the keyword.`,
   ].join("\n");
 }
 
@@ -181,16 +182,21 @@ export function createSquashStageHandler(
         return mapAgentError(checkResult, "during squash completion check");
       }
 
-      let result = mapResponseToResult(checkResult.responseText);
+      let result = mapResponseToResult(
+        checkResult.responseText,
+        undefined,
+        SQUASH_CHECK_KEYWORDS,
+      );
 
-      if (result.outcome === "needs_clarification" && checkResult.sessionId) {
+      if (result.outcome === "needs_clarification") {
         const clarifyPrompt = buildClarificationPrompt(
           checkResult.responseText,
+          SQUASH_CHECK_KEYWORDS,
         );
         ctx.promptSinks?.a?.(clarifyPrompt);
         const retryResult = await sendFollowUp(
           opts.agent,
-          checkResult.sessionId,
+          checkResult.sessionId ?? squashResult.sessionId,
           clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
@@ -206,7 +212,28 @@ export function createSquashStageHandler(
         }
 
         checkResult = retryResult;
-        result = mapResponseToResult(retryResult.responseText);
+        result = mapResponseToResult(
+          retryResult.responseText,
+          undefined,
+          SQUASH_CHECK_KEYWORDS,
+        );
+      }
+
+      // If still ambiguous after the in-session retry, verify
+      // the squash actually happened by checking whether the
+      // commit count decreased.
+      if (result.outcome === "needs_clarification") {
+        const postCount = (
+          opts.countBranchCommits ?? defaultCountBranchCommits
+        )(ctx.worktreePath, opts.defaultBranch);
+        if (postCount < count) {
+          result = { outcome: "completed", message: result.message };
+        } else {
+          result = {
+            outcome: "blocked",
+            message: `${squashResult.responseText}\n\n---\n\n${checkResult.responseText}`,
+          };
+        }
       }
 
       if (result.outcome === "blocked") {

--- a/src/stage-testplan.test.ts
+++ b/src/stage-testplan.test.ts
@@ -3,8 +3,10 @@ import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import type { StageContext } from "./pipeline.js";
 import {
   buildTestPlanSelfCheckPrompt,
+  buildTestPlanVerdictPrompt,
   buildTestPlanVerifyPrompt,
   createTestPlanStageHandler,
+  TEST_PLAN_VERDICT_KEYWORDS,
   type TestPlanStageOptions,
 } from "./stage-testplan.js";
 
@@ -13,7 +15,7 @@ import {
 function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
   return {
     sessionId: "sess-1",
-    responseText: "All items verified.\n\nDONE",
+    responseText: "All items verified.",
     status: "success",
     errorType: undefined,
     stderrText: "",
@@ -31,14 +33,22 @@ function makeStream(result: AgentResult): AgentStream {
   };
 }
 
+/**
+ * Create a mock agent that returns the given results in sequence.
+ * The first call to `invoke` returns `invokeResult`.
+ * Subsequent calls to `resume` return from `resumeResults` in order.
+ */
 function makeAgent(
-  verifyResult: AgentResult,
-  checkResult?: AgentResult,
+  invokeResult: AgentResult,
+  ...resumeResults: AgentResult[]
 ): AgentAdapter {
-  const invoke = vi.fn().mockReturnValue(makeStream(verifyResult));
-  const resume = vi
-    .fn()
-    .mockReturnValue(makeStream(checkResult ?? verifyResult));
+  const invoke = vi.fn().mockReturnValue(makeStream(invokeResult));
+  let resumeCall = 0;
+  const resume = vi.fn().mockImplementation(() => {
+    const r = resumeResults[resumeCall] ?? invokeResult;
+    resumeCall++;
+    return makeStream(r);
+  });
   return { invoke, resume };
 }
 
@@ -57,7 +67,11 @@ function makeOpts(
   overrides: Partial<TestPlanStageOptions> = {},
 ): TestPlanStageOptions {
   return {
-    agent: makeAgent(makeResult()),
+    agent: makeAgent(
+      makeResult(),
+      makeResult(),
+      makeResult({ responseText: "DONE" }),
+    ),
     issueTitle: "Fix the widget",
     issueBody: "The widget is broken.",
     ...overrides,
@@ -142,10 +156,13 @@ describe("buildTestPlanVerifyPrompt", () => {
 // ---- buildTestPlanSelfCheckPrompt ------------------------------------------
 
 describe("buildTestPlanSelfCheckPrompt", () => {
-  test("mentions FIXED and DONE keywords", () => {
+  test("mentions fix and done actions without verdict keywords", () => {
     const prompt = buildTestPlanSelfCheckPrompt();
-    expect(prompt).toContain("FIXED");
-    expect(prompt).toContain("DONE");
+    expect(prompt).toContain("fix them now");
+    expect(prompt).toContain("you are done");
+    // Should NOT contain the verdict keywords — those are in the verdict prompt
+    expect(prompt).not.toContain("FIXED");
+    expect(prompt).not.toContain("DONE");
   });
 
   test("mentions CI status check", () => {
@@ -160,6 +177,25 @@ describe("buildTestPlanSelfCheckPrompt", () => {
   });
 });
 
+// ---- buildTestPlanVerdictPrompt --------------------------------------------
+
+describe("buildTestPlanVerdictPrompt", () => {
+  test("mentions FIXED and DONE keywords", () => {
+    const prompt = buildTestPlanVerdictPrompt();
+    expect(prompt).toContain("FIXED");
+    expect(prompt).toContain("DONE");
+  });
+});
+
+// ---- TEST_PLAN_VERDICT_KEYWORDS --------------------------------------------
+
+describe("TEST_PLAN_VERDICT_KEYWORDS", () => {
+  test("contains FIXED and DONE", () => {
+    expect(TEST_PLAN_VERDICT_KEYWORDS).toContain("FIXED");
+    expect(TEST_PLAN_VERDICT_KEYWORDS).toContain("DONE");
+  });
+});
+
 // ---- createTestPlanStageHandler --------------------------------------------
 
 describe("createTestPlanStageHandler", () => {
@@ -169,15 +205,22 @@ describe("createTestPlanStageHandler", () => {
     expect(stage.name).toBe("Test plan verification");
   });
 
-  // -- two-step flow ---------------------------------------------------------
+  // -- three-step flow -------------------------------------------------------
 
-  test("invokes agent for verification then resumes for self-check", async () => {
+  test("invokes agent for verification then resumes for self-check and verdict", async () => {
     const verifyResult = makeResult({
       sessionId: "sess-verify",
       responseText: "Verified items.",
     });
-    const checkResult = makeResult({ responseText: "All good.\n\nDONE" });
-    const agent = makeAgent(verifyResult, checkResult);
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "All good.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "DONE",
+    });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
 
     await stage.handler(BASE_CTX);
@@ -185,8 +228,17 @@ describe("createTestPlanStageHandler", () => {
     expect(agent.invoke).toHaveBeenCalledWith(expect.any(String), {
       cwd: "/tmp/wt",
     });
-    expect(agent.resume).toHaveBeenCalledWith(
+    // Two resume calls: self-check work + verdict
+    expect(agent.resume).toHaveBeenCalledTimes(2);
+    expect(agent.resume).toHaveBeenNthCalledWith(
+      1,
       "sess-verify",
+      expect.any(String),
+      { cwd: "/tmp/wt" },
+    );
+    expect(agent.resume).toHaveBeenNthCalledWith(
+      2,
+      "sess-check",
       expect.any(String),
       { cwd: "/tmp/wt" },
     );
@@ -202,66 +254,189 @@ describe("createTestPlanStageHandler", () => {
 
   // -- outcome mapping: DONE vs FIXED ----------------------------------------
 
-  test("returns completed when agent says DONE", async () => {
+  test("returns completed when verdict says DONE", async () => {
     const verifyResult = makeResult({ sessionId: "sess-1" });
     const checkResult = makeResult({
-      responseText: "Everything is fine.\n\nDONE",
+      sessionId: "sess-check",
+      responseText: "Everything is fine.",
     });
-    const agent = makeAgent(verifyResult, checkResult);
+    const verdictResult = makeResult({ responseText: "DONE" });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("completed");
   });
 
-  test("returns not_approved when agent says FIXED (triggers loop)", async () => {
+  test("returns not_approved when verdict says FIXED (triggers loop)", async () => {
     const verifyResult = makeResult({ sessionId: "sess-1" });
     const checkResult = makeResult({
-      responseText: "Fixed a checklist item.\n\nFIXED",
+      sessionId: "sess-check",
+      responseText: "Fixed a checklist item.",
     });
-    const agent = makeAgent(verifyResult, checkResult);
+    const verdictResult = makeResult({ responseText: "FIXED" });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("not_approved");
   });
 
-  test("returns completed when agent says COMPLETED", async () => {
+  test("out-of-scope keyword COMPLETED → clarification retry → fallback to not_approved", async () => {
     const verifyResult = makeResult({ sessionId: "sess-1" });
-    const checkResult = makeResult({ responseText: "All set.\n\nCOMPLETED" });
-    const agent = makeAgent(verifyResult, checkResult);
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "All set.",
+    });
+    const verdictResult = makeResult({ responseText: "COMPLETED" });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("out-of-scope keyword BLOCKED → clarification retry → fallback to not_approved", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Cannot verify.",
+    });
+    const verdictResult = makeResult({ responseText: "BLOCKED" });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("out-of-scope keyword NOT_APPROVED → clarification retry → fallback to not_approved", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Not right.",
+    });
+    const verdictResult = makeResult({ responseText: "NOT_APPROVED" });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("ambiguous verdict response → clarification retry → fallback to not_approved", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "I looked at things.",
+    });
+    const verdictResult = makeResult({ responseText: "I looked at things." });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  // -- internal clarification retry ------------------------------------------
+
+  test("ambiguous verdict → internal clarification → DONE", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Verified.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "I think it looks good",
+    });
+    const clarifiedResult = makeResult({ responseText: "DONE" });
+    const agent = makeAgent(
+      verifyResult,
+      checkResult,
+      verdictResult,
+      clarifiedResult,
+    );
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
     expect(result.outcome).toBe("completed");
+    // (self-check + verdict + clarification)
+    expect(agent.resume).toHaveBeenCalledTimes(3);
   });
 
-  test("returns blocked when agent says BLOCKED", async () => {
+  test("out-of-scope COMPLETED → internal clarification → FIXED", async () => {
     const verifyResult = makeResult({ sessionId: "sess-1" });
     const checkResult = makeResult({
-      responseText: "Cannot verify.\n\nBLOCKED",
+      sessionId: "sess-check",
+      responseText: "Fixed things.",
     });
-    const agent = makeAgent(verifyResult, checkResult);
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "COMPLETED",
+    });
+    const clarifiedResult = makeResult({ responseText: "FIXED" });
+    const agent = makeAgent(
+      verifyResult,
+      checkResult,
+      verdictResult,
+      clarifiedResult,
+    );
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("blocked");
-  });
 
-  test("returns not_approved on NOT_APPROVED", async () => {
-    const verifyResult = makeResult({ sessionId: "sess-1" });
-    const checkResult = makeResult({
-      responseText: "Not right.\n\nNOT_APPROVED",
-    });
-    const agent = makeAgent(verifyResult, checkResult);
-    const stage = createTestPlanStageHandler(makeOpts({ agent }));
-    const result = await stage.handler(BASE_CTX);
     expect(result.outcome).toBe("not_approved");
+    expect(agent.resume).toHaveBeenCalledTimes(3);
   });
 
-  test("returns needs_clarification on ambiguous response", async () => {
+  test("ambiguous verdict → clarification also ambiguous → fallback to not_approved", async () => {
     const verifyResult = makeResult({ sessionId: "sess-1" });
-    const checkResult = makeResult({ responseText: "I looked at things." });
-    const agent = makeAgent(verifyResult, checkResult);
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Verified.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "Looks fine",
+    });
+    const stillAmbiguous = makeResult({ responseText: "It is fine" });
+    const agent = makeAgent(
+      verifyResult,
+      checkResult,
+      verdictResult,
+      stillAmbiguous,
+    );
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.outcome).toBe("needs_clarification");
+
+    // Falls back to not_approved so the pipeline loops (or restarts
+    // from an earlier stage) rather than advancing past an uncertain
+    // verdict.
+    expect(result.outcome).toBe("not_approved");
+    expect(agent.resume).toHaveBeenCalledTimes(3);
+  });
+
+  test("clarification retry error → returns error", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Verified.",
+    });
+    const verdictResult = makeResult({
+      sessionId: "sess-verdict",
+      responseText: "I think so",
+    });
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "clarify crash",
+      responseText: "",
+    });
+    const agent = makeAgent(
+      verifyResult,
+      checkResult,
+      verdictResult,
+      errorResult,
+    );
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("clarify crash");
   });
 
   // -- error handling --------------------------------------------------------
@@ -314,15 +489,39 @@ describe("createTestPlanStageHandler", () => {
     expect(result.message).toContain("test plan self-check");
   });
 
-  // -- message preservation --------------------------------------------------
-
-  test("preserves self-check response text in message", async () => {
-    const text = "Fixed several checklist items.\n\nFIXED";
+  test("returns error when verdict follow-up fails", async () => {
     const verifyResult = makeResult({ sessionId: "sess-1" });
-    const checkResult = makeResult({ responseText: text });
-    const agent = makeAgent(verifyResult, checkResult);
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Did some work.",
+    });
+    const verdictResult = makeResult({
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "verdict crash",
+      responseText: "",
+    });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
     const stage = createTestPlanStageHandler(makeOpts({ agent }));
     const result = await stage.handler(BASE_CTX);
-    expect(result.message).toBe(text);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("verdict crash");
+    expect(result.message).toContain("test plan verdict");
+  });
+
+  // -- message preservation --------------------------------------------------
+
+  test("preserves verdict response text in message", async () => {
+    const verifyResult = makeResult({ sessionId: "sess-1" });
+    const checkResult = makeResult({
+      sessionId: "sess-check",
+      responseText: "Fixed several checklist items.",
+    });
+    const verdictResult = makeResult({ responseText: "FIXED" });
+    const agent = makeAgent(verifyResult, checkResult, verdictResult);
+    const stage = createTestPlanStageHandler(makeOpts({ agent }));
+    const result = await stage.handler(BASE_CTX);
+    expect(result.message).toBe("FIXED");
   });
 });

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -1,13 +1,14 @@
 /**
  * Stage 6 — Test plan verification loop.
  *
- * Two-step flow per iteration:
+ * Three-step flow per iteration:
  *   1. Send a verification prompt to Agent A instructing it to verify
  *      PR test plan items and issue task checklist items.
- *   2. Resume the session with a self-check prompt.
+ *   2. Resume the session with a self-check work prompt — the agent
+ *      performs fixes if needed but does **not** embed a verdict keyword.
+ *   3. A dedicated verdict follow-up asks for exactly FIXED or DONE.
  *
- * The agent responds with FIXED (loop again) or DONE (proceed).  The
- * pipeline engine's built-in loop control manages the 3-automatic /
+ * The pipeline engine's built-in loop control manages the 3-automatic /
  * 4th-asks-user budget — the handler returns `"not_approved"` on FIXED
  * so the engine loops.
  */
@@ -22,6 +23,7 @@ import {
   mapFixOrDoneResponse,
   sendFollowUp,
 } from "./stage-util.js";
+import { buildClarificationPrompt } from "./step-parser.js";
 
 export interface TestPlanStageOptions {
   agent: AgentAdapter;
@@ -97,11 +99,22 @@ export function buildTestPlanSelfCheckPrompt(): string {
     `  recursively) when applicable.`,
     `- Is CI still passing?`,
     ``,
-    `If you found and fixed issues during verification, end your`,
-    `response with the keyword FIXED.`,
+    `If you found issues during verification, fix them now.`,
+    `If everything is verified and passing, you are done.`,
+  ].join("\n");
+}
+
+export const TEST_PLAN_VERDICT_KEYWORDS = ["FIXED", "DONE"] as const;
+
+export function buildTestPlanVerdictPrompt(): string {
+  return [
+    `You have finished the test plan verification pass.`,
+    `Respond with exactly one of the following keywords:`,
     ``,
-    `If everything is verified and passing with no changes needed,`,
-    `end your response with the keyword DONE.`,
+    `- FIXED — if you found and fixed issues`,
+    `- DONE — if everything is verified and passing with no changes needed`,
+    ``,
+    `Do not include any other commentary — just the keyword.`,
   ].join("\n");
 }
 
@@ -133,7 +146,7 @@ export function createTestPlanStageHandler(
         return mapAgentError(verifyResult, "during test plan verification");
       }
 
-      // Step 2: Send self-check prompt (resume the same session).
+      // Step 2: Send self-check work prompt (resume the same session).
       const selfCheckPrompt = buildTestPlanSelfCheckPrompt();
       ctx.promptSinks?.a?.(selfCheckPrompt);
       const checkResult = await sendFollowUp(
@@ -150,7 +163,67 @@ export function createTestPlanStageHandler(
         return mapAgentError(checkResult, "during test plan self-check");
       }
 
-      return mapFixOrDoneResponse(checkResult.responseText);
+      // Step 3: Verdict follow-up — ask for exactly FIXED or DONE.
+      const verdictPrompt = buildTestPlanVerdictPrompt();
+      ctx.promptSinks?.a?.(verdictPrompt);
+      const verdictResult = await sendFollowUp(
+        opts.agent,
+        checkResult.sessionId,
+        verdictPrompt,
+        ctx.worktreePath,
+        ctx.streamSinks?.a,
+        undefined,
+        ctx.usageSinks?.a,
+      );
+
+      if (verdictResult.status === "error") {
+        return mapAgentError(verdictResult, "during test plan verdict");
+      }
+
+      let result = mapFixOrDoneResponse(
+        verdictResult.responseText,
+        TEST_PLAN_VERDICT_KEYWORDS,
+      );
+
+      // Internal clarification retry (same pattern as other stages).
+      if (result.outcome === "needs_clarification") {
+        const clarifyPrompt = buildClarificationPrompt(
+          verdictResult.responseText,
+          TEST_PLAN_VERDICT_KEYWORDS,
+        );
+        ctx.promptSinks?.a?.(clarifyPrompt);
+        const retryResult = await sendFollowUp(
+          opts.agent,
+          verdictResult.sessionId ?? checkResult.sessionId,
+          clarifyPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+
+        if (retryResult.status === "error") {
+          return mapAgentError(
+            retryResult,
+            "during test plan verdict clarification",
+          );
+        }
+
+        result = mapFixOrDoneResponse(
+          retryResult.responseText,
+          TEST_PLAN_VERDICT_KEYWORDS,
+        );
+      }
+
+      // If still ambiguous after the in-session retry, fall back to
+      // not_approved so the pipeline loops (or restarts from an
+      // earlier stage).  Treating ambiguity as "completed" would
+      // advance past a verdict that may have been FIXED.
+      if (result.outcome === "needs_clarification") {
+        result = { outcome: "not_approved", message: result.message };
+      }
+
+      return result;
     },
   };
 }

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -312,6 +312,58 @@ describe("mapParsedStepToResult", () => {
     );
     expect(result).toEqual({ outcome: "completed", message: "ok" });
   });
+
+  test("rejects out-of-scope keyword when validKeywords is provided", () => {
+    const result = mapParsedStepToResult(
+      { status: "completed", keyword: "COMPLETED" },
+      "All done. COMPLETED",
+      undefined,
+      ["FIXED", "DONE"],
+    );
+    expect(result.outcome).toBe("needs_clarification");
+    expect(result.validVerdicts).toEqual(["FIXED", "DONE"]);
+  });
+
+  test("accepts in-scope keyword when validKeywords is provided", () => {
+    const result = mapParsedStepToResult(
+      { status: "fixed", keyword: "FIXED" },
+      "Patched. FIXED",
+      undefined,
+      ["FIXED", "DONE"],
+    );
+    expect(result).toEqual({ outcome: "completed", message: "Patched. FIXED" });
+  });
+
+  test("attaches validVerdicts on ambiguous when validKeywords provided", () => {
+    const result = mapParsedStepToResult(
+      { status: "ambiguous", keyword: undefined },
+      "no keyword here",
+      undefined,
+      ["FIXED", "DONE"],
+    );
+    expect(result.outcome).toBe("needs_clarification");
+    expect(result.validVerdicts).toEqual(["FIXED", "DONE"]);
+  });
+
+  test("does not attach validVerdicts when validKeywords is not provided", () => {
+    const result = mapParsedStepToResult(
+      { status: "ambiguous", keyword: undefined },
+      "no keyword here",
+    );
+    expect(result.outcome).toBe("needs_clarification");
+    expect(result.validVerdicts).toBeUndefined();
+  });
+
+  test("keyword comparison is case-insensitive", () => {
+    const result = mapParsedStepToResult(
+      { status: "fixed", keyword: "FIXED" },
+      "FIXED",
+      undefined,
+      ["fixed", "done"],
+    );
+    // "FIXED" matches "fixed" (case-insensitive), so it should be accepted.
+    expect(result.outcome).toBe("completed");
+  });
 });
 
 // ---- mapResponseToResult ---------------------------------------------------
@@ -343,6 +395,63 @@ describe("mapResponseToResult", () => {
     const text = "Long response.\n\nCOMPLETED";
     const result = mapResponseToResult(text);
     expect(result.message).toBe(text);
+  });
+
+  test("rejects out-of-scope keyword with validKeywords", () => {
+    const result = mapResponseToResult("All done.\n\nCOMPLETED", undefined, [
+      "FIXED",
+      "DONE",
+    ]);
+    expect(result.outcome).toBe("needs_clarification");
+    expect(result.validVerdicts).toEqual(["FIXED", "DONE"]);
+  });
+
+  test("accepts in-scope keyword with validKeywords (exact response)", () => {
+    const result = mapResponseToResult("FIXED", undefined, ["FIXED", "DONE"]);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("rejects in-scope keyword with extra commentary when validKeywords is provided", () => {
+    const result = mapResponseToResult("Patched.\n\nFIXED", undefined, [
+      "FIXED",
+      "DONE",
+    ]);
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("passes validKeywords through with overrides (exact response)", () => {
+    const result = mapResponseToResult("FIXED", { fixed: "not_approved" }, [
+      "FIXED",
+      "DONE",
+    ]);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  // -- strict parser regression tests ----------------------------------------
+
+  test("rejects two in-scope keywords in one response", () => {
+    const result = mapResponseToResult("COMPLETED then BLOCKED", undefined, [
+      "COMPLETED",
+      "BLOCKED",
+    ]);
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("rejects extra commentary ending in valid keyword", () => {
+    const result = mapResponseToResult(
+      "Round 1 items are now APPROVED",
+      undefined,
+      ["APPROVED", "NOT_APPROVED"],
+    );
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("accepts keyword with trailing punctuation", () => {
+    const result = mapResponseToResult("COMPLETED.", undefined, [
+      "COMPLETED",
+      "BLOCKED",
+    ]);
+    expect(result.outcome).toBe("completed");
   });
 });
 
@@ -394,6 +503,60 @@ describe("mapFixOrDoneResponse", () => {
     const text = "Fixed several items.\n\nFIXED";
     const result = mapFixOrDoneResponse(text);
     expect(result.message).toBe(text);
+  });
+
+  test("rejects out-of-scope keyword with validKeywords", () => {
+    const result = mapFixOrDoneResponse("Review passed.\n\nAPPROVED", [
+      "FIXED",
+      "DONE",
+    ]);
+    expect(result.outcome).toBe("needs_clarification");
+    expect(result.validVerdicts).toEqual(["FIXED", "DONE"]);
+  });
+
+  test("accepts DONE with validKeywords containing DONE (exact response)", () => {
+    const result = mapFixOrDoneResponse("DONE", ["FIXED", "DONE"]);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("accepts FIXED with validKeywords containing FIXED (exact response)", () => {
+    const result = mapFixOrDoneResponse("FIXED", ["FIXED", "DONE"]);
+    expect(result.outcome).toBe("not_approved");
+  });
+
+  test("rejects in-scope keyword with extra commentary when validKeywords is provided", () => {
+    const result = mapFixOrDoneResponse("All good.\n\nDONE", ["FIXED", "DONE"]);
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("attaches validVerdicts on ambiguous with validKeywords", () => {
+    const result = mapFixOrDoneResponse("I looked at things.", [
+      "FIXED",
+      "DONE",
+    ]);
+    expect(result.outcome).toBe("needs_clarification");
+    expect(result.validVerdicts).toEqual(["FIXED", "DONE"]);
+  });
+
+  test("backward compatible without validKeywords", () => {
+    const result = mapFixOrDoneResponse("Patched.\n\nFIXED");
+    expect(result.outcome).toBe("not_approved");
+    expect(result.validVerdicts).toBeUndefined();
+  });
+
+  // -- strict parser regression tests ----------------------------------------
+
+  test("rejects FIXED and DONE in same response with validKeywords", () => {
+    const result = mapFixOrDoneResponse("FIXED and DONE", ["FIXED", "DONE"]);
+    expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("rejects DONE with extra commentary when validKeywords is provided", () => {
+    const result = mapFixOrDoneResponse("ISSUE_NO_CHANGES\n\nDONE", [
+      "FIXED",
+      "DONE",
+    ]);
+    expect(result.outcome).toBe("needs_clarification");
   });
 });
 

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -11,7 +11,11 @@ import type {
 } from "./agent.js";
 import { t } from "./i18n/index.js";
 import type { StageOutcome, StageResult } from "./pipeline.js";
-import { type ParsedStep, parseStepStatus } from "./step-parser.js";
+import {
+  type ParsedStep,
+  parseStepStatus,
+  parseVerdictKeyword,
+} from "./step-parser.js";
 
 /**
  * Callback that receives streaming output chunks from an agent process.
@@ -131,12 +135,33 @@ export function buildErrorDetail(result: AgentResult): string {
  * supply `overrides` to remap specific statuses — for example the
  * self-check stage maps the FIXED keyword to `"not_approved"` so the
  * pipeline loops.
+ *
+ * When `validKeywords` is provided, a parsed keyword that is not in the
+ * set is rejected as `needs_clarification` with the valid set attached
+ * to the result for scoped clarification prompts.
  */
 export function mapParsedStepToResult(
   parsed: ParsedStep,
   responseText: string,
   overrides?: Partial<Record<ParsedStep["status"], StageOutcome>>,
+  validKeywords?: readonly string[],
 ): StageResult {
+  // Reject out-of-scope keywords when a valid set is provided.
+  if (
+    validKeywords &&
+    validKeywords.length > 0 &&
+    parsed.keyword !== undefined
+  ) {
+    const upper = validKeywords.map((k) => k.toUpperCase());
+    if (!upper.includes(parsed.keyword.toUpperCase())) {
+      return {
+        outcome: "needs_clarification",
+        message: responseText,
+        validVerdicts: validKeywords,
+      };
+    }
+  }
+
   const outcomeMap: Record<ParsedStep["status"], StageOutcome> = {
     completed: "completed",
     fixed: "completed",
@@ -147,10 +172,18 @@ export function mapParsedStepToResult(
     ...overrides,
   };
 
-  return {
+  const result: StageResult = {
     outcome: outcomeMap[parsed.status],
     message: responseText,
   };
+
+  // Attach valid keywords when the outcome is ambiguous so the pipeline
+  // engine can build a scoped clarification prompt.
+  if (result.outcome === "needs_clarification" && validKeywords) {
+    result.validVerdicts = validKeywords;
+  }
+
+  return result;
 }
 
 /**
@@ -324,15 +357,40 @@ export async function sendFollowUp(
 /**
  * Convenience: parse response text and convert to a `StageResult` in one
  * call.
+ *
+ * When `validKeywords` is provided, the strict verdict parser is used:
+ * the response must contain exactly one valid keyword with no extra
+ * commentary.  Responses with multiple valid keywords, out-of-scope
+ * keywords, or significant extra text are rejected as
+ * `needs_clarification`.
  */
 export function mapResponseToResult(
   responseText: string,
   overrides?: Partial<Record<ParsedStep["status"], StageOutcome>>,
+  validKeywords?: readonly string[],
 ): StageResult {
+  if (validKeywords && validKeywords.length > 0) {
+    const verdict = parseVerdictKeyword(responseText, validKeywords);
+    if (verdict.keyword === undefined) {
+      return {
+        outcome: "needs_clarification",
+        message: responseText,
+        validVerdicts: validKeywords,
+      };
+    }
+    // Feed the matched keyword through parseStepStatus for status mapping.
+    return mapParsedStepToResult(
+      parseStepStatus(verdict.keyword),
+      responseText,
+      overrides,
+      validKeywords,
+    );
+  }
   return mapParsedStepToResult(
     parseStepStatus(responseText),
     responseText,
     overrides,
+    validKeywords,
   );
 }
 
@@ -383,15 +441,50 @@ export function buildDocConsistencyInstructions(indent = ""): string {
  *
  * Shared by the self-check (stage 3) and test-plan verification
  * (stage 6) handlers.
+ *
+ * When `validKeywords` is provided, the strict verdict parser is used:
+ * the response must contain exactly one valid keyword with no extra
+ * commentary.
  */
-export function mapFixOrDoneResponse(responseText: string): StageResult {
-  const parsed = parseStepStatus(responseText);
-
-  if (parsed.status === "fixed" && parsed.keyword === "FIXED") {
-    return mapParsedStepToResult(parsed, responseText, {
-      fixed: "not_approved",
-    });
+export function mapFixOrDoneResponse(
+  responseText: string,
+  validKeywords?: readonly string[],
+): StageResult {
+  if (validKeywords && validKeywords.length > 0) {
+    const verdict = parseVerdictKeyword(responseText, validKeywords);
+    if (verdict.keyword === undefined) {
+      return {
+        outcome: "needs_clarification",
+        message: responseText,
+        validVerdicts: validKeywords,
+      };
+    }
+    // Feed the matched keyword through parseStepStatus for status mapping.
+    const parsed = parseStepStatus(verdict.keyword);
+    if (parsed.status === "fixed" && parsed.keyword === "FIXED") {
+      return mapParsedStepToResult(
+        parsed,
+        responseText,
+        { fixed: "not_approved" },
+        validKeywords,
+      );
+    }
+    return mapParsedStepToResult(
+      parsed,
+      responseText,
+      undefined,
+      validKeywords,
+    );
   }
 
-  return mapParsedStepToResult(parsed, responseText);
+  const parsed = parseStepStatus(responseText);
+  if (parsed.status === "fixed" && parsed.keyword === "FIXED") {
+    return mapParsedStepToResult(
+      parsed,
+      responseText,
+      { fixed: "not_approved" },
+      validKeywords,
+    );
+  }
+  return mapParsedStepToResult(parsed, responseText, undefined, validKeywords);
 }

--- a/src/step-parser.test.ts
+++ b/src/step-parser.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { buildClarificationPrompt, parseStepStatus } from "./step-parser.js";
+import {
+  buildClarificationPrompt,
+  parseStepStatus,
+  parseVerdictKeyword,
+} from "./step-parser.js";
 
 // ---------------------------------------------------------------------------
 // parseStepStatus
@@ -144,6 +148,38 @@ describe("buildClarificationPrompt", () => {
     expect(prompt).toContain("NOT_APPROVED");
     expect(prompt).toContain("BLOCKED");
   });
+
+  test("lists only the specified keywords when validKeywords is provided", () => {
+    const prompt = buildClarificationPrompt("ambiguous", ["FIXED", "DONE"]);
+    expect(prompt).toContain("FIXED");
+    expect(prompt).toContain("DONE");
+    // Should NOT contain keywords outside the valid set.
+    expect(prompt).not.toContain("COMPLETED");
+    expect(prompt).not.toContain("APPROVED");
+    expect(prompt).not.toContain("NOT_APPROVED");
+    expect(prompt).not.toContain("BLOCKED");
+  });
+
+  test("falls back to all keywords when validKeywords is undefined", () => {
+    const prompt = buildClarificationPrompt("ambiguous", undefined);
+    expect(prompt).toContain("COMPLETED");
+    expect(prompt).toContain("FIXED");
+    expect(prompt).toContain("DONE");
+    expect(prompt).toContain("APPROVED");
+    expect(prompt).toContain("NOT_APPROVED");
+    expect(prompt).toContain("BLOCKED");
+  });
+
+  test("falls back to all keywords when validKeywords is empty", () => {
+    const prompt = buildClarificationPrompt("ambiguous", []);
+    expect(prompt).toContain("COMPLETED");
+    expect(prompt).toContain("BLOCKED");
+  });
+
+  test("scoped prompt uses 'verdict keyword' phrasing", () => {
+    const prompt = buildClarificationPrompt("ambiguous", ["APPROVED"]);
+    expect(prompt).toContain("verdict keyword");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -189,5 +225,123 @@ describe("parseStepStatus — edge cases", () => {
     const r = parseStepStatus("Status: NOT_APPROVED");
     expect(r.status).toBe("not_approved");
     expect(r.keyword).toBe("NOT_APPROVED");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVerdictKeyword — strict verdict parser
+// ---------------------------------------------------------------------------
+describe("parseVerdictKeyword", () => {
+  const reviewKw = ["APPROVED", "NOT_APPROVED"] as const;
+  const checkKw = ["COMPLETED", "BLOCKED"] as const;
+  const fixKw = ["FIXED", "DONE"] as const;
+
+  // -- exact match ----------------------------------------------------------
+  test("returns keyword on exact match", () => {
+    expect(parseVerdictKeyword("APPROVED", reviewKw)).toEqual({
+      keyword: "APPROVED",
+    });
+  });
+
+  test("exact match is case-insensitive", () => {
+    expect(parseVerdictKeyword("completed", checkKw)).toEqual({
+      keyword: "COMPLETED",
+    });
+  });
+
+  test("trims whitespace around keyword", () => {
+    expect(parseVerdictKeyword("  BLOCKED\n", checkKw)).toEqual({
+      keyword: "BLOCKED",
+    });
+  });
+
+  // -- rejection of extra commentary ----------------------------------------
+  test("rejects keyword with extra commentary before", () => {
+    expect(
+      parseVerdictKeyword("I think it worked. COMPLETED", checkKw),
+    ).toEqual({ keyword: undefined });
+  });
+
+  test("rejects keyword with extra commentary after", () => {
+    expect(
+      parseVerdictKeyword("APPROVED — earlier items are now fixed", reviewKw),
+    ).toEqual({ keyword: undefined });
+  });
+
+  test("rejects keyword ending in valid keyword with extra text", () => {
+    // Regression: response ends with valid keyword but has commentary.
+    expect(
+      parseVerdictKeyword("Round 1 items are now APPROVED", reviewKw),
+    ).toEqual({ keyword: undefined });
+  });
+
+  // -- rejection of multiple valid keywords ---------------------------------
+  test("rejects when two in-scope keywords appear", () => {
+    // Regression: "NOT_APPROVED — earlier items are now APPROVED"
+    expect(
+      parseVerdictKeyword(
+        "NOT_APPROVED — earlier items are now APPROVED",
+        reviewKw,
+      ),
+    ).toEqual({ keyword: undefined });
+  });
+
+  test("rejects FIXED and DONE in the same response", () => {
+    expect(parseVerdictKeyword("FIXED and DONE", fixKw)).toEqual({
+      keyword: undefined,
+    });
+  });
+
+  test("rejects COMPLETED and BLOCKED in the same response", () => {
+    expect(
+      parseVerdictKeyword("COMPLETED at first but then BLOCKED", checkKw),
+    ).toEqual({ keyword: undefined });
+  });
+
+  // -- no keyword -----------------------------------------------------------
+  test("returns undefined for text with no valid keyword", () => {
+    expect(parseVerdictKeyword("I looked at things.", checkKw)).toEqual({
+      keyword: undefined,
+    });
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(parseVerdictKeyword("", checkKw)).toEqual({
+      keyword: undefined,
+    });
+  });
+
+  test("returns undefined for whitespace only", () => {
+    expect(parseVerdictKeyword("  \n\t  ", checkKw)).toEqual({
+      keyword: undefined,
+    });
+  });
+
+  // -- keyword not in valid set ---------------------------------------------
+  test("ignores out-of-scope keyword", () => {
+    // DONE is valid in fixKw but not in checkKw.
+    expect(parseVerdictKeyword("DONE", checkKw)).toEqual({
+      keyword: undefined,
+    });
+  });
+
+  // -- keyword with minor punctuation ---------------------------------------
+  test("accepts keyword with trailing period", () => {
+    expect(parseVerdictKeyword("COMPLETED.", checkKw)).toEqual({
+      keyword: "COMPLETED",
+    });
+  });
+
+  test("accepts keyword with trailing exclamation", () => {
+    expect(parseVerdictKeyword("BLOCKED!", checkKw)).toEqual({
+      keyword: "BLOCKED",
+    });
+  });
+
+  // -- NOT_APPROVED substring handling --------------------------------------
+  test("does not match APPROVED inside NOT_APPROVED", () => {
+    expect(parseVerdictKeyword("NOT_APPROVED", reviewKw)).toEqual({
+      keyword: "NOT_APPROVED",
+    });
   });
 });

--- a/src/step-parser.ts
+++ b/src/step-parser.ts
@@ -81,10 +81,88 @@ export function parseStepStatus(text: string): ParsedStep {
 }
 
 /**
+ * Strictly parse a verdict response for exactly one valid keyword.
+ *
+ * Unlike `parseStepStatus` (which scans free-form text for the *last*
+ * keyword), this function requires the response to be essentially just
+ * the keyword — optionally surrounded by whitespace and punctuation.
+ *
+ * Returns `{ keyword }` when exactly one valid keyword is found and no
+ * other valid keyword appears in the text.  Returns `{ keyword: undefined }`
+ * when the response is ambiguous: no keyword, multiple valid keywords,
+ * or significant extra commentary.
+ */
+export function parseVerdictKeyword(
+  text: string,
+  validKeywords: readonly string[],
+): { keyword: string | undefined } {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return { keyword: undefined };
+
+  const upper = trimmed.toUpperCase();
+
+  // Fast path: exact match (most well-behaved agents).
+  for (const kw of validKeywords) {
+    if (upper === kw.toUpperCase()) return { keyword: kw };
+  }
+
+  // Count how many distinct valid keywords appear as whole words.
+  const found: string[] = [];
+  for (const kw of validKeywords) {
+    const kwUpper = kw.toUpperCase();
+    const pattern = new RegExp(`(?<![\\w])${escapeRegExp(kwUpper)}(?![\\w])`);
+    if (pattern.test(upper)) {
+      found.push(kw);
+    }
+  }
+
+  if (found.length !== 1) {
+    // Zero keywords or multiple keywords → ambiguous.
+    return { keyword: undefined };
+  }
+
+  // Exactly one keyword found — verify there is no significant extra text.
+  // Strip the keyword and all non-alphanumeric characters; if anything
+  // substantive remains, treat as extra commentary.
+  const kwUpper = found[0].toUpperCase();
+  const stripped = upper
+    .replace(new RegExp(`(?<![\\w])${escapeRegExp(kwUpper)}(?![\\w])`), "")
+    .replace(/[^A-Z0-9]/g, "");
+
+  if (stripped.length > 0) {
+    // Extra words remain → ambiguous.
+    return { keyword: undefined };
+  }
+
+  return { keyword: found[0] };
+}
+
+/** Escape special regex characters in a string. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
  * Build a single-shot clarification prompt to send back to the agent when
  * the previous response was ambiguous.
+ *
+ * When `validKeywords` is provided, only those keywords are listed.
+ * Otherwise the prompt falls back to listing all recognised keywords.
  */
-export function buildClarificationPrompt(_originalResponse: string): string {
+export function buildClarificationPrompt(
+  _originalResponse: string,
+  validKeywords?: readonly string[],
+): string {
+  if (validKeywords && validKeywords.length > 0) {
+    const keywordList = validKeywords.join(", ");
+    return [
+      "Your previous response did not contain a clear verdict keyword.",
+      `Respond with exactly one of the following keywords: ${keywordList}`,
+      "",
+      "Do not include any other commentary — just the keyword.",
+    ].join("\n");
+  }
+
   return [
     "Your previous response did not end with a clear status keyword.",
     "Please reply with exactly one of the following keywords to indicate",


### PR DESCRIPTION
## Summary

- Introduces a two-step verdict pattern across all pipeline stages: agents perform their task freely, then a dedicated follow-up prompt asks for exactly one verdict keyword. This prevents misparsed keywords when agents use verdict words in non-verdict contexts.
- Adds a strict verdict parser (`parseVerdictKeyword`) that requires the response to be essentially just the keyword — rejects extra commentary, multiple valid keywords, and out-of-scope keywords. This replaces the old "last keyword wins" `parseStepStatus` for verdict follow-up responses.
- Parameterizes verdict helpers (`mapResponseToResult`, `mapFixOrDoneResponse`, `buildClarificationPrompt`) to accept substep-scoped valid keyword sets, rejecting out-of-scope keywords as `needs_clarification`.
- Adds `validVerdicts` field to `StageResult` so the pipeline engine builds correctly scoped clarification prompts without knowing stage internals.
- After the in-session clarification retry, stages that still get an ambiguous response use conservative fallbacks: FIXED/DONE loops (self-check, test-plan) fall back to `not_approved` so the pipeline loops again; COMPLETED/BLOCKED substeps (implement, author completion) fall back to `blocked` so the user is asked to intervene. Artifact-producing stages (create-PR, squash, PR finalization) verify a post-condition before proceeding.
- Extracts rebase logic from `index.ts` into a dedicated `rebase.ts` module with its own test file.
- Strict-parses the issue-sync verdict response: `parseIssueSyncResponse` now validates that every non-blank line matches a recognised keyword pattern and returns a `{ changes, valid }` result. Self-contradictory responses (e.g. `ISSUE_NO_CHANGES` mixed with `ISSUE_UPDATED:`) are rejected. When the response is malformed, a single clarification retry is attempted before falling back to "failed".

Closes #193

## Test plan

- [x] `pnpm vitest run` passes all 1451 tests
- [x] `pnpm tsc --noEmit` shows no type errors
- [x] `pnpm biome check` reports no lint issues
- [x] Strict parser: response with two in-scope keywords (e.g. `NOT_APPROVED — earlier items are now APPROVED`) is rejected
- [x] Strict parser: response with extra commentary ending in valid keyword is rejected
- [x] Strict parser: exact keyword with trailing punctuation is accepted
- [x] Reviewer verdict: ambiguous response triggers clarification retry with only `APPROVED`/`NOT_APPROVED`
- [x] PR finalization: uses strict verdict parser instead of `endsWith("PR_FINALIZED")`
- [x] Unresolved summary: uses strict verdict parser instead of `endsWith("NONE")`; ambiguous verdict triggers scoped clarification retry
- [x] Self-check stage: work and verdict are separate steps; `FIXED`/`DONE` parsed from follow-up only
- [x] Test-plan stage: same two-step split as self-check
- [x] Implementation stage: internal clarification retry on ambiguous completion check
- [x] Create-PR stage: `buildClarificationPrompt` called with scoped keywords; twice-ambiguous verdict verifies PR exists via `findPrNumber` before completing, reports `BLOCKED` if no PR found
- [x] Squash stage: `buildClarificationPrompt` called with scoped keywords; twice-ambiguous verdict verifies commit count decreased before completing, reports `BLOCKED` if unchanged
- [x] Rebase: verdict follow-up with `COMPLETED`/`BLOCKED` parsed from dedicated prompt
- [x] Issue-sync: status keyword parsed separately from sync work response; malformed verdict triggers clarification retry; still-malformed after retry reports "failed" status; self-contradictory `ISSUE_NO_CHANGES` mixed with change lines is rejected
- [x] Out-of-scope keywords (e.g. `APPROVED` in a `COMPLETED`/`BLOCKED` substep) trigger internal clarification retry; after retry, stages use conservative fallbacks (not_approved for FIXED/DONE loops, blocked for COMPLETED/BLOCKED substeps) rather than silently advancing
- [x] Pipeline engine: `needs_clarification` with `validVerdicts` set builds a scoped clarification prompt containing only the specified keywords (direct engine-level regression test)
- [x] `docs/pipeline.md` accurately describes the strict verdict parsing, per-substep keyword contracts, conservative fallbacks, and post-condition checks for artifact-producing stages
- [x] Unresolved summary uses verdict session ID (not stale review invoke session) when verdict advances session
- [x] Issue sync verdict failure reports `failed` status (not `completed`)
- [x] Clarification retries fall back to the prior session ID when the immediately preceding turn omits one
- [x] Unresolved summary twice-ambiguous verdict conservatively includes summary text rather than bubbling to the pipeline engine
- [x] PR finalization twice-ambiguous verdict verifies PR body consistency: `Closes #N` must not have a contradictory `## Not addressed` section, and `Part of #N` must include one; the body must use exactly one reference form — both present is self-contradictory and blocks
- [x] Author completion twice-ambiguous verdict returns `blocked` so the user can decide how to proceed