### PR TITLE
Review check-run annotations even when CI passes (#215)

### DIFF
--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
-import type { CiRun, CiStatus, CiVerdict } from "./ci.js";
+import type { CiFinding, CiRun, CiStatus, CiVerdict } from "./ci.js";
 import { type CiPollOptions, pollCiAndFix } from "./ci-poll.js";
 import type { StageContext } from "./pipeline.js";
 
@@ -40,8 +40,13 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
   };
 }
 
-function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
-  return { verdict, runs };
+function makeCiStatus(
+  verdict: CiVerdict,
+  runs: CiRun[] = [],
+  findings: CiFinding[] = [],
+  findingsIncomplete = false,
+): CiStatus {
+  return { verdict, runs, findings, findingsIncomplete };
 }
 
 const BASE_CTX: StageContext = {
@@ -629,5 +634,336 @@ describe("pollCiAndFix", () => {
     expect(result.message).toContain("still pending");
 
     vi.restoreAllMocks();
+  });
+
+  // -- CI passes with findings — agent reviews --------------------------------
+
+  test("presents findings to agent and returns passed when agent acknowledges", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        rule: "no-unused-vars",
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent = makeAgent();
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha }),
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Findings were reviewed");
+    expect(agent.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("CI Findings"),
+      expect.any(Object),
+    );
+  });
+
+  test("re-polls CI when agent pushes a fix for findings", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused import",
+        file: "src/index.ts",
+        line: 1,
+        checkRunId: 600,
+        checkRunName: "Lint",
+      },
+    ];
+
+    // First poll: pass with findings. After agent fix: pass clean.
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()], findings))
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()]));
+
+    // SHA sequence: top-of-loop, shaBeforeReview, shaAfterReview (changed),
+    // top-of-loop again for second poll.
+    let shaCall = 0;
+    const shas = ["sha-1", "sha-1", "sha-2", "sha-2"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+
+    const agent = makeAgent();
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha }),
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("CI checks passed");
+    expect(agent.invoke).toHaveBeenCalledTimes(1);
+    // CI was polled twice: first with findings, then clean after fix.
+    expect(getCiStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns error when agent fails during findings review", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("sha");
+
+    const agent = makeAgent(
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "crash",
+        responseText: "",
+      }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("Agent error during CI fix");
+
+    errorSpy.mockRestore();
+  });
+
+  test("routes to findings review when findingsIncomplete even with no findings", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()], [], true))
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()]));
+
+    // SHA sequence: top-of-loop, shaBeforeReview, shaAfterReview (unchanged).
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent = makeAgent();
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha }),
+    );
+
+    // Agent was invoked with the findings prompt (not the clean-pass exit).
+    expect(agent.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("CI Findings"),
+      expect.any(Object),
+    );
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("annotations could not be fetched");
+
+    // SHA unchanged → findings acknowledged.
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Findings were reviewed");
+  });
+
+  // -- findings-review counter is decoupled from fix-attempt counter --------
+
+  test("maxFixAttempts=0 still allows findings review", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent = makeAgent();
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha, maxFixAttempts: 0 }),
+    );
+
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Findings were reviewed");
+    expect(agent.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  test("maxFixAttempts=0 re-polls after findings-driven push", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused import",
+        file: "src/index.ts",
+        line: 1,
+        checkRunId: 600,
+        checkRunName: "Lint",
+      },
+    ];
+    // First poll: pass with findings. After agent fix: pass clean.
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()], findings))
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()]));
+
+    let shaCall = 0;
+    const shas = ["sha-1", "sha-1", "sha-2", "sha-2"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+
+    const agent = makeAgent();
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha, maxFixAttempts: 0 }),
+    );
+
+    // Should pass cleanly — not hit fixLoopExhausted.
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("CI checks passed");
+    expect(agent.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  test("findings reviews do not consume failure-fix budget", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+
+    // Sequence: pass with findings → agent pushes →
+    // CI fails → agent fixes → CI passes.
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()], findings))
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass", [makeCiRun()]));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    // SHA sequence: top-of-loop (sha-1), shaBeforeReview (sha-1),
+    // shaAfterReview (sha-2, agent pushed), top-of-loop (sha-2),
+    // top-of-loop after fix (sha-3).
+    let shaCall = 0;
+    const shas = ["sha-1", "sha-1", "sha-2", "sha-2", "sha-3"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+
+    const invokeResults = [
+      makeStream(makeResult({ responseText: "Reviewed findings." })),
+      makeStream(makeResult({ responseText: "Fixed CI." })),
+    ];
+    let invokeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
+      resume: vi.fn(),
+    };
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        agent,
+        getCiStatus,
+        collectFailureLogs,
+        getHeadSha,
+        maxFixAttempts: 1,
+      }),
+    );
+
+    // Should succeed: findings review (1 review) + CI failure fix (1 fix).
+    // With the old coupled counter, this would have exhausted the budget.
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("CI checks passed");
+    expect(agent.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  test("caps findings-review re-polls at maxFixAttempts", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+
+    // Agent keeps pushing but findings persist.
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+
+    // SHA changes after every review to simulate agent pushing.
+    let shaCounter = 0;
+    const getHeadSha = vi.fn().mockImplementation(() => {
+      const sha = `sha-${Math.floor(shaCounter / 2)}`;
+      shaCounter++;
+      return sha;
+    });
+
+    const invokeResults = [
+      makeStream(makeResult()),
+      makeStream(makeResult()),
+      makeStream(makeResult()),
+    ];
+    let invokeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
+      resume: vi.fn(),
+    };
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        agent,
+        getCiStatus,
+        getHeadSha,
+        maxFixAttempts: 2,
+      }),
+    );
+
+    // Should return passedWithFindings after exhausting the review budget,
+    // not ci.stillFailing or ci.fixLoopExhausted.
+    expect(result.passed).toBe(true);
+    expect(result.message).toContain("Findings were reviewed");
+    // maxFixAttempts=2 → max(1,2)=2 findings reviews allowed.
+    expect(agent.invoke).toHaveBeenCalledTimes(2);
+  });
+
+  test("findings prompt includes structured finding details", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable 'x'",
+        file: "src/app.ts",
+        line: 10,
+        rule: "no-unused-vars",
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent = makeAgent();
+    await pollCiAndFix(makeOpts({ agent, getCiStatus, getHeadSha }));
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("Unused variable 'x'");
+    expect(invokedPrompt).toContain("src/app.ts:10");
+    expect(invokedPrompt).toContain("no-unused-vars");
+    expect(invokedPrompt).toContain("ESLint (check run 500)");
   });
 });

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -16,7 +16,7 @@ import {
 } from "./ci.js";
 import { t } from "./i18n/index.js";
 import type { StageContext } from "./pipeline.js";
-import { buildCiFixPrompt } from "./stage-cicheck.js";
+import { buildCiFindingsPrompt, buildCiFixPrompt } from "./stage-cicheck.js";
 import {
   buildErrorDetail,
   drainToSink,
@@ -108,7 +108,12 @@ async function waitForCi(
       if (elapsed >= pollTimeout) {
         return {
           timedOut: true,
-          ciStatus: { verdict: "pending" as const, runs: [] },
+          ciStatus: {
+            verdict: "pending" as const,
+            runs: [],
+            findings: [],
+            findingsIncomplete: false,
+          },
         };
       }
       await delay(pollInterval);
@@ -163,7 +168,14 @@ export async function pollCiAndFix(
   const emptyGrace =
     options.emptyRunsGracePeriodMs ?? DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS;
 
-  for (let attempt = 0; attempt <= maxFix; attempt++) {
+  // Track failure-fix and findings-review attempts independently so
+  // that "pass with findings" never exhausts the failure-fix budget.
+  // Always allow at least one findings review even with maxFix = 0.
+  const maxFindingsReviews = Math.max(1, maxFix);
+  let fixAttempts = 0;
+  let findingsReviews = 0;
+
+  while (true) {
     // Read HEAD SHA from the worktree so we only consider CI runs
     // triggered by the most recent push (initial or fix).
     const commitSha = readHeadSha(ctx.worktreePath);
@@ -187,17 +199,73 @@ export async function pollCiAndFix(
       };
     }
 
-    if (ciStatus.verdict === "pass") {
+    if (
+      ciStatus.verdict === "pass" &&
+      ciStatus.findings.length === 0 &&
+      !ciStatus.findingsIncomplete
+    ) {
       return { passed: true, message: t()["ci.passed"] };
     }
 
+    // CI passed with findings — present for agent review.
+    if (ciStatus.verdict === "pass") {
+      if (findingsReviews >= maxFindingsReviews) {
+        // Findings-review budget exhausted — accept as passed.
+        return { passed: true, message: t()["ci.passedWithFindings"] };
+      }
+      findingsReviews++;
+
+      const shaBeforeReview = readHeadSha(ctx.worktreePath);
+
+      const findingsPrompt = buildCiFindingsPrompt(
+        ctx,
+        { issueTitle, issueBody },
+        ciStatus.findings,
+        ciStatus.findingsIncomplete,
+      );
+      ctx.promptSinks?.a?.(findingsPrompt);
+      const reviewStream = agent.invoke(findingsPrompt, {
+        cwd: ctx.worktreePath,
+        onUsage: ctx.usageSinks?.a,
+      });
+      const drained = ctx.streamSinks?.a
+        ? drainToSink(reviewStream, ctx.streamSinks.a)
+        : undefined;
+      const reviewResult = await reviewStream.result;
+      if (drained) await drained;
+
+      if (reviewResult.sessionId) {
+        ctx.onSessionId?.("a", reviewResult.sessionId);
+      }
+
+      if (reviewResult.status === "error") {
+        logAgentFailure(reviewResult, "during CI findings review");
+        const detail = buildErrorDetail(reviewResult);
+        return {
+          passed: false,
+          message: t()["ci.agentError"](detail),
+        };
+      }
+
+      const shaAfterReview = readHeadSha(ctx.worktreePath);
+      if (shaBeforeReview !== shaAfterReview) {
+        // Agent pushed changes — re-poll CI without consuming
+        // the failure-fix budget.
+        continue;
+      }
+
+      // Agent reviewed but did not push — findings acknowledged.
+      return { passed: true, message: t()["ci.passedWithFindings"] };
+    }
+
     // CI failed — if we've exhausted fix attempts, give up.
-    if (attempt >= maxFix) {
+    if (fixAttempts >= maxFix) {
       return {
         passed: false,
         message: t()["ci.stillFailing"](maxFix),
       };
     }
+    fixAttempts++;
 
     // Collect failure logs and send fix prompt to the agent.
     const failedRuns = ciStatus.runs.filter((r) => {
@@ -249,7 +317,4 @@ export async function pollCiAndFix(
 
     // Agent pushed a fix — loop back to poll CI again.
   }
-
-  // Should not reach here, but guard.
-  return { passed: false, message: t()["ci.fixLoopExhausted"] };
 }

--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -11,6 +11,7 @@ const {
   fetchCiRuns,
   getCiStatus,
   collectFailureLogs,
+  collectFindings,
 } = await import("./ci.js");
 
 const mockExecFileSync = vi.mocked(execFileSync);
@@ -393,25 +394,30 @@ describe("fetchCiRuns", () => {
 // getCiStatus
 // ---------------------------------------------------------------------------
 describe("getCiStatus", () => {
-  test("returns pass verdict for successful runs", () => {
+  test("returns pass verdict for successful runs with empty findings", () => {
     mockExecFileSync.mockReturnValue(JSON.stringify([run()]));
     const status = getCiStatus("org", "repo", "main");
     expect(status.verdict).toBe("pass");
     expect(status.runs).toHaveLength(1);
+    expect(status.findings).toEqual([]);
   });
 
-  test("returns fail verdict for failed runs", () => {
+  test("returns fail verdict with empty findings for failed runs", () => {
     mockExecFileSync.mockReturnValue(
       JSON.stringify([run({ conclusion: "failure" })]),
     );
-    expect(getCiStatus("org", "repo", "main").verdict).toBe("fail");
+    const status = getCiStatus("org", "repo", "main");
+    expect(status.verdict).toBe("fail");
+    expect(status.findings).toEqual([]);
   });
 
-  test("returns pending verdict for in-progress runs", () => {
+  test("returns pending verdict with empty findings for in-progress runs", () => {
     mockExecFileSync.mockReturnValue(
       JSON.stringify([run({ status: "in_progress" })]),
     );
-    expect(getCiStatus("org", "repo", "main").verdict).toBe("pending");
+    const status = getCiStatus("org", "repo", "main");
+    expect(status.verdict).toBe("pending");
+    expect(status.findings).toEqual([]);
   });
 
   test("passes commitSha to fetchCiRuns and evaluates filtered result", () => {
@@ -433,6 +439,38 @@ describe("getCiStatus", () => {
     const status = getCiStatus("org", "repo", "main", "zzz");
     expect(status.verdict).toBe("pass");
     expect(status.runs).toEqual([]);
+  });
+
+  test("sets findingsIncomplete when annotation fetch fails on pass", () => {
+    const checkRunsResponse = {
+      check_runs: [
+        {
+          id: 800,
+          name: "Linter",
+          status: "completed",
+          conclusion: "success",
+          head_sha: "abc123",
+          output: { title: null, summary: null, text: null },
+          annotations_count: 2,
+          app: { slug: "some-linter" },
+        },
+      ],
+    };
+
+    mockExecFileSync
+      // gh run list → no workflow runs
+      .mockReturnValueOnce("[]")
+      // gh api check-runs → one check run with annotations
+      .mockReturnValueOnce(JSON.stringify(checkRunsResponse))
+      // gh api annotations → fails
+      .mockImplementationOnce(() => {
+        throw new Error("transient API error");
+      });
+
+    const status = getCiStatus("org", "repo", "main");
+    expect(status.verdict).toBe("pass");
+    expect(status.findings).toEqual([]);
+    expect(status.findingsIncomplete).toBe(true);
   });
 
   test("failing check run causes fail verdict", () => {
@@ -698,6 +736,125 @@ describe("collectFailureLogs", () => {
 });
 
 // ---------------------------------------------------------------------------
+// collectFindings
+// ---------------------------------------------------------------------------
+describe("collectFindings", () => {
+  test("returns empty findings for workflow-only runs", () => {
+    const runs = [run({ source: "workflow" })];
+    const result = collectFindings("org", "repo", runs);
+    expect(result.findings).toEqual([]);
+    expect(result.incomplete).toBe(false);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  test("returns empty findings when annotationsCount is 0", () => {
+    const runs = [
+      run({ source: "check", annotationsCount: 0, databaseId: 100 }),
+    ];
+    const result = collectFindings("org", "repo", runs);
+    expect(result.findings).toEqual([]);
+    expect(result.incomplete).toBe(false);
+    expect(mockExecFileSync).not.toHaveBeenCalled();
+  });
+
+  test("collects findings from check run with annotations", () => {
+    const annotations = [
+      {
+        path: "src/app.ts",
+        start_line: 10,
+        end_line: 10,
+        annotation_level: "warning",
+        message: "Unused variable",
+        title: "no-unused-vars",
+      },
+      {
+        path: "src/util.ts",
+        start_line: 25,
+        end_line: 25,
+        annotation_level: "notice",
+        message: "Consider simplifying",
+      },
+    ];
+
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([annotations]));
+
+    const runs = [
+      run({
+        databaseId: 500,
+        name: "ESLint",
+        source: "check",
+        annotationsCount: 2,
+      }),
+    ];
+    const result = collectFindings("org", "repo", runs);
+
+    expect(result.findings).toHaveLength(2);
+    expect(result.incomplete).toBe(false);
+    expect(result.findings[0]).toEqual({
+      level: "warning",
+      message: "Unused variable",
+      file: "src/app.ts",
+      line: 10,
+      rule: "no-unused-vars",
+      checkRunId: 500,
+      checkRunName: "ESLint",
+    });
+    expect(result.findings[1]).toEqual({
+      level: "notice",
+      message: "Consider simplifying",
+      file: "src/util.ts",
+      line: 25,
+      rule: undefined,
+      checkRunId: 500,
+      checkRunName: "ESLint",
+    });
+  });
+
+  test("sets incomplete flag when annotation fetch fails", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("API error");
+    });
+
+    const runs = [
+      run({ databaseId: 600, source: "check", annotationsCount: 1 }),
+    ];
+    const result = collectFindings("org", "repo", runs);
+    expect(result.findings).toEqual([]);
+    expect(result.incomplete).toBe(true);
+  });
+
+  test("skips workflow runs and collects from check runs only", () => {
+    const annotations = [
+      {
+        path: "src/index.ts",
+        start_line: 1,
+        end_line: 1,
+        annotation_level: "warning",
+        message: "Missing return type",
+        title: "explicit-return-type",
+      },
+    ];
+
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([annotations]));
+
+    const runs = [
+      run({ databaseId: 1, source: "workflow" }),
+      run({
+        databaseId: 700,
+        name: "TypeCheck",
+        source: "check",
+        annotationsCount: 1,
+      }),
+    ];
+    const result = collectFindings("org", "repo", runs);
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].checkRunId).toBe(700);
+    expect(result.incomplete).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // edge cases
 // ---------------------------------------------------------------------------
 describe("edge cases", () => {
@@ -719,11 +876,12 @@ describe("edge cases", () => {
     ).toBe("fail");
   });
 
-  test("getCiStatus with empty runs returns pass", () => {
+  test("getCiStatus with empty runs returns pass with empty findings", () => {
     mockExecFileSync.mockReturnValue("[]");
     const status = getCiStatus("org", "repo", "main");
     expect(status.verdict).toBe("pass");
     expect(status.runs).toEqual([]);
+    expect(status.findings).toEqual([]);
   });
 
   test("normaliseCiConclusion handles null status", () => {

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -39,10 +39,36 @@ export interface CiRun {
 
 export type CiVerdict = "pass" | "fail" | "pending";
 
+/** A single annotation-level finding from a check run. */
+export interface CiFinding {
+  /** Annotation level: "notice", "warning", or "failure". */
+  level: string;
+  /** Human-readable message from the annotation. */
+  message: string;
+  /** File path relative to the repository root. */
+  file: string;
+  /** Start line in the file. */
+  line: number;
+  /** Optional annotation title (often a rule ID). */
+  rule?: string;
+  /** Database ID of the check run that produced this finding. */
+  checkRunId: number;
+  /** Name of the check run that produced this finding. */
+  checkRunName: string;
+}
+
 export interface CiStatus {
   verdict: CiVerdict;
   /** Individual check runs used to compute the verdict. */
   runs: CiRun[];
+  /** Annotation findings from passing check runs. */
+  findings: CiFinding[];
+  /**
+   * True when at least one annotation fetch failed for a check run
+   * that reported a non-zero annotation count.  Consumers must not
+   * treat an empty `findings` array as "clean" when this is set.
+   */
+  findingsIncomplete?: boolean;
 }
 
 /**
@@ -140,6 +166,80 @@ interface CheckRunAnnotation {
   title?: string;
 }
 
+// ---- annotation collection -----------------------------------------------
+
+/**
+ * Fetch annotations for a single check run from the GitHub Checks API.
+ * Paginates automatically to collect all pages.
+ */
+function fetchCheckRunAnnotations(
+  owner: string,
+  repo: string,
+  checkRunId: number,
+): CheckRunAnnotation[] {
+  const raw = execFileSync(
+    "gh",
+    [
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=100`,
+    ],
+    { encoding: "utf-8" },
+  );
+  const pages: CheckRunAnnotation[][] = JSON.parse(raw);
+  return pages.flat();
+}
+
+/**
+ * Collect annotation-level findings from a set of CI runs.
+ *
+ * Only check runs (source = "check") with a non-zero annotation count
+ * are inspected.  Returns an empty array when no annotations exist.
+ */
+export function collectFindings(
+  owner: string,
+  repo: string,
+  runs: CiRun[],
+): { findings: CiFinding[]; incomplete: boolean } {
+  const findings: CiFinding[] = [];
+  let incomplete = false;
+
+  for (const run of runs) {
+    if (
+      run.source !== "check" ||
+      run.annotationsCount == null ||
+      run.annotationsCount === 0
+    ) {
+      continue;
+    }
+
+    let annotations: CheckRunAnnotation[];
+    try {
+      annotations = fetchCheckRunAnnotations(owner, repo, run.databaseId);
+    } catch {
+      // Annotation fetch failed — flag as incomplete so callers
+      // do not treat an empty findings list as a clean pass.
+      incomplete = true;
+      continue;
+    }
+
+    for (const a of annotations) {
+      findings.push({
+        level: a.annotation_level,
+        message: a.message,
+        file: a.path,
+        line: a.start_line,
+        rule: a.title,
+        checkRunId: run.databaseId,
+        checkRunName: run.name,
+      });
+    }
+  }
+
+  return { findings, incomplete };
+}
+
 // ---- gh CLI wrappers -----------------------------------------------------
 
 /**
@@ -220,23 +320,10 @@ function collectCheckRunLogs(owner: string, repo: string, run: CiRun): string {
     if (text) sections.push(`Details: ${text}`);
   }
 
-  // Fetch annotations when present, paginating to collect all pages.
-  // --slurp wraps each page into an outer JSON array so the entire
-  // output is valid JSON even when multiple pages are returned.
+  // Fetch annotations when present via the shared helper.
   if (annotationsCount != null && annotationsCount > 0) {
     try {
-      const raw = execFileSync(
-        "gh",
-        [
-          "api",
-          "--paginate",
-          "--slurp",
-          `repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=100`,
-        ],
-        { encoding: "utf-8" },
-      );
-      const pages: CheckRunAnnotation[][] = JSON.parse(raw);
-      const annotations: CheckRunAnnotation[] = pages.flat();
+      const annotations = fetchCheckRunAnnotations(owner, repo, checkRunId);
       if (annotations.length > 0) {
         const lines = annotations.map(
           (a) =>
@@ -317,7 +404,14 @@ export function getCiStatus(
   commitSha?: string,
 ): CiStatus {
   const runs = fetchCiRuns(owner, repo, branch, commitSha);
-  return { verdict: evaluateCiRuns(runs), runs };
+  const verdict = evaluateCiRuns(runs);
+  // Collect annotation findings only when CI passes — avoids
+  // redundant API calls during pending/failing polls.
+  const { findings, incomplete } =
+    verdict === "pass"
+      ? collectFindings(owner, repo, runs)
+      : { findings: [] as CiFinding[], incomplete: false };
+  return { verdict, runs, findings, findingsIncomplete: incomplete };
 }
 
 /**

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -214,9 +214,10 @@ export const en: Messages = {
     `CI checks still pending after ${seconds}s. ` +
     `The pipeline cannot proceed until CI completes.`,
   "ci.passed": "CI checks passed.",
+  "ci.passedWithFindings":
+    "CI checks passed. Findings were reviewed by the agent.",
   "ci.stillFailing": (attempts) =>
     `CI still failing after ${attempts} fix attempt(s).`,
-  "ci.fixLoopExhausted": "CI fix loop exhausted.",
   "ci.agentError": (detail) => `Agent error during CI fix: ${detail}`,
   "squash.completed": "Commits squashed and CI passed.",
   "squash.singleCommitSkip": "Single commit — skipping squash.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -248,9 +248,10 @@ export const ko: Messages = {
     `CI 검사가 ${seconds}초 후에도 보류 중입니다. ` +
     `CI가 완료될 때까지 파이프라인을 진행할 수 없습니다.`,
   "ci.passed": "CI 검사를 통과했습니다.",
+  "ci.passedWithFindings":
+    "CI 검사를 통과했습니다. 에이전트가 발견 사항을 검토했습니다.",
   "ci.stillFailing": (attempts) =>
     `${attempts}회 수정 시도 후에도 CI가 여전히 실패합니다.`,
-  "ci.fixLoopExhausted": "CI 수정 반복이 소진되었습니다.",
   "ci.agentError": (detail) => `CI 수정 중 에이전트 오류: ${detail}`,
   "squash.completed": "커밋이 스쿼시되고 CI를 통과했습니다.",
   "squash.singleCommitSkip": "커밋이 하나뿐이므로 스쿼시를 건너뜁니다.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -211,8 +211,8 @@ export interface Messages {
 
   "ci.pendingTimeout": (seconds: number) => string;
   "ci.passed": string;
+  "ci.passedWithFindings": string;
   "ci.stillFailing": (attempts: number) => string;
-  "ci.fixLoopExhausted": string;
   "ci.agentError": (detail: string) => string;
   "squash.completed": string;
   "squash.singleCommitSkip": string;

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
-import type { CiRun, CiStatus, CiVerdict } from "./ci.js";
+import type { CiFinding, CiRun, CiStatus, CiVerdict } from "./ci.js";
 import type { StageContext } from "./pipeline.js";
 import {
+  buildCiFindingsPrompt,
   buildCiFixPrompt,
   type CiCheckStageOptions,
   createCiCheckStageHandler,
@@ -44,8 +45,13 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
   };
 }
 
-function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
-  return { verdict, runs };
+function makeCiStatus(
+  verdict: CiVerdict,
+  runs: CiRun[] = [],
+  findings: CiFinding[] = [],
+  findingsIncomplete = false,
+): CiStatus {
+  return { verdict, runs, findings, findingsIncomplete };
 }
 
 const BASE_CTX: StageContext = {
@@ -616,5 +622,320 @@ describe("createCiCheckStageHandler", () => {
     const result = await stage.handler(BASE_CTX);
 
     expect(result.message).toBe(fixResponse);
+  });
+
+  // -- CI passes with findings — agent reviews --------------------------------
+
+  test("presents findings to agent when CI passes with annotations", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        rule: "no-unused-vars",
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, getHeadSha });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    // Agent was invoked with the findings prompt (not the fix prompt).
+    expect(agent.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("CI Findings"),
+      expect.any(Object),
+    );
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("Unused variable");
+    expect(invokedPrompt).toContain("src/app.ts:10");
+    expect(invokedPrompt).toContain("no-unused-vars");
+
+    // SHA unchanged → findings acknowledged, completed.
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("Findings were reviewed");
+  });
+
+  test("returns not_approved when agent pushes a fix for findings", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused import",
+        file: "src/index.ts",
+        line: 1,
+        checkRunId: 600,
+        checkRunName: "Lint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+
+    let shaCall = 0;
+    const shas = ["before-sha", "after-sha"];
+    const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
+
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "Fixed the import." })),
+        ),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, getHeadSha });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("not_approved");
+    expect(result.message).toBe("Fixed the import.");
+  });
+
+  test("returns error when agent fails during findings review", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("sha");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            status: "error",
+            errorType: "execution_error",
+            stderrText: "crash",
+            responseText: "",
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, getHeadSha });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("error");
+    expect(result.message).toContain("findings review");
+  });
+
+  test("returns completed with clean pass when no findings", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()]));
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn(),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("CI checks passed");
+    expect(agent.invoke).not.toHaveBeenCalled();
+  });
+
+  test("routes to findings review when findingsIncomplete even with no findings", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], [], true));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({ agent, getCiStatus, getHeadSha });
+    const stage = createCiCheckStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    // Agent was invoked — not the clean-pass exit.
+    expect(agent.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("CI Findings"),
+      expect.any(Object),
+    );
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("annotations could not be fetched");
+
+    // SHA unchanged → findings acknowledged.
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("Findings were reviewed");
+  });
+
+  test("includes user instruction in findings prompt", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const ctx = {
+      ...BASE_CTX,
+      userInstruction: "Ignore the unused variable warnings",
+    };
+    const opts = makeOpts({ agent, getCiStatus, getHeadSha });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(ctx);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("Ignore the unused variable warnings");
+  });
+});
+
+// ---- buildCiFindingsPrompt --------------------------------------------------
+
+describe("buildCiFindingsPrompt", () => {
+  const sampleFindings: CiFinding[] = [
+    {
+      level: "warning",
+      message: "Unused variable 'x'",
+      file: "src/app.ts",
+      line: 10,
+      rule: "no-unused-vars",
+      checkRunId: 500,
+      checkRunName: "ESLint",
+    },
+    {
+      level: "notice",
+      message: "Consider simplifying",
+      file: "src/util.ts",
+      line: 25,
+      checkRunId: 500,
+      checkRunName: "ESLint",
+    },
+  ];
+
+  test("includes repo context", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).toContain("Owner: org");
+    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("Branch: issue-42");
+  });
+
+  test("includes issue details", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).toContain("Issue #42: Fix the widget");
+    expect(prompt).toContain("The widget is broken.");
+  });
+
+  test("includes structured findings", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).toContain("CI Findings");
+    expect(prompt).toContain(
+      "src/app.ts:10: [warning] Unused variable 'x' (no-unused-vars)",
+    );
+    expect(prompt).toContain("src/util.ts:25: [notice] Consider simplifying");
+  });
+
+  test("groups findings by check run", () => {
+    const mixed: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Issue A",
+        file: "a.ts",
+        line: 1,
+        checkRunId: 100,
+        checkRunName: "Lint",
+      },
+      {
+        level: "warning",
+        message: "Issue B",
+        file: "b.ts",
+        line: 2,
+        checkRunId: 200,
+        checkRunName: "CodeQL",
+      },
+    ];
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), mixed);
+    expect(prompt).toContain("Lint (check run 100)");
+    expect(prompt).toContain("CodeQL (check run 200)");
+  });
+
+  test("includes doc consistency instructions", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).toContain("CHANGELOG");
+    expect(prompt).toContain("MkDocs");
+  });
+
+  test("includes PR sync instructions", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).toContain("gh pr view");
+    expect(prompt).toContain("gh pr edit");
+  });
+
+  test("includes incomplete note when findingsIncomplete is true", () => {
+    const prompt = buildCiFindingsPrompt(
+      BASE_CTX,
+      makeOpts(),
+      sampleFindings,
+      true,
+    );
+    expect(prompt).toContain("annotations could not be fetched");
+    expect(prompt).toContain("may be incomplete");
+  });
+
+  test("omits incomplete note when findingsIncomplete is false", () => {
+    const prompt = buildCiFindingsPrompt(
+      BASE_CTX,
+      makeOpts(),
+      sampleFindings,
+      false,
+    );
+    expect(prompt).not.toContain("annotations could not be fetched");
+  });
+
+  test("includes user instruction when present", () => {
+    const ctx = { ...BASE_CTX, userInstruction: "Focus on warnings only" };
+    const prompt = buildCiFindingsPrompt(ctx, makeOpts(), sampleFindings);
+    expect(prompt).toContain("Additional feedback");
+    expect(prompt).toContain("Focus on warnings only");
+  });
+
+  test("omits feedback section when no instruction", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).not.toContain("Additional feedback");
   });
 });

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -12,7 +12,7 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiRun, CiStatus, GetCiStatusFn } from "./ci.js";
+import type { CiFinding, CiRun, CiStatus, GetCiStatusFn } from "./ci.js";
 import {
   collectFailureLogs as defaultCollectFailureLogs,
   getCiStatus as defaultGetCiStatus,
@@ -110,6 +110,86 @@ export function buildCiFixPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Format findings into a structured block for inclusion in the
+ * findings-review prompt.
+ */
+function formatFindings(findings: CiFinding[]): string {
+  const byRun = new Map<string, CiFinding[]>();
+  for (const f of findings) {
+    const key = `${f.checkRunName} (check run ${f.checkRunId})`;
+    const group = byRun.get(key) ?? [];
+    group.push(f);
+    byRun.set(key, group);
+  }
+
+  const sections: string[] = [];
+  for (const [header, group] of byRun) {
+    const lines = group.map((f) => {
+      const rule = f.rule ? ` (${f.rule})` : "";
+      return `- ${f.file}:${f.line}: [${f.level}] ${f.message}${rule}`;
+    });
+    sections.push(`### ${header}\n${lines.join("\n")}`);
+  }
+  return sections.join("\n\n");
+}
+
+export function buildCiFindingsPrompt(
+  ctx: StageContext,
+  opts: Pick<CiCheckStageOptions, "issueTitle" | "issueBody">,
+  findings: CiFinding[],
+  findingsIncomplete?: boolean,
+): string {
+  const lines = [
+    `CI passed but check runs reported findings (annotations).`,
+    `Review the findings below and decide whether any should be addressed.`,
+    ``,
+    `## Repository`,
+    `- Owner: ${ctx.owner}`,
+    `- Repo: ${ctx.repo}`,
+    `- Branch: ${ctx.branch}`,
+    `- Worktree: ${ctx.worktreePath}`,
+    ``,
+    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
+    ``,
+    opts.issueBody,
+    ``,
+    `## CI Findings`,
+    ``,
+    formatFindings(findings),
+  ];
+
+  if (findingsIncomplete) {
+    lines.push(
+      ``,
+      `**Note:** Some check run annotations could not be fetched.`,
+      `The findings above may be incomplete.  Check the PR's Checks`,
+      `tab for the full list of annotations.`,
+    );
+  }
+
+  lines.push(
+    ``,
+    `## Instructions`,
+    ``,
+    `For each finding, decide whether it should be fixed or can be`,
+    `safely ignored.  If you fix any findings:`,
+    ``,
+    buildDocConsistencyInstructions(),
+    ``,
+    `${buildPrSyncInstructions(ctx.issueNumber)}`,
+    ``,
+    `Then commit and push the branch so a new CI run is triggered.`,
+    `If all findings are acceptable as-is, explain your reasoning.`,
+  );
+
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+
+  return lines.join("\n");
+}
+
 // ---- handler ---------------------------------------------------------------
 
 export function createCiCheckStageHandler(
@@ -175,10 +255,57 @@ export function createCiCheckStageHandler(
         await delay(pollInterval);
       }
 
-      // ---- CI passed -------------------------------------------------------
+      // ---- CI passed (clean) ------------------------------------------------
+
+      if (
+        ciStatus.verdict === "pass" &&
+        ciStatus.findings.length === 0 &&
+        !ciStatus.findingsIncomplete
+      ) {
+        return { outcome: "completed", message: t()["ci.passed"] };
+      }
+
+      // ---- CI passed with findings — present for review -------------------
 
       if (ciStatus.verdict === "pass") {
-        return { outcome: "completed", message: t()["ci.passed"] };
+        const shaBeforeReview = readHeadSha(ctx.worktreePath);
+
+        const findingsPrompt = buildCiFindingsPrompt(
+          ctx,
+          opts,
+          ciStatus.findings,
+          ciStatus.findingsIncomplete,
+        );
+        ctx.promptSinks?.a?.(findingsPrompt);
+        const reviewResult = await invokeOrResume(
+          opts.agent,
+          ctx.savedAgentASessionId,
+          findingsPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+
+        if (reviewResult.sessionId) {
+          ctx.onSessionId?.("a", reviewResult.sessionId);
+        }
+
+        if (reviewResult.status === "error") {
+          return mapAgentError(reviewResult, "during CI findings review");
+        }
+
+        const shaAfterReview = readHeadSha(ctx.worktreePath);
+        if (shaBeforeReview !== shaAfterReview) {
+          // Agent pushed changes — loop back to re-check CI.
+          return {
+            outcome: "not_approved",
+            message: reviewResult.responseText,
+          };
+        }
+
+        // Agent reviewed but did not push — findings acknowledged.
+        return { outcome: "completed", message: t()["ci.passedWithFindings"] };
       }
 
       // ---- CI failed — collect logs and send to agent ----------------------

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -568,7 +568,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
 const stubGetHeadSha = () => "abc123";
 
 function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
-  return { verdict, runs };
+  return { verdict, runs, findings: [] };
 }
 
 // ---- Stage 4 through pipeline ----------------------------------------------

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -52,7 +52,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
 }
 
 function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
-  return { verdict, runs };
+  return { verdict, runs, findings: [] };
 }
 
 const BASE_CTX: StageContext = {
@@ -2682,6 +2682,7 @@ describe("comment validation", () => {
       getCiStatus: () => ({
         verdict: "pass" as const,
         runs: [makeCiRun()],
+        findings: [],
       }),
     });
     const stage = createReviewStageHandler(opts);

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -46,7 +46,7 @@ function makeCiRun(overrides: Partial<CiRun> = {}): CiRun {
 }
 
 function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
-  return { verdict, runs };
+  return { verdict, runs, findings: [] };
 }
 
 const BASE_CTX: StageContext = {


### PR DESCRIPTION
## Summary

- Adds a `CiFinding` model to represent individual check-run annotations (level, message, file, line, rule, source check-run).
- Extends `CiStatus` to carry a `findings` array and a `findingsIncomplete` flag alongside the verdict, collected only when CI passes.
- `collectFindings` returns `{ findings, incomplete }` so callers can distinguish "no findings" from "annotations exist but could not be fetched". A failed annotation fetch no longer silently produces a clean pass.
- Introduces a "passed with findings" control flow in both `stage-cicheck` and `ci-poll`, distinct from "passed clean" and "failed". When findings exist (or fetching was incomplete), they are formatted and presented to the agent for review before declaring CI as passed.
- Adds `buildCiFindingsPrompt` to format findings as structured context for the agent, grouped by check run. Includes doc-consistency and PR-sync instructions so the workflow is consistent with the CI-fix prompt.
- Decouples the findings-review counter from the failure-fix counter in `ci-poll`. Findings-driven re-polls no longer consume the `maxFixAttempts` budget, and `maxFixAttempts = 0` still allows at least one findings review.
- Adds `ci.passedWithFindings` i18n key (English + Korean).

Closes #215

## Test plan

- [x] `CiFinding` model correctly represents annotation fields (level, message, file, line, rule, checkRunId, checkRunName)
- [x] `collectFindings` fetches annotations only for check runs with `source === "check"` and non-zero annotation count
- [x] `collectFindings` returns empty findings when no check runs have annotations
- [x] `collectFindings` sets `incomplete: true` when annotation fetch fails for a run with annotations
- [x] `getCiStatus` populates `findings` and `findingsIncomplete` only when verdict is `"pass"`
- [x] `getCiStatus` sets `findingsIncomplete` when annotation fetch fails on a passing run
- [x] `buildCiFindingsPrompt` includes repository context, issue details, formatted findings, doc-consistency and PR-sync instructions
- [x] `buildCiFindingsPrompt` includes incomplete-fetch note when `findingsIncomplete` is true
- [x] `formatFindings` groups annotations by check run with correct formatting
- [x] `stage-cicheck` routes to findings review when `findingsIncomplete` is true even with no findings
- [x] `stage-cicheck` returns `"completed"` with `passedWithFindings` message when findings exist but agent makes no changes
- [x] `stage-cicheck` returns `"not_approved"` and re-polls CI when agent pushes changes in response to findings
- [x] `ci-poll` routes to findings review when `findingsIncomplete` is true even with no findings
- [x] `ci-poll` returns `passed: true` with `passedWithFindings` message when agent acknowledges findings without changes
- [x] `ci-poll` re-polls CI when agent pushes changes in response to findings
- [x] `ci-poll` handles agent errors during findings review
- [x] `ci-poll` with `maxFixAttempts=0` still allows findings review
- [x] `ci-poll` with `maxFixAttempts=0` re-polls after findings-driven push (no `fixLoopExhausted`)
- [x] `ci-poll` findings reviews do not consume failure-fix budget (mixed findings→failure scenario)
- [x] `ci-poll` caps findings-review re-polls at `maxFixAttempts` independently
- [x] All existing CI pass/fail tests continue to pass (no regressions)
- [x] i18n keys `ci.passedWithFindings` defined in en, ko, and Messages interface