### PR TITLE
Fix separator bar wrapping to two lines (#203)

### DIFF
--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -320,7 +320,7 @@ export function AgentPane({
         </Text>
       </Box>
       {showSeparator && (
-        <Box flexShrink={0}>
+        <Box flexShrink={0} overflow="hidden" height={1}>
           <Text dimColor>
             {contentWidth > 0 ? "\u2500".repeat(contentWidth) : ""}
           </Text>

--- a/src/ui/App.layout.test.tsx
+++ b/src/ui/App.layout.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Integration test: verify that the App component's root container applies
+ * computeLayoutWidth() so that no serialised output row reaches the exact
+ * terminal edge.
+ *
+ * This renders the real App (with pipeline/notify mocked out) and a fake
+ * TTY stdout so useTerminalDimensions() returns concrete dimensions.
+ * If App regresses to width="100%" instead of width={layoutWidth}, or
+ * stops calling computeLayoutWidth(), the rows will reach the full
+ * terminal width and the assertion will fail.
+ */
+import { EventEmitter } from "node:events";
+import { cleanup, render } from "ink-testing-library";
+import stringWidth from "string-width";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { initI18n } from "../i18n/index.js";
+import { PipelineEventEmitter } from "../pipeline-events.js";
+
+const TERMINAL_WIDTH = 80;
+const TERMINAL_HEIGHT = 24;
+
+// Fake stdout that useTerminalDimensions treats as a real TTY.
+const fakeStdout = Object.assign(new EventEmitter(), {
+  isTTY: true as const,
+  columns: TERMINAL_WIDTH,
+  rows: TERMINAL_HEIGHT,
+});
+
+// Override useStdout so useTerminalDimensions sees TTY dimensions.
+vi.mock("ink", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("ink")>();
+  return {
+    ...actual,
+    useStdout: () => ({ stdout: fakeStdout, write: vi.fn() }),
+  };
+});
+
+// Prevent the pipeline from actually executing.
+vi.mock("../pipeline.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../pipeline.js")>();
+  return {
+    ...actual,
+    runPipeline: vi.fn(async () => ({
+      success: true,
+      stoppedAt: undefined,
+      message: "",
+    })),
+  };
+});
+
+vi.mock("../notify.js", () => ({
+  notifyInputWaiting: vi.fn(),
+}));
+
+const { App } = await import("./App.js");
+
+const minimalOptions = {
+  context: {
+    owner: "test",
+    repo: "repo",
+    issueNumber: 1,
+    baseSha: "abc",
+  },
+} as never;
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("App layout width contract (issue #203)", () => {
+  test("all serialized rows stay strictly below terminal width", async () => {
+    initI18n("en");
+    const emitter = new PipelineEventEmitter();
+
+    const { lastFrame } = render(
+      <App
+        emitter={emitter}
+        pipelineOptions={minimalOptions}
+        onExit={vi.fn()}
+      />,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+
+    // Sanity: some content rendered.
+    expect(lines.length).toBeGreaterThan(0);
+
+    // Every row must stay strictly below the terminal width.
+    // computeLayoutWidth(80) = 79, so content fits in 79 columns.
+    for (const line of lines) {
+      expect(stringWidth(line)).toBeLessThan(TERMINAL_WIDTH);
+    }
+  });
+});

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -19,7 +19,20 @@ import { StatusBar } from "./StatusBar.js";
 import { TokenBar } from "./TokenBar.js";
 import { createTuiUserPrompt } from "./TuiUserPrompt.js";
 
-// ---- Terminal dimension hooks ------------------------------------------------
+// ---- Terminal helpers --------------------------------------------------------
+
+/**
+ * Reserve one column so no serialized output row reaches the exact terminal
+ * edge.  Some terminals visually wrap at column N when N characters are
+ * written, which confuses log-update's line counting and produces stale-row
+ * artifacts (see issue #203).  Ink's output serialization trims trailing
+ * spaces, so the gap is invisible.
+ */
+export function computeLayoutWidth(
+  terminalWidth: number | undefined,
+): number | undefined {
+  return terminalWidth !== undefined ? terminalWidth - 1 : undefined;
+}
 
 /** Read terminal dimensions from stdout, re-rendering on resize. */
 export function useTerminalDimensions(): {
@@ -263,6 +276,9 @@ export function App({
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
     useTerminalDimensions();
+
+  const layoutWidth = computeLayoutWidth(terminalWidth);
+
   const messages = t();
   const [inputRequest, setInputRequest] = useState<InputRequest | null>(null);
   const resolveRef = useRef<((value: string) => void) | null>(null);
@@ -319,7 +335,7 @@ export function App({
       hasTokenData,
       preferredLayout,
       {
-        terminalWidth,
+        terminalWidth: layoutWidth,
         paneHeaderTexts,
       },
     );
@@ -328,7 +344,7 @@ export function App({
     inputHeight,
     hasTokenData,
     preferredLayout,
-    terminalWidth,
+    layoutWidth,
     paneHeaderTexts,
   ]);
 
@@ -338,18 +354,18 @@ export function App({
       : preferredLayout;
 
   // Content width budget for bordered components (StatusBar, TokenBar):
-  // terminal width minus border (2) and paddingX (2).
+  // layout width minus border (2) and paddingX (2).
   const borderedContentWidth =
-    terminalWidth !== undefined ? terminalWidth - 4 : undefined;
+    layoutWidth !== undefined ? layoutWidth - 4 : undefined;
 
   // Per-box content width for the split TokenBar.
-  // Row layout: each box gets half the terminal width.
-  // Column layout: each box gets the full terminal width.
+  // Row layout: each box gets half the layout width.
+  // Column layout: each box gets the full layout width.
   const tokenBarContentWidth =
-    terminalWidth !== undefined
+    layoutWidth !== undefined
       ? effectiveLayout === "row"
-        ? Math.floor(terminalWidth / 2) - 4
-        : terminalWidth - 4
+        ? Math.floor(layoutWidth / 2) - 4
+        : layoutWidth - 4
       : undefined;
 
   const notificationsRef = useRef(notifications);
@@ -435,7 +451,11 @@ export function App({
   }, [dispatch, abortController]);
 
   return (
-    <Box flexDirection="column" width="100%" height={terminalHeight ?? "100%"}>
+    <Box
+      flexDirection="column"
+      width={layoutWidth ?? "100%"}
+      height={terminalHeight ?? "100%"}
+    >
       {/* Agent panes: side by side (row) or stacked (column) */}
       <Box flexDirection={effectiveLayout} flexGrow={1}>
         <AgentPane

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "../pipeline-events.js";
 import { AgentPane, renderPromptRows, splitIntoRows } from "./AgentPane.js";
 import {
+  computeLayoutWidth,
   computeVisibilityFlags,
   inputAreaHeight,
   useTerminalHeight,
@@ -2904,6 +2905,52 @@ describe("AgentPane showSeparator", () => {
         l.includes("\u2500") && !l.includes("\u250C") && !l.includes("\u2514"),
     );
     expect(separatorLines.length).toBeGreaterThan(0);
+  });
+
+  test("computeLayoutWidth keeps pane rows below terminal width (unit)", async () => {
+    // Unit test: verifies the arithmetic of computeLayoutWidth() by
+    // building a manual harness with the derived width.  The companion
+    // integration test in App.layout.test.tsx renders the real App
+    // component to ensure it actually consumes computeLayoutWidth().
+    const terminalWidth = 80;
+    const layoutWidth = computeLayoutWidth(terminalWidth) as number;
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={layoutWidth} height={12}>
+        <Box flexDirection="row" flexGrow={1}>
+          <AgentPane
+            label="Agent A"
+            agent="a"
+            emitter={emitter}
+            color="blue"
+            isFocused
+          />
+          <AgentPane
+            label="Agent B"
+            agent="b"
+            emitter={emitter}
+            color="green"
+          />
+        </Box>
+      </Box>,
+    );
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    // Sanity: the separator characters rendered.
+    const separatorLines = lines.filter(
+      (l) =>
+        l.includes("\u2500") && !l.includes("\u250C") && !l.includes("\u2514"),
+    );
+    expect(separatorLines.length).toBeGreaterThan(0);
+
+    for (const line of lines) {
+      // Every serialized row must stay strictly below the terminal width.
+      // This prevents cursor-wrapping artifacts (issue #203).
+      expect(stringWidth(line)).toBeLessThan(terminalWidth);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Extract `computeLayoutWidth()` from `App.tsx` so the defensive one-column clamp is a single, testable function.  The root layout uses `computeLayoutWidth(terminalWidth)` so no serialized output row reaches the exact terminal edge.  Ink's output serialization trims trailing spaces, so the gap is invisible.  This prevents terminal-level cursor wrapping that caused the separator bar (and potentially other full-width rows) to produce stale-row artifacts in iTerm2 and tmux at certain widths.
- Keep `overflow="hidden"` and `height={1}` on the separator `<Box>` in `AgentPane.tsx` as a defensive clamp.
- Add unit and integration regression tests: a unit test in `components.test.tsx` verifies `computeLayoutWidth()` arithmetic with a manual harness; an integration test in `App.layout.test.tsx` renders the real `App` component with a fake TTY stdout and asserts every serialized row stays strictly below the terminal width.  The integration test will fail if `App` stops consuming `computeLayoutWidth()` or if the root container regresses to `width="100%"`.

Closes #203

## Test plan

- [x] Open the TUI in iTerm2 and resize the terminal across a range of widths (60–200 columns); confirm the separator line never wraps to two rows
- [x] Open the TUI in tmux and verify the same behavior
- [x] Confirm the separator renders correctly in both single-pane and dual-pane layouts
- [x] Verify that focusing/unfocusing a pane does not cause the separator to wrap
- [x] Run `pnpm vitest run` and confirm all tests pass (1456 tests)