### PR TITLE
Fix pane display race (#205)

### DIFF
--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -210,10 +210,11 @@ export async function pollCiAndFix(
       cwd: ctx.worktreePath,
       onUsage: ctx.usageSinks?.a,
     });
-    if (ctx.streamSinks?.a) {
-      drainToSink(fixStream, ctx.streamSinks.a);
-    }
+    const drained = ctx.streamSinks?.a
+      ? drainToSink(fixStream, ctx.streamSinks.a)
+      : undefined;
     const fixResult = await fixStream.result;
+    if (drained) await drained;
 
     if (fixResult.sessionId) {
       ctx.onSessionId?.("a", fixResult.sessionId);

--- a/src/rebase.ts
+++ b/src/rebase.ts
@@ -88,10 +88,11 @@ export function createRebaseHandler(
       cwd: ctx.worktreePath,
       onUsage: ctx.usageSinks?.a,
     });
-    if (ctx.streamSinks?.a) {
-      drainToSink(stream, ctx.streamSinks.a);
-    }
+    const drained = ctx.streamSinks?.a
+      ? drainToSink(stream, ctx.streamSinks.a)
+      : undefined;
     const result = await stream.result;
+    if (drained) await drained;
 
     if (result.sessionId) {
       ctx.onSessionId?.("a", result.sessionId);

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -2518,8 +2518,6 @@ describe("Pipeline event emitter integration", () => {
     const result = await runPipeline(
       makePipelineOpts({ stages: [stage], events: emitter }),
     );
-    // Allow fire-and-forget drain to flush.
-    await new Promise((r) => setTimeout(r, 20));
 
     expect(result.success).toBe(true);
     expect(chunkEvents.length).toBe(2);
@@ -2634,7 +2632,6 @@ describe("Pipeline event emitter integration", () => {
     const result = await runPipeline(
       makePipelineOpts({ stages: [stage], events: emitter }),
     );
-    await new Promise((r) => setTimeout(r, 20));
 
     expect(result.success).toBe(true);
     const agentBChunks = chunkEvents.filter((e) => e.agent === "b");
@@ -2783,9 +2780,6 @@ describe("agent:chunk events emitted during stage execution", () => {
     const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
     await runPipeline(makePipelineOpts({ stages: [stage], events: emitter }));
 
-    // Allow fire-and-forget drainToSink to flush.
-    await new Promise((r) => setTimeout(r, 20));
-
     // All chunks should be tagged as agent "a".
     expect(agentChunks.length).toBeGreaterThanOrEqual(2);
     for (const ev of agentChunks) {
@@ -2825,8 +2819,6 @@ describe("agent:chunk events emitted during stage execution", () => {
     });
     await runPipeline(makePipelineOpts({ stages: [stage], events: emitter }));
 
-    await new Promise((r) => setTimeout(r, 20));
-
     // At minimum, agent B chunks should appear (reviewer).
     expect(seenAgents.has("b")).toBe(true);
   });
@@ -2849,8 +2841,6 @@ describe("agent:chunk events emitted during stage execution", () => {
 
     const stage = createImplementStageHandler({ agent, ...ISSUE_CTX });
     await runPipeline(makePipelineOpts({ stages: [stage], events: emitter }));
-
-    await new Promise((r) => setTimeout(r, 20));
 
     // Enter must come before any chunk, exit must come after handler returns.
     const enterIdx = timeline.indexOf("enter:2");

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -748,8 +748,9 @@ async function handleUnresolvedSummary(
       cwd,
       onUsage: usageSink,
     });
-    if (sink) drainToSink(stream, sink);
+    const drained = sink ? drainToSink(stream, sink) : undefined;
     result = await stream.result;
+    if (drained) await drained;
   }
 
   if (result.status === "error") {
@@ -782,8 +783,9 @@ async function handleUnresolvedSummary(
       cwd,
       onUsage: usageSink,
     });
-    if (sink) drainToSink(stream, sink);
+    const drained = sink ? drainToSink(stream, sink) : undefined;
     verdictResult = await stream.result;
+    if (drained) await drained;
   }
 
   if (verdictResult.status === "error") {
@@ -825,8 +827,9 @@ async function handleUnresolvedSummary(
         cwd,
         onUsage: usageSink,
       });
-      if (sink) drainToSink(stream, sink);
+      const drained = sink ? drainToSink(stream, sink) : undefined;
       retryResult = await stream.result;
+      if (drained) await drained;
     }
 
     if (retryResult.status === "error") {

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -725,8 +725,6 @@ describe("invokeOrResume with StreamSink", () => {
     const sink = (chunk: string) => collected.push(chunk);
 
     const out = await invokeOrResume(agent, undefined, "prompt", "/cwd", sink);
-    // Allow microtask queue to flush for the fire-and-forget drain.
-    await new Promise((r) => setTimeout(r, 10));
 
     expect(out).toBe(result);
     expect(collected).toEqual(["chunk1", "chunk2"]);
@@ -749,7 +747,6 @@ describe("invokeOrResume with StreamSink", () => {
       "/cwd",
       (chunk) => collected.push(chunk),
     );
-    await new Promise((r) => setTimeout(r, 10));
 
     expect(out).toBe(result);
     expect(collected).toEqual(["a", "b", "c"]);
@@ -781,7 +778,6 @@ describe("sendFollowUp with StreamSink", () => {
     const out = await sendFollowUp(agent, "sess-1", "prompt", "/cwd", (chunk) =>
       collected.push(chunk),
     );
-    await new Promise((r) => setTimeout(r, 10));
 
     expect(out.responseText).toBe("follow-up done");
     expect(collected).toEqual(["f1", "f2"]);
@@ -802,6 +798,45 @@ describe("sendFollowUp with StreamSink", () => {
 // ---- drainToSink edge cases -------------------------------------------------
 
 describe("drainToSink", () => {
+  test("all chunks are delivered before caller resumes (regression for #205)", async () => {
+    const result = makeResult({ responseText: "ok" });
+    // Iterator that yields on separate event-loop turns, simulating
+    // real I/O where chunks arrive after stream.result resolves.
+    const chunks = ["x", "y", "z"];
+    let idx = 0;
+    const stream: AgentStream = {
+      [Symbol.asyncIterator]() {
+        return {
+          next: async () => {
+            await new Promise<void>((r) => setTimeout(r, 0));
+            if (idx < chunks.length) {
+              return { done: false, value: chunks[idx++] };
+            }
+            return { done: true, value: "" };
+          },
+        };
+      },
+      result: Promise.resolve(result),
+      child: {} as AgentStream["child"],
+    };
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(stream),
+      resume: vi.fn(),
+    };
+
+    const collected: string[] = [];
+    await invokeOrResume(agent, undefined, "prompt", "/cwd", (chunk) =>
+      collected.push(chunk),
+    );
+
+    // Before the fix, drainToSink was fire-and-forget so the function
+    // returned as soon as stream.result resolved — while the iterator
+    // still had pending setTimeout turns.  This assertion would fail
+    // because collected would be incomplete.
+    expect(collected).toEqual(["x", "y", "z"]);
+  });
+
   test("result resolves independently even when sink throws", async () => {
     const result = makeResult({ responseText: "completed" });
     const agent: AgentAdapter = {
@@ -815,10 +850,8 @@ describe("drainToSink", () => {
       throw new Error("sink exploded");
     });
 
-    // drainToSink runs fire-and-forget, so the error is swallowed
-    // and .result should still resolve.
+    // drainToSink swallows sink errors, so .result should still resolve.
     const out = await invokeOrResume(agent, undefined, "prompt", "/cwd", sink);
-    await new Promise((r) => setTimeout(r, 10));
 
     expect(out).toBe(result);
     // sink was called at least once before the error stopped the drain.
@@ -840,7 +873,6 @@ describe("drainToSink", () => {
     await invokeOrResume(agent, undefined, "prompt", "/cwd", (chunk) =>
       collected.push(chunk),
     );
-    await new Promise((r) => setTimeout(r, 10));
 
     expect(collected).toEqual(["first", "second", "third"]);
   });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -188,17 +188,22 @@ export function mapParsedStepToResult(
 
 /**
  * Drain the async iterator of a stream, forwarding chunks to a sink.
- * The task runs detached — the returned promise is the stream's
- * `.result` (which resolves independently of the iterator).
+ *
+ * Returns a promise that resolves when the iterator is fully consumed.
+ * Callers should await this promise after `stream.result` to guarantee
+ * all chunks have been delivered before injecting the next prompt.
  */
-export function drainToSink(stream: AgentStream, sink: StreamSink): void {
-  (async () => {
+export function drainToSink(
+  stream: AgentStream,
+  sink: StreamSink,
+): Promise<void> {
+  return (async () => {
     try {
       for await (const chunk of stream) {
         sink(chunk);
       }
     } catch {
-      // Fire-and-forget: sink errors must not become unhandled rejections.
+      // Sink errors must not become unhandled rejections.
     }
   })();
 }
@@ -234,8 +239,9 @@ async function retryOnTimeout(
       cwd,
       onUsage: usageSink,
     });
-    if (sink) drainToSink(stream, sink);
+    const drained = sink ? drainToSink(stream, sink) : undefined;
     result = await stream.result;
+    if (drained) await drained;
   }
 
   return result;
@@ -291,8 +297,9 @@ async function invokeOrResumeOnce(
   const opts = { cwd, onUsage: usageSink };
   if (savedSessionId) {
     const stream = agent.resume(savedSessionId, prompt, opts);
-    if (sink) drainToSink(stream, sink);
+    const drained = sink ? drainToSink(stream, sink) : undefined;
     const result = await stream.result;
+    if (drained) await drained;
     if (result.status === "success") {
       return result;
     }
@@ -310,8 +317,10 @@ async function invokeOrResumeOnce(
     // Session expired or unknown error — fall back to fresh invoke.
   }
   const stream = agent.invoke(prompt, opts);
-  if (sink) drainToSink(stream, sink);
-  return stream.result;
+  const drained = sink ? drainToSink(stream, sink) : undefined;
+  const result = await stream.result;
+  if (drained) await drained;
+  return result;
 }
 
 /**
@@ -341,8 +350,9 @@ export async function sendFollowUp(
     cwd,
     onUsage: usageSink,
   });
-  if (sink) drainToSink(stream, sink);
+  const drained = sink ? drainToSink(stream, sink) : undefined;
   const result = await stream.result;
+  if (drained) await drained;
   return retryOnTimeout(
     agent,
     result,


### PR DESCRIPTION
## Summary

- Changed `drainToSink` from fire-and-forget (`void`) to returning `Promise<void>`, and awaited the drain promise after `stream.result` at all 9 production call sites (`stage-util.ts`, `stage-review.ts`, `rebase.ts`, `ci-poll.ts`).
- Removed 10 `setTimeout` flush hacks in tests that existed solely to work around the race condition.
- Added a regression test in `stage-util.test.ts` that exercises the orchestrator boundary: a stream whose async iterator yields on separate event-loop turns verifies that `invokeOrResume` delivers all chunks before returning. This test would fail with the old fire-and-forget implementation.

Closes #205

## Test plan

- [x] `pnpm vitest run` passes all 1454 tests
- [x] `pnpm tsc --noEmit` has no type errors
- [x] `pnpm biome check` reports no lint issues
- [x] Regression test `all chunks are delivered before caller resumes` validates the drain ordering guarantee at the stage level
- [ ] Run a pipeline and observe Agent B's pane during the Review stage: verdict prompt appears only after the review response finishes rendering
- [x] No `setTimeout` flush hacks remain in test files for drainToSink