### PR TITLE
Guard cleanup prompts against accidental Ctrl+C (#204)

### DIFF
--- a/src/cleanup-confirm.test.ts
+++ b/src/cleanup-confirm.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  type CleanupInterruptState,
+  resilientConfirm,
+} from "./cleanup-confirm.js";
+
+// Mock @inquirer/prompts so we can control what confirm() does.
+vi.mock("@inquirer/prompts", () => ({
+  confirm: vi.fn(),
+}));
+
+// Dynamically import so the mock is in place.
+const { confirm } = await import("@inquirer/prompts");
+const mockConfirm = vi.mocked(confirm);
+
+/** Build an error that looks like @inquirer/core ExitPromptError. */
+function exitPromptError(): Error {
+  const err = new Error("User force closed the prompt with SIGINT");
+  err.name = "ExitPromptError";
+  return err;
+}
+
+describe("resilientConfirm", () => {
+  const opts = { message: "Delete?" };
+  const warning = "Cleanup in progress. Press Ctrl+C again to force quit.";
+
+  beforeEach(() => {
+    mockConfirm.mockReset();
+  });
+
+  test("returns the value from confirm() on success", async () => {
+    mockConfirm.mockResolvedValueOnce(true);
+    const state: CleanupInterruptState = { count: 0 };
+    const result = await resilientConfirm(opts, state, warning);
+    expect(result).toBe(true);
+    expect(state.count).toBe(0);
+  });
+
+  test("first ExitPromptError warns and re-asks the prompt", async () => {
+    mockConfirm
+      .mockRejectedValueOnce(exitPromptError())
+      .mockResolvedValueOnce(true);
+    const state: CleanupInterruptState = { count: 0 };
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const result = await resilientConfirm(opts, state, warning);
+    expect(result).toBe(true);
+    expect(state.count).toBe(1);
+    expect(spy).toHaveBeenCalledWith(`\n${warning}`);
+    expect(mockConfirm).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  test("second ExitPromptError force-exits the process", async () => {
+    mockConfirm.mockRejectedValueOnce(exitPromptError());
+    const state: CleanupInterruptState = { count: 1 };
+    const spy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    await resilientConfirm(opts, state, warning);
+    expect(spy).toHaveBeenCalledWith(1);
+    spy.mockRestore();
+  });
+
+  test("re-throws non-ExitPromptError errors", async () => {
+    const otherError = new Error("something else");
+    mockConfirm.mockRejectedValueOnce(otherError);
+    const state: CleanupInterruptState = { count: 0 };
+    await expect(resilientConfirm(opts, state, warning)).rejects.toThrow(
+      "something else",
+    );
+    expect(state.count).toBe(0);
+  });
+
+  test("first interrupt re-prompts, second force-exits", async () => {
+    mockConfirm
+      .mockRejectedValueOnce(exitPromptError())
+      .mockRejectedValueOnce(exitPromptError());
+    const state: CleanupInterruptState = { count: 0 };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+
+    await resilientConfirm(opts, state, warning);
+
+    expect(logSpy).toHaveBeenCalledWith(`\n${warning}`);
+    expect(state.count).toBe(2);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  test("shared state accumulates across multiple prompts", async () => {
+    mockConfirm
+      .mockRejectedValueOnce(exitPromptError())
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const state: CleanupInterruptState = { count: 0 };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+
+    // First prompt: interrupted → warns, re-asks, user answers false
+    const r1 = await resilientConfirm(opts, state, warning);
+    expect(r1).toBe(false);
+    expect(state.count).toBe(1);
+
+    // Second prompt: answered normally → count unchanged
+    const r2 = await resilientConfirm(opts, state, warning);
+    expect(r2).toBe(true);
+    expect(state.count).toBe(1);
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+});

--- a/src/cleanup-confirm.ts
+++ b/src/cleanup-confirm.ts
@@ -1,0 +1,44 @@
+import { confirm } from "@inquirer/prompts";
+
+/**
+ * Shared state for tracking Ctrl+C presses during the cleanup phase.
+ * Both the process-level SIGINT handler and prompt-level ExitPromptError
+ * handler increment the same counter so that the "two strikes" logic
+ * works regardless of *where* the signal is caught.
+ */
+export interface CleanupInterruptState {
+  count: number;
+}
+
+/**
+ * SIGINT-resilient wrapper around `@inquirer/prompts` `confirm()`.
+ *
+ * `@inquirer/core` intercepts Ctrl+C on its own readline interface and
+ * rejects with `ExitPromptError` — the process-level SIGINT handler
+ * never fires while a prompt is active.  This wrapper catches that
+ * error and applies the same two-strike policy:
+ *
+ * - **1st interrupt** → print a warning, re-ask the same prompt
+ * - **2nd interrupt** → force-exit with `process.exit(1)`
+ */
+export async function resilientConfirm(
+  options: Parameters<typeof confirm>[0],
+  state: CleanupInterruptState,
+  warningMessage: string,
+): Promise<boolean> {
+  for (;;) {
+    try {
+      return await confirm(options);
+    } catch (error: unknown) {
+      if (error instanceof Error && error.name === "ExitPromptError") {
+        state.count++;
+        if (state.count >= 2) {
+          process.exit(1);
+        }
+        console.log(`\n${warningMessage}`);
+        continue;
+      }
+      throw error;
+    }
+  }
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -272,6 +272,8 @@ export const en: Messages = {
   "cleanup.deletingRemoteBranch": "  Deleting remote branch...",
   "cleanup.closingPr": "  Closing PR...",
   "cleanup.done": "Cleanup complete.",
+  "cleanup.forceQuitWarning":
+    "Cleanup in progress. Press Ctrl+C again to force quit.",
   "prompt.yesCleanup": "Yes",
   "prompt.noSkipCleanup": "No",
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -312,7 +312,9 @@ export const ko: Messages = {
   "cleanup.deletingRemoteBranch":
     "  \uC6D0\uACA9 \uBE0C\uB79C\uCE58 \uC0AD\uC81C \uC911...",
   "cleanup.closingPr": "  PR \uB2EB\uB294 \uC911...",
-  "cleanup.done": "\uC815\uB9AC \uC644\uB8CC.",
+  "cleanup.done": "정리 완료.",
+  "cleanup.forceQuitWarning":
+    "정리가 진행 중입니다. 강제 종료하려면 Ctrl+C를 다시 누르세요.",
   "prompt.yesCleanup": "\uC608",
   "prompt.noSkipCleanup": "\uC544\uB2C8\uC624",
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -253,6 +253,7 @@ export interface Messages {
   "cleanup.deletingRemoteBranch": string;
   "cleanup.closingPr": string;
   "cleanup.done": string;
+  "cleanup.forceQuitWarning": string;
   "prompt.yesCleanup": string;
   "prompt.noSkipCleanup": string;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,10 @@ import {
   remoteBranchExists,
   stopDockerCompose,
 } from "./cleanup.js";
+import {
+  type CleanupInterruptState,
+  resilientConfirm,
+} from "./cleanup-confirm.js";
 import { createCodexAdapter } from "./codex-adapter.js";
 import type { NotificationSettings, PipelineSettings } from "./config.js";
 import { loadConfig } from "./config.js";
@@ -148,6 +152,10 @@ interface CleanupResult {
 
 /**
  * Run post-pipeline cancellation cleanup using interactive prompts.
+ *
+ * Each `confirm()` call is wrapped with {@link resilientConfirm} so that
+ * Ctrl+C during a prompt increments the shared interrupt counter instead
+ * of silently aborting the whole cleanup flow.
  */
 async function runCancellationCleanup(opts: {
   owner: string;
@@ -156,8 +164,10 @@ async function runCancellationCleanup(opts: {
   branch: string;
   worktreePath: string;
   prNumber: number | undefined;
+  interruptState: CleanupInterruptState;
 }): Promise<CleanupResult> {
   const m = t();
+  const warn = m["cleanup.forceQuitWarning"];
   const result: CleanupResult = {
     deletedWorktree: false,
     deletedRemoteBranch: false,
@@ -168,10 +178,11 @@ async function runCancellationCleanup(opts: {
 
   // Stop docker compose services.
   if (hasDockerComposeRunning(opts.worktreePath)) {
-    const stop = await confirm({
-      message: m["cleanup.stopDockerCompose"],
-      default: true,
-    });
+    const stop = await resilientConfirm(
+      { message: m["cleanup.stopDockerCompose"], default: true },
+      opts.interruptState,
+      warn,
+    );
     if (stop) {
       console.log(m["cleanup.stoppingServices"]);
       stopDockerCompose(opts.worktreePath);
@@ -179,10 +190,11 @@ async function runCancellationCleanup(opts: {
   }
 
   // Delete local worktree and branch.
-  const deleteWt = await confirm({
-    message: m["cleanup.deleteWorktree"],
-    default: false,
-  });
+  const deleteWt = await resilientConfirm(
+    { message: m["cleanup.deleteWorktree"], default: false },
+    opts.interruptState,
+    warn,
+  );
   if (deleteWt) {
     console.log(m["cleanup.deletingWorktree"]);
     removeWorktree(opts.owner, opts.repo, opts.issueNumber, opts.branch);
@@ -191,10 +203,11 @@ async function runCancellationCleanup(opts: {
 
   // Delete remote branch (only if one was pushed).
   if (remoteBranchExists(opts.owner, opts.repo, opts.branch)) {
-    const delRemote = await confirm({
-      message: m["cleanup.deleteRemoteBranch"](opts.branch),
-      default: false,
-    });
+    const delRemote = await resilientConfirm(
+      { message: m["cleanup.deleteRemoteBranch"](opts.branch), default: false },
+      opts.interruptState,
+      warn,
+    );
     if (delRemote) {
       console.log(m["cleanup.deletingRemoteBranch"]);
       try {
@@ -208,10 +221,11 @@ async function runCancellationCleanup(opts: {
 
   // Close PR (only if one exists).
   if (opts.prNumber !== undefined) {
-    const close = await confirm({
-      message: m["cleanup.closePr"](opts.prNumber),
-      default: false,
-    });
+    const close = await resilientConfirm(
+      { message: m["cleanup.closePr"](opts.prNumber), default: false },
+      opts.interruptState,
+      warn,
+    );
     if (close) {
       console.log(m["cleanup.closingPr"]);
       try {
@@ -817,8 +831,7 @@ try {
     });
   });
 
-  // Remove the SIGINT suppressor so the default handler takes over
-  // (allows Ctrl+C to kill during cleanup prompts).
+  // Remove the SIGINT suppressor installed for the TUI phase.
   process.off("SIGINT", sigintHandler);
 
   console.log();
@@ -835,6 +848,25 @@ try {
     }
     process.stdin.ref();
 
+    // Guard cleanup prompts against accidental Ctrl+C.  The first
+    // Ctrl+C already cancelled the pipeline; during cleanup the user
+    // gets one warning before a second Ctrl+C force-quits.
+    //
+    // The counter is shared between the process-level SIGINT handler
+    // (for interrupts between prompts) and the prompt-level
+    // ExitPromptError handler inside resilientConfirm (for interrupts
+    // during a prompt, which @inquirer/core intercepts on its readline
+    // interface before the process handler can fire).
+    const interruptState: CleanupInterruptState = { count: 0 };
+    const cleanupSigint = () => {
+      interruptState.count++;
+      if (interruptState.count >= 2) {
+        process.exit(1);
+      }
+      console.log(`\n${m["cleanup.forceQuitWarning"]}`);
+    };
+    process.on("SIGINT", cleanupSigint);
+
     try {
       const cleanup = await runCancellationCleanup({
         owner,
@@ -843,6 +875,7 @@ try {
         branch: wt.branch,
         worktreePath: wt.path,
         prNumber: runState.prNumber ?? findPrNumber(owner, repo, wt.branch),
+        interruptState,
       });
 
       // If the user destroyed resume prerequisites (worktree, remote
@@ -858,6 +891,8 @@ try {
       }
     } catch {
       // If cleanup prompts fail (e.g. second Ctrl+C), just exit.
+    } finally {
+      process.off("SIGINT", cleanupSigint);
     }
   } else {
     console.log();


### PR DESCRIPTION
## Summary

- Extract a `resilientConfirm()` wrapper (`src/cleanup-confirm.ts`) that catches `ExitPromptError` thrown by `@inquirer/core` when the user presses Ctrl+C during a prompt. The wrapper shares a `CleanupInterruptState` counter with the process-level SIGINT handler so that the two-strike policy works regardless of where the signal is caught (readline layer vs. process layer).
- The 1st cleanup-phase Ctrl+C prints a warning and re-asks the current prompt (giving the user a chance to reconsider); the 2nd Ctrl+C force-exits.
- Add the `cleanup.forceQuitWarning` i18n key to English and Korean message bundles.
- Add focused unit tests for `resilientConfirm` covering success, re-prompt after first interrupt, force-exit on second interrupt, re-throw of unrelated errors, and shared state accumulation.

Closes #204

## Test plan

- [ ] Run a pipeline, cancel with Ctrl+C during execution, verify cleanup prompts appear
- [ ] During cleanup prompts, press Ctrl+C once — verify warning is printed and the same prompt is re-asked
- [ ] Press Ctrl+C a second time during cleanup — verify the process force-exits
- [ ] Complete cleanup prompts normally (without extra Ctrl+C) — verify process exits cleanly
- [x] `pnpm vitest run` — all 1604 tests pass (including new `cleanup-confirm.test.ts`)
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes