### PR TITLE
Include GitHub check runs in CI verdict (#214)

### DIFF
--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -35,6 +35,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     conclusion: "success",
     headBranch: "issue-42",
     headSha: "abc123",
+    source: "workflow",
     ...overrides,
   };
 }
@@ -161,7 +162,11 @@ describe("pollCiAndFix", () => {
 
     expect(result.passed).toBe(true);
     expect(agent.invoke).toHaveBeenCalledTimes(1);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 200 }),
+    );
     const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
     expect(invokedPrompt).toContain("CI Failure Logs");
@@ -281,8 +286,16 @@ describe("pollCiAndFix", () => {
     await pollCiAndFix(makeOpts({ agent, getCiStatus, collectFailureLogs }));
 
     expect(collectFailureLogs).toHaveBeenCalledTimes(2);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 201);
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 200 }),
+    );
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 201 }),
+    );
 
     const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
@@ -321,7 +334,43 @@ describe("pollCiAndFix", () => {
     const agent = makeAgent();
     await pollCiAndFix(makeOpts({ agent, getCiStatus, collectFailureLogs }));
 
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 300);
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 300 }),
+    );
+  });
+
+  // -- check run failure triggers fix -----------------------------------------
+
+  test("collects logs from failed check runs with source check", async () => {
+    const runs = [
+      makeCiRun({
+        databaseId: 500,
+        name: "CodeQL",
+        conclusion: "failure",
+        source: "check",
+      }),
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("fail", runs))
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi
+      .fn()
+      .mockReturnValue("CodeQL: SQL injection found");
+
+    const agent = makeAgent();
+    await pollCiAndFix(makeOpts({ agent, getCiStatus, collectFailureLogs }));
+
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 500, source: "check" }),
+    );
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("CodeQL: SQL injection found");
   });
 
   // -- fix attempt 1 fails, attempt 2 succeeds -------------------------------
@@ -486,6 +535,61 @@ describe("pollCiAndFix", () => {
       "issue-42",
       "bbb222",
     );
+  });
+
+  // -- transient getCiStatus error retried ------------------------------------
+
+  test("retries on transient getCiStatus error then succeeds", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("502 Bad Gateway");
+      })
+      .mockReturnValueOnce(makeCiStatus("pass"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const delay = vi.fn().mockResolvedValue(undefined);
+
+    const result = await pollCiAndFix(makeOpts({ getCiStatus, delay }));
+
+    expect(result.passed).toBe(true);
+    expect(getCiStatus).toHaveBeenCalledTimes(2);
+    expect(delay).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("502 Bad Gateway");
+
+    warnSpy.mockRestore();
+  });
+
+  test("returns timeout when getCiStatus keeps failing", async () => {
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      throw new Error("persistent failure");
+    });
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        getCiStatus,
+        delay,
+        pollIntervalMs: 100,
+        pollTimeoutMs: 1000,
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("still pending");
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   // -- timeout during fix loop (pending after agent pushes fix) ---------------

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -8,7 +8,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiStatus, GetCiStatusFn } from "./ci.js";
+import type { CiRun, CiStatus, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -45,7 +45,7 @@ export interface CiPollOptions {
   /** Injected for testability. Defaults to `ci.getCiStatus`. */
   getCiStatus?: GetCiStatusFn;
   /** Injected for testability. Defaults to `ci.collectFailureLogs`. */
-  collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  collectFailureLogs?: (owner: string, repo: string, run: CiRun) => string;
   /**
    * Read the current HEAD SHA from the worktree.  Called before each
    * CI poll so that fix pushes automatically target the new commit.
@@ -96,7 +96,25 @@ async function waitForCi(
   const startTime = Date.now();
 
   while (true) {
-    const ciStatus = getCiStatus(owner, repo, branch, commitSha);
+    let ciStatus: CiStatus;
+    try {
+      ciStatus = getCiStatus(owner, repo, branch, commitSha);
+    } catch (err) {
+      // Transient lookup error — log and retry on the next poll cycle.
+      console.warn(
+        `CI status lookup failed (will retry): ${err instanceof Error ? err.message : err}`,
+      );
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= pollTimeout) {
+        return {
+          timedOut: true,
+          ciStatus: { verdict: "pending" as const, runs: [] },
+        };
+      }
+      await delay(pollInterval);
+      continue;
+    }
+
     const elapsed = Date.now() - startTime;
 
     if (ciStatus.verdict !== "pending") {
@@ -189,7 +207,7 @@ export async function pollCiAndFix(
 
     const logSections: string[] = [];
     for (const run of failedRuns) {
-      const logs = collectLogs(ctx.owner, ctx.repo, run.databaseId);
+      const logs = collectLogs(ctx.owner, ctx.repo, run);
       if (logs) {
         logSections.push(`### ${run.name} (run ${run.databaseId})\n\n${logs}`);
       }

--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -29,6 +29,13 @@ function run(
     conclusion: string;
     headBranch: string;
     headSha: string;
+    source: "workflow" | "check";
+    checkOutput: {
+      title: string | null;
+      summary: string | null;
+      text: string | null;
+    };
+    annotationsCount: number;
   }> = {},
 ) {
   return {
@@ -38,6 +45,7 @@ function run(
     conclusion: "success",
     headBranch: "main",
     headSha: "abc123",
+    source: "workflow" as const,
     ...overrides,
   };
 }
@@ -231,6 +239,154 @@ describe("fetchCiRuns", () => {
     const args = mockExecFileSync.mock.calls[0][1] as string[];
     expect(args).not.toContain("--commit");
   });
+
+  test("merges workflow runs and non-Actions check runs", () => {
+    const workflowRun = {
+      databaseId: 1,
+      name: "CI",
+      status: "completed",
+      conclusion: "success",
+      headBranch: "main",
+      headSha: "abc123",
+    };
+    const checkRunsResponse = {
+      check_runs: [
+        {
+          id: 500,
+          name: "CodeQL",
+          status: "completed",
+          conclusion: "failure",
+          head_sha: "abc123",
+          output: { title: null, summary: null, text: null },
+          annotations_count: 0,
+          app: { slug: "github-code-scanning" },
+        },
+        {
+          id: 501,
+          name: "build",
+          status: "completed",
+          conclusion: "success",
+          head_sha: "abc123",
+          output: { title: null, summary: null, text: null },
+          annotations_count: 0,
+          app: { slug: "github-actions" },
+        },
+      ],
+    };
+
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify([workflowRun]))
+      .mockReturnValueOnce(JSON.stringify(checkRunsResponse));
+
+    const result = fetchCiRuns("org", "repo", "main", "abc123");
+
+    // Workflow run + CodeQL check run (github-actions filtered out).
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual(
+      expect.objectContaining({
+        databaseId: 1,
+        name: "CI",
+        source: "workflow",
+      }),
+    );
+    expect(result[1]).toEqual(
+      expect.objectContaining({
+        databaseId: 500,
+        name: "CodeQL",
+        source: "check",
+        conclusion: "failure",
+        checkOutput: { title: null, summary: null, text: null },
+        annotationsCount: 0,
+      }),
+    );
+  });
+
+  test("uses commitSha as ref for check runs API", () => {
+    mockExecFileSync
+      .mockReturnValueOnce("[]")
+      .mockReturnValueOnce(JSON.stringify({ check_runs: [] }));
+
+    fetchCiRuns("org", "repo", "main", "deadbeef");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      ["api", "repos/org/repo/commits/deadbeef/check-runs?per_page=100"],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("uses branch as ref for check runs when no commitSha", () => {
+    mockExecFileSync
+      .mockReturnValueOnce("[]")
+      .mockReturnValueOnce(JSON.stringify({ check_runs: [] }));
+
+    fetchCiRuns("org", "repo", "my-branch");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      ["api", "repos/org/repo/commits/my-branch/check-runs?per_page=100"],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("URL-encodes branch ref containing slashes", () => {
+    mockExecFileSync
+      .mockReturnValueOnce("[]")
+      .mockReturnValueOnce(JSON.stringify({ check_runs: [] }));
+
+    fetchCiRuns("org", "repo", "user/issue-42");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      ["api", "repos/org/repo/commits/user%2Fissue-42/check-runs?per_page=100"],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("throws when check runs API fails", () => {
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify([{ ...run(), source: undefined }]))
+      .mockImplementationOnce(() => {
+        throw new Error("API error");
+      });
+
+    expect(() => fetchCiRuns("org", "repo", "main")).toThrow("API error");
+  });
+
+  test("filters out github-actions check runs to avoid duplicates", () => {
+    const checkRunsResponse = {
+      check_runs: [
+        {
+          id: 10,
+          name: "Actions check",
+          status: "completed",
+          conclusion: "success",
+          head_sha: "abc",
+          output: { title: null, summary: null, text: null },
+          annotations_count: 0,
+          app: { slug: "github-actions" },
+        },
+        {
+          id: 11,
+          name: "External check",
+          status: "completed",
+          conclusion: "success",
+          head_sha: "abc",
+          output: { title: null, summary: null, text: null },
+          annotations_count: 0,
+          app: { slug: "some-app" },
+        },
+      ],
+    };
+
+    mockExecFileSync
+      .mockReturnValueOnce("[]")
+      .mockReturnValueOnce(JSON.stringify(checkRunsResponse));
+
+    const result = fetchCiRuns("org", "repo", "main");
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("External check");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -278,15 +434,43 @@ describe("getCiStatus", () => {
     expect(status.verdict).toBe("pass");
     expect(status.runs).toEqual([]);
   });
+
+  test("failing check run causes fail verdict", () => {
+    const checkRunsResponse = {
+      check_runs: [
+        {
+          id: 500,
+          name: "CodeQL",
+          status: "completed",
+          conclusion: "failure",
+          head_sha: "abc123",
+          output: { title: null, summary: null, text: null },
+          annotations_count: 0,
+          app: { slug: "github-code-scanning" },
+        },
+      ],
+    };
+
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify([run()]))
+      .mockReturnValueOnce(JSON.stringify(checkRunsResponse));
+
+    const status = getCiStatus("org", "repo", "main");
+    expect(status.verdict).toBe("fail");
+    expect(status.runs).toHaveLength(2);
+    expect(status.runs[1]).toEqual(
+      expect.objectContaining({ name: "CodeQL", source: "check" }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
 // collectFailureLogs
 // ---------------------------------------------------------------------------
 describe("collectFailureLogs", () => {
-  test("calls gh run view with --log-failed", () => {
+  test("calls gh run view with --log-failed for workflow runs", () => {
     mockExecFileSync.mockReturnValue("error log output");
-    const logs = collectFailureLogs("org", "repo", 12345);
+    const logs = collectFailureLogs("org", "repo", run({ databaseId: 12345 }));
     expect(logs).toBe("error log output");
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
@@ -295,18 +479,221 @@ describe("collectFailureLogs", () => {
     );
   });
 
-  test("propagates error when gh command fails", () => {
+  test("propagates error when gh command fails for workflow runs", () => {
     mockExecFileSync.mockImplementation(() => {
       throw new Error("run not found");
     });
-    expect(() => collectFailureLogs("org", "repo", 999)).toThrow(
-      "run not found",
+    expect(() =>
+      collectFailureLogs("org", "repo", run({ databaseId: 999 })),
+    ).toThrow("run not found");
+  });
+
+  test("returns empty string when logs are empty for workflow runs", () => {
+    mockExecFileSync.mockReturnValue("");
+    expect(collectFailureLogs("org", "repo", run({ databaseId: 1 }))).toBe("");
+  });
+
+  test("uses carried-forward output and skips detail re-fetch", () => {
+    const annotations = [
+      {
+        path: "src/auth.ts",
+        start_line: 42,
+        end_line: 42,
+        annotation_level: "failure",
+        message: "SQL injection vulnerability",
+      },
+    ];
+
+    // Only one call expected: annotations (no detail re-fetch).
+    // --slurp wraps pages in an outer array.
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([annotations]));
+
+    const logs = collectFailureLogs(
+      "org",
+      "repo",
+      run({
+        databaseId: 500,
+        source: "check",
+        checkOutput: {
+          title: "2 vulnerabilities found",
+          summary: "SQL injection in auth.ts",
+          text: "Detailed explanation here.",
+        },
+        annotationsCount: 1,
+      }),
+    );
+    expect(logs).toContain("Title: 2 vulnerabilities found");
+    expect(logs).toContain("Summary: SQL injection in auth.ts");
+    expect(logs).toContain("Details: Detailed explanation here.");
+    expect(logs).toContain("src/auth.ts:42: [failure] SQL injection");
+    // Detail was NOT re-fetched.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "api",
+        "--paginate",
+        "--slurp",
+        "repos/org/repo/check-runs/500/annotations?per_page=100",
+      ],
+      { encoding: "utf-8" },
     );
   });
 
-  test("returns empty string when logs are empty", () => {
-    mockExecFileSync.mockReturnValue("");
-    expect(collectFailureLogs("org", "repo", 1)).toBe("");
+  test("re-fetches detail when checkOutput is not carried forward", () => {
+    const detail = {
+      id: 500,
+      name: "CodeQL",
+      status: "completed",
+      conclusion: "failure",
+      head_sha: "abc",
+      output: {
+        title: "2 vulnerabilities found",
+        summary: "SQL injection in auth.ts",
+        text: "Detailed explanation here.",
+      },
+      annotations_count: 1,
+    };
+    const annotations = [
+      {
+        path: "src/auth.ts",
+        start_line: 42,
+        end_line: 42,
+        annotation_level: "failure",
+        message: "SQL injection vulnerability",
+      },
+    ];
+
+    mockExecFileSync
+      .mockReturnValueOnce(JSON.stringify(detail))
+      // --slurp wraps pages in an outer array.
+      .mockReturnValueOnce(JSON.stringify([annotations]));
+
+    const logs = collectFailureLogs(
+      "org",
+      "repo",
+      run({ databaseId: 500, source: "check" }),
+    );
+    expect(logs).toContain("Title: 2 vulnerabilities found");
+    expect(logs).toContain("Summary: SQL injection in auth.ts");
+    expect(logs).toContain("Details: Detailed explanation here.");
+    expect(logs).toContain("src/auth.ts:42: [failure] SQL injection");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns output-only context when annotations fetch fails", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("network error");
+    });
+
+    const logs = collectFailureLogs(
+      "org",
+      "repo",
+      run({
+        databaseId: 600,
+        source: "check",
+        checkOutput: {
+          title: "Analysis failed",
+          summary: "Build error during analysis",
+          text: null,
+        },
+        annotationsCount: 1,
+      }),
+    );
+    expect(logs).toContain("Title: Analysis failed");
+    expect(logs).toContain("Summary: Build error during analysis");
+    expect(logs).not.toContain("Annotations");
+  });
+
+  test("skips annotation fetch when annotations_count is 0", () => {
+    const logs = collectFailureLogs(
+      "org",
+      "repo",
+      run({
+        databaseId: 700,
+        source: "check",
+        checkOutput: {
+          title: null,
+          summary: "Check failed with output only",
+          text: null,
+        },
+        annotationsCount: 0,
+      }),
+    );
+    expect(logs).toContain("Summary: Check failed with output only");
+    // No API calls at all: output carried forward and no annotations.
+    expect(mockExecFileSync).toHaveBeenCalledTimes(0);
+  });
+
+  test("returns fallback when check run detail fetch fails", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+
+    // No carried-forward data → triggers a detail re-fetch which fails.
+    const logs = collectFailureLogs(
+      "org",
+      "repo",
+      run({ databaseId: 800, source: "check" }),
+    );
+    expect(logs).toBe("Unable to retrieve check run details.");
+  });
+
+  test("paginates annotations with --slurp and flattens pages", () => {
+    // Simulate two pages of annotations as gh api --paginate --slurp
+    // would return: an outer array containing one array per page.
+    const page1 = Array.from({ length: 100 }, (_, i) => ({
+      path: `src/file${i}.ts`,
+      start_line: i + 1,
+      end_line: i + 1,
+      annotation_level: "warning",
+      message: `Issue ${i}`,
+    }));
+    const page2 = Array.from({ length: 50 }, (_, i) => ({
+      path: `src/file${100 + i}.ts`,
+      start_line: 100 + i + 1,
+      end_line: 100 + i + 1,
+      annotation_level: "warning",
+      message: `Issue ${100 + i}`,
+    }));
+
+    // --slurp wraps pages into an outer array.
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([page1, page2]));
+
+    const logs = collectFailureLogs(
+      "org",
+      "repo",
+      run({
+        databaseId: 900,
+        source: "check",
+        checkOutput: {
+          title: "150 issues found",
+          summary: "Large scan result",
+          text: null,
+        },
+        annotationsCount: 150,
+      }),
+    );
+
+    // All 150 annotations from both pages should appear.
+    expect(logs).toContain("file0.ts");
+    expect(logs).toContain("file99.ts");
+    expect(logs).toContain("file100.ts");
+    expect(logs).toContain("file149.ts");
+    expect(logs).toContain("Issue 0");
+    expect(logs).toContain("Issue 149");
+
+    // Verify --paginate --slurp was passed.
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "api",
+        "--paginate",
+        "--slurp",
+        "repos/org/repo/check-runs/900/annotations?per_page=100",
+      ],
+      { encoding: "utf-8" },
+    );
   });
 });
 
@@ -357,8 +744,15 @@ describe("edge cases", () => {
     expect(normaliseCiConclusion(r)).toBe("failure");
   });
 
-  test("fetchCiRuns returns empty array on malformed JSON", () => {
-    mockExecFileSync.mockReturnValue("not json");
+  test("fetchCiRuns returns empty array on malformed workflow JSON", () => {
+    mockExecFileSync
+      .mockReturnValueOnce("not json")
+      .mockReturnValueOnce(JSON.stringify({ check_runs: [] }));
     expect(fetchCiRuns("org", "repo", "main")).toEqual([]);
+  });
+
+  test("fetchCiRuns throws on malformed check-runs JSON", () => {
+    mockExecFileSync.mockReturnValueOnce("[]").mockReturnValueOnce("not json");
+    expect(() => fetchCiRuns("org", "repo", "main")).toThrow();
   });
 });

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -17,6 +17,8 @@ export type CheckConclusion =
   | "pending"
   | "neutral";
 
+export type CiRunSource = "workflow" | "check";
+
 export interface CiRun {
   databaseId: number;
   name: string;
@@ -24,6 +26,15 @@ export interface CiRun {
   conclusion: string;
   headBranch: string;
   headSha: string;
+  source: CiRunSource;
+  /** Populated for check runs from the list endpoint; avoids a re-fetch. */
+  checkOutput?: {
+    title: string | null;
+    summary: string | null;
+    text: string | null;
+  };
+  /** Populated for check runs from the list endpoint; avoids a re-fetch. */
+  annotationsCount?: number;
 }
 
 export type CiVerdict = "pass" | "fail" | "pending";
@@ -103,14 +114,155 @@ export function normaliseCiConclusion(run: CiRun): CheckConclusion {
   return "failure";
 }
 
+// ---- internal types for Checks API ----------------------------------------
+
+interface CheckRunApiEntry {
+  id: number;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  head_sha: string;
+  output: {
+    title: string | null;
+    summary: string | null;
+    text: string | null;
+  };
+  annotations_count: number;
+  app?: { slug?: string };
+}
+
+interface CheckRunAnnotation {
+  path: string;
+  start_line: number;
+  end_line: number;
+  annotation_level: string;
+  message: string;
+  title?: string;
+}
+
 // ---- gh CLI wrappers -----------------------------------------------------
+
+/**
+ * Fetch check runs from the GitHub Checks API for a given ref.
+ * Filters out check runs created by GitHub Actions (already covered
+ * by `gh run list`).
+ */
+function fetchCheckRunsFromApi(
+  owner: string,
+  repo: string,
+  ref: string,
+): CiRun[] {
+  const output = execFileSync(
+    "gh",
+    [
+      "api",
+      `repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}/check-runs?per_page=100`,
+    ],
+    { encoding: "utf-8" },
+  );
+
+  const parsed = JSON.parse(output);
+  const entries: CheckRunApiEntry[] = parsed.check_runs ?? [];
+
+  // Exclude check runs created by GitHub Actions — those are already
+  // covered by the workflow run list.
+  return entries
+    .filter((entry) => entry.app?.slug !== "github-actions")
+    .map((entry) => ({
+      databaseId: entry.id,
+      name: entry.name,
+      status: entry.status,
+      conclusion: entry.conclusion ?? "",
+      headBranch: "",
+      headSha: entry.head_sha,
+      source: "check" as const,
+      checkOutput: entry.output,
+      annotationsCount: entry.annotations_count,
+    }));
+}
+
+/**
+ * Collect failure context for a check run by fetching its output
+ * and annotations from the Checks API.
+ *
+ * When the parent `CiRun` already carries `checkOutput` and
+ * `annotationsCount` (populated from the list endpoint), the
+ * detail re-fetch is skipped to avoid a redundant API call.
+ */
+function collectCheckRunLogs(owner: string, repo: string, run: CiRun): string {
+  const sections: string[] = [];
+  const checkRunId = run.databaseId;
+
+  // Use carried-forward data when available; otherwise re-fetch.
+  let output = run.checkOutput;
+  let annotationsCount = run.annotationsCount;
+
+  if (output === undefined) {
+    let detail: CheckRunApiEntry | undefined;
+    try {
+      const raw = execFileSync(
+        "gh",
+        ["api", `repos/${owner}/${repo}/check-runs/${checkRunId}`],
+        { encoding: "utf-8" },
+      );
+      detail = JSON.parse(raw);
+    } catch {
+      return "Unable to retrieve check run details.";
+    }
+    output = detail?.output;
+    annotationsCount = detail?.annotations_count;
+  }
+
+  if (output) {
+    const { title, summary, text } = output;
+    if (title) sections.push(`Title: ${title}`);
+    if (summary) sections.push(`Summary: ${summary}`);
+    if (text) sections.push(`Details: ${text}`);
+  }
+
+  // Fetch annotations when present, paginating to collect all pages.
+  // --slurp wraps each page into an outer JSON array so the entire
+  // output is valid JSON even when multiple pages are returned.
+  if (annotationsCount != null && annotationsCount > 0) {
+    try {
+      const raw = execFileSync(
+        "gh",
+        [
+          "api",
+          "--paginate",
+          "--slurp",
+          `repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=100`,
+        ],
+        { encoding: "utf-8" },
+      );
+      const pages: CheckRunAnnotation[][] = JSON.parse(raw);
+      const annotations: CheckRunAnnotation[] = pages.flat();
+      if (annotations.length > 0) {
+        const lines = annotations.map(
+          (a) =>
+            `  ${a.path}:${a.start_line}: [${a.annotation_level}] ${a.message}`,
+        );
+        sections.push(`Annotations:\n${lines.join("\n")}`);
+      }
+    } catch {
+      // Annotations fetch failed; output-only context is still useful.
+    }
+  }
+
+  return sections.length > 0
+    ? sections.join("\n\n")
+    : "No detailed check run output available.";
+}
 
 /**
  * Fetch the latest CI runs for `branch` in `owner/repo`.
  *
- * When `commitSha` is provided, uses `gh run list --commit` to let
- * the server filter by SHA.  This avoids pagination issues where the
- * target commit's runs could be paged out on high-activity branches.
+ * Queries both GitHub Actions workflow runs (`gh run list`) and
+ * Checks API check runs.  Check runs from GitHub Actions are
+ * excluded to avoid double-counting.
+ *
+ * When `commitSha` is provided, uses `gh run list --commit` and
+ * `commits/{sha}/check-runs` to filter by SHA.
  */
 export function fetchCiRuns(
   owner: string,
@@ -118,6 +270,7 @@ export function fetchCiRuns(
   branch: string,
   commitSha?: string,
 ): CiRun[] {
+  // ---- workflow runs via gh CLI -------------------------------------------
   const args = [
     "run",
     "list",
@@ -134,11 +287,21 @@ export function fetchCiRuns(
     args.push("--commit", commitSha);
   }
   const output = execFileSync("gh", args, { encoding: "utf-8" });
+  let workflowRuns: CiRun[];
   try {
-    return JSON.parse(output);
+    workflowRuns = (JSON.parse(output) as Omit<CiRun, "source">[]).map((r) => ({
+      ...r,
+      source: "workflow" as const,
+    }));
   } catch {
-    return [];
+    workflowRuns = [];
   }
+
+  // ---- check runs via Checks API ------------------------------------------
+  const ref = commitSha ?? branch;
+  const checkRuns = fetchCheckRunsFromApi(owner, repo, ref);
+
+  return [...workflowRuns, ...checkRuns];
 }
 
 /**
@@ -158,19 +321,25 @@ export function getCiStatus(
 }
 
 /**
- * Collect failure logs for a specific run ID.
+ * Collect failure logs for a CI run.
+ *
+ * For workflow runs, uses `gh run view --log-failed`.
+ * For check runs, fetches output and annotations from the Checks API.
  */
 export function collectFailureLogs(
   owner: string,
   repo: string,
-  runId: number,
+  run: CiRun,
 ): string {
+  if (run.source === "check") {
+    return collectCheckRunLogs(owner, repo, run);
+  }
   const output = execFileSync(
     "gh",
     [
       "run",
       "view",
-      String(runId),
+      String(run.databaseId),
       "--repo",
       `${owner}/${repo}`,
       "--log-failed",

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -39,6 +39,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     conclusion: "success",
     headBranch: "issue-42",
     headSha: "abc123",
+    source: "workflow",
     ...overrides,
   };
 }
@@ -231,7 +232,11 @@ describe("createCiCheckStageHandler", () => {
     const stage = createCiCheckStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 200 }),
+    );
     expect(agent.invoke).toHaveBeenCalledWith(
       expect.stringContaining("CI Failure Logs"),
       { cwd: "/tmp/wt" },
@@ -380,8 +385,16 @@ describe("createCiCheckStageHandler", () => {
 
     // Should collect from the two failed runs only
     expect(collectFailureLogs).toHaveBeenCalledTimes(2);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 201);
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 200 }),
+    );
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 201 }),
+    );
 
     const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
       .calls[0][0] as string;
@@ -409,15 +422,52 @@ describe("createCiCheckStageHandler", () => {
     expect(invokedPrompt).toContain("No detailed failure logs available");
   });
 
-  test("propagates getCiStatus exception as thrown error", async () => {
-    const getCiStatus = vi.fn().mockImplementation(() => {
-      throw new Error("network timeout");
-    });
+  test("retries on transient getCiStatus error then succeeds", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockImplementationOnce(() => {
+        throw new Error("network timeout");
+      })
+      .mockReturnValueOnce(makeCiStatus("pass"));
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const opts = makeOpts({ getCiStatus });
     const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
 
-    await expect(stage.handler(BASE_CTX)).rejects.toThrow("network timeout");
+    expect(result.outcome).toBe("completed");
+    expect(getCiStatus).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("network timeout");
+
+    warnSpy.mockRestore();
+  });
+
+  test("returns timeout error when getCiStatus keeps failing", async () => {
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      throw new Error("persistent API error");
+    });
+
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const opts = makeOpts({ getCiStatus, delay, pollTimeoutMs: 1000 });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("still pending");
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    vi.restoreAllMocks();
   });
 
   test("propagates collectFailureLogs exception as thrown error", async () => {

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -12,7 +12,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiStatus, GetCiStatusFn } from "./ci.js";
+import type { CiRun, CiStatus, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -47,7 +47,7 @@ export interface CiCheckStageOptions {
   /** Injected for testability. Defaults to `ci.getCiStatus`. */
   getCiStatus?: GetCiStatusFn;
   /** Injected for testability. Defaults to `ci.collectFailureLogs`. */
-  collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  collectFailureLogs?: (owner: string, repo: string, run: CiRun) => string;
   /**
    * Read the current HEAD SHA from the worktree.  Called before each
    * CI poll so that fix pushes automatically target the new commit.
@@ -135,7 +135,24 @@ export function createCiCheckStageHandler(
       let ciStatus: CiStatus;
       while (true) {
         const commitSha = readHeadSha(ctx.worktreePath);
-        ciStatus = getCiStatus(ctx.owner, ctx.repo, ctx.branch, commitSha);
+
+        try {
+          ciStatus = getCiStatus(ctx.owner, ctx.repo, ctx.branch, commitSha);
+        } catch (err) {
+          // Transient lookup error — log and retry on the next poll cycle.
+          console.warn(
+            `CI status lookup failed (will retry): ${err instanceof Error ? err.message : err}`,
+          );
+          const elapsed = Date.now() - startTime;
+          if (elapsed >= pollTimeout) {
+            return {
+              outcome: "error",
+              message: t()["ci.pendingTimeout"](Math.round(pollTimeout / 1000)),
+            };
+          }
+          await delay(pollInterval);
+          continue;
+        }
 
         const elapsed = Date.now() - startTime;
 
@@ -173,7 +190,7 @@ export function createCiCheckStageHandler(
 
       const logSections: string[] = [];
       for (const run of failedRuns) {
-        const logs = collectLogs(ctx.owner, ctx.repo, run.databaseId);
+        const logs = collectLogs(ctx.owner, ctx.repo, run);
         if (logs) {
           logSections.push(
             `### ${run.name} (run ${run.databaseId})\n\n${logs}`,

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -560,6 +560,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     conclusion: "success",
     headBranch: "issue-5",
     headSha: "abc123",
+    source: "workflow",
     ...overrides,
   };
 }

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -46,6 +46,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     conclusion: "success",
     headBranch: "issue-42",
     headSha: "abc123",
+    source: "workflow",
     ...overrides,
   };
 }

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -23,7 +23,7 @@
  */
 
 import type { AgentAdapter, AgentResult } from "./agent.js";
-import type { GetCiStatusFn } from "./ci.js";
+import type { CiRun, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -71,7 +71,7 @@ export interface ReviewStageOptions {
   /** Injected for testability. */
   getCiStatus?: GetCiStatusFn;
   /** Injected for testability. */
-  collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  collectFailureLogs?: (owner: string, repo: string, run: CiRun) => string;
   /** Injected for testability. Defaults to `worktree.getHeadSha`. */
   getHeadSha?: (cwd: string) => string;
   pollIntervalMs?: number;

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -40,6 +40,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
     conclusion: "success",
     headBranch: "issue-42",
     headSha: "abc123",
+    source: "workflow",
     ...overrides,
   };
 }
@@ -544,8 +545,16 @@ describe("createSquashStageHandler", () => {
     await stage.handler(BASE_CTX);
 
     expect(collectFailureLogs).toHaveBeenCalledTimes(2);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 200);
-    expect(collectFailureLogs).toHaveBeenCalledWith("org", "repo", 201);
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 200 }),
+    );
+    expect(collectFailureLogs).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      expect.objectContaining({ databaseId: 201 }),
+    );
   });
 
   // -- non-terminal non-blocked completion outcome ----------------------------

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -13,7 +13,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { GetCiStatusFn } from "./ci.js";
+import type { CiRun, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -42,7 +42,7 @@ export interface SquashStageOptions {
   /** Injected for testability. */
   getCiStatus?: GetCiStatusFn;
   /** Injected for testability. */
-  collectFailureLogs?: (owner: string, repo: string, runId: number) => string;
+  collectFailureLogs?: (owner: string, repo: string, run: CiRun) => string;
   /** Injected for testability. Defaults to `worktree.getHeadSha`. */
   getHeadSha?: (cwd: string) => string;
   pollIntervalMs?: number;


### PR DESCRIPTION
## Summary

- `fetchCiRuns` now queries the GitHub Checks API (`commits/{sha}/check-runs`) alongside `gh run list`, so check runs created via the Checks API (e.g. CodeQL code scanning) block the pipeline when they fail.
- Added a `source: "workflow" | "check"` discriminator to `CiRun` so `collectFailureLogs` can branch on the run type: workflow runs use `gh run view --log-failed`, while check runs fetch `output` fields (title, summary, text) and annotations from the API.
- GitHub Actions check runs are filtered out to avoid double-counting with workflow runs.
- Annotations are fetched with `gh api --paginate --slurp` and flattened, correctly handling multi-page responses for check runs with >100 findings (e.g. large CodeQL scans).
- `CiRun` carries `checkOutput` and `annotationsCount` from the list endpoint so `collectCheckRunLogs` can skip the redundant detail re-fetch when the data is already available.
- Updated `collectFailureLogs` signature from `(owner, repo, runId)` to `(owner, repo, run)` across all consuming stages (ci-poll, stage-cicheck, stage-review, stage-squash).
- The branch ref passed to the Checks API is URL-encoded so branch names containing slashes (e.g. `user/issue-42`) don't break the API path.
- Checks API errors (network failures, 403/404, malformed responses) now propagate as exceptions instead of silently degrading to workflow-only, ensuring `getCiStatus` cannot return `"pass"` without evaluating check runs.
- Both polling loops (`waitForCi` in ci-poll.ts and the stage-5 handler) catch transient `getCiStatus` errors and retry on the next poll cycle instead of aborting the stage. Persistent errors surface as a timeout once the poll deadline is reached.

Closes #214

## Test plan

- [x] `fetchCiRuns` merges workflow runs and non-Actions check runs
- [x] GitHub Actions check runs are filtered out to avoid duplicates
- [x] `commitSha` is used as ref for check runs API; falls back to branch name
- [x] Branch names with slashes are URL-encoded in the Checks API path
- [x] Checks API errors propagate (no silent degradation to workflow-only)
- [x] Failing check run causes `fail` verdict in `getCiStatus`
- [x] `collectFailureLogs` uses `gh run view --log-failed` for workflow runs
- [x] `collectFailureLogs` fetches output (title/summary/text) and annotations for check runs
- [x] Carried-forward `checkOutput` skips redundant detail re-fetch
- [x] Annotations paginated with `--paginate --slurp` and flattened across pages
- [x] Output-only context returned when annotations fetch fails
- [x] Annotation fetch skipped when `annotations_count` is 0
- [x] Fallback message returned when check run detail fetch fails
- [x] `pollCiAndFix` passes full `CiRun` to `collectFailureLogs` for check runs
- [x] Transient `getCiStatus` errors retried in both polling loops (ci-poll, stage-5)
- [x] Persistent `getCiStatus` errors surface as timeout after poll deadline
- [x] All existing tests continue to pass