### PR TITLE
Fix InputArea choices overlap on small terminals (#195)

### DIFF
--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -46,7 +46,7 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
 
   if (request.choices) {
     return (
-      <Box flexDirection="column" paddingX={1}>
+      <Box flexDirection="column" paddingX={1} flexShrink={0}>
         {request.message.split("\n").map((line, i) => (
           // biome-ignore lint/suspicious/noArrayIndexKey: static message lines never reorder
           <Text key={i}>{line || " "}</Text>
@@ -66,7 +66,7 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
   }
 
   return (
-    <Box flexDirection="column" paddingX={1}>
+    <Box flexDirection="column" paddingX={1} flexShrink={0}>
       {request.message.split("\n").map((line, i) => (
         // biome-ignore lint/suspicious/noArrayIndexKey: static message lines never reorder
         <Text key={i}>{line || " "}</Text>

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1349,6 +1349,61 @@ describe("InputArea", () => {
     expect(lastFrame()).toContain("Blocked. Choose:");
     expect(lastFrame()).not.toContain("Pipeline running...");
   });
+
+  test("choices do not overlap message in a height-constrained layout", () => {
+    const request: InputRequest = {
+      message: "ERROR: spawn E2BIG",
+      choices: [
+        { label: "Retry", value: "retry" },
+        { label: "Abort", value: "abort" },
+      ],
+    };
+    // The filler's height exceeds the container so Ink must shrink
+    // something.  Without flexShrink={0} on InputArea, the message
+    // Text gets collapsed to height 0 and choices overwrite it.
+    const filler = Array.from({ length: 20 }, (_, i) => `line-${i}`).join("\n");
+    const { lastFrame } = render(
+      <Box flexDirection="column" height={12}>
+        <Box flexGrow={1}>
+          <Text>{filler}</Text>
+        </Box>
+        <InputArea request={request} onSubmit={() => {}} />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    const msgIdx = lines.findIndex((l) => l.includes("ERROR: spawn E2BIG"));
+    const choiceIdx = lines.findIndex((l) => l.includes("Retry"));
+    expect(msgIdx).toBeGreaterThanOrEqual(0);
+    expect(choiceIdx).toBeGreaterThanOrEqual(0);
+    expect(msgIdx).toBeLessThan(choiceIdx);
+  });
+
+  test("text input does not overlap message in a height-constrained layout", () => {
+    const request: InputRequest = {
+      message: "Enter your instruction:",
+    };
+    const filler = Array.from({ length: 20 }, (_, i) => `line-${i}`).join("\n");
+    const { lastFrame } = render(
+      <Box flexDirection="column" height={12}>
+        <Box flexGrow={1}>
+          <Text>{filler}</Text>
+        </Box>
+        <InputArea request={request} onSubmit={() => {}} />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    const msgIdx = lines.findIndex((l) =>
+      l.includes("Enter your instruction:"),
+    );
+    const promptIdx = lines.findIndex((l) => l.includes(">"));
+    expect(msgIdx).toBeGreaterThanOrEqual(0);
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    expect(msgIdx).toBeLessThan(promptIdx);
+  });
 });
 
 // ---- Deferred resolution (issue #105) ----------------------------------------


### PR DESCRIPTION
## Summary

- Add `flexShrink={0}` to the two outer `<Box>` elements in `InputArea.tsx` (the choices branch and the text-input branch) so Ink's layout engine never collapses the component when terminal height is tight.
- This matches the approach already used by `StatusBar` (`StatusBar.tsx:327`).
- Add regression tests that render InputArea inside a height-constrained parent with overflowing content, verifying message and choices/text-input stay on separate lines.

Closes #195

## Test plan

- [x] Resize terminal to a small height (e.g. 10–15 rows) while a pipeline is paused at a choice prompt — verify the message line and choices render on separate lines without overlapping.
- [x] Verify the text-input prompt (non-choice input) also renders correctly at small terminal heights.
- [x] Confirm normal-sized terminal rendering is unaffected.