### PR TITLE
Triage CodeQL findings (#216)

### DIFF
--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -76,6 +76,7 @@ function makeOpts(overrides: Partial<CiPollOptions> = {}): CiPollOptions {
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
     getHeadSha: vi.fn().mockReturnValue("abc123"),
+    fetchCodeScanningAlerts: vi.fn().mockReturnValue([]),
     delay: vi.fn().mockResolvedValue(undefined),
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
@@ -648,6 +649,7 @@ describe("pollCiAndFix", () => {
         rule: "no-unused-vars",
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -677,6 +679,7 @@ describe("pollCiAndFix", () => {
         line: 1,
         checkRunId: 600,
         checkRunName: "Lint",
+        commitSha: "abc123",
       },
     ];
 
@@ -713,6 +716,7 @@ describe("pollCiAndFix", () => {
         line: 10,
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -780,6 +784,7 @@ describe("pollCiAndFix", () => {
         line: 10,
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -806,6 +811,7 @@ describe("pollCiAndFix", () => {
         line: 1,
         checkRunId: 600,
         checkRunName: "Lint",
+        commitSha: "abc123",
       },
     ];
     // First poll: pass with findings. After agent fix: pass clean.
@@ -838,6 +844,7 @@ describe("pollCiAndFix", () => {
         line: 10,
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
 
@@ -895,6 +902,7 @@ describe("pollCiAndFix", () => {
         line: 10,
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
 
@@ -949,6 +957,7 @@ describe("pollCiAndFix", () => {
         rule: "no-unused-vars",
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -965,5 +974,117 @@ describe("pollCiAndFix", () => {
     expect(invokedPrompt).toContain("src/app.ts:10");
     expect(invokedPrompt).toContain("no-unused-vars");
     expect(invokedPrompt).toContain("ESLint (check run 500)");
+  });
+
+  // -- triage: code scanning alert correlation --------------------------------
+
+  test("fetches code scanning alerts when CI passes with findings", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "SQL injection",
+        file: "src/db.ts",
+        line: 42,
+        rule: "js/sql-injection",
+        checkRunId: 500,
+        checkRunName: "CodeQL",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    const agent = makeAgent();
+    await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha, fetchCodeScanningAlerts }),
+    );
+
+    expect(fetchCodeScanningAlerts).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-42",
+    );
+  });
+
+  test("includes triage instructions when alerts are correlated", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "SQL injection",
+        file: "src/db.ts",
+        line: 42,
+        rule: "js/sql-injection",
+        checkRunId: 500,
+        checkRunName: "CodeQL",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([
+      {
+        number: 10,
+        rule: { id: "js/sql-injection" },
+        tool: { name: "CodeQL" },
+        most_recent_instance: {
+          location: { path: "src/db.ts", start_line: 42 },
+          commit_sha: "abc123",
+        },
+        state: "open",
+        html_url: "https://github.com/org/repo/security/code-scanning/10",
+      },
+    ]);
+
+    const agent = makeAgent();
+    await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha, fetchCodeScanningAlerts }),
+    );
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("CodeQL Triage");
+    expect(invokedPrompt).toContain("Alert #10");
+    expect(invokedPrompt).toContain("[alert #10]");
+  });
+
+  test("does not fetch alerts on clean pass", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()]));
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    await pollCiAndFix(makeOpts({ getCiStatus, fetchCodeScanningAlerts }));
+
+    expect(fetchCodeScanningAlerts).not.toHaveBeenCalled();
+  });
+
+  test("does not fetch alerts on CI failure", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    const agent = makeAgent();
+    await pollCiAndFix(
+      makeOpts({
+        agent,
+        getCiStatus,
+        collectFailureLogs,
+        fetchCodeScanningAlerts,
+      }),
+    );
+
+    // fetchCodeScanningAlerts should not be called during the failure fix
+    // phase — only during findings review.
+    expect(fetchCodeScanningAlerts).not.toHaveBeenCalled();
   });
 });

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -8,9 +8,16 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiRun, CiStatus, GetCiStatusFn } from "./ci.js";
+import type {
+  CiRun,
+  CiStatus,
+  FetchCodeScanningAlertsFn,
+  GetCiStatusFn,
+} from "./ci.js";
 import {
+  correlateFindings,
   collectFailureLogs as defaultCollectFailureLogs,
+  fetchCodeScanningAlerts as defaultFetchAlerts,
   getCiStatus as defaultGetCiStatus,
   normaliseCiConclusion,
 } from "./ci.js";
@@ -52,6 +59,8 @@ export interface CiPollOptions {
    * Injected for testability.  Defaults to `worktree.getHeadSha`.
    */
   getHeadSha?: (cwd: string) => string;
+  /** Injected for testability. Defaults to `ci.fetchCodeScanningAlerts`. */
+  fetchCodeScanningAlerts?: FetchCodeScanningAlertsFn;
   /** Delay in ms between polls when CI is pending. Default 30 000. */
   pollIntervalMs?: number;
   /** Max time in ms to wait for pending CI. Default 600 000 (10 min). */
@@ -165,6 +174,7 @@ export async function pollCiAndFix(
 
   const { ctx, agent, issueTitle, issueBody } = options;
   const readHeadSha = options.getHeadSha ?? defaultGetHeadSha;
+  const fetchAlerts = options.fetchCodeScanningAlerts ?? defaultFetchAlerts;
   const emptyGrace =
     options.emptyRunsGracePeriodMs ?? DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS;
 
@@ -217,11 +227,20 @@ export async function pollCiAndFix(
 
       const shaBeforeReview = readHeadSha(ctx.worktreePath);
 
+      // Fetch code scanning alerts and correlate to findings so
+      // the agent can dismiss false positives by alert number.
+      const alerts = fetchAlerts(ctx.owner, ctx.repo, ctx.branch);
+      const correlated =
+        alerts.length > 0
+          ? correlateFindings(ciStatus.findings, alerts)
+          : undefined;
+
       const findingsPrompt = buildCiFindingsPrompt(
         ctx,
         { issueTitle, issueBody },
         ciStatus.findings,
         ciStatus.findingsIncomplete,
+        correlated,
       );
       ctx.promptSinks?.a?.(findingsPrompt);
       const reviewStream = agent.invoke(findingsPrompt, {

--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -12,6 +12,9 @@ const {
   getCiStatus,
   collectFailureLogs,
   collectFindings,
+  fetchCodeScanningAlerts,
+  correlateFindings,
+  dismissCodeScanningAlert,
 } = await import("./ci.js");
 
 const mockExecFileSync = vi.mocked(execFileSync);
@@ -798,6 +801,7 @@ describe("collectFindings", () => {
       rule: "no-unused-vars",
       checkRunId: 500,
       checkRunName: "ESLint",
+      commitSha: "abc123",
     });
     expect(result.findings[1]).toEqual({
       level: "notice",
@@ -807,6 +811,7 @@ describe("collectFindings", () => {
       rule: undefined,
       checkRunId: 500,
       checkRunName: "ESLint",
+      commitSha: "abc123",
     });
   });
 
@@ -912,5 +917,232 @@ describe("edge cases", () => {
   test("fetchCiRuns throws on malformed check-runs JSON", () => {
     mockExecFileSync.mockReturnValueOnce("[]").mockReturnValueOnce("not json");
     expect(() => fetchCiRuns("org", "repo", "main")).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchCodeScanningAlerts
+// ---------------------------------------------------------------------------
+describe("fetchCodeScanningAlerts", () => {
+  test("fetches and flattens paginated alerts", () => {
+    const alerts = [
+      {
+        number: 1,
+        rule: { id: "js/sql-injection" },
+        tool: { name: "CodeQL" },
+        most_recent_instance: {
+          location: { path: "src/db.ts", start_line: 42 },
+          commit_sha: "abc123",
+        },
+        state: "open",
+        html_url: "https://github.com/org/repo/security/code-scanning/1",
+      },
+    ];
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([alerts]));
+
+    const result = fetchCodeScanningAlerts("org", "repo", "my-branch");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+    expect(result[0].rule.id).toBe("js/sql-injection");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "api",
+        "--paginate",
+        "--slurp",
+        "repos/org/repo/code-scanning/alerts?ref=my-branch&state=open&per_page=100",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("URL-encodes ref containing slashes", () => {
+    mockExecFileSync.mockReturnValueOnce(JSON.stringify([[]]));
+    fetchCodeScanningAlerts("org", "repo", "user/issue-42");
+    const args = mockExecFileSync.mock.calls[0][1] as string[];
+    expect(args[3]).toContain("ref=user%2Fissue-42");
+  });
+
+  test("returns empty array on API error", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("404 Not Found");
+    });
+    const result = fetchCodeScanningAlerts("org", "repo", "main");
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// correlateFindings
+// ---------------------------------------------------------------------------
+describe("correlateFindings", () => {
+  const makeAlert = (
+    overrides: Partial<{
+      number: number;
+      ruleId: string;
+      toolName: string;
+      path: string;
+      startLine: number;
+      commitSha: string;
+      htmlUrl: string;
+    }> = {},
+  ) => ({
+    number: overrides.number ?? 1,
+    rule: { id: overrides.ruleId ?? "js/sql-injection" },
+    tool: { name: overrides.toolName ?? "CodeQL" },
+    most_recent_instance: {
+      location: {
+        path: overrides.path ?? "src/db.ts",
+        start_line: overrides.startLine ?? 42,
+      },
+      commit_sha: overrides.commitSha ?? "abc123",
+    },
+    state: "open" as const,
+    html_url:
+      overrides.htmlUrl ??
+      "https://github.com/org/repo/security/code-scanning/1",
+  });
+
+  const makeFinding = (
+    overrides: Partial<{
+      rule: string;
+      checkRunName: string;
+      file: string;
+      line: number;
+      commitSha: string;
+    }> = {},
+  ) => ({
+    level: "warning",
+    message: "SQL injection vulnerability",
+    file: overrides.file ?? "src/db.ts",
+    line: overrides.line ?? 42,
+    rule: overrides.rule ?? "js/sql-injection",
+    checkRunId: 500,
+    checkRunName: overrides.checkRunName ?? "CodeQL",
+    commitSha: overrides.commitSha ?? "abc123",
+  });
+
+  test("matches finding to alert on all five fields", () => {
+    const findings = [makeFinding()];
+    const alerts = [makeAlert()];
+    const result = correlateFindings(findings, alerts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].alertNumber).toBe(1);
+    expect(result[0].alertUrl).toContain("code-scanning/1");
+    expect(result[0].finding).toBe(findings[0]);
+  });
+
+  test("requires exact SHA match — mismatched SHA yields no alert", () => {
+    const findings = [makeFinding({ commitSha: "new-sha" })];
+    const alerts = [makeAlert({ commitSha: "old-sha" })];
+    const result = correlateFindings(findings, alerts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].alertNumber).toBeUndefined();
+  });
+
+  test("returns undefined alertNumber when no match", () => {
+    const findings = [makeFinding({ rule: "js/xss" })];
+    const alerts = [makeAlert({ ruleId: "js/sql-injection" })];
+    const result = correlateFindings(findings, alerts);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].alertNumber).toBeUndefined();
+    expect(result[0].alertUrl).toBeUndefined();
+  });
+
+  test("handles multiple findings with mixed matches", () => {
+    const findings = [
+      makeFinding({ rule: "js/sql-injection", file: "src/db.ts", line: 42 }),
+      makeFinding({ rule: "js/xss", file: "src/ui.ts", line: 10 }),
+    ];
+    const alerts = [
+      makeAlert({
+        number: 1,
+        ruleId: "js/sql-injection",
+        path: "src/db.ts",
+        startLine: 42,
+      }),
+    ];
+    const result = correlateFindings(findings, alerts);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].alertNumber).toBe(1);
+    expect(result[1].alertNumber).toBeUndefined();
+  });
+
+  test("matches correct alert among multiple alerts", () => {
+    const findings = [makeFinding({ rule: "js/xss", file: "src/ui.ts" })];
+    const alerts = [
+      makeAlert({
+        number: 1,
+        ruleId: "js/sql-injection",
+        path: "src/db.ts",
+      }),
+      makeAlert({
+        number: 2,
+        ruleId: "js/xss",
+        toolName: "CodeQL",
+        path: "src/ui.ts",
+        startLine: 42,
+      }),
+    ];
+    const result = correlateFindings(findings, alerts);
+
+    expect(result[0].alertNumber).toBe(2);
+  });
+
+  test("handles findings with no rule gracefully", () => {
+    const findings = [makeFinding({ rule: undefined as unknown as string })];
+    // Override: the finding's rule field is undefined.
+    findings[0].rule = undefined;
+    const alerts = [makeAlert({ ruleId: "" })];
+    const result = correlateFindings(findings, alerts);
+
+    // Should match: undefined rule maps to "" which matches alert's "".
+    expect(result[0].alertNumber).toBe(1);
+  });
+
+  test("returns empty array for empty inputs", () => {
+    expect(correlateFindings([], [])).toEqual([]);
+    expect(correlateFindings([], [makeAlert()])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dismissCodeScanningAlert
+// ---------------------------------------------------------------------------
+describe("dismissCodeScanningAlert", () => {
+  test("calls gh api with correct PATCH arguments", () => {
+    mockExecFileSync.mockReturnValueOnce("{}");
+    dismissCodeScanningAlert("org", "repo", 42, "Test-only code");
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "api",
+        "-X",
+        "PATCH",
+        "repos/org/repo/code-scanning/alerts/42",
+        "-f",
+        "state=dismissed",
+        "-f",
+        "dismissed_reason=false positive",
+        "-f",
+        "dismissed_comment=Test-only code",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+
+  test("propagates API error", () => {
+    mockExecFileSync.mockImplementationOnce(() => {
+      throw new Error("403 Forbidden");
+    });
+    expect(() => dismissCodeScanningAlert("org", "repo", 42, "reason")).toThrow(
+      "403 Forbidden",
+    );
   });
 });

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -55,6 +55,8 @@ export interface CiFinding {
   checkRunId: number;
   /** Name of the check run that produced this finding. */
   checkRunName: string;
+  /** Commit SHA of the check run that produced this finding. */
+  commitSha: string;
 }
 
 export interface CiStatus {
@@ -233,6 +235,7 @@ export function collectFindings(
         rule: a.title,
         checkRunId: run.databaseId,
         checkRunName: run.name,
+        commitSha: run.headSha,
       });
     }
   }
@@ -441,4 +444,158 @@ export function collectFailureLogs(
     { encoding: "utf-8" },
   );
   return typeof output === "string" ? output : "";
+}
+
+// ---- code scanning alerts (CodeQL) ----------------------------------------
+
+/** A code scanning alert from the GitHub Code Scanning API. */
+export interface CodeScanningAlert {
+  number: number;
+  rule: { id: string };
+  tool: { name: string };
+  most_recent_instance: {
+    location: {
+      path: string;
+      start_line: number;
+    };
+    commit_sha: string;
+  };
+  state: string;
+  html_url: string;
+}
+
+/**
+ * Signature shared by `fetchCodeScanningAlerts` and injectable overrides.
+ */
+export type FetchCodeScanningAlertsFn = (
+  owner: string,
+  repo: string,
+  ref: string,
+) => CodeScanningAlert[];
+
+/**
+ * Signature shared by `dismissCodeScanningAlert` and injectable overrides.
+ */
+export type DismissCodeScanningAlertFn = (
+  owner: string,
+  repo: string,
+  alertNumber: number,
+  reason: string,
+) => void;
+
+/**
+ * Fetch open code scanning alerts for a given ref from the GitHub
+ * Code Scanning API.  Returns an empty array when the API returns
+ * a 404 (code scanning not enabled) or other error.
+ */
+export function fetchCodeScanningAlerts(
+  owner: string,
+  repo: string,
+  ref: string,
+): CodeScanningAlert[] {
+  try {
+    const raw = execFileSync(
+      "gh",
+      [
+        "api",
+        "--paginate",
+        "--slurp",
+        `repos/${owner}/${repo}/code-scanning/alerts?ref=${encodeURIComponent(ref)}&state=open&per_page=100`,
+      ],
+      { encoding: "utf-8" },
+    );
+    const pages: CodeScanningAlert[][] = JSON.parse(raw);
+    return pages.flat();
+  } catch {
+    // Code scanning may not be enabled on the repo, or the ref
+    // may not exist yet.  Return empty so callers degrade
+    // gracefully to the non-triage prompt.
+    return [];
+  }
+}
+
+/** Result of correlating a CiFinding to a code scanning alert. */
+export interface CorrelatedFinding {
+  finding: CiFinding;
+  /** The matched alert number, or undefined if no match was found. */
+  alertNumber?: number;
+  /** The HTML URL of the matched alert, or undefined. */
+  alertUrl?: string;
+}
+
+/**
+ * Correlate CI findings with code scanning alerts.
+ *
+ * Matches on: rule.id ↔ finding.rule, tool.name ↔ finding.checkRunName,
+ * location.path ↔ finding.file, location.start_line ↔ finding.line,
+ * and commit_sha ↔ finding.commitSha.
+ *
+ * Returns one `CorrelatedFinding` per input finding.  Findings without
+ * a matching alert get `alertNumber: undefined`.
+ */
+export function correlateFindings(
+  findings: CiFinding[],
+  alerts: CodeScanningAlert[],
+): CorrelatedFinding[] {
+  // Index alerts for efficient lookup: key = "rule|tool|path|line|sha".
+  const alertIndex = new Map<string, CodeScanningAlert>();
+  for (const alert of alerts) {
+    const key = [
+      alert.rule.id,
+      alert.tool.name,
+      alert.most_recent_instance.location.path,
+      alert.most_recent_instance.location.start_line,
+      alert.most_recent_instance.commit_sha,
+    ].join("|");
+    alertIndex.set(key, alert);
+  }
+
+  return findings.map((finding) => {
+    // Try exact match first (all five fields).
+    const exactKey = [
+      finding.rule ?? "",
+      finding.checkRunName,
+      finding.file,
+      finding.line,
+      finding.commitSha,
+    ].join("|");
+    const exactMatch = alertIndex.get(exactKey);
+    if (exactMatch) {
+      return {
+        finding,
+        alertNumber: exactMatch.number,
+        alertUrl: exactMatch.html_url,
+      };
+    }
+
+    return { finding };
+  });
+}
+
+/**
+ * Dismiss a code scanning alert as a false positive via the GitHub
+ * Code Scanning API.
+ */
+export function dismissCodeScanningAlert(
+  owner: string,
+  repo: string,
+  alertNumber: number,
+  reason: string,
+): void {
+  execFileSync(
+    "gh",
+    [
+      "api",
+      "-X",
+      "PATCH",
+      `repos/${owner}/${repo}/code-scanning/alerts/${alertNumber}`,
+      "-f",
+      "state=dismissed",
+      "-f",
+      "dismissed_reason=false positive",
+      "-f",
+      `dismissed_comment=${reason}`,
+    ],
+    { encoding: "utf-8" },
+  );
 }

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -78,6 +78,7 @@ function makeOpts(
     getCiStatus: vi.fn().mockReturnValue(makeCiStatus("pass")),
     collectFailureLogs: vi.fn().mockReturnValue(""),
     getHeadSha: vi.fn().mockReturnValue("abc123"),
+    fetchCodeScanningAlerts: vi.fn().mockReturnValue([]),
     delay: vi.fn().mockResolvedValue(undefined),
     pollIntervalMs: 100,
     pollTimeoutMs: 1000,
@@ -636,6 +637,7 @@ describe("createCiCheckStageHandler", () => {
         rule: "no-unused-vars",
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -677,6 +679,7 @@ describe("createCiCheckStageHandler", () => {
         line: 1,
         checkRunId: 600,
         checkRunName: "Lint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -713,6 +716,7 @@ describe("createCiCheckStageHandler", () => {
         line: 10,
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -799,6 +803,7 @@ describe("createCiCheckStageHandler", () => {
         line: 10,
         checkRunId: 500,
         checkRunName: "ESLint",
+        commitSha: "abc123",
       },
     ];
     const getCiStatus = vi
@@ -837,6 +842,7 @@ describe("buildCiFindingsPrompt", () => {
       rule: "no-unused-vars",
       checkRunId: 500,
       checkRunName: "ESLint",
+      commitSha: "abc123",
     },
     {
       level: "notice",
@@ -845,6 +851,7 @@ describe("buildCiFindingsPrompt", () => {
       line: 25,
       checkRunId: 500,
       checkRunName: "ESLint",
+      commitSha: "abc123",
     },
   ];
 
@@ -879,6 +886,7 @@ describe("buildCiFindingsPrompt", () => {
         line: 1,
         checkRunId: 100,
         checkRunName: "Lint",
+        commitSha: "abc123",
       },
       {
         level: "warning",
@@ -887,6 +895,7 @@ describe("buildCiFindingsPrompt", () => {
         line: 2,
         checkRunId: 200,
         checkRunName: "CodeQL",
+        commitSha: "abc123",
       },
     ];
     const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), mixed);
@@ -937,5 +946,238 @@ describe("buildCiFindingsPrompt", () => {
   test("omits feedback section when no instruction", () => {
     const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
     expect(prompt).not.toContain("Additional feedback");
+  });
+
+  test("includes triage instructions when correlated findings have alerts", () => {
+    const correlated = [
+      {
+        finding: sampleFindings[0],
+        alertNumber: 42,
+        alertUrl: "https://github.com/org/repo/security/code-scanning/42",
+      },
+      { finding: sampleFindings[1] },
+    ];
+    const prompt = buildCiFindingsPrompt(
+      BASE_CTX,
+      makeOpts(),
+      sampleFindings,
+      false,
+      correlated,
+    );
+    expect(prompt).toContain("CodeQL Triage");
+    expect(prompt).toContain("Evaluation criteria");
+    expect(prompt).toContain("real issue");
+    expect(prompt).toContain("false positive");
+    expect(prompt).toContain("Alert #42");
+    expect(prompt).toContain("[alert #42]");
+    expect(prompt).toContain("gh api -X PATCH");
+    expect(prompt).toContain("dismissed_reason=false positive");
+  });
+
+  test("omits triage instructions when no alerts are correlated", () => {
+    const correlated = [
+      { finding: sampleFindings[0] },
+      { finding: sampleFindings[1] },
+    ];
+    const prompt = buildCiFindingsPrompt(
+      BASE_CTX,
+      makeOpts(),
+      sampleFindings,
+      false,
+      correlated,
+    );
+    expect(prompt).not.toContain("CodeQL Triage");
+    expect(prompt).not.toContain("gh api -X PATCH");
+  });
+
+  test("omits triage section when correlated is undefined", () => {
+    const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
+    expect(prompt).not.toContain("CodeQL Triage");
+  });
+
+  test("includes alert number in findings list when correlated", () => {
+    const correlated = [
+      {
+        finding: sampleFindings[0],
+        alertNumber: 7,
+        alertUrl: "https://example.com",
+      },
+    ];
+    const prompt = buildCiFindingsPrompt(
+      BASE_CTX,
+      makeOpts(),
+      [sampleFindings[0]],
+      false,
+      correlated,
+    );
+    expect(prompt).toContain("[alert #7]");
+  });
+});
+
+// ---- createCiCheckStageHandler — triage integration -------------------------
+
+describe("createCiCheckStageHandler — triage", () => {
+  test("fetches code scanning alerts when CI passes with findings", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "SQL injection",
+        file: "src/db.ts",
+        line: 42,
+        rule: "js/sql-injection",
+        checkRunId: 500,
+        checkRunName: "CodeQL",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({
+      agent,
+      getCiStatus,
+      getHeadSha,
+      fetchCodeScanningAlerts,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(fetchCodeScanningAlerts).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      "issue-42",
+    );
+  });
+
+  test("includes triage instructions when alerts are correlated", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "SQL injection",
+        file: "src/db.ts",
+        line: 42,
+        rule: "js/sql-injection",
+        checkRunId: 500,
+        checkRunName: "CodeQL",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([
+      {
+        number: 10,
+        rule: { id: "js/sql-injection" },
+        tool: { name: "CodeQL" },
+        most_recent_instance: {
+          location: { path: "src/db.ts", start_line: 42 },
+          commit_sha: "abc123",
+        },
+        state: "open",
+        html_url: "https://github.com/org/repo/security/code-scanning/10",
+      },
+    ]);
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({
+      agent,
+      getCiStatus,
+      getHeadSha,
+      fetchCodeScanningAlerts,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("CodeQL Triage");
+    expect(invokedPrompt).toContain("Alert #10");
+    expect(invokedPrompt).toContain("[alert #10]");
+    expect(invokedPrompt).toContain("dismissed_reason=false positive");
+  });
+
+  test("omits triage when no code scanning alerts are found", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        rule: "no-unused-vars",
+        checkRunId: 500,
+        checkRunName: "ESLint",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(makeResult())),
+      resume: vi.fn().mockReturnValue(makeStream(makeResult())),
+    };
+
+    const opts = makeOpts({
+      agent,
+      getCiStatus,
+      getHeadSha,
+      fetchCodeScanningAlerts,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).not.toContain("CodeQL Triage");
+  });
+
+  test("does not fetch alerts on clean pass", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()]));
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    const opts = makeOpts({ getCiStatus, fetchCodeScanningAlerts });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(fetchCodeScanningAlerts).not.toHaveBeenCalled();
+  });
+
+  test("does not fetch alerts on CI failure", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("error");
+    const fetchCodeScanningAlerts = vi.fn().mockReturnValue([]);
+
+    const opts = makeOpts({
+      getCiStatus,
+      collectFailureLogs,
+      fetchCodeScanningAlerts,
+    });
+    const stage = createCiCheckStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(fetchCodeScanningAlerts).not.toHaveBeenCalled();
   });
 });

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -12,9 +12,18 @@
  */
 
 import type { AgentAdapter } from "./agent.js";
-import type { CiFinding, CiRun, CiStatus, GetCiStatusFn } from "./ci.js";
+import type {
+  CiFinding,
+  CiRun,
+  CiStatus,
+  CorrelatedFinding,
+  FetchCodeScanningAlertsFn,
+  GetCiStatusFn,
+} from "./ci.js";
 import {
+  correlateFindings,
   collectFailureLogs as defaultCollectFailureLogs,
+  fetchCodeScanningAlerts as defaultFetchAlerts,
   getCiStatus as defaultGetCiStatus,
   normaliseCiConclusion,
 } from "./ci.js";
@@ -54,6 +63,8 @@ export interface CiCheckStageOptions {
    * Injected for testability.  Defaults to `worktree.getHeadSha`.
    */
   getHeadSha?: (cwd: string) => string;
+  /** Injected for testability. Defaults to `ci.fetchCodeScanningAlerts`. */
+  fetchCodeScanningAlerts?: FetchCodeScanningAlertsFn;
   /** Delay in ms between polls when CI is pending. Default 30 000. */
   pollIntervalMs?: number;
   /** Max time in ms to wait for pending CI. Default 600 000 (10 min). */
@@ -112,26 +123,114 @@ export function buildCiFixPrompt(
 
 /**
  * Format findings into a structured block for inclusion in the
- * findings-review prompt.
+ * findings-review prompt.  When correlated findings are available,
+ * each finding includes its alert number for dismiss operations.
  */
-function formatFindings(findings: CiFinding[]): string {
-  const byRun = new Map<string, CiFinding[]>();
-  for (const f of findings) {
+function formatFindings(findings: CiFinding[]): string;
+function formatFindings(correlated: CorrelatedFinding[]): string;
+function formatFindings(items: CiFinding[] | CorrelatedFinding[]): string {
+  // Normalise to CorrelatedFinding shape.
+  const correlated: CorrelatedFinding[] = items.map((item) =>
+    "finding" in item ? item : { finding: item },
+  );
+
+  const byRun = new Map<string, CorrelatedFinding[]>();
+  for (const cf of correlated) {
+    const f = cf.finding;
     const key = `${f.checkRunName} (check run ${f.checkRunId})`;
     const group = byRun.get(key) ?? [];
-    group.push(f);
+    group.push(cf);
     byRun.set(key, group);
   }
 
   const sections: string[] = [];
   for (const [header, group] of byRun) {
-    const lines = group.map((f) => {
+    const lines = group.map((cf) => {
+      const f = cf.finding;
       const rule = f.rule ? ` (${f.rule})` : "";
-      return `- ${f.file}:${f.line}: [${f.level}] ${f.message}${rule}`;
+      const alert = cf.alertNumber != null ? ` [alert #${cf.alertNumber}]` : "";
+      return `- ${f.file}:${f.line}: [${f.level}] ${f.message}${rule}${alert}`;
     });
     sections.push(`### ${header}\n${lines.join("\n")}`);
   }
   return sections.join("\n\n");
+}
+
+/**
+ * Build triage criteria and dismiss instructions for CodeQL findings.
+ * Only included when at least one finding is correlated to an alert.
+ */
+function buildTriageInstructions(
+  ctx: StageContext,
+  correlated: CorrelatedFinding[],
+): string {
+  const hasAlerts = correlated.some((cf) => cf.alertNumber != null);
+  if (!hasAlerts) return "";
+
+  const dismissible = correlated.filter((cf) => cf.alertNumber != null);
+
+  const lines = [
+    ``,
+    `## CodeQL Triage`,
+    ``,
+    `For each finding marked with an alert number (\`[alert #N]\`), evaluate`,
+    `whether it is a **real issue** or a **false positive**.`,
+    ``,
+    `### Evaluation criteria`,
+    ``,
+    `A finding is a **real issue** when:`,
+    `- The flagged code path is reachable in production.`,
+    `- An attacker-controlled or untrusted input can reach the sink`,
+    `  without adequate sanitisation or validation.`,
+    `- The reported weakness (e.g. SQL injection, XSS, path traversal)`,
+    `  is exploitable given the application's threat model.`,
+    ``,
+    `A finding is a **false positive** when:`,
+    `- The data is already sanitised or validated before it reaches the`,
+    `  flagged location, but CodeQL cannot see through the sanitiser.`,
+    `- The flagged code is dead, test-only, or unreachable in production.`,
+    `- The "source" is not actually attacker-controlled (e.g. a hardcoded`,
+    `  constant, an environment variable set at deploy time).`,
+    `- The framework or library provides built-in protection that makes`,
+    `  the flagged pattern safe (e.g. parameterised queries).`,
+    ``,
+    `### Actions`,
+    ``,
+    `- **Real issue:** Fix the code.  After fixing, commit and push.`,
+    `- **False positive:** For each false-positive alert, run these`,
+    `  commands (one pair per alert):`,
+    ``,
+    `  \`\`\``,
+    `  gh api -X PATCH "repos/${ctx.owner}/${ctx.repo}/code-scanning/alerts/{number}" \\`,
+    `    -f state=dismissed \\`,
+    `    -f "dismissed_reason=false positive" \\`,
+    `    -f "dismissed_comment={your brief explanation}"`,
+    `  \`\`\``,
+    ``,
+    `  Then leave one PR comment summarising all dismissed alerts and`,
+    `  the reasoning for each.  First, find the PR number:`,
+    ``,
+    `  \`\`\``,
+    `  gh pr view --repo ${ctx.owner}/${ctx.repo} ${ctx.branch} --json number --jq .number`,
+    `  \`\`\``,
+    ``,
+    `  Then post the comment:`,
+    ``,
+    `  \`\`\``,
+    `  gh pr comment --repo ${ctx.owner}/${ctx.repo} <pr_number> --body "..."`,
+    `  \`\`\``,
+    ``,
+    `### Dismissible alerts`,
+    ``,
+  ];
+
+  for (const cf of dismissible) {
+    const f = cf.finding;
+    const rule = f.rule ?? "(unknown rule)";
+    lines.push(`- Alert #${cf.alertNumber}: ${rule} at ${f.file}:${f.line}`);
+  }
+
+  return lines.join("\n");
 }
 
 export function buildCiFindingsPrompt(
@@ -139,6 +238,7 @@ export function buildCiFindingsPrompt(
   opts: Pick<CiCheckStageOptions, "issueTitle" | "issueBody">,
   findings: CiFinding[],
   findingsIncomplete?: boolean,
+  correlated?: CorrelatedFinding[],
 ): string {
   const lines = [
     `CI passed but check runs reported findings (annotations).`,
@@ -156,7 +256,7 @@ export function buildCiFindingsPrompt(
     ``,
     `## CI Findings`,
     ``,
-    formatFindings(findings),
+    correlated ? formatFindings(correlated) : formatFindings(findings),
   ];
 
   if (findingsIncomplete) {
@@ -166,6 +266,10 @@ export function buildCiFindingsPrompt(
       `The findings above may be incomplete.  Check the PR's Checks`,
       `tab for the full list of annotations.`,
     );
+  }
+
+  if (correlated) {
+    lines.push(buildTriageInstructions(ctx, correlated));
   }
 
   lines.push(
@@ -198,6 +302,7 @@ export function createCiCheckStageHandler(
   const getCiStatus = opts.getCiStatus ?? defaultGetCiStatus;
   const collectLogs = opts.collectFailureLogs ?? defaultCollectFailureLogs;
   const readHeadSha = opts.getHeadSha ?? defaultGetHeadSha;
+  const fetchAlerts = opts.fetchCodeScanningAlerts ?? defaultFetchAlerts;
   const pollInterval = opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const pollTimeout = opts.pollTimeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
   const emptyGrace =
@@ -270,11 +375,20 @@ export function createCiCheckStageHandler(
       if (ciStatus.verdict === "pass") {
         const shaBeforeReview = readHeadSha(ctx.worktreePath);
 
+        // Fetch code scanning alerts and correlate to findings so
+        // the agent can dismiss false positives by alert number.
+        const alerts = fetchAlerts(ctx.owner, ctx.repo, ctx.branch);
+        const correlated =
+          alerts.length > 0
+            ? correlateFindings(ciStatus.findings, alerts)
+            : undefined;
+
         const findingsPrompt = buildCiFindingsPrompt(
           ctx,
           opts,
           ciStatus.findings,
           ciStatus.findingsIncomplete,
+          correlated,
         );
         ctx.promptSinks?.a?.(findingsPrompt);
         const reviewResult = await invokeOrResume(


### PR DESCRIPTION
## Summary

- Add code scanning alert fetching, correlation, and dismissal via the GitHub Code Scanning API
- Correlate CI findings to alerts by matching rule ID, tool name, file path, line number, and commit SHA (exact match only — no fallback)
- Generate triage instructions in the agent prompt with evaluation criteria for real-issue vs false-positive judgment, including `gh api` dismiss commands with alert numbers and `gh pr view` discovery for the PR number
- Wire up the correlation step in both `stage-cicheck` and `ci-poll` before invoking the agent for findings review

Closes #216

## Test plan

- [x] `fetchCodeScanningAlerts` returns paginated alerts for a branch ref (URL-encodes slashes in ref)
- [x] `fetchCodeScanningAlerts` returns empty array on API error (graceful degradation)
- [x] `correlateFindings` matches findings to alerts on all five fields (rule, tool, file, line, commit SHA)
- [x] `correlateFindings` requires exact SHA match — mismatched SHA yields no alert
- [x] `correlateFindings` returns `alertNumber: undefined` when no alert matches
- [x] `dismissCodeScanningAlert` calls `gh api -X PATCH` with correct arguments
- [x] `buildCiFindingsPrompt` includes triage instructions and dismiss commands when correlated findings have alerts
- [x] `buildCiFindingsPrompt` omits triage section when no alerts are correlated or correlated is undefined
- [x] Finding lines include `[alert #N]` annotation when correlated
- [x] `createCiCheckStageHandler` fetches alerts and correlates when CI passes with findings
- [x] `createCiCheckStageHandler` does not fetch alerts on clean pass or CI failure
- [x] `pollCiAndFix` fetches and correlates alerts for findings review
- [x] `pollCiAndFix` does not fetch alerts on clean pass or CI failure