### PR TITLE
Sync review-loop state from PR comments (#208)

### DIFF
--- a/src/fetch-pr-comments.test.ts
+++ b/src/fetch-pr-comments.test.ts
@@ -1,0 +1,57 @@
+import { execFileSync } from "node:child_process";
+import { afterEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const { fetchPrComments } = await import("./pr-comments.js");
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+afterEach(() => {
+  mockExecFileSync.mockReset();
+});
+
+describe("fetchPrComments", () => {
+  test("passes --paginate and --slurp to gh api", () => {
+    mockExecFileSync.mockReturnValue("[[]]");
+    fetchPrComments("org", "repo", 5);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      ["api", "repos/org/repo/issues/5/comments", "--paginate", "--slurp"],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("flattens multi-page slurp output into a single array", () => {
+    // --slurp wraps each page in an outer array: [[page1...], [page2...]]
+    const page1 = [
+      { body: "comment 1", user: { login: "a" } },
+      { body: "comment 2", user: { login: "b" } },
+    ];
+    const page2 = [{ body: "comment 3", user: { login: "a" } }];
+    mockExecFileSync.mockReturnValue(JSON.stringify([page1, page2]));
+
+    const result = fetchPrComments("org", "repo", 10);
+    expect(result).toEqual([...page1, ...page2]);
+    expect(result).toHaveLength(3);
+  });
+
+  test("handles single-page slurp output", () => {
+    const page = [{ body: "only comment", user: { login: "a" } }];
+    mockExecFileSync.mockReturnValue(JSON.stringify([page]));
+
+    const result = fetchPrComments("org", "repo", 1);
+    expect(result).toEqual(page);
+    expect(result).toHaveLength(1);
+  });
+
+  test("returns empty array when PR has no comments", () => {
+    // --slurp with zero results still produces [[]]
+    mockExecFileSync.mockReturnValue("[[]]");
+
+    const result = fetchPrComments("org", "repo", 1);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -227,6 +227,10 @@ export const en: Messages = {
     `Round ${round} fixes applied, CI passed. Proceeding to next review round.`,
   "review.finalizationUnverified": (issueNumber) =>
     `PR finalization verdict was ambiguous and the PR body does not reference issue #${issueNumber}. Manual verification required.`,
+  "review.missingAuthorComment": (round) =>
+    `Expected [Author Round ${round}] comment not found on PR. Cannot proceed with review.`,
+  "review.missingReviewerComment": (round) =>
+    `Expected [Reviewer Round ${round}] comment not found on PR. Cannot proceed with author fix.`,
 
   // ---- stage-util errors -------------------------------------------------
 

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -90,6 +90,8 @@ describe("catalogs are complete", () => {
       "review.unresolvedItems": ["Review approved.", "item 1"],
       "review.fixesApplied": [1],
       "review.finalizationUnverified": [42],
+      "review.missingAuthorComment": [2],
+      "review.missingReviewerComment": [3],
       "worktree.alreadyExists": ["/tmp/wt"],
     };
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -261,6 +261,10 @@ export const ko: Messages = {
     `${round}라운드 수정 적용 완료, CI 통과. 다음 리뷰 라운드로 진행합니다.`,
   "review.finalizationUnverified": (issueNumber) =>
     `PR 마무리 판정이 모호하고 PR 본문에 이슈 #${issueNumber} 참조가 없습니다. 수동 확인이 필요합니다.`,
+  "review.missingAuthorComment": (round) =>
+    `PR에서 [Author Round ${round}] 코멘트를 찾을 수 없습니다. 리뷰를 진행할 수 없습니다.`,
+  "review.missingReviewerComment": (round) =>
+    `PR에서 [Reviewer Round ${round}] 코멘트를 찾을 수 없습니다. 작성자 수정을 진행할 수 없습니다.`,
 
   // ---- stage-util errors -------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -220,6 +220,8 @@ export interface Messages {
   "review.unresolvedItems": (base: string, summary: string) => string;
   "review.fixesApplied": (round: number) => string;
   "review.finalizationUnverified": (issueNumber: number) => string;
+  "review.missingAuthorComment": (round: number) => string;
+  "review.missingReviewerComment": (round: number) => string;
 
   // ---- stage-util errors -------------------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,12 @@ import type {
 import { createDoneStageHandler } from "./pipeline.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
 import { checkMergeable, findPrNumber } from "./pr.js";
+import {
+  fetchPrComments,
+  type PrComment,
+  parsePrReviewState,
+  reconcileWithPr,
+} from "./pr-comments.js";
 import { createRebaseHandler } from "./rebase.js";
 import {
   deleteRunState,
@@ -423,6 +429,41 @@ try {
     startFromStage = 5;
   }
 
+  // Reconcile local review-loop state with PR comments on resume.
+  if (resuming && savedState) {
+    // Ensure PR number is up to date.
+    if (savedState.prNumber === undefined) {
+      savedState.prNumber = findPrNumber(owner, repo, wt.branch);
+    }
+    if (savedState.prNumber !== undefined) {
+      let prComments: PrComment[];
+      try {
+        prComments = fetchPrComments(owner, repo, savedState.prNumber);
+      } catch (err) {
+        console.error(
+          `\n  PR comment fetch failed for PR #${savedState.prNumber}.`,
+        );
+        console.error(
+          "  Cannot reconcile local state with PR — aborting resume.",
+        );
+        console.error(
+          `  Cause: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        process.exit(1);
+      }
+      const prState = parsePrReviewState(prComments);
+      const { warnings } = reconcileWithPr(savedState, prState);
+      for (const w of warnings) {
+        console.warn(`  ${w}`);
+      }
+      // Update startFromStage if reconciliation demoted currentStage.
+      if (startFromStage !== undefined) {
+        startFromStage = savedState.currentStage;
+      }
+      saveRunState(savedState);
+    }
+  }
+
   console.log();
   console.log(m["boot.startingPipeline"](owner, repo, issueNumber, resuming));
   console.log(m["boot.agentA"](modelDisplayName(agentAConfig)));
@@ -502,6 +543,24 @@ try {
       agentA,
       agentB,
       ...issueCtx,
+      getPrNumber: () => runState.prNumber,
+      onReviewProgress: (subStep, verdict) => {
+        runState.reviewSubStep = subStep;
+        if (verdict !== undefined) {
+          runState.lastVerdict = verdict;
+        } else if (subStep === "review" || subStep === "verdict") {
+          // Entering a pre-verdict step for a (possibly new) round —
+          // clear the stale verdict from the previous round so that
+          // reconciliation does not falsely invalidate sessions.
+          runState.lastVerdict = undefined;
+        }
+        saveRunState(runState);
+      },
+      onReviewPosted: (round) => {
+        runState.reviewCount = round;
+        saveRunState(runState);
+        emitter.emit("review:posted", { round });
+      },
     }),
     autoBudget: pipelineSettings.reviewAutoRounds,
   };
@@ -519,6 +578,10 @@ try {
     currentStage: 2,
     stageLoopCount: 0,
     reviewRound: 0,
+    selfCheckCount: 0,
+    reviewCount: 0,
+    reviewSubStep: undefined,
+    lastVerdict: undefined,
     executionMode,
     agentA: {
       cli: agentAConfig.cli,
@@ -555,6 +618,14 @@ try {
     | undefined;
 
   const emitter = new PipelineEventEmitter();
+
+  // Persist selfCheckCount on stage-3 exit.
+  emitter.on("stage:exit", (ev) => {
+    if (ev.stageNumber === 3) {
+      runState.selfCheckCount += 1;
+      saveRunState(runState);
+    }
+  });
 
   const doneStage = createDoneStageHandler({
     events: emitter,
@@ -741,6 +812,8 @@ try {
       cliTypeA: agentAConfig.cli,
       cliTypeB: agentBConfig.cli,
       notifications,
+      initialSelfCheckCount: runState.selfCheckCount,
+      initialReviewCount: runState.reviewCount,
     });
   });
 
@@ -748,9 +821,6 @@ try {
   // (allows Ctrl+C to kill during cleanup prompts).
   process.off("SIGINT", sigintHandler);
 
-  console.error(
-    `[done-stage-debug] pipelineResult: ${JSON.stringify(pipelineResult)}`,
-  );
   console.log();
   console.log(pipelineResult.message);
 

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -21,6 +21,10 @@ export interface StageNameOverrideEvent {
   stageName: string;
 }
 
+export interface ReviewPostedEvent {
+  round: number;
+}
+
 export interface AgentInvokeEvent {
   agent: "a" | "b";
   type: "invoke" | "resume";
@@ -43,6 +47,7 @@ interface PipelineEventMap {
   "stage:enter": [StageEnterEvent];
   "stage:exit": [StageExitEvent];
   "stage:name-override": [StageNameOverrideEvent];
+  "review:posted": [ReviewPostedEvent];
   "agent:invoke": [AgentInvokeEvent];
 }
 

--- a/src/pr-comments.test.ts
+++ b/src/pr-comments.test.ts
@@ -1,0 +1,775 @@
+import { describe, expect, test } from "vitest";
+import type { PrComment } from "./pr-comments.js";
+import {
+  authorRoundPattern,
+  deriveReviewSubStep,
+  hasComment,
+  parsePrReviewState,
+  reconcileWithPr,
+  reviewerRoundPattern,
+} from "./pr-comments.js";
+import { RUN_STATE_VERSION, type RunState } from "./run-state.js";
+
+// ---- helpers ---------------------------------------------------------------
+
+function makeComment(body: string): PrComment {
+  return { body, user: { login: "bot" } };
+}
+
+function makeRunState(overrides: Partial<RunState> = {}): RunState {
+  return {
+    version: RUN_STATE_VERSION,
+    owner: "org",
+    repo: "repo",
+    issueNumber: 42,
+    branch: "issue-42",
+    worktreePath: "/tmp/wt/issue-42",
+    baseSha: undefined,
+    prNumber: 10,
+    currentStage: 7,
+    stageLoopCount: 0,
+    reviewRound: 1,
+    selfCheckCount: 0,
+    reviewCount: 0,
+    reviewSubStep: undefined,
+    lastVerdict: undefined,
+    executionMode: "auto",
+    agentA: {
+      cli: "claude",
+      model: "opus",
+      contextWindow: undefined,
+      effortLevel: undefined,
+      sessionId: "sess-a",
+    },
+    agentB: {
+      cli: "claude",
+      model: "sonnet",
+      contextWindow: undefined,
+      effortLevel: undefined,
+      sessionId: "sess-b",
+    },
+    issueSyncStatus: "skipped",
+    issueChanges: [],
+    ...overrides,
+  };
+}
+
+// ---- parsePrReviewState ----------------------------------------------------
+
+describe("parsePrReviewState", () => {
+  test("returns zeros for empty comments", () => {
+    const state = parsePrReviewState([]);
+    expect(state.maxReviewerRound).toBe(0);
+    expect(state.maxAuthorRound).toBe(0);
+    expect(state.maxVerdictRound).toBe(0);
+    expect(state.latestVerdict).toBeUndefined();
+  });
+
+  test("extracts max reviewer round", () => {
+    const comments = [
+      makeComment("**[Reviewer Round 1]** Some review."),
+      makeComment("**[Reviewer Round 3]** Another review."),
+      makeComment("**[Reviewer Round 2]** Middle review."),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxReviewerRound).toBe(3);
+  });
+
+  test("extracts max author round", () => {
+    const comments = [
+      makeComment("**[Author Round 1]** Fixes applied."),
+      makeComment("**[Author Round 2]** More fixes."),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxAuthorRound).toBe(2);
+  });
+
+  test("extracts verdict with APPROVED", () => {
+    const comments = [
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxVerdictRound).toBe(2);
+    expect(state.latestVerdict).toBe("APPROVED");
+  });
+
+  test("extracts verdict with NOT_APPROVED", () => {
+    const comments = [makeComment("[Review Verdict Round 1: NOT_APPROVED]")];
+    const state = parsePrReviewState(comments);
+    expect(state.maxVerdictRound).toBe(1);
+    expect(state.latestVerdict).toBe("NOT_APPROVED");
+  });
+
+  test("handles mixed comments", () => {
+    const comments = [
+      makeComment("**[Reviewer Round 1]** Review 1."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix 1."),
+      makeComment("**[Reviewer Round 2]** Review 2."),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxReviewerRound).toBe(2);
+    expect(state.maxAuthorRound).toBe(1);
+    expect(state.maxVerdictRound).toBe(2);
+    expect(state.latestVerdict).toBe("APPROVED");
+  });
+
+  test("ignores comments without matching patterns", () => {
+    const comments = [
+      makeComment("Regular PR comment."),
+      makeComment("LGTM!"),
+      makeComment("Some discussion about the approach."),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxReviewerRound).toBe(0);
+    expect(state.maxAuthorRound).toBe(0);
+    expect(state.maxVerdictRound).toBe(0);
+  });
+
+  test("handles bold markdown markers", () => {
+    const comments = [
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Author Round 1] Fix."),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxReviewerRound).toBe(1);
+    expect(state.maxAuthorRound).toBe(1);
+  });
+
+  test("handles duplicates by taking max round", () => {
+    const comments = [
+      makeComment("**[Reviewer Round 2]** First attempt."),
+      makeComment("**[Reviewer Round 2]** Duplicate after crash."),
+    ];
+    const state = parsePrReviewState(comments);
+    expect(state.maxReviewerRound).toBe(2);
+  });
+});
+
+// ---- hasComment / patterns -------------------------------------------------
+
+describe("hasComment", () => {
+  test("finds reviewer round comment", () => {
+    const comments = [makeComment("**[Reviewer Round 1]** Review.")];
+    expect(hasComment(comments, reviewerRoundPattern(1))).toBe(true);
+    expect(hasComment(comments, reviewerRoundPattern(2))).toBe(false);
+  });
+
+  test("finds author round comment", () => {
+    const comments = [makeComment("**[Author Round 3]** Fix.")];
+    expect(hasComment(comments, authorRoundPattern(3))).toBe(true);
+    expect(hasComment(comments, authorRoundPattern(1))).toBe(false);
+  });
+
+  test("returns false for empty list", () => {
+    expect(hasComment([], reviewerRoundPattern(1))).toBe(false);
+  });
+});
+
+// ---- reconcileWithPr -------------------------------------------------------
+
+describe("reconcileWithPr", () => {
+  test("no-op when PR has no review comments and local state is fresh", () => {
+    const state = makeRunState({
+      reviewRound: 0,
+      stageLoopCount: 0,
+      reviewCount: 0,
+      currentStage: 7,
+    });
+    const prState = parsePrReviewState([]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(result.warnings).toHaveLength(0);
+    expect(result.sessionsInvalidated).toBe(false);
+    expect(state.agentA.sessionId).toBe("sess-a");
+  });
+
+  test("corrects stale stage-7 local state against empty PR history", () => {
+    // Local state thinks review round 1 started, but the PR has
+    // no review comments — the reviewer comment never made it.
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 1,
+      stageLoopCount: 0,
+      reviewCount: 1,
+      reviewSubStep: "verdict",
+      lastVerdict: undefined,
+    });
+    const prState = parsePrReviewState([]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.reviewRound).toBe(0);
+    expect(state.stageLoopCount).toBe(0);
+    expect(state.reviewCount).toBe(0);
+    expect(state.reviewSubStep).toBeUndefined();
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+  });
+
+  test("corrects stale stage-8 local state against empty PR history", () => {
+    // Local state claims past stage 7, but the PR has no review
+    // comments at all — everything must be corrected and demoted.
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+      reviewSubStep: "unresolved_summary",
+      lastVerdict: "APPROVED",
+    });
+    const prState = parsePrReviewState([]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(7);
+    expect(state.reviewRound).toBe(0);
+    expect(state.stageLoopCount).toBe(0);
+    expect(state.reviewCount).toBe(0);
+    expect(state.reviewSubStep).toBeUndefined();
+    expect(state.lastVerdict).toBeUndefined();
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+  });
+
+  test("corrects reviewCount from PR", () => {
+    const state = makeRunState({ reviewCount: 0, reviewRound: 1 });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.reviewCount).toBe(2);
+    expect(result.warnings.some((w) => w.includes("reviewCount"))).toBe(true);
+  });
+
+  test("corrects reviewRound and stageLoopCount at stage 7", () => {
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 1,
+      stageLoopCount: 0,
+      reviewCount: 0,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: NOT_APPROVED]"),
+      makeComment("**[Author Round 2]** Fix."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.reviewRound).toBe(2);
+    expect(state.stageLoopCount).toBe(1);
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+  });
+
+  test("demotes currentStage when PR has no APPROVED verdict", () => {
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: NOT_APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(7);
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(
+      result.warnings.some((w) => w.includes("currentStage demoted")),
+    ).toBe(true);
+  });
+
+  test("does not demote when PR has APPROVED verdict for max round", () => {
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+      reviewSubStep: "unresolved_summary",
+      lastVerdict: "APPROVED",
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(8);
+    expect(result.sessionsInvalidated).toBe(false);
+  });
+
+  test("invalidates sessions when past stage 7 with matching counters but divergent verdict", () => {
+    // Stage 8 with correct round counters, but local state has
+    // wrong verdict — sessions carry stale context and must be
+    // invalidated even though currentStage > 7.
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+      reviewSubStep: "verdict",
+      lastVerdict: undefined,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    // No demotion — max round is APPROVED.
+    expect(state.currentStage).toBe(8);
+    // But sessions must be invalidated due to verdict divergence.
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+    expect(state.reviewSubStep).toBe("unresolved_summary");
+    expect(state.lastVerdict).toBe("APPROVED");
+  });
+
+  test("demotes when older round is APPROVED but newer round has no verdict", () => {
+    // Round 2 is APPROVED, but a Round 3 reviewer comment exists
+    // without a verdict — stage 7 is still incomplete.
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+      makeComment("**[Reviewer Round 3]** Another review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(7);
+    expect(state.reviewRound).toBe(3);
+    expect(state.stageLoopCount).toBe(2);
+    expect(state.reviewCount).toBe(3);
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(
+      result.warnings.some((w) => w.includes("currentStage demoted")),
+    ).toBe(true);
+  });
+
+  test("reconciles reviewRound but not stageLoopCount when beyond stage 7", () => {
+    // Stage 8 with correct APPROVED verdict for max round, but
+    // reviewRound is stale.  stageLoopCount belongs to stage 8 now,
+    // so PR sync must not overwrite it with the review-derived value.
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 1,
+      stageLoopCount: 0,
+      reviewCount: 1,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    // Should NOT demote — max round (2) is APPROVED.
+    expect(state.currentStage).toBe(8);
+    // reviewRound corrected, but stageLoopCount left alone (it's stage 8's counter).
+    expect(state.reviewRound).toBe(2);
+    expect(state.stageLoopCount).toBe(0);
+    expect(state.reviewCount).toBe(2);
+    expect(result.sessionsInvalidated).toBe(true);
+  });
+
+  test("promotes currentStage when local state is behind PR", () => {
+    // Regression: stage 7 posts [Reviewer Round 1] but the process
+    // dies before run-state.json is updated from stage 6 to stage 7.
+    // Reconciliation must promote currentStage to 7 and set
+    // stageLoopCount from the PR round so the pipeline resumes in
+    // the review loop instead of re-running earlier stages.
+    const state = makeRunState({
+      currentStage: 6,
+      reviewRound: 0,
+      stageLoopCount: 3, // stage 6 loop counter
+      reviewCount: 0,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(7);
+    expect(state.reviewRound).toBe(1);
+    // stageLoopCount is now stage 7's counter: max(0, 1-1) = 0
+    expect(state.stageLoopCount).toBe(0);
+    expect(state.reviewCount).toBe(1);
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+    expect(
+      result.warnings.some((w) => w.includes("currentStage promoted")),
+    ).toBe(true);
+  });
+
+  test("promotes currentStage and sets stageLoopCount for multi-round PR", () => {
+    // Local state stuck at stage 5 but PR has two review rounds.
+    const state = makeRunState({
+      currentStage: 5,
+      reviewRound: 0,
+      stageLoopCount: 1,
+      reviewCount: 0,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(7);
+    expect(state.reviewRound).toBe(2);
+    // stageLoopCount derived from PR: max(0, 2-1) = 1
+    expect(state.stageLoopCount).toBe(1);
+    expect(state.reviewCount).toBe(2);
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(
+      result.warnings.some((w) => w.includes("currentStage promoted")),
+    ).toBe(true);
+  });
+
+  test("does not overwrite stageLoopCount when resuming before stage 7", () => {
+    // Regression: resuming in stage 6 (test plan) with a prNumber set
+    // and no review comments yet.  stageLoopCount is the test-plan
+    // loop counter and must not be zeroed by PR sync.
+    const state = makeRunState({
+      currentStage: 6,
+      reviewRound: 0,
+      stageLoopCount: 3,
+      reviewCount: 0,
+    });
+    const prState = parsePrReviewState([]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(6);
+    expect(state.stageLoopCount).toBe(3);
+    expect(state.reviewRound).toBe(0);
+    expect(result.sessionsInvalidated).toBe(false);
+  });
+
+  test("invalidates sessions when any state diverges", () => {
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 1,
+      stageLoopCount: 0,
+      reviewCount: 0,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+  });
+
+  test("invalidates sessions when sub-step diverges despite matching round", () => {
+    // Round numbers match (round 2) but local state has no
+    // reviewSubStep — the PR shows reviewer round 2 posted without
+    // a verdict, so derived sub-step is "verdict".  The mismatch
+    // triggers session invalidation.
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+    expect(state.reviewSubStep).toBe("verdict");
+  });
+
+  test("no session invalidation when all fields match including sub-step", () => {
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+      reviewSubStep: "verdict",
+      lastVerdict: undefined,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(result.sessionsInvalidated).toBe(false);
+    expect(state.agentA.sessionId).toBe("sess-a");
+    expect(state.agentB.sessionId).toBe("sess-b");
+  });
+
+  test("no session invalidation when round 2 resumes before verdict and round 1 was NOT_APPROVED", () => {
+    // Regression: after onReviewProgress clears lastVerdict on entering
+    // a pre-verdict step, a resume in round 2 (before any round-2
+    // verdict) must not invalidate sessions just because round 1 ended
+    // NOT_APPROVED.  The key invariant is that local lastVerdict is
+    // undefined (cleared by the fix), matching the PR-derived verdict
+    // for the incomplete round 2.
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+      reviewSubStep: "verdict",
+      lastVerdict: undefined,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(result.sessionsInvalidated).toBe(false);
+    expect(state.agentA.sessionId).toBe("sess-a");
+    expect(state.agentB.sessionId).toBe("sess-b");
+    expect(state.lastVerdict).toBeUndefined();
+  });
+
+  test("no session invalidation when only reviewCount diverges", () => {
+    // Regression: reviewCount is a persisted UI counter, not
+    // authoritative review state.  If the reviewer comment was posted
+    // but the process crashed before run-state.json updated
+    // reviewCount, the mismatch should correct the counter without
+    // invalidating agent sessions (round, verdict, and sub-step all
+    // match the PR).
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 1, // stale — should become 2
+      reviewSubStep: "verdict",
+      lastVerdict: undefined,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.reviewCount).toBe(2);
+    expect(result.sessionsInvalidated).toBe(false);
+    expect(state.agentA.sessionId).toBe("sess-a");
+    expect(state.agentB.sessionId).toBe("sess-b");
+  });
+
+  test("handles APPROVED at stage 7 — re-enters at the approved round", () => {
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 1,
+      stageLoopCount: 0,
+      reviewCount: 0,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    // reviewRound stays at 1 (max round is 1, matches local)
+    expect(state.reviewRound).toBe(1);
+    expect(state.stageLoopCount).toBe(0);
+    // reviewCount updated from 0 to 1
+    expect(state.reviewCount).toBe(1);
+    expect(result.sessionsInvalidated).toBe(true);
+    // Sub-step set to unresolved_summary (conservative resume point
+    // for APPROVED verdict).
+    expect(state.reviewSubStep).toBe("unresolved_summary");
+    expect(state.lastVerdict).toBe("APPROVED");
+  });
+
+  test("preserves sessions when past stage 7 with approved verdict and pr_finalization sub-step", () => {
+    // Regression: after stage 7 completes and advances to stage 8,
+    // reviewSubStep remains "pr_finalization".  deriveReviewSubStep
+    // returns "unresolved_summary" for an APPROVED round because
+    // PR comments cannot encode post-approval progress.  This
+    // mismatch must NOT trigger session invalidation — local state
+    // is authoritative once stage 7 is complete.
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 2,
+      reviewSubStep: "pr_finalization",
+      lastVerdict: "APPROVED",
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      makeComment("**[Reviewer Round 2]** Review."),
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(8);
+    expect(state.reviewSubStep).toBe("pr_finalization");
+    expect(state.lastVerdict).toBe("APPROVED");
+    expect(result.sessionsInvalidated).toBe(false);
+    expect(state.agentA.sessionId).toBe("sess-a");
+    expect(state.agentB.sessionId).toBe("sess-b");
+  });
+
+  test("invalidates sessions when verdict diverges within same round", () => {
+    // Local state thinks no verdict yet, but PR shows APPROVED.
+    const state = makeRunState({
+      currentStage: 7,
+      reviewRound: 1,
+      stageLoopCount: 0,
+      reviewCount: 1,
+      reviewSubStep: "verdict",
+      lastVerdict: undefined,
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.reviewSubStep).toBe("unresolved_summary");
+    expect(state.lastVerdict).toBe("APPROVED");
+  });
+
+  test("demotes currentStage when verdict exists but reviewer comment is missing", () => {
+    // Regression: an orphan verdict (e.g. from a partial failure or
+    // stale history) without the corresponding reviewer comment must
+    // not keep currentStage past 7.
+    const state = makeRunState({
+      currentStage: 8,
+      reviewRound: 2,
+      stageLoopCount: 1,
+      reviewCount: 1,
+      reviewSubStep: "unresolved_summary",
+      lastVerdict: "APPROVED",
+    });
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix."),
+      // Verdict for round 2 exists but reviewer comment does not.
+      makeComment("[Review Verdict Round 2: APPROVED]"),
+    ]);
+    const result = reconcileWithPr(state, prState);
+
+    expect(state.currentStage).toBe(7);
+    expect(result.sessionsInvalidated).toBe(true);
+    expect(state.agentA.sessionId).toBeUndefined();
+    expect(state.agentB.sessionId).toBeUndefined();
+    expect(
+      result.warnings.some((w) => w.includes("currentStage demoted")),
+    ).toBe(true);
+  });
+});
+
+// ---- deriveReviewSubStep ---------------------------------------------------
+
+describe("deriveReviewSubStep", () => {
+  test("returns review when no reviewer comment for round", () => {
+    const prState = parsePrReviewState([]);
+    const { subStep, verdict } = deriveReviewSubStep(prState, 1);
+    expect(subStep).toBe("review");
+    expect(verdict).toBeUndefined();
+  });
+
+  test("returns verdict when reviewer comment exists but no verdict", () => {
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+    ]);
+    const { subStep, verdict } = deriveReviewSubStep(prState, 1);
+    expect(subStep).toBe("verdict");
+    expect(verdict).toBeUndefined();
+  });
+
+  test("returns unresolved_summary for APPROVED verdict", () => {
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: APPROVED]"),
+    ]);
+    const { subStep, verdict } = deriveReviewSubStep(prState, 1);
+    expect(subStep).toBe("unresolved_summary");
+    expect(verdict).toBe("APPROVED");
+  });
+
+  test("returns author_fix for NOT_APPROVED without author response", () => {
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+    ]);
+    const { subStep, verdict } = deriveReviewSubStep(prState, 1);
+    expect(subStep).toBe("author_fix");
+    expect(verdict).toBe("NOT_APPROVED");
+  });
+
+  test("returns ci_poll when author responded after NOT_APPROVED", () => {
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+      makeComment("[Review Verdict Round 1: NOT_APPROVED]"),
+      makeComment("**[Author Round 1]** Fix applied."),
+    ]);
+    const { subStep, verdict } = deriveReviewSubStep(prState, 1);
+    expect(subStep).toBe("ci_poll");
+    expect(verdict).toBe("NOT_APPROVED");
+  });
+
+  test("returns review when round is ahead of PR state", () => {
+    const prState = parsePrReviewState([
+      makeComment("**[Reviewer Round 1]** Review."),
+    ]);
+    const { subStep, verdict } = deriveReviewSubStep(prState, 2);
+    expect(subStep).toBe("review");
+    expect(verdict).toBeUndefined();
+  });
+});

--- a/src/pr-comments.ts
+++ b/src/pr-comments.ts
@@ -1,0 +1,398 @@
+/**
+ * PR comment fetching, parsing, posting, and state reconciliation.
+ *
+ * PR comments are the source of truth for review-loop state.  This
+ * module provides utilities to read, parse, and post PR comments, and
+ * to reconcile local RunState with the PR-derived state on resume.
+ */
+
+import { execFileSync } from "node:child_process";
+
+import type { ReviewSubStep, RunState } from "./run-state.js";
+
+// ---- types ---------------------------------------------------------------
+
+export interface PrComment {
+  body: string;
+  user: { login: string };
+}
+
+/**
+ * Review state derived from PR comments.
+ */
+export interface PrReviewState {
+  /** Max round number found in `[Reviewer Round {n}]` comments. */
+  maxReviewerRound: number;
+  /** Max round number found in `[Author Round {n}]` comments. */
+  maxAuthorRound: number;
+  /** Max round number found in `[Review Verdict Round {n}]` comments. */
+  maxVerdictRound: number;
+  /** Verdict from the highest-numbered verdict comment. */
+  latestVerdict: "APPROVED" | "NOT_APPROVED" | undefined;
+}
+
+export interface ReconciliationResult {
+  warnings: string[];
+  sessionsInvalidated: boolean;
+}
+
+// ---- comment patterns ----------------------------------------------------
+
+/**
+ * Match `[Reviewer Round {n}]` or `**[Reviewer Round {n}]**` at the
+ * start of a comment body (allowing leading whitespace/bold markers).
+ */
+const REVIEWER_ROUND_RE = /^\s*\*{0,2}\[Reviewer Round (\d+)\]/;
+
+/**
+ * Match `[Author Round {n}]` or `**[Author Round {n}]**`.
+ */
+const AUTHOR_ROUND_RE = /^\s*\*{0,2}\[Author Round (\d+)\]/;
+
+/**
+ * Match `[Review Verdict Round {n}: APPROVED|NOT_APPROVED]`.
+ * This is posted by agentcoop (not agents), so no bold markers.
+ */
+const VERDICT_ROUND_RE =
+  /^\s*\[Review Verdict Round (\d+): (APPROVED|NOT_APPROVED)\]/;
+
+// ---- fetch / post --------------------------------------------------------
+
+/**
+ * Fetch all comments on a PR.
+ *
+ * Throws if the API call fails (e.g. network error, auth failure,
+ * rate limit).  Callers must handle the error — silently returning
+ * `[]` would make reconciliation skip PR sync without warning.
+ */
+export function fetchPrComments(
+  owner: string,
+  repo: string,
+  prNumber: number,
+): PrComment[] {
+  const output = execFileSync(
+    "gh",
+    [
+      "api",
+      `repos/${owner}/${repo}/issues/${prNumber}/comments`,
+      "--paginate",
+      "--slurp",
+    ],
+    { encoding: "utf-8" },
+  );
+  // --slurp wraps all pages in an outer array: [[page1...], [page2...]].
+  // Flatten to a single array of comments.
+  const pages: PrComment[][] = JSON.parse(output);
+  return pages.flat();
+}
+
+/**
+ * Post a comment on a PR.
+ */
+export function postPrComment(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  body: string,
+): void {
+  execFileSync(
+    "gh",
+    [
+      "pr",
+      "comment",
+      String(prNumber),
+      "--repo",
+      `${owner}/${repo}`,
+      "--body",
+      body,
+    ],
+    { encoding: "utf-8" },
+  );
+}
+
+// ---- parsing -------------------------------------------------------------
+
+/**
+ * Parse PR comments to extract review-loop state.
+ *
+ * Uses max round numbers (not occurrence count) since duplicates
+ * are possible after crash/resume.
+ */
+export function parsePrReviewState(comments: PrComment[]): PrReviewState {
+  let maxReviewerRound = 0;
+  let maxAuthorRound = 0;
+  let maxVerdictRound = 0;
+  let latestVerdict: "APPROVED" | "NOT_APPROVED" | undefined;
+
+  for (const comment of comments) {
+    const reviewerMatch = comment.body.match(REVIEWER_ROUND_RE);
+    if (reviewerMatch) {
+      const round = Number(reviewerMatch[1]);
+      if (round > maxReviewerRound) maxReviewerRound = round;
+    }
+
+    const authorMatch = comment.body.match(AUTHOR_ROUND_RE);
+    if (authorMatch) {
+      const round = Number(authorMatch[1]);
+      if (round > maxAuthorRound) maxAuthorRound = round;
+    }
+
+    const verdictMatch = comment.body.match(VERDICT_ROUND_RE);
+    if (verdictMatch) {
+      const round = Number(verdictMatch[1]);
+      if (round > maxVerdictRound) {
+        maxVerdictRound = round;
+        latestVerdict = verdictMatch[2] as "APPROVED" | "NOT_APPROVED";
+      }
+    }
+  }
+
+  return {
+    maxReviewerRound,
+    maxAuthorRound,
+    maxVerdictRound,
+    latestVerdict,
+  };
+}
+
+/**
+ * Check whether any comment matches the given pattern.
+ */
+export function hasComment(comments: PrComment[], pattern: RegExp): boolean {
+  return comments.some((c) => pattern.test(c.body));
+}
+
+/**
+ * Build a regex that matches a specific reviewer round comment.
+ */
+export function reviewerRoundPattern(round: number): RegExp {
+  return new RegExp(`^\\s*\\*{0,2}\\[Reviewer Round ${round}\\]`);
+}
+
+/**
+ * Build a regex that matches a specific author round comment.
+ */
+export function authorRoundPattern(round: number): RegExp {
+  return new RegExp(`^\\s*\\*{0,2}\\[Author Round ${round}\\]`);
+}
+
+// ---- sub-step derivation -------------------------------------------------
+
+/**
+ * Derive the review sub-step and verdict for a specific round from
+ * PR comments.  This tells the handler where to resume after a crash
+ * or interruption.
+ *
+ * Conservative: when in doubt, choose an earlier sub-step so that
+ * incomplete work is re-done rather than skipped.
+ */
+export function deriveReviewSubStep(
+  prState: PrReviewState,
+  round: number,
+): {
+  subStep: ReviewSubStep;
+  verdict: "APPROVED" | "NOT_APPROVED" | undefined;
+} {
+  const hasReview = prState.maxReviewerRound >= round;
+  const hasVerdict = prState.maxVerdictRound >= round;
+  const hasAuthor = prState.maxAuthorRound >= round;
+
+  if (!hasReview) {
+    return { subStep: "review", verdict: undefined };
+  }
+
+  if (!hasVerdict) {
+    return { subStep: "verdict", verdict: undefined };
+  }
+
+  // Verdict exists for this round.  Since round is derived from
+  // prMaxRound during reconciliation, latestVerdict is the verdict
+  // for this specific round.
+  const verdict =
+    prState.maxVerdictRound === round ? prState.latestVerdict : undefined;
+
+  if (verdict === "APPROVED") {
+    // Conservative: re-enter at unresolved_summary because we cannot
+    // determine from PR comments whether unresolved summary or PR
+    // finalization completed.
+    return { subStep: "unresolved_summary", verdict };
+  }
+
+  // NOT_APPROVED (or unknown verdict for this round).
+  if (!hasAuthor) {
+    return { subStep: "author_fix", verdict };
+  }
+
+  // Author responded — the fix work is done.  Resume at CI poll.
+  return { subStep: "ci_poll", verdict };
+}
+
+// ---- reconciliation ------------------------------------------------------
+
+/**
+ * Reconcile local RunState with PR-derived review state.
+ *
+ * Mutates `runState` in place and returns warnings for any
+ * corrections.  When any review-state field changes, saved agent
+ * sessions are invalidated (cleared) because they carry stale
+ * context.
+ */
+export function reconcileWithPr(
+  runState: RunState,
+  prState: PrReviewState,
+): ReconciliationResult {
+  const warnings: string[] = [];
+  let stateChanged = false;
+
+  const prMaxRound = Math.max(
+    prState.maxReviewerRound,
+    prState.maxAuthorRound,
+    prState.maxVerdictRound,
+  );
+
+  // 1. Reconcile reviewCount from PR.  reviewCount is a persisted UI
+  //    counter, not part of the authoritative review state.  A mismatch
+  //    (e.g. the reviewer comment was posted but the process crashed
+  //    before run-state.json was updated) should NOT invalidate agent
+  //    sessions — only true review-state divergence warrants that.
+  if (prState.maxReviewerRound !== runState.reviewCount) {
+    warnings.push(
+      `PR sync: reviewCount corrected from ${runState.reviewCount} to ${prState.maxReviewerRound}`,
+    );
+    runState.reviewCount = prState.maxReviewerRound;
+  }
+
+  // 2. Demote currentStage if local claims stage 7 completed but
+  //    the max round does not have an APPROVED verdict.
+  //    A verdict is only trusted when the corresponding reviewer
+  //    comment exists — an orphan verdict (e.g. from a partial
+  //    failure or stale history) must not keep currentStage past 7.
+  const maxRoundApproved =
+    prState.maxVerdictRound === prMaxRound &&
+    prState.latestVerdict === "APPROVED" &&
+    prState.maxReviewerRound >= prMaxRound;
+  if (runState.currentStage > 7 && !maxRoundApproved) {
+    warnings.push(
+      `PR sync: currentStage demoted from ${runState.currentStage} to 7 (stage 7 work incomplete on PR)`,
+    );
+    runState.currentStage = 7;
+    stateChanged = true;
+  }
+
+  // 2b. Promote currentStage if local state is behind the PR.
+  //     When PR comments show the review loop has started (any
+  //     reviewer/author/verdict round > 0) but local currentStage
+  //     is still before stage 7, the process must have died after
+  //     posting review comments but before updating run-state.json.
+  //     Promote to stage 7 so the pipeline resumes in the review
+  //     loop rather than re-running earlier stages.
+  if (runState.currentStage < 7 && prMaxRound > 0) {
+    warnings.push(
+      `PR sync: currentStage promoted from ${runState.currentStage} to 7 (PR has review round ${prMaxRound})`,
+    );
+    runState.currentStage = 7;
+    stateChanged = true;
+  }
+
+  // 3. Reconcile reviewRound and stageLoopCount.
+  //    reviewRound reflects the final review round reached and must be
+  //    correct regardless of the current stage.  stageLoopCount, however,
+  //    is a generic per-stage loop counter (used by stage 6 for test-plan
+  //    iterations, stage 7 for review iterations, etc.).  PR-derived
+  //    round data should only drive stageLoopCount when the pipeline will
+  //    resume stage 7 — otherwise the current stage's own loop counter
+  //    must be left alone.
+  const correctReviewRound = prMaxRound;
+
+  if (runState.reviewRound !== correctReviewRound) {
+    warnings.push(
+      `PR sync: reviewRound corrected from ${runState.reviewRound} to ${correctReviewRound}`,
+    );
+    runState.reviewRound = correctReviewRound;
+    stateChanged = true;
+  }
+  if (runState.currentStage === 7) {
+    const correctStageLoopCount = Math.max(0, prMaxRound - 1);
+    if (runState.stageLoopCount !== correctStageLoopCount) {
+      warnings.push(
+        `PR sync: stageLoopCount corrected from ${runState.stageLoopCount} to ${correctStageLoopCount}`,
+      );
+      runState.stageLoopCount = correctStageLoopCount;
+      stateChanged = true;
+    }
+  }
+
+  // 4. Reconcile reviewSubStep and lastVerdict.  This detects
+  //    verdict and position mismatches even when round numbers
+  //    already match.  The check runs regardless of currentStage:
+  //    sessions from stage 7 are passed to later stages (e.g.
+  //    squash at stage 8), so a verdict/sub-step divergence must
+  //    trigger session invalidation even when currentStage > 7.
+  //
+  //    Exception: when currentStage > 7 and the max round is
+  //    APPROVED, local state is authoritative for post-approval
+  //    progress.  PR comments cannot encode whether unresolved
+  //    summary or PR finalization completed, so deriveReviewSubStep
+  //    conservatively returns "unresolved_summary".  Comparing that
+  //    against a local "pr_finalization" would be a false mismatch
+  //    that needlessly invalidates sessions carried forward to
+  //    later stages.
+  if (runState.reviewRound > 0) {
+    const derived = deriveReviewSubStep(prState, runState.reviewRound);
+
+    // Skip sub-step reconciliation when the pipeline has already
+    // advanced past stage 7 with an approved verdict AND local
+    // state already acknowledges the approval.  If the local
+    // verdict is wrong (e.g. still undefined), the pipeline never
+    // actually completed the approved path, so sub-step correction
+    // is still needed.
+    const skipSubStepReconciliation =
+      runState.currentStage > 7 &&
+      maxRoundApproved &&
+      runState.lastVerdict === "APPROVED";
+
+    if (!skipSubStepReconciliation) {
+      if (runState.reviewSubStep !== derived.subStep) {
+        warnings.push(
+          `PR sync: reviewSubStep corrected from ${runState.reviewSubStep} to ${derived.subStep}`,
+        );
+        runState.reviewSubStep = derived.subStep;
+        stateChanged = true;
+      }
+    }
+    if (runState.lastVerdict !== derived.verdict) {
+      warnings.push(
+        `PR sync: lastVerdict corrected from ${runState.lastVerdict} to ${derived.verdict}`,
+      );
+      runState.lastVerdict = derived.verdict;
+      stateChanged = true;
+    }
+  } else {
+    // No review rounds on the PR — clear any stale post-verdict fields.
+    if (runState.reviewSubStep !== undefined) {
+      warnings.push(
+        `PR sync: reviewSubStep corrected from ${runState.reviewSubStep} to undefined`,
+      );
+      runState.reviewSubStep = undefined;
+      stateChanged = true;
+    }
+    if (runState.lastVerdict !== undefined) {
+      warnings.push(
+        `PR sync: lastVerdict corrected from ${runState.lastVerdict} to undefined`,
+      );
+      runState.lastVerdict = undefined;
+      stateChanged = true;
+    }
+  }
+
+  // 5. Invalidate agent sessions when any review state diverged.
+  if (stateChanged) {
+    runState.agentA.sessionId = undefined;
+    runState.agentB.sessionId = undefined;
+    warnings.push(
+      "PR sync: agent sessions invalidated due to state divergence",
+    );
+  }
+
+  return { warnings, sessionsInvalidated: stateChanged };
+}

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -33,6 +33,8 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
     currentStage: 2,
     stageLoopCount: 0,
     reviewRound: 0,
+    selfCheckCount: 0,
+    reviewCount: 0,
     executionMode: "auto",
     agentA: {
       cli: "claude",
@@ -242,6 +244,30 @@ describe("loadRunState — migration from v1 (unversioned)", () => {
     saveRunState(makeRunState({ currentStage: 7 }));
     const loaded = loadRunState("org", "repo", 42);
     expect(loaded?.currentStage).toBe(7);
+  });
+});
+
+describe("selfCheckCount and reviewCount persistence", () => {
+  test("round-trips selfCheckCount and reviewCount", () => {
+    const state = makeRunState({ selfCheckCount: 3, reviewCount: 5 });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.selfCheckCount).toBe(3);
+    expect(loaded?.reviewCount).toBe(5);
+  });
+
+  test("defaults to zero for old state files without count fields", () => {
+    const { selfCheckCount: _, reviewCount: __, ...raw } = makeRunState();
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+
+    expect(loaded).toBeDefined();
+    expect(loaded?.selfCheckCount).toBe(0);
+    expect(loaded?.reviewCount).toBe(0);
   });
 });
 

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -20,6 +20,19 @@ import type { IssueChange, IssueSyncStatus } from "./issue-sync.js";
 
 // ---- public types --------------------------------------------------------
 
+/**
+ * Sub-step within stage 7 (review loop).  Used to track progress
+ * within a single review round so that resume can skip completed
+ * steps rather than re-running the entire round.
+ */
+export type ReviewSubStep =
+  | "review"
+  | "verdict"
+  | "unresolved_summary"
+  | "pr_finalization"
+  | "author_fix"
+  | "ci_poll";
+
 export interface AgentState {
   cli: string;
   model: string;
@@ -52,6 +65,14 @@ export interface RunState {
   currentStage: number;
   stageLoopCount: number;
   reviewRound: number;
+  /** Total number of self-check stage iterations completed. */
+  selfCheckCount: number;
+  /** Total number of review stage iterations completed. */
+  reviewCount: number;
+  /** Current sub-step within a review round.  Undefined outside stage 7. */
+  reviewSubStep: ReviewSubStep | undefined;
+  /** Last known review verdict for the current round. */
+  lastVerdict: "APPROVED" | "NOT_APPROVED" | undefined;
   executionMode: "auto" | "step";
   agentA: AgentState;
   agentB: AgentState;
@@ -123,6 +144,12 @@ function isValidRunState(
     typeof r.currentStage === "number" &&
     typeof r.stageLoopCount === "number" &&
     typeof r.reviewRound === "number" &&
+    (r.selfCheckCount === undefined || typeof r.selfCheckCount === "number") &&
+    (r.reviewCount === undefined || typeof r.reviewCount === "number") &&
+    (r.reviewSubStep === undefined || typeof r.reviewSubStep === "string") &&
+    (r.lastVerdict === undefined ||
+      r.lastVerdict === "APPROVED" ||
+      r.lastVerdict === "NOT_APPROVED") &&
     (r.executionMode === "auto" || r.executionMode === "step") &&
     isValidAgentState(r.agentA) &&
     isValidAgentState(r.agentB) &&
@@ -182,6 +209,11 @@ export function loadRunState(
     version: (r.version as number) ?? 1,
     baseSha: (r.baseSha as string | undefined) ?? undefined,
     prNumber: raw.prNumber ?? undefined,
+    selfCheckCount: (r.selfCheckCount as number | undefined) ?? 0,
+    reviewCount: (r.reviewCount as number | undefined) ?? 0,
+    reviewSubStep: (r.reviewSubStep as ReviewSubStep | undefined) ?? undefined,
+    lastVerdict:
+      (r.lastVerdict as "APPROVED" | "NOT_APPROVED" | undefined) ?? undefined,
     issueSyncStatus:
       (raw.issueSyncStatus as IssueSyncStatus | undefined) ?? "skipped",
     issueChanges: (raw.issueChanges as IssueChange[] | undefined) ?? [],

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -7,6 +7,7 @@ import {
   buildAuthorFixPrompt,
   buildPrFinalizationPrompt,
   buildPrFinalizationVerdictPrompt,
+  buildResumeUnresolvedSummaryPrompt,
   buildReviewPrompt,
   buildReviewVerdictPrompt,
   buildUnresolvedSummaryPrompt,
@@ -116,6 +117,7 @@ function makeOpts(
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
     emptyRunsGracePeriodMs: 0,
+    postPrComment: vi.fn(),
     ...overrides,
   };
 }
@@ -285,6 +287,17 @@ describe("buildUnresolvedSummaryPrompt", () => {
     // in the dedicated verdict follow-up.
     expect(prompt).not.toContain("NONE");
     expect(prompt).not.toContain("COMPLETED");
+  });
+});
+
+describe("buildResumeUnresolvedSummaryPrompt", () => {
+  test("includes repo context and instructs B to read its review", () => {
+    const prompt = buildResumeUnresolvedSummaryPrompt(BASE_CTX, 2);
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).toContain("[Reviewer Round 2]");
+    expect(prompt).toContain("[Reviewer Unresolved Round 2]");
   });
 });
 
@@ -1105,6 +1118,61 @@ describe("createReviewStageHandler", () => {
     expect(result.message).toContain("review verdict clarification");
   });
 
+  test("ambiguous fresh verdict without sessionId invokes B fresh for clarification", async () => {
+    // Regression: when B is invoked fresh for the verdict (no prior
+    // session) and returns an ambiguous response without a sessionId,
+    // the clarification retry must invoke fresh again instead of
+    // crashing with "no session ID".
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        // 1st invoke: review (returns no sessionId)
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: undefined,
+              responseText: "Some review text.",
+            }),
+          ),
+        )
+        // 2nd invoke: fresh verdict (ambiguous, no sessionId)
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: undefined,
+              responseText: "I think it looks okay.",
+            }),
+          ),
+        )
+        // 3rd invoke: fresh clarification → APPROVED
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-b-fresh",
+              responseText: "APPROVED",
+            }),
+          ),
+        )
+        // subsequent invokes: unresolved summary + verdict
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+
+    const opts = makeOpts({ agentB });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    // Should complete without throwing "no session ID".
+    expect(result.outcome).toBe("completed");
+    // B.invoke called at least 3 times: review, fresh verdict,
+    // fresh clarification.
+    expect(
+      (agentB.invoke as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThanOrEqual(3);
+  });
+
   // -- PR finalization clarification paths ----------------------------------------
 
   test("ambiguous finalization verdict → clarification → PR_FINALIZED completes", async () => {
@@ -1532,7 +1600,7 @@ describe("createReviewStageHandler", () => {
     expect(calls[1][0]).toBe("sess-b-after-verdict");
   });
 
-  test("throws when B returns no sessionId (verdict follow-up needs session)", async () => {
+  test("invokes B fresh for verdict when B returns no sessionId", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -1547,7 +1615,65 @@ describe("createReviewStageHandler", () => {
 
     const opts = makeOpts({ agentB });
     const stage = createReviewStageHandler(opts);
-    await expect(stage.handler(BASE_CTX)).rejects.toThrow("no session ID");
+    const result = await stage.handler(BASE_CTX);
+
+    // Handler recovers by invoking B fresh for the verdict instead
+    // of crashing.  B is invoked at least twice: review + fresh
+    // verdict (plus further invocations for unresolved summary).
+    expect(
+      (agentB.invoke as ReturnType<typeof vi.fn>).mock.calls.length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(result.outcome).toBe("completed");
+  });
+
+  test("uses resume prompt with repo context for unresolved summary when no B session", async () => {
+    // When PR comments show an APPROVED verdict for the current round,
+    // the handler skips straight to unresolved_summary with no B session.
+    // It should invoke B fresh with the resume prompt that includes
+    // repo context and instructions to read the review from the PR.
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        // 1st invoke: unresolved summary work step (fresh, no session)
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-b-fresh",
+              responseText: "No unresolved items.",
+            }),
+          ),
+        )
+        // 2nd invoke: unresolved summary verdict
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+
+    const opts = makeOpts({
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        // APPROVED verdict already posted — handler enters at
+        // unresolved_summary with no B session.
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+        {
+          body: "[Review Verdict Round 1: APPROVED]",
+          user: { login: "bot" },
+        },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    // B.invoke should have been called (not resume) since there's
+    // no session, and the prompt should contain repo context.
+    const invokeCall = (agentB.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    const prompt: string = invokeCall[0];
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("[Reviewer Round 1]");
   });
 
   // -- PR finalization on approval ---------------------------------------------
@@ -2202,7 +2328,7 @@ describe("createReviewStageHandler", () => {
     expect(result.message).not.toContain("Unresolved items:");
   });
 
-  test("throws when B returns no sessionId on lastAutoIteration (verdict follow-up needs session)", async () => {
+  test("invokes B fresh for verdict when B returns no sessionId on lastAutoIteration", async () => {
     const agentB: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
         makeStream(
@@ -2218,7 +2344,12 @@ describe("createReviewStageHandler", () => {
     const opts = makeOpts({ agentB });
     const stage = createReviewStageHandler(opts);
     const ctx = { ...BASE_CTX, lastAutoIteration: true };
-    await expect(stage.handler(ctx)).rejects.toThrow("no session ID");
+    const result = await stage.handler(ctx);
+
+    // Handler recovers by invoking B fresh instead of crashing.
+    expect(agentB.invoke).toHaveBeenCalledTimes(2);
+    // Result depends on downstream mocks, but should not throw.
+    expect(result).toBeDefined();
   });
 
   // -- CI passes after fix on second attempt ----------------------------------
@@ -2375,5 +2506,526 @@ describe("onSessionId", () => {
     await stage.handler(ctx);
     expect(sessionCalls).toContainEqual(["b", "sess-b-1"]);
     expect(sessionCalls).toContainEqual(["a", "sess-a-1"]);
+  });
+});
+
+// ---- verdict posting ---------------------------------------------------------
+
+describe("verdict posting", () => {
+  test("posts APPROVED verdict as PR comment", async () => {
+    const postPrComment = vi.fn();
+    const opts = makeOpts({
+      getPrNumber: () => 99,
+      postPrComment,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** LGTM.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(postPrComment).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      99,
+      "[Review Verdict Round 1: APPROVED]",
+    );
+  });
+
+  test("posts NOT_APPROVED verdict as PR comment", async () => {
+    const postPrComment = vi.fn();
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b", responseText: "Needs work." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const opts = makeOpts({
+      agentA,
+      agentB,
+      getPrNumber: () => 99,
+      postPrComment,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(postPrComment).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      99,
+      "[Review Verdict Round 1: NOT_APPROVED]",
+    );
+  });
+
+  test("skips verdict posting when getPrNumber returns undefined", async () => {
+    const postPrComment = vi.fn();
+    const opts = makeOpts({
+      getPrNumber: () => undefined,
+      postPrComment,
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(postPrComment).not.toHaveBeenCalled();
+  });
+
+  test("propagates error when verdict posting throws", async () => {
+    const postPrComment = vi.fn().mockImplementation(() => {
+      throw new Error("network error");
+    });
+    const opts = makeOpts({
+      getPrNumber: () => 99,
+      postPrComment,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+
+    // Verdict posting is required — failure must propagate so the
+    // pipeline can retry or surface the error.
+    await expect(stage.handler(BASE_CTX)).rejects.toThrow("network error");
+  });
+});
+
+// ---- comment validation ------------------------------------------------------
+
+describe("comment validation", () => {
+  test("returns error when expected author comment is missing for round > 1", async () => {
+    const opts = makeOpts({
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        // Only reviewer round 1 — no author round 1 comment.
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    const ctx: StageContext = { ...BASE_CTX, iteration: 1 }; // round 2
+    const result = await stage.handler(ctx);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("[Author Round 1]");
+  });
+
+  test("refetches comments after review step so reviewer comment is validated", async () => {
+    // After posting the review, the handler refetches PR comments
+    // so the reviewer comment validation sees the newly posted
+    // comment instead of skipping verification.
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b", responseText: "Needs work." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "COMPLETED" })),
+        ),
+    };
+    const fetchPrComments = vi
+      .fn()
+      // First call: no comments yet (sub-step derivation).
+      .mockReturnValueOnce([])
+      // Second call (refetch after review): reviewer comment now exists.
+      .mockReturnValueOnce([
+        {
+          body: "**[Reviewer Round 1]** Needs work.",
+          user: { login: "bot" },
+        },
+      ]);
+    const opts = makeOpts({
+      agentA,
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments,
+      getCiStatus: () => ({
+        verdict: "pass" as const,
+        runs: [makeCiRun()],
+      }),
+    });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("not_approved");
+    // The handler called fetchPrComments twice: once for derivation,
+    // once as a refetch after posting the review.
+    expect(fetchPrComments).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns error when refetch after review does not find reviewer comment", async () => {
+    // If the reviewer comment was never actually posted (e.g., agent
+    // error on the PR side), the refetch should catch the gap.
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b", responseText: "Needs work." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+    const fetchPrComments = vi.fn().mockReturnValue([]);
+    const postPrComment = vi.fn();
+    const opts = makeOpts({
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments,
+      postPrComment,
+    });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("[Reviewer Round 1]");
+    expect(postPrComment).not.toHaveBeenCalled();
+  });
+
+  test("returns error on APPROVED path when reviewer comment is missing", async () => {
+    // Even when the verdict is APPROVED, the handler must verify
+    // that the reviewer comment actually made it onto the PR.
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b", responseText: "LGTM." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "APPROVED" }))),
+    };
+    const fetchPrComments = vi.fn().mockReturnValue([]);
+    const postPrComment = vi.fn();
+    const opts = makeOpts({
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments,
+      postPrComment,
+    });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("[Reviewer Round 1]");
+    expect(postPrComment).not.toHaveBeenCalled();
+  });
+
+  test("skips comment validation when getPrNumber returns undefined", async () => {
+    const fetchPrComments = vi.fn();
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b", responseText: "Needs work." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const opts = makeOpts({
+      agentA,
+      agentB,
+      getPrNumber: () => undefined,
+      fetchPrComments,
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    // fetchPrComments should not be called when PR number is undefined.
+    expect(fetchPrComments).not.toHaveBeenCalled();
+  });
+
+  test("proceeds when expected author comment exists for round > 1", async () => {
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-b", responseText: "Still issues." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        )
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+        ),
+    };
+    const agentA: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-a", responseText: "Fixed again." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+    };
+    const opts = makeOpts({
+      agentA,
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+        { body: "**[Author Round 1]** Fixes.", user: { login: "bot" } },
+        { body: "**[Reviewer Round 2]** More issues.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    const ctx: StageContext = { ...BASE_CTX, iteration: 1 }; // round 2
+    const result = await stage.handler(ctx);
+
+    // Should proceed (not return error about missing comment).
+    expect(result.outcome).not.toBe("error");
+  });
+
+  test("resume at verdict returns error before invoking Agent B when reviewer comment is missing for current round", async () => {
+    // Regression: if deriveReviewSubStep determines we're at the
+    // verdict sub-step (maxReviewerRound >= round) but the specific
+    // round's reviewer comment is absent (e.g., round 2 exists but
+    // round 1 does not), the handler must NOT invoke Agent B with
+    // buildResumeVerdictPrompt referencing the missing comment.
+    const agentB: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+    const opts = makeOpts({
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        // Round 2 reviewer comment exists but round 1 is missing.
+        // parsePrReviewState returns maxReviewerRound=2, so
+        // deriveReviewSubStep(prState, 1) yields subStep="verdict"
+        // (hasReview is true since 2 >= 1, but no verdict exists).
+        // However, hasComment(reviewerRoundPattern(1)) is false.
+        { body: "**[Reviewer Round 2]** Review.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    // No saved session — handler takes the fresh-invoke branch for
+    // the verdict prompt, which is where the guard must fire.
+    const ctx: StageContext = { ...BASE_CTX, savedAgentBSessionId: undefined };
+    const result = await stage.handler(ctx);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("[Reviewer Round 1]");
+    // Agent B must not have been called at all.
+    expect(agentB.invoke).not.toHaveBeenCalled();
+    expect(agentB.resume).not.toHaveBeenCalled();
+  });
+});
+
+// ---- onReviewPosted callback --------------------------------------------------
+
+describe("onReviewPosted", () => {
+  test("fires with correct round when review step posts a comment", async () => {
+    const onReviewPosted = vi.fn();
+    const fetchPrComments = vi
+      .fn()
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([
+        {
+          body: "**[Reviewer Round 1]** Looks good.",
+          user: { login: "bot" },
+        },
+      ]);
+    const opts = makeOpts({
+      getPrNumber: () => 99,
+      fetchPrComments,
+      onReviewPosted,
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(onReviewPosted).toHaveBeenCalledWith(1);
+  });
+
+  test("does not fire when resuming at verdict (no new review posted)", async () => {
+    const onReviewPosted = vi.fn();
+    const opts = makeOpts({
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        {
+          body: "**[Reviewer Round 1]** Needs work.",
+          user: { login: "bot" },
+        },
+      ],
+      onReviewPosted,
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(onReviewPosted).not.toHaveBeenCalled();
+  });
+
+  test("does not fire when refetch still cannot find the reviewer comment", async () => {
+    const onReviewPosted = vi.fn();
+    // Both initial fetch and refetch return no reviewer comment.
+    const fetchPrComments = vi.fn().mockReturnValue([]);
+    const opts = makeOpts({
+      getPrNumber: () => 99,
+      fetchPrComments,
+      onReviewPosted,
+    });
+    const stage = createReviewStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(onReviewPosted).not.toHaveBeenCalled();
+    expect(result.outcome).toBe("error");
+  });
+});
+
+// ---- saved Agent B session reuse on resume ------------------------------------
+
+describe("saved Agent B session reuse on resume", () => {
+  test("resume at verdict reuses saved Agent B session", async () => {
+    const agentB: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        // 1st resume: review verdict
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "APPROVED" })),
+        )
+        // 2nd resume: unresolved summary
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-b-verdict",
+              responseText: "No unresolved items.",
+            }),
+          ),
+        )
+        // 3rd resume: unresolved verdict
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+
+    const opts = makeOpts({
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        // Reviewer comment present — handler derives currentStep=verdict.
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler({
+      ...BASE_CTX,
+      savedAgentBSessionId: "saved-b-sess",
+    });
+
+    // The verdict step should resume the saved B session, not invoke fresh.
+    expect(agentB.invoke).not.toHaveBeenCalled();
+    const firstResumeCall = (agentB.resume as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(firstResumeCall[0]).toBe("saved-b-sess");
+  });
+
+  test("resume at unresolved_summary reuses saved Agent B session", async () => {
+    const agentB: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi
+        .fn()
+        // 1st resume: unresolved summary
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-b-unresolved",
+              responseText: "No unresolved items.",
+            }),
+          ),
+        )
+        // 2nd resume: unresolved verdict
+        .mockReturnValue(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+
+    const opts = makeOpts({
+      agentB,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+        {
+          body: "[Review Verdict Round 1: APPROVED]",
+          user: { login: "bot" },
+        },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+    await stage.handler({
+      ...BASE_CTX,
+      savedAgentBSessionId: "saved-b-sess",
+    });
+
+    // The unresolved summary step should resume the saved B session.
+    expect(agentB.invoke).not.toHaveBeenCalled();
+    const firstResumeCall = (agentB.resume as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(firstResumeCall[0]).toBe("saved-b-sess");
   });
 });

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -34,6 +34,17 @@ import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import { getPrBody as defaultGetPrBody } from "./pr.js";
 import {
+  authorRoundPattern,
+  fetchPrComments as defaultFetchPrComments,
+  postPrComment as defaultPostPrComment,
+  deriveReviewSubStep,
+  hasComment,
+  type PrComment,
+  parsePrReviewState,
+  reviewerRoundPattern,
+} from "./pr-comments.js";
+import type { ReviewSubStep } from "./run-state.js";
+import {
   buildDocConsistencyInstructions,
   drainToSink,
   invokeOrResume,
@@ -76,6 +87,35 @@ export interface ReviewStageOptions {
     repo: string,
     branch: string,
   ) => string | undefined;
+  /** Returns the current PR number, or undefined if not yet created. */
+  getPrNumber?: () => number | undefined;
+  /** Injected for testability. Defaults to `pr-comments.fetchPrComments`. */
+  fetchPrComments?: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+  ) => PrComment[];
+  /** Injected for testability. Defaults to `pr-comments.postPrComment`. */
+  postPrComment?: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+    body: string,
+  ) => void;
+  /**
+   * Called at each sub-step transition within a review round so the
+   * caller can persist progress for accurate resume.
+   */
+  onReviewProgress?: (
+    subStep: ReviewSubStep,
+    verdict?: "APPROVED" | "NOT_APPROVED",
+  ) => void;
+  /**
+   * Called when the review step actually posts a new reviewer comment,
+   * so the caller can update `reviewCount` only when a review was
+   * genuinely posted (not on every stage-7 exit).
+   */
+  onReviewPosted?: (round: number) => void;
 }
 
 // ---- prompt builders ---------------------------------------------------------
@@ -298,6 +338,36 @@ export function buildUnresolvedSummaryPrompt(round: number): string {
   ].join("\n");
 }
 
+/**
+ * Prompt for resuming the unresolved-summary step when Agent B has no
+ * saved session.  Gives B repository context and tells it to read its
+ * own review from the PR before deciding what is unresolved.
+ */
+export function buildResumeUnresolvedSummaryPrompt(
+  ctx: StageContext,
+  round: number,
+): string {
+  return [
+    `You previously reviewed a pull request and the review was approved.`,
+    `The process was interrupted before you could summarise unresolved items.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    ``,
+    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `2. Read your \`[Reviewer Round ${round}]\` review comment to`,
+    `   understand which items you raised.`,
+    `3. Check the code on the branch to see which items were addressed`,
+    `   and which remain unresolved.`,
+    `4. If there are unresolved items, post a PR comment prefixed with`,
+    `   \`**[Reviewer Unresolved Round ${round}]**\` listing each one.`,
+    `5. If there are no unresolved items, simply confirm that there is`,
+    `   nothing left to address.`,
+  ].join("\n");
+}
+
 export function buildPrFinalizationPrompt(
   ctx: StageContext,
   opts: ReviewStageOptions,
@@ -334,6 +404,37 @@ export function buildPrFinalizationPrompt(
 }
 
 /**
+ * Prompt for resuming when the reviewer comment was already posted but
+ * the process died before recording the verdict.  Agent B reads its
+ * own review and provides just the verdict keyword.
+ */
+export function buildResumeVerdictPrompt(
+  ctx: StageContext,
+  round: number,
+): string {
+  return [
+    `You previously posted a review on a pull request, prefixed with`,
+    `\`**[Reviewer Round ${round}]**\`.  The process was interrupted`,
+    `before your verdict was recorded.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    ``,
+    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `2. Read your \`[Reviewer Round ${round}]\` review comment.`,
+    `3. Based on your review, respond with exactly one of the`,
+    `   following keywords:`,
+    ``,
+    `   - APPROVED — if the changes are ready to merge`,
+    `   - NOT_APPROVED — if changes are needed`,
+    ``,
+    `   Do not include any other commentary — just the keyword.`,
+  ].join("\n");
+}
+
+/**
  * Check whether the response is exactly the PR_FINALIZED keyword.
  * Uses the strict verdict parser to reject extra commentary.
  */
@@ -354,96 +455,278 @@ export function createReviewStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       const round = ctx.iteration + 1; // 1-based for display
 
-      // Step 1: Agent B reviews (resume if saved session).
-      const reviewPrompt = buildReviewPrompt(ctx, opts, round);
-      ctx.promptSinks?.b?.(reviewPrompt);
-      const reviewResult = await invokeOrResume(
-        opts.agentB,
-        ctx.savedAgentBSessionId,
-        reviewPrompt,
-        ctx.worktreePath,
-        ctx.streamSinks?.b,
-        undefined,
-        ctx.usageSinks?.b,
-      );
+      // Fetch PR comments for sub-step derivation and validation.
+      const prNumber = opts.getPrNumber?.();
+      const fetchComments = opts.fetchPrComments ?? defaultFetchPrComments;
+      let comments: PrComment[] =
+        prNumber !== undefined
+          ? fetchComments(ctx.owner, ctx.repo, prNumber)
+          : [];
 
-      if (reviewResult.sessionId) {
-        ctx.onSessionId?.("b", reviewResult.sessionId);
+      // Derive where to resume from PR comments.
+      const prState = parsePrReviewState(comments);
+      let currentStep: ReviewSubStep = deriveReviewSubStep(
+        prState,
+        round,
+      ).subStep;
+
+      // Validate expected previous-round author comment when starting
+      // a fresh review (not resuming mid-round).
+      if (round > 1 && currentStep === "review") {
+        if (
+          prNumber !== undefined &&
+          !hasComment(comments, authorRoundPattern(round - 1))
+        ) {
+          return {
+            outcome: "error",
+            message: t()["review.missingAuthorComment"](round - 1),
+          };
+        }
       }
 
-      if (reviewResult.status === "error") {
-        return mapAgentError(reviewResult, "during review");
-      }
+      // Track Agent B's session across steps within this round.
+      // When resuming mid-round (skipping the review step), seed from
+      // the saved session so verdict / unresolved_summary can reuse it.
+      let agentBSessionId: string | undefined =
+        currentStep !== "review" ? ctx.savedAgentBSessionId : undefined;
+      // Whether the review step ran in this invocation, used to gate
+      // onReviewPosted until the PR comment is confirmed.
+      let reviewStepRan = false;
 
-      // Verdict follow-up: ask B for exactly APPROVED / NOT_APPROVED.
-      const verdictPrompt = buildReviewVerdictPrompt();
-      ctx.promptSinks?.b?.(verdictPrompt);
-      let verdictResult = await sendFollowUp(
-        opts.agentB,
-        reviewResult.sessionId,
-        verdictPrompt,
-        ctx.worktreePath,
-        ctx.streamSinks?.b,
-        undefined,
-        ctx.usageSinks?.b,
-      );
-
-      if (verdictResult.status === "error") {
-        return mapAgentError(verdictResult, "during review verdict");
-      }
-
-      let reviewVerdict = parseVerdictKeyword(
-        verdictResult.responseText,
-        REVIEW_VERDICT_KEYWORDS,
-      );
-
-      // Clarification retry if ambiguous, extra commentary, or
-      // multiple valid keywords.
-      if (reviewVerdict.keyword === undefined) {
-        const clarifyPrompt = buildClarificationPrompt(
-          verdictResult.responseText,
-          REVIEW_VERDICT_KEYWORDS,
-        );
-        ctx.promptSinks?.b?.(clarifyPrompt);
-        const retryResult = await sendFollowUp(
+      // ---- review --------------------------------------------------
+      if (currentStep === "review") {
+        opts.onReviewProgress?.("review");
+        const reviewPrompt = buildReviewPrompt(ctx, opts, round);
+        ctx.promptSinks?.b?.(reviewPrompt);
+        const reviewResult = await invokeOrResume(
           opts.agentB,
-          verdictResult.sessionId ?? reviewResult.sessionId,
-          clarifyPrompt,
+          ctx.savedAgentBSessionId,
+          reviewPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.b,
           undefined,
           ctx.usageSinks?.b,
         );
 
-        if (retryResult.status === "error") {
-          return mapAgentError(
-            retryResult,
-            "during review verdict clarification",
-          );
+        if (reviewResult.sessionId) {
+          ctx.onSessionId?.("b", reviewResult.sessionId);
         }
 
-        verdictResult = retryResult;
-        reviewVerdict = parseVerdictKeyword(
+        if (reviewResult.status === "error") {
+          return mapAgentError(reviewResult, "during review");
+        }
+
+        agentBSessionId = reviewResult.sessionId;
+        // Defer onReviewPosted until after the reviewer comment is
+        // verified on the PR — see the validation block below.
+        reviewStepRan = true;
+
+        // Refetch comments so subsequent validations see the newly
+        // posted reviewer comment instead of skipping verification.
+        if (prNumber !== undefined) {
+          comments = fetchComments(ctx.owner, ctx.repo, prNumber);
+        }
+
+        currentStep = "verdict";
+      }
+
+      // ---- verdict -------------------------------------------------
+      if (currentStep === "verdict") {
+        opts.onReviewProgress?.("verdict");
+
+        let verdictResult: AgentResult;
+
+        if (agentBSessionId) {
+          // Follow-up on review session (normal flow).
+          const verdictPrompt = buildReviewVerdictPrompt();
+          ctx.promptSinks?.b?.(verdictPrompt);
+          verdictResult = await sendFollowUp(
+            opts.agentB,
+            agentBSessionId,
+            verdictPrompt,
+            ctx.worktreePath,
+            ctx.streamSinks?.b,
+            undefined,
+            ctx.usageSinks?.b,
+          );
+        } else {
+          // No review session — review was already posted on the PR.
+          // Verify the reviewer comment exists before asking Agent B
+          // to read it, so we never send a prompt based on a false
+          // premise (issue #208, item 5).
+          if (
+            prNumber !== undefined &&
+            !hasComment(comments, reviewerRoundPattern(round))
+          ) {
+            return {
+              outcome: "error",
+              message: t()["review.missingReviewerComment"](round),
+            };
+          }
+          // Invoke Agent B fresh to read its own review and provide
+          // the verdict keyword.
+          const resumePrompt = buildResumeVerdictPrompt(ctx, round);
+          ctx.promptSinks?.b?.(resumePrompt);
+          verdictResult = await invokeOrResume(
+            opts.agentB,
+            undefined,
+            resumePrompt,
+            ctx.worktreePath,
+            ctx.streamSinks?.b,
+            undefined,
+            ctx.usageSinks?.b,
+          );
+          if (verdictResult.sessionId) {
+            ctx.onSessionId?.("b", verdictResult.sessionId);
+          }
+        }
+
+        if (verdictResult.status === "error") {
+          return mapAgentError(verdictResult, "during review verdict");
+        }
+
+        let reviewVerdict = parseVerdictKeyword(
           verdictResult.responseText,
           REVIEW_VERDICT_KEYWORDS,
         );
+
+        // Clarification retry if ambiguous, extra commentary, or
+        // multiple valid keywords.
+        if (reviewVerdict.keyword === undefined) {
+          const clarifyPrompt = buildClarificationPrompt(
+            verdictResult.responseText,
+            REVIEW_VERDICT_KEYWORDS,
+          );
+          ctx.promptSinks?.b?.(clarifyPrompt);
+          const clarifySessionId = verdictResult.sessionId ?? agentBSessionId;
+          let retryResult: AgentResult;
+          if (clarifySessionId) {
+            retryResult = await sendFollowUp(
+              opts.agentB,
+              clarifySessionId,
+              clarifyPrompt,
+              ctx.worktreePath,
+              ctx.streamSinks?.b,
+              undefined,
+              ctx.usageSinks?.b,
+            );
+          } else {
+            // No session from either the fresh verdict invoke or a
+            // prior review step — invoke fresh again for clarification.
+            retryResult = await invokeOrResume(
+              opts.agentB,
+              undefined,
+              clarifyPrompt,
+              ctx.worktreePath,
+              ctx.streamSinks?.b,
+              undefined,
+              ctx.usageSinks?.b,
+            );
+          }
+
+          if (retryResult.status === "error") {
+            return mapAgentError(
+              retryResult,
+              "during review verdict clarification",
+            );
+          }
+
+          verdictResult = retryResult;
+          reviewVerdict = parseVerdictKeyword(
+            verdictResult.responseText,
+            REVIEW_VERDICT_KEYWORDS,
+          );
+        }
+
+        // Post review verdict as a PR comment so it can be recovered.
+        const reviewParsed = reviewVerdict.keyword
+          ? parseStepStatus(reviewVerdict.keyword)
+          : { status: "ambiguous" as const, keyword: undefined };
+        if (
+          reviewParsed.status === "approved" ||
+          reviewParsed.status === "not_approved"
+        ) {
+          // Verify the reviewer comment exists before posting the
+          // verdict.  If Agent B never got the review onto the PR,
+          // posting a verdict without the underlying review would
+          // make PR history misleading and confuse reconciliation.
+          if (prNumber !== undefined) {
+            if (!hasComment(comments, reviewerRoundPattern(round))) {
+              return {
+                outcome: "error",
+                message: t()["review.missingReviewerComment"](round),
+              };
+            }
+            const verdictText =
+              reviewParsed.status === "approved" ? "APPROVED" : "NOT_APPROVED";
+            const post = opts.postPrComment ?? defaultPostPrComment;
+            post(
+              ctx.owner,
+              ctx.repo,
+              prNumber,
+              `[Review Verdict Round ${round}: ${verdictText}]`,
+            );
+          }
+        }
+
+        agentBSessionId = verdictResult.sessionId ?? agentBSessionId;
+
+        if (reviewParsed.status === "approved") {
+          opts.onReviewProgress?.("unresolved_summary", "APPROVED");
+          currentStep = "unresolved_summary";
+        } else if (reviewParsed.status === "not_approved") {
+          opts.onReviewProgress?.("author_fix", "NOT_APPROVED");
+          currentStep = "author_fix";
+        } else {
+          return {
+            outcome: "needs_clarification",
+            message: verdictResult.responseText,
+            validVerdicts: REVIEW_VERDICT_KEYWORDS,
+          };
+        }
       }
 
-      // Step 2: If approved — ask B for unresolved summary, then complete.
-      const reviewParsed = reviewVerdict.keyword
-        ? parseStepStatus(reviewVerdict.keyword)
-        : { status: "ambiguous" as const, keyword: undefined };
-      if (reviewParsed.status === "approved") {
+      // ---- Validate reviewer comment on resume path ----------------
+      // When resuming at unresolved_summary or author_fix (verdict block
+      // was skipped), verify the reviewer comment still exists.  The
+      // fresh-verdict path already checks this before posting.
+      if (
+        (currentStep === "unresolved_summary" ||
+          currentStep === "author_fix") &&
+        prNumber !== undefined
+      ) {
+        if (!hasComment(comments, reviewerRoundPattern(round))) {
+          return {
+            outcome: "error",
+            message: t()["review.missingReviewerComment"](round),
+          };
+        }
+      }
+
+      // Fire onReviewPosted only after confirming the reviewer comment
+      // exists on the PR.  When there is no PR, the callback still
+      // fires — the PR is the only place we can verify.
+      if (reviewStepRan) {
+        opts.onReviewPosted?.(round);
+      }
+
+      // ---- APPROVED path: unresolved summary + PR finalization -----
+      if (currentStep === "unresolved_summary") {
+        opts.onReviewProgress?.("unresolved_summary", "APPROVED");
+
         const { error, summary } = await handleUnresolvedSummary(
           opts,
-          verdictResult.sessionId ?? reviewResult.sessionId,
+          agentBSessionId,
           round,
           ctx.worktreePath,
+          ctx,
           ctx.streamSinks?.b,
           ctx.promptSinks?.b,
           ctx.usageSinks?.b,
         );
         if (error) return error;
+
+        opts.onReviewProgress?.("pr_finalization", "APPROVED");
 
         // PR finalization: Agent A verifies issue reference and
         // "Not addressed" section before the pipeline advances.
@@ -539,11 +822,6 @@ export function createReviewStageHandler(
           const hasNotAddressed =
             body !== undefined && /^## Not addressed/im.test(body);
 
-          // The body must contain exactly one reference form.  Both
-          // present is self-contradictory (closes implies full fix,
-          // "Part of" implies partial).  Then validate the companion:
-          //   - Closes #N  → no "## Not addressed" section
-          //   - Part of #N → "## Not addressed" must be present
           const exclusiveRef = closesRef !== partOfRef;
           const bodyValid =
             exclusiveRef &&
@@ -566,154 +844,157 @@ export function createReviewStageHandler(
         return { outcome: "completed", message };
       }
 
-      // Treat anything other than not_approved as ambiguous → needs_clarification.
-      if (reviewParsed.status !== "not_approved") {
-        return {
-          outcome: "needs_clarification",
-          message: verdictResult.responseText,
-          validVerdicts: REVIEW_VERDICT_KEYWORDS,
-        };
-      }
+      // ---- NOT_APPROVED path: author fix + CI poll -----------------
+      if (currentStep === "author_fix") {
+        opts.onReviewProgress?.("author_fix", "NOT_APPROVED");
 
-      // Step 3: NOT_APPROVED — Agent A fixes (resume if saved session).
-      const fixPrompt = buildAuthorFixPrompt(ctx, opts, round);
-      ctx.promptSinks?.a?.(fixPrompt);
-      const fixResult = await invokeOrResume(
-        opts.agentA,
-        ctx.savedAgentASessionId,
-        fixPrompt,
-        ctx.worktreePath,
-        ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
-      );
-
-      if (fixResult.sessionId) {
-        ctx.onSessionId?.("a", fixResult.sessionId);
-      }
-
-      if (fixResult.status === "error") {
-        return mapAgentError(fixResult, "during author fix");
-      }
-
-      // Completion check on Agent A (with clarification retry,
-      // same pattern as stage 4 / stage 8).
-      const authorCheckPrompt = buildAuthorCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(authorCheckPrompt);
-      let checkResult = await sendFollowUp(
-        opts.agentA,
-        fixResult.sessionId,
-        authorCheckPrompt,
-        ctx.worktreePath,
-        ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
-      );
-
-      if (checkResult.status === "error") {
-        return mapAgentError(checkResult, "during author completion check");
-      }
-
-      let checkMapped = mapResponseToResult(
-        checkResult.responseText,
-        undefined,
-        AUTHOR_CHECK_KEYWORDS,
-      );
-
-      if (checkMapped.outcome === "needs_clarification") {
-        const retryPrompt = buildClarificationPrompt(
-          checkResult.responseText,
-          AUTHOR_CHECK_KEYWORDS,
-        );
-        ctx.promptSinks?.a?.(retryPrompt);
-        const retryResult = await sendFollowUp(
+        const fixPrompt = buildAuthorFixPrompt(ctx, opts, round);
+        ctx.promptSinks?.a?.(fixPrompt);
+        const fixResult = await invokeOrResume(
           opts.agentA,
-          checkResult.sessionId ?? fixResult.sessionId,
-          retryPrompt,
+          ctx.savedAgentASessionId,
+          fixPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
           undefined,
           ctx.usageSinks?.a,
         );
 
-        if (retryResult.status === "error") {
-          return mapAgentError(
-            retryResult,
-            "during author completion clarification",
-          );
+        if (fixResult.sessionId) {
+          ctx.onSessionId?.("a", fixResult.sessionId);
         }
 
-        checkResult = retryResult;
-        checkMapped = mapResponseToResult(
+        if (fixResult.status === "error") {
+          return mapAgentError(fixResult, "during author fix");
+        }
+
+        // Completion check on Agent A (with clarification retry,
+        // same pattern as stage 4 / stage 8).
+        const authorCheckPrompt = buildAuthorCompletionCheckPrompt();
+        ctx.promptSinks?.a?.(authorCheckPrompt);
+        let checkResult = await sendFollowUp(
+          opts.agentA,
+          fixResult.sessionId,
+          authorCheckPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+
+        if (checkResult.status === "error") {
+          return mapAgentError(checkResult, "during author completion check");
+        }
+
+        let checkMapped = mapResponseToResult(
           checkResult.responseText,
           undefined,
           AUTHOR_CHECK_KEYWORDS,
         );
-      }
 
-      if (
-        checkMapped.outcome === "blocked" ||
-        checkMapped.outcome === "needs_clarification"
-      ) {
-        // Surface a blocked condition so the user can decide how to
-        // proceed.  Treating an ambiguous author-completion verdict as
-        // progress would poll stale CI on an unchanged head when the
-        // agent actually meant BLOCKED.
-        return {
-          outcome: "blocked",
-          message: `${fixResult.responseText}\n\n---\n\n${checkResult.responseText}`,
-        };
-      }
+        if (checkMapped.outcome === "needs_clarification") {
+          const retryPrompt = buildClarificationPrompt(
+            checkResult.responseText,
+            AUTHOR_CHECK_KEYWORDS,
+          );
+          ctx.promptSinks?.a?.(retryPrompt);
+          const retryResult = await sendFollowUp(
+            opts.agentA,
+            checkResult.sessionId ?? fixResult.sessionId,
+            retryPrompt,
+            ctx.worktreePath,
+            ctx.streamSinks?.a,
+            undefined,
+            ctx.usageSinks?.a,
+          );
 
-      if (
-        checkMapped.outcome !== "completed" &&
-        checkMapped.outcome !== "fixed" &&
-        checkMapped.outcome !== "approved"
-      ) {
-        return checkMapped;
-      }
+          if (retryResult.status === "error") {
+            return mapAgentError(
+              retryResult,
+              "during author completion clarification",
+            );
+          }
 
-      // Step 4: Poll CI after Agent A pushes.
-      const ciResult = await pollCiAndFix({
-        ctx,
-        agent: opts.agentA,
-        issueTitle: opts.issueTitle,
-        issueBody: opts.issueBody,
-        getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
-        collectFailureLogs:
-          opts.collectFailureLogs ?? defaultCollectFailureLogs,
-        getHeadSha: opts.getHeadSha,
-        emptyRunsGracePeriodMs: opts.emptyRunsGracePeriodMs,
-        pollIntervalMs: opts.pollIntervalMs,
-        pollTimeoutMs: opts.pollTimeoutMs,
-        maxFixAttempts: opts.maxFixAttempts,
-        delay: opts.delay,
-      });
-
-      if (!ciResult.passed) {
-        return { outcome: "error", message: ciResult.message };
-      }
-
-      // CI passed — return not_approved so the engine loops for next round.
-      let message = t()["review.fixesApplied"](round);
-
-      if (ctx.lastAutoIteration) {
-        const { error, summary } = await handleUnresolvedSummary(
-          opts,
-          verdictResult.sessionId ?? reviewResult.sessionId,
-          round,
-          ctx.worktreePath,
-          ctx.streamSinks?.b,
-          ctx.promptSinks?.b,
-          ctx.usageSinks?.b,
-        );
-        if (error) return error;
-        if (summary) {
-          message = t()["review.unresolvedItems"](message, summary);
+          checkResult = retryResult;
+          checkMapped = mapResponseToResult(
+            checkResult.responseText,
+            undefined,
+            AUTHOR_CHECK_KEYWORDS,
+          );
         }
+
+        if (
+          checkMapped.outcome === "blocked" ||
+          checkMapped.outcome === "needs_clarification"
+        ) {
+          return {
+            outcome: "blocked",
+            message: `${fixResult.responseText}\n\n---\n\n${checkResult.responseText}`,
+          };
+        }
+
+        if (
+          checkMapped.outcome !== "completed" &&
+          checkMapped.outcome !== "fixed" &&
+          checkMapped.outcome !== "approved"
+        ) {
+          return checkMapped;
+        }
+
+        opts.onReviewProgress?.("ci_poll", "NOT_APPROVED");
+        currentStep = "ci_poll";
       }
 
-      return { outcome: "not_approved", message };
+      // ---- CI poll (NOT_APPROVED path) -----------------------------
+      if (currentStep === "ci_poll") {
+        const ciResult = await pollCiAndFix({
+          ctx,
+          agent: opts.agentA,
+          issueTitle: opts.issueTitle,
+          issueBody: opts.issueBody,
+          getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
+          collectFailureLogs:
+            opts.collectFailureLogs ?? defaultCollectFailureLogs,
+          getHeadSha: opts.getHeadSha,
+          emptyRunsGracePeriodMs: opts.emptyRunsGracePeriodMs,
+          pollIntervalMs: opts.pollIntervalMs,
+          pollTimeoutMs: opts.pollTimeoutMs,
+          maxFixAttempts: opts.maxFixAttempts,
+          delay: opts.delay,
+        });
+
+        if (!ciResult.passed) {
+          return { outcome: "error", message: ciResult.message };
+        }
+
+        // CI passed — return not_approved so the engine loops for
+        // the next round.
+        let message = t()["review.fixesApplied"](round);
+
+        if (ctx.lastAutoIteration) {
+          const { error, summary } = await handleUnresolvedSummary(
+            opts,
+            agentBSessionId,
+            round,
+            ctx.worktreePath,
+            ctx,
+            ctx.streamSinks?.b,
+            ctx.promptSinks?.b,
+            ctx.usageSinks?.b,
+          );
+          if (error) return error;
+          if (summary) {
+            message = t()["review.unresolvedItems"](message, summary);
+          }
+        }
+
+        return { outcome: "not_approved", message };
+      }
+
+      return {
+        outcome: "error",
+        message: `Unexpected review sub-step: ${currentStep}`,
+      };
     },
   };
 }
@@ -737,11 +1018,18 @@ async function handleUnresolvedSummary(
   sessionId: string | undefined,
   round: number,
   cwd: string,
+  ctx: StageContext,
   sink?: StreamSink,
   promptSink?: PromptSink,
   usageSink?: UsageSink,
 ): Promise<UnresolvedSummaryResult> {
-  const summaryPrompt = buildUnresolvedSummaryPrompt(round);
+  // When resuming without a session, use the richer resume prompt
+  // that gives Agent B repository context and tells it to read its
+  // own review from the PR.  With a live session the agent already
+  // has full context from the review step.
+  const summaryPrompt = sessionId
+    ? buildUnresolvedSummaryPrompt(round)
+    : buildResumeUnresolvedSummaryPrompt(ctx, round);
   promptSink?.(summaryPrompt);
 
   // If we have a session, resume; otherwise invoke fresh.

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -259,6 +259,10 @@ export interface AppProps {
   onCancel?: () => void;
   /** Timestamp (ms) when agentcoop started, for wall-clock elapsed time. */
   startedAt?: number;
+  /** Persisted self-check count for StatusBar initialisation on resume. */
+  initialSelfCheckCount?: number;
+  /** Persisted review count for StatusBar initialisation on resume. */
+  initialReviewCount?: number;
 }
 
 export function App({
@@ -273,6 +277,8 @@ export function App({
   notifications,
   onCancel,
   startedAt,
+  initialSelfCheckCount,
+  initialReviewCount,
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
     useTerminalDimensions();
@@ -503,6 +509,8 @@ export function App({
         contentWidth={borderedContentWidth}
         paused={inputRequest !== null}
         startedAt={startedAt}
+        initialSelfCheckCount={initialSelfCheckCount}
+        initialReviewCount={initialReviewCount}
       />
       <InputArea request={inputRequest} onSubmit={handleSubmit} />
     </Box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -4,6 +4,7 @@ import stringWidth from "string-width";
 import { t } from "../i18n/index.js";
 import type {
   PipelineEventEmitter,
+  ReviewPostedEvent,
   StageEnterEvent,
   StageExitEvent,
   StageNameOverrideEvent,
@@ -33,6 +34,10 @@ interface StatusBarProps {
   paused?: boolean;
   /** Timestamp (ms) when agentcoop started, for wall-clock elapsed time. */
   startedAt?: number;
+  /** Persisted self-check count from RunState (initial value on resume). */
+  initialSelfCheckCount?: number;
+  /** Persisted review count from RunState (initial value on resume). */
+  initialReviewCount?: number;
 }
 
 // ---- Elapsed time helpers ----------------------------------------------------
@@ -195,11 +200,15 @@ export function StatusBar({
   contentWidth,
   paused = false,
   startedAt,
+  initialSelfCheckCount,
+  initialReviewCount,
 }: StatusBarProps) {
   const [stage, setStage] = useState<StageEnterEvent | null>(null);
   const [lastOutcome, setLastOutcome] = useState<string | null>(null);
-  const [selfCheckCount, setSelfCheckCount] = useState(0);
-  const [reviewCount, setReviewCount] = useState(0);
+  const [selfCheckCount, setSelfCheckCount] = useState(
+    initialSelfCheckCount ?? 0,
+  );
+  const [reviewCount, setReviewCount] = useState(initialReviewCount ?? 0);
 
   useEffect(() => {
     const onEnter = (ev: StageEnterEvent) => {
@@ -210,19 +219,22 @@ export function StatusBar({
       setLastOutcome(ev.outcome);
       if (ev.stageNumber === SELF_CHECK_STAGE) {
         setSelfCheckCount((c) => c + 1);
-      } else if (ev.stageNumber === REVIEW_STAGE) {
-        setReviewCount((c) => c + 1);
       }
+    };
+    const onReviewPosted = (_ev: ReviewPostedEvent) => {
+      setReviewCount((c) => c + 1);
     };
     const onNameOverride = (ev: StageNameOverrideEvent) => {
       setStage((prev) => (prev ? { ...prev, stageName: ev.stageName } : prev));
     };
     emitter.on("stage:enter", onEnter);
     emitter.on("stage:exit", onExit);
+    emitter.on("review:posted", onReviewPosted);
     emitter.on("stage:name-override", onNameOverride);
     return () => {
       emitter.off("stage:enter", onEnter);
       emitter.off("stage:exit", onExit);
+      emitter.off("review:posted", onReviewPosted);
       emitter.off("stage:name-override", onNameOverride);
     };
   }, [emitter]);

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -994,7 +994,27 @@ describe("StatusBar", () => {
     expect(frame).not.toContain("completed");
   });
 
-  test("increments review count on stage:exit for review stage", async () => {
+  test("increments review count on review:posted event", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+        />
+      </Box>,
+    );
+
+    emitter.emit("review:posted", { round: 1 });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame();
+    expect(frame).toContain("Completed: self-check \u00d70, review \u00d71");
+  });
+
+  test("does not increment review count on stage-7 exit alone", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
       <Box width={200}>
@@ -1016,7 +1036,8 @@ describe("StatusBar", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame();
-    expect(frame).toContain("Completed: self-check \u00d70, review \u00d71");
+    // Review count stays 0 — no review:posted event was emitted.
+    expect(frame).not.toContain("review \u00d71");
   });
 
   test("hides cumulative counts when both are zero", () => {


### PR DESCRIPTION
## Summary

- Add `selfCheckCount` and `reviewCount` to `RunState` so completion counts survive restarts
- Post review verdicts (`[Review Verdict Round n: APPROVED|NOT_APPROVED]`) as PR comments so they are recoverable from PR history
- Reconstruct review-loop state from PR comments on resume, reconciling `reviewRound`, `stageLoopCount`, `currentStage`, `reviewCount`, `reviewSubStep`, and `lastVerdict` against the actual PR state
- Add `ReviewSubStep` type and `reviewSubStep`/`lastVerdict` fields to `RunState` to track intra-round position within stage 7
- Derive a resumable sub-step from PR comments (`deriveReviewSubStep`) so the handler can skip completed work (review posted → verdict, verdict posted → unresolved summary or author fix)
- Restructure the review stage handler with a `currentStep` state machine that skips to the correct sub-step on resume instead of replaying the entire round
- Broaden session invalidation to cover verdict and sub-step mismatches, not just round-counter changes — including when `currentStage` is past stage 7 (sessions are passed to later stages like squash)
- Treat `reviewCount` as a UI-only counter: correct it from PR state but do not invalidate agent sessions when it is the only field that diverges
- Skip sub-step reconciliation when `currentStage > 7`, max round is APPROVED, and local `lastVerdict` already acknowledges the approval — PR comments cannot encode post-approval progress, so the mismatch between local `"pr_finalization"` and derived `"unresolved_summary"` is expected and must not invalidate sessions
- Clear `lastVerdict` when `onReviewProgress` enters a pre-verdict step (`review` or `verdict`), so that a stale verdict from the previous NOT_APPROVED round does not cause false session invalidation on resume
- Reconcile stale local state even when the PR exists but has no review-loop comments (`prMaxRound === 0`), so counters, stage demotion, and session invalidation still run
- Validate expected round comments exist on the PR before instructing agents to read them, including refetching after posting to verify delivery — applies to both APPROVED and NOT_APPROVED paths
- Guard the resume-at-verdict path against missing reviewer comments — the reviewer-comment existence check now runs before `buildResumeVerdictPrompt` is sent to Agent B, preventing it from being invoked with a prompt referencing a nonexistent PR comment
- Defer `onReviewPosted` callback until after the reviewer comment is confirmed on the PR, preventing `reviewCount` from incrementing when the comment was never posted
- Reuse saved Agent B sessions when resuming mid-round at `verdict` or `unresolved_summary` — previously the handler always discarded the saved session and invoked Agent B fresh on these resume paths
- Increment `reviewCount` only when a new review is actually posted (via `review:posted` pipeline event), not on every stage-7 exit, preventing count drift on mid-round resume
- Treat verdict comment posting as required state synchronization — failures propagate to the pipeline's error handler for retry, rather than being silently swallowed
- Add `buildResumeUnresolvedSummaryPrompt` so Agent B gets repository context and instructions to read its own review when resuming at the unresolved-summary step with no saved session
- Make `fetchPrComments` throw on API failure instead of silently returning `[]`, and abort resume with a clear error message when PR comment fetch fails (prevents silent fallback to stale local state)
- Clear `reviewSubStep` and `lastVerdict` when the PR-derived round is 0, so stale post-verdict fields do not survive reconciliation against an empty PR history
- Scope `stageLoopCount` correction to stage 7 only — `stageLoopCount` is a generic per-stage loop counter (used by stage 6 for test-plan iterations, stage 7 for review iterations, etc.), so PR-derived review rounds must not overwrite it when resuming a different stage
- New `src/pr-comments.ts` module for fetching, parsing, posting, and reconciling PR comments
- Require the reviewer comment to exist for the verdict's round before trusting `maxRoundApproved` — orphan verdicts (from partial failures or stale history) can no longer keep `currentStage` past 7
- Fix crash when verdict clarification retry has no session ID (both the fresh verdict invoke and the prior review step returned no session): invoke Agent B fresh instead of calling `sendFollowUp` with `undefined`
- Fix `fetchPrComments` to handle multi-page `gh api --paginate` output by adding `--slurp` and flattening the nested arrays — without this, PRs with enough comments to spill onto page 2 would fail during resume/reconciliation
- Promote `currentStage` from <7 to 7 when PR comments show the review loop has started but local state is still on an earlier stage (e.g., process died after posting `[Reviewer Round 1]` but before updating `run-state.json` from stage 6 to 7) — without this forward correction, the pipeline would re-run earlier stages instead of resuming the review loop
- Remove leftover `[done-stage-debug]` `console.error` dump from the pipeline exit path

Closes #208

## Test plan

- [x] Verify `selfCheckCount` and `reviewCount` persist in `run-state.json` and survive restarts
- [x] Verify old state files without count fields default to zero on load
- [x] Verify `[Review Verdict Round n: APPROVED]` is posted to the PR after an approved review
- [x] Verify `[Review Verdict Round n: NOT_APPROVED]` is posted after a not-approved review
- [x] Verify verdict posting failure propagates to the pipeline (not silently swallowed)
- [x] Verify verdict posting is skipped when PR number is not available
- [x] Verify `parsePrReviewState` extracts max round numbers from reviewer, author, and verdict comments
- [x] Verify duplicate comments are handled by taking max round (not count)
- [x] Verify human/unrelated PR comments are ignored by the parser
- [x] Verify `reconcileWithPr` corrects `reviewRound`, `stageLoopCount`, `reviewCount`, `reviewSubStep`, and `lastVerdict` from PR state
- [x] Verify `currentStage` is demoted from >7 to 7 when the max round does not have an APPROVED verdict
- [x] Verify `currentStage` is NOT demoted when the max round has an APPROVED verdict
- [x] Verify `currentStage` is demoted when an older round is APPROVED but a newer round has no verdict
- [x] Verify `currentStage` is promoted from <7 to 7 when PR has review rounds but local state is behind
- [x] Verify `currentStage` promotion sets `stageLoopCount` from the PR-derived round
- [x] Verify `reviewRound` is reconciled even when `currentStage` is beyond stage 7, but `stageLoopCount` is left alone (it belongs to the current stage)
- [x] Verify `stageLoopCount` is not overwritten when resuming before stage 7 with no PR review comments
- [x] Verify agent sessions are invalidated when sub-step diverges despite matching round numbers
- [x] Verify agent sessions are invalidated when verdict diverges within the same round
- [x] Verify agent sessions are invalidated when past stage 7 with matching counters but divergent verdict/sub-step
- [x] Verify agent sessions are preserved when past stage 7 with approved verdict and `pr_finalization` sub-step (no false mismatch)
- [x] Verify agent sessions are preserved when all fields match, including `reviewSubStep` and `lastVerdict`
- [x] Verify no false session invalidation when round 2 resumes before verdict and round 1 was NOT_APPROVED (stale `lastVerdict` cleared)
- [x] Verify no false session invalidation when only `reviewCount` diverges (UI-only counter correction)
- [x] Verify reconciliation corrects stale stage-7 local state against empty PR history (including clearing `reviewSubStep`)
- [x] Verify reconciliation corrects and demotes stale stage-8 local state against empty PR history (including clearing `reviewSubStep` and `lastVerdict`)
- [x] Verify no-op when PR has no review comments and local state is fresh
- [x] Verify `deriveReviewSubStep` returns the correct sub-step for each PR comment state (review, verdict, unresolved_summary, author_fix, ci_poll)
- [x] Verify comment validation returns error when expected `[Author Round n]` is missing
- [x] Verify reviewer comment is refetched after posting and validated (not skipped)
- [x] Verify error when refetch after review does not find the reviewer comment (NOT_APPROVED path)
- [x] Verify error on APPROVED path when reviewer comment is missing
- [x] Verify comment validation is skipped when PR number is unavailable
- [x] Verify `onReviewPosted` fires with the correct round when a review is posted
- [x] Verify `onReviewPosted` does not fire when resuming mid-round
- [x] Verify `onReviewPosted` does not fire when refetch cannot find the reviewer comment
- [x] Verify resume at verdict reuses saved Agent B session
- [x] Verify resume at unresolved_summary reuses saved Agent B session
- [x] Verify handler invokes Agent B fresh for verdict when B returns no session ID (recovery instead of crash)
- [x] Verify resume at unresolved_summary with no B session uses the resume prompt with repo context
- [x] Verify `fetchPrComments` failure aborts resume instead of silently skipping PR sync
- [x] Verify StatusBar initializes counts from persisted values on resume
- [x] Verify StatusBar increments review count on `review:posted` event (not stage-7 exit)
- [x] Verify StatusBar does not increment review count on stage-7 exit alone
- [x] Verify orphan verdict (verdict exists but reviewer comment missing) triggers `currentStage` demotion on resume
- [x] Verify resume at verdict returns error before invoking Agent B when reviewer comment is missing for current round
- [x] Verify ambiguous fresh verdict without sessionId invokes B fresh for clarification instead of crashing
- [x] Verify `fetchPrComments` passes `--slurp` flag and flattens multi-page output into a single array
- [x] Verify `fetchPrComments` handles single-page and empty-comment cases correctly
- [x] Run `pnpm vitest run` — all tests pass
- [x] Run `pnpm tsc --noEmit` — no type errors
- [x] Run `pnpm biome check` — no lint issues