### PR TITLE
Fix inconsistent retryResult variable usage (#197)

### DIFF
--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -181,7 +181,7 @@ export function createCreatePrStageHandler(
 
         checkResult = retryResult;
         result = mapResponseToResult(
-          retryResult.responseText,
+          checkResult.responseText,
           undefined,
           PR_CHECK_KEYWORDS,
         );

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -632,7 +632,7 @@ export function createReviewStageHandler(
 
         checkResult = retryResult;
         checkMapped = mapResponseToResult(
-          retryResult.responseText,
+          checkResult.responseText,
           undefined,
           AUTHOR_CHECK_KEYWORDS,
         );
@@ -839,7 +839,6 @@ async function handleUnresolvedSummary(
       };
     }
 
-    verdictResult = retryResult;
     verdict = parseVerdictKeyword(
       retryResult.responseText,
       UNRESOLVED_KEYWORDS,

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -219,7 +219,7 @@ export function createSelfCheckStageHandler(
 
         verdictCheckResult = retryResult;
         result = mapFixOrDoneResponse(
-          retryResult.responseText,
+          verdictCheckResult.responseText,
           FIX_OR_DONE_KEYWORDS,
         );
       }

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -213,7 +213,7 @@ export function createSquashStageHandler(
 
         checkResult = retryResult;
         result = mapResponseToResult(
-          retryResult.responseText,
+          checkResult.responseText,
           undefined,
           SQUASH_CHECK_KEYWORDS,
         );


### PR DESCRIPTION
## Summary

- Removed dead `verdictResult = retryResult` assignment in `src/stage-review.ts` (line 842) where `verdictResult` was never read afterward.
- Changed four `retryResult.responseText` references to use the assigned variable (`checkResult`, `verdictCheckResult`) instead, making the reassignment meaningful and the pattern consistent across all clarification retry blocks.

Closes #197

## Test plan

- [x] Verify `src/stage-review.ts` no longer assigns `verdictResult = retryResult` in the unresolved-summary retry block (~line 842)
- [x] Verify `src/stage-review.ts` uses `checkResult.responseText` (not `retryResult.responseText`) after the author-check retry (~line 635)
- [x] Verify `src/stage-createpr.ts` uses `checkResult.responseText` after the PR-completion retry (~line 184)
- [x] Verify `src/stage-selfcheck.ts` uses `verdictCheckResult.responseText` after the fix-verdict retry (~line 222)
- [x] Verify `src/stage-squash.ts` uses `checkResult.responseText` after the squash-completion retry (~line 216)
- [x] Run `pnpm vitest run` and confirm all tests pass
- [x] Run `pnpm tsc --noEmit` and confirm no type errors
- [x] Run `pnpm biome check` and confirm no lint issues