### PR TITLE
Extend PipelineEventEmitter with diagnostic events (#198)

### DIFF
--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -3,6 +3,10 @@ import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import type { CiFinding, CiRun, CiStatus, CiVerdict } from "./ci.js";
 import { type CiPollOptions, pollCiAndFix } from "./ci-poll.js";
 import type { StageContext } from "./pipeline.js";
+import {
+  type PipelineCiPollEvent,
+  PipelineEventEmitter,
+} from "./pipeline-events.js";
 
 // ---- helpers ---------------------------------------------------------------
 
@@ -1086,5 +1090,212 @@ describe("pollCiAndFix", () => {
     // fetchCodeScanningAlerts should not be called during the failure fix
     // phase — only during findings review.
     expect(fetchCodeScanningAlerts).not.toHaveBeenCalled();
+  });
+
+  // -- pipeline:ci-poll event emission ----------------------------------------
+
+  test("emits start, status, done events on clean pass", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    await pollCiAndFix(makeOpts({ events }));
+
+    expect(collected).toEqual([
+      { action: "start", sha: "abc123" },
+      { action: "status", sha: "abc123", verdict: "pass" },
+      { action: "done", sha: "abc123", verdict: "pass" },
+    ]);
+  });
+
+  test("emits done with pending verdict on timeout", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pending"));
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    await pollCiAndFix(
+      makeOpts({
+        events,
+        getCiStatus,
+        delay,
+        pollIntervalMs: 100,
+        pollTimeoutMs: 1000,
+      }),
+    );
+
+    expect(collected[0]).toEqual({ action: "start", sha: "abc123" });
+    const done = collected[collected.length - 1];
+    expect(done.action).toBe("done");
+    expect(done.verdict).toBe("pending");
+
+    vi.restoreAllMocks();
+  });
+
+  test("emits events across fix loop", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+    const agent = makeAgent();
+
+    await pollCiAndFix(
+      makeOpts({ events, agent, getCiStatus, collectFailureLogs }),
+    );
+
+    // Each polling round gets start → status → done, even when
+    // transitioning into a fix loop.
+    const actions = collected.map((e) => e.action);
+    expect(actions).toEqual([
+      "start",
+      "status",
+      "done",
+      "start",
+      "status",
+      "done",
+    ]);
+    expect(collected[1].verdict).toBe("fail");
+    expect(collected[2]).toEqual({
+      action: "done",
+      sha: "abc123",
+      verdict: "fail",
+    });
+    expect(collected[5].verdict).toBe("pass");
+  });
+
+  test("emits done on fix attempts exhausted", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    const invokeResults = [makeStream(makeResult())];
+    let call = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => invokeResults[call++]),
+      resume: vi.fn(),
+    };
+
+    await pollCiAndFix(
+      makeOpts({
+        events,
+        agent,
+        getCiStatus,
+        collectFailureLogs,
+        maxFixAttempts: 1,
+      }),
+    );
+
+    const done = collected[collected.length - 1];
+    expect(done.action).toBe("done");
+    expect(done.verdict).toBe("fail");
+  });
+
+  test("emits done on agent error during CI fix", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+    const agent = makeAgent(
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "crash",
+        responseText: "",
+      }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await pollCiAndFix(
+      makeOpts({ events, agent, getCiStatus, collectFailureLogs }),
+    );
+
+    const done = collected[collected.length - 1];
+    expect(done.action).toBe("done");
+    expect(done.verdict).toBe("fail");
+
+    errorSpy.mockRestore();
+  });
+
+  test("emits done on agent error during findings review", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const agent = makeAgent(
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "crash",
+        responseText: "",
+      }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await pollCiAndFix(makeOpts({ events, agent, getCiStatus }));
+
+    const done = collected[collected.length - 1];
+    expect(done.action).toBe("done");
+    expect(done.verdict).toBe("pass");
+
+    errorSpy.mockRestore();
+  });
+
+  test("falls back to ctx.events when options.events is not provided", async () => {
+    const events = new PipelineEventEmitter();
+    const collected: PipelineCiPollEvent[] = [];
+    events.on("pipeline:ci-poll", (e) => collected.push(e));
+
+    const ctxWithEvents: StageContext = { ...BASE_CTX, events };
+
+    await pollCiAndFix(makeOpts({ ctx: ctxWithEvents }));
+
+    expect(collected).toEqual([
+      { action: "start", sha: "abc123" },
+      { action: "status", sha: "abc123", verdict: "pass" },
+      { action: "done", sha: "abc123", verdict: "pass" },
+    ]);
   });
 });

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -23,6 +23,7 @@ import {
 } from "./ci.js";
 import { t } from "./i18n/index.js";
 import type { StageContext } from "./pipeline.js";
+import type { PipelineEventEmitter } from "./pipeline-events.js";
 import { buildCiFindingsPrompt, buildCiFixPrompt } from "./stage-cicheck.js";
 import {
   buildErrorDetail,
@@ -76,6 +77,8 @@ export interface CiPollOptions {
   emptyRunsGracePeriodMs?: number;
   /** Injected for testability. Defaults to a real delay function. */
   delay?: (ms: number) => Promise<void>;
+  /** Pipeline event emitter for diagnostic events. */
+  events?: PipelineEventEmitter;
 }
 
 export interface CiPollResult {
@@ -101,6 +104,7 @@ async function waitForCi(
   delay: (ms: number) => Promise<void>,
   commitSha?: string,
   emptyRunsGracePeriod?: number,
+  onStatus?: (verdict: string) => void,
 ): Promise<{ timedOut: boolean; ciStatus: CiStatus }> {
   const startTime = Date.now();
 
@@ -128,6 +132,8 @@ async function waitForCi(
       await delay(pollInterval);
       continue;
     }
+
+    onStatus?.(ciStatus.verdict);
 
     const elapsed = Date.now() - startTime;
 
@@ -177,6 +183,7 @@ export async function pollCiAndFix(
   const fetchAlerts = options.fetchCodeScanningAlerts ?? defaultFetchAlerts;
   const emptyGrace =
     options.emptyRunsGracePeriodMs ?? DEFAULT_EMPTY_RUNS_GRACE_PERIOD_MS;
+  const events = options.events ?? ctx.events;
 
   // Track failure-fix and findings-review attempts independently so
   // that "pass with findings" never exhausts the failure-fix budget.
@@ -190,6 +197,8 @@ export async function pollCiAndFix(
     // triggered by the most recent push (initial or fix).
     const commitSha = readHeadSha(ctx.worktreePath);
 
+    events?.emit("pipeline:ci-poll", { action: "start", sha: commitSha });
+
     const { timedOut, ciStatus } = await waitForCi(
       ctx.owner,
       ctx.repo,
@@ -200,7 +209,22 @@ export async function pollCiAndFix(
       delay,
       commitSha,
       emptyGrace,
+      (verdict) =>
+        events?.emit("pipeline:ci-poll", {
+          action: "status",
+          sha: commitSha,
+          verdict,
+        }),
     );
+
+    // Close the polling session for this SHA.  Every `start` gets
+    // exactly one matching `done`, regardless of what happens next
+    // (timeout, clean pass, findings review, or fix loop).
+    events?.emit("pipeline:ci-poll", {
+      action: "done",
+      sha: commitSha,
+      verdict: ciStatus.verdict,
+    });
 
     if (timedOut) {
       return {
@@ -242,7 +266,7 @@ export async function pollCiAndFix(
         ciStatus.findingsIncomplete,
         correlated,
       );
-      ctx.promptSinks?.a?.(findingsPrompt);
+      ctx.promptSinks?.a?.(findingsPrompt, "ci-fix");
       const reviewStream = agent.invoke(findingsPrompt, {
         cwd: ctx.worktreePath,
         onUsage: ctx.usageSinks?.a,
@@ -310,7 +334,7 @@ export async function pollCiAndFix(
       { agent, issueTitle, issueBody },
       failureLogs,
     );
-    ctx.promptSinks?.a?.(fixPrompt);
+    ctx.promptSinks?.a?.(fixPrompt, "ci-fix");
     const fixStream = agent.invoke(fixPrompt, {
       cwd: ctx.worktreePath,
       onUsage: ctx.usageSinks?.a,

--- a/src/pipeline-events.test.ts
+++ b/src/pipeline-events.test.ts
@@ -4,7 +4,10 @@ import {
   type AgentInvokeEvent,
   type AgentPromptEvent,
   type AgentUsageEvent,
+  type PipelineCiPollEvent,
   PipelineEventEmitter,
+  type PipelineLoopEvent,
+  type PipelineVerdictEvent,
   type StageEnterEvent,
   type StageExitEvent,
   type StageNameOverrideEvent,
@@ -64,7 +67,11 @@ describe("PipelineEventEmitter", () => {
     const handler = vi.fn();
     emitter.on("agent:prompt", handler);
 
-    const event: AgentPromptEvent = { agent: "a", prompt: "Do the thing" };
+    const event: AgentPromptEvent = {
+      agent: "a",
+      prompt: "Do the thing",
+      kind: "work",
+    };
     emitter.emit("agent:prompt", event);
 
     expect(handler).toHaveBeenCalledWith(event);
@@ -131,5 +138,80 @@ describe("PipelineEventEmitter", () => {
 
     expect(chunkHandler).toHaveBeenCalledTimes(1);
     expect(enterHandler).not.toHaveBeenCalled();
+  });
+
+  test("emits and receives agent:prompt events with kind", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("agent:prompt", handler);
+
+    const event: AgentPromptEvent = {
+      agent: "a",
+      prompt: "Fix it",
+      kind: "ci-fix",
+    };
+    emitter.emit("agent:prompt", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives pipeline:verdict events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("pipeline:verdict", handler);
+
+    const event: PipelineVerdictEvent = {
+      agent: "a",
+      keyword: "COMPLETED",
+      raw: "All done.\n\nCOMPLETED",
+    };
+    emitter.emit("pipeline:verdict", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives pipeline:loop events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("pipeline:loop", handler);
+
+    const event: PipelineLoopEvent = {
+      stageNumber: 2,
+      stageName: "Implement",
+      remaining: 1,
+      exhausted: false,
+    };
+    emitter.emit("pipeline:loop", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("emits and receives pipeline:ci-poll events", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("pipeline:ci-poll", handler);
+
+    const event: PipelineCiPollEvent = {
+      action: "start",
+      sha: "abc123",
+    };
+    emitter.emit("pipeline:ci-poll", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
+  });
+
+  test("pipeline:ci-poll done event includes verdict", () => {
+    const emitter = new PipelineEventEmitter();
+    const handler = vi.fn();
+    emitter.on("pipeline:ci-poll", handler);
+
+    const event: PipelineCiPollEvent = {
+      action: "done",
+      sha: "abc123",
+      verdict: "pass",
+    };
+    emitter.emit("pipeline:ci-poll", event);
+
+    expect(handler).toHaveBeenCalledWith(event);
   });
 });

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -30,14 +30,70 @@ export interface AgentInvokeEvent {
   type: "invoke" | "resume";
 }
 
+/**
+ * Distinguishes the type of prompt sent to an agent without requiring
+ * consumers to inspect prompt text.
+ *
+ * - `"work"` — primary stage prompt
+ * - `"verdict-followup"` — verdict clarification prompt
+ * - `"ci-fix"` — CI failure fix prompt
+ * - `"summary"` — unresolved summary request
+ */
+export type AgentPromptKind =
+  | "work"
+  | "verdict-followup"
+  | "ci-fix"
+  | "summary";
+
 export interface AgentPromptEvent {
   agent: "a" | "b";
   prompt: string;
+  /** Type of prompt. */
+  kind: AgentPromptKind;
 }
 
 export interface AgentUsageEvent {
   agent: "a" | "b";
   usage: TokenUsage;
+}
+
+/**
+ * Emitted whenever the orchestrator parses a verdict keyword from an
+ * agent response.
+ */
+export interface PipelineVerdictEvent {
+  /** Which agent produced the response. */
+  agent: "a" | "b";
+  /** The parsed keyword (e.g. `"COMPLETED"`, `"BLOCKED"`). */
+  keyword: string;
+  /** The raw text the keyword was extracted from. */
+  raw: string;
+}
+
+/**
+ * Emitted on auto-budget consumption and exhaustion.
+ */
+export interface PipelineLoopEvent {
+  /** 1-based stage number. */
+  stageNumber: number;
+  /** Human-readable stage name. */
+  stageName: string;
+  /** Auto-iterations remaining after this advance. */
+  remaining: number;
+  /** `true` when the auto-budget has been exhausted. */
+  exhausted: boolean;
+}
+
+/**
+ * Emitted on CI polling start, status change, and completion.
+ */
+export interface PipelineCiPollEvent {
+  /** Phase of the polling lifecycle. */
+  action: "start" | "status" | "done";
+  /** Commit SHA being polled (when available). */
+  sha?: string;
+  /** CI verdict (when available). */
+  verdict?: string;
 }
 
 interface PipelineEventMap {
@@ -49,6 +105,9 @@ interface PipelineEventMap {
   "stage:name-override": [StageNameOverrideEvent];
   "review:posted": [ReviewPostedEvent];
   "agent:invoke": [AgentInvokeEvent];
+  "pipeline:verdict": [PipelineVerdictEvent];
+  "pipeline:loop": [PipelineLoopEvent];
+  "pipeline:ci-poll": [PipelineCiPollEvent];
 }
 
 export class PipelineEventEmitter extends EventEmitter<PipelineEventMap> {}

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -148,6 +148,8 @@ export interface StageContext {
    * async operations to bail out early when the user presses Ctrl+C.
    */
   signal?: AbortSignal;
+  /** Pipeline event emitter for diagnostic events. */
+  events?: PipelineEventEmitter;
 }
 
 // ---- user interaction interface ------------------------------------------
@@ -506,6 +508,12 @@ export async function runPipeline(
       }
 
       const canContinue = advanceLoop(lc);
+      events?.emit("pipeline:loop", {
+        stageNumber: stage.number,
+        stageName: stage.name,
+        remaining: lc.autoRemaining,
+        exhausted: !canContinue,
+      });
       if (!canContinue) {
         const approved = await prompt.confirmContinueLoop(
           stage.name,
@@ -620,13 +628,19 @@ async function runStage(
   // and track which agent is currently running.
   const promptSinks = events
     ? {
-        a: (prompt: string) => {
+        a: (
+          prompt: string,
+          kind: import("./pipeline-events.js").AgentPromptKind,
+        ) => {
           events.emit("agent:invoke", { agent: "a", type: "invoke" });
-          events.emit("agent:prompt", { agent: "a", prompt });
+          events.emit("agent:prompt", { agent: "a", prompt, kind });
         },
-        b: (prompt: string) => {
+        b: (
+          prompt: string,
+          kind: import("./pipeline-events.js").AgentPromptKind,
+        ) => {
           events.emit("agent:invoke", { agent: "b", type: "invoke" });
-          events.emit("agent:prompt", { agent: "b", prompt });
+          events.emit("agent:prompt", { agent: "b", prompt, kind });
         },
       }
     : undefined;
@@ -668,6 +682,7 @@ async function runStage(
       promptSinks,
       usageSinks,
       signal,
+      events,
     };
 
     // Clear one-shot fields after use.
@@ -773,6 +788,12 @@ async function runStage(
     // ---- loop control ----------------------------------------------------
 
     const canContinue = advanceLoop(lc);
+    events?.emit("pipeline:loop", {
+      stageNumber: stage.number,
+      stageName: stage.name,
+      remaining: lc.autoRemaining,
+      exhausted: !canContinue,
+    });
     // Notify caller after loop counter change for persistence.
     onStageTransition?.(stage.number, lc.iteration);
     if (!canContinue) {

--- a/src/rebase.ts
+++ b/src/rebase.ts
@@ -83,7 +83,7 @@ export function createRebaseHandler(
 ): (ctx: StageContext) => Promise<RebaseResult> {
   return async (ctx) => {
     const rebasePrompt = buildRebasePrompt(ctx, defaultBranch);
-    ctx.promptSinks?.a?.(rebasePrompt);
+    ctx.promptSinks?.a?.(rebasePrompt, "work");
     const stream = agent.invoke(rebasePrompt, {
       cwd: ctx.worktreePath,
       onUsage: ctx.usageSinks?.a,
@@ -104,7 +104,7 @@ export function createRebaseHandler(
 
     // Verdict follow-up: ask for exactly COMPLETED or BLOCKED.
     const verdictPrompt = buildRebaseVerdictPrompt();
-    ctx.promptSinks?.a?.(verdictPrompt);
+    ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup");
     let verdictResult = await sendFollowUp(
       agent,
       result.sessionId,
@@ -123,6 +123,13 @@ export function createRebaseHandler(
       verdictResult.responseText,
       REBASE_KEYWORDS,
     );
+    if (verdict.keyword !== undefined) {
+      ctx.events?.emit("pipeline:verdict", {
+        agent: "a",
+        keyword: verdict.keyword,
+        raw: verdictResult.responseText,
+      });
+    }
 
     // Clarification retry if ambiguous, extra commentary, or
     // multiple valid keywords.
@@ -131,7 +138,7 @@ export function createRebaseHandler(
         verdictResult.responseText,
         REBASE_KEYWORDS,
       );
-      ctx.promptSinks?.a?.(clarifyPrompt);
+      ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
       const retryResult = await sendFollowUp(
         agent,
         verdictResult.sessionId ?? result.sessionId,
@@ -151,6 +158,13 @@ export function createRebaseHandler(
         verdictResult.responseText,
         REBASE_KEYWORDS,
       );
+      if (verdict.keyword !== undefined) {
+        ctx.events?.emit("pipeline:verdict", {
+          agent: "a",
+          keyword: verdict.keyword,
+          raw: verdictResult.responseText,
+        });
+      }
     }
 
     const success = verdict.keyword?.toUpperCase() === "COMPLETED";

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -390,7 +390,7 @@ export function createCiCheckStageHandler(
           ciStatus.findingsIncomplete,
           correlated,
         );
-        ctx.promptSinks?.a?.(findingsPrompt);
+        ctx.promptSinks?.a?.(findingsPrompt, "ci-fix");
         const reviewResult = await invokeOrResume(
           opts.agent,
           ctx.savedAgentASessionId,
@@ -445,7 +445,7 @@ export function createCiCheckStageHandler(
           : "No detailed failure logs available.";
 
       const prompt = buildCiFixPrompt(ctx, opts, failureLogs);
-      ctx.promptSinks?.a?.(prompt);
+      ctx.promptSinks?.a?.(prompt, "ci-fix");
       const fixResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -29,6 +29,7 @@ import {
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
+  type VerdictContext,
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
@@ -111,7 +112,7 @@ export function createCreatePrStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the PR creation prompt (resume if saved session).
       const prompt = buildCreatePrPrompt(ctx, opts);
-      ctx.promptSinks?.a?.(prompt);
+      ctx.promptSinks?.a?.(prompt, "work");
       const prResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -135,7 +136,7 @@ export function createCreatePrStageHandler(
       // session, because re-entering the handler would re-run the
       // side-effectful PR creation step.
       const prCheckPrompt = buildPrCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(prCheckPrompt);
+      ctx.promptSinks?.a?.(prCheckPrompt, "verdict-followup");
       let checkResult = await sendFollowUp(
         opts.agent,
         prResult.sessionId,
@@ -150,10 +151,15 @@ export function createCreatePrStageHandler(
         return mapAgentError(checkResult, "during PR completion check");
       }
 
+      const verdictCtx: VerdictContext | undefined = ctx.events
+        ? { events: ctx.events, agent: "a" }
+        : undefined;
+
       let result = mapResponseToResult(
         checkResult.responseText,
         undefined,
         PR_CHECK_KEYWORDS,
+        verdictCtx,
       );
 
       if (result.outcome === "needs_clarification") {
@@ -161,7 +167,7 @@ export function createCreatePrStageHandler(
           checkResult.responseText,
           PR_CHECK_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt);
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId ?? prResult.sessionId,
@@ -184,6 +190,7 @@ export function createCreatePrStageHandler(
           checkResult.responseText,
           undefined,
           PR_CHECK_KEYWORDS,
+          verdictCtx,
         );
       }
 

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -16,6 +16,7 @@ import {
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
+  type VerdictContext,
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
@@ -87,7 +88,7 @@ export function createImplementStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the implementation prompt (resume if saved session).
       const prompt = buildImplementPrompt(ctx, opts);
-      ctx.promptSinks?.a?.(prompt);
+      ctx.promptSinks?.a?.(prompt, "work");
       const implResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -108,7 +109,7 @@ export function createImplementStageHandler(
 
       // Step 2: Resume the session and ask for completion status.
       const checkPrompt = buildCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(checkPrompt);
+      ctx.promptSinks?.a?.(checkPrompt, "verdict-followup");
       const checkResult = await sendFollowUp(
         opts.agent,
         implResult.sessionId,
@@ -123,10 +124,15 @@ export function createImplementStageHandler(
         return mapAgentError(checkResult, "during completion check");
       }
 
+      const verdictCtx: VerdictContext | undefined = ctx.events
+        ? { events: ctx.events, agent: "a" }
+        : undefined;
+
       let result = mapResponseToResult(
         checkResult.responseText,
         undefined,
         IMPLEMENT_CHECK_KEYWORDS,
+        verdictCtx,
       );
 
       // Internal clarification retry (same pattern as stage 4 / stage 8).
@@ -135,7 +141,7 @@ export function createImplementStageHandler(
           checkResult.responseText,
           IMPLEMENT_CHECK_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt);
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId ?? implResult.sessionId,
@@ -154,6 +160,7 @@ export function createImplementStageHandler(
           retryResult.responseText,
           undefined,
           IMPLEMENT_CHECK_KEYWORDS,
+          verdictCtx,
         );
       }
 

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -54,6 +54,7 @@ import {
   type StreamSink,
   sendFollowUp,
   type UsageSink,
+  type VerdictContext,
 } from "./stage-util.js";
 import {
   buildClarificationPrompt,
@@ -434,16 +435,6 @@ export function buildResumeVerdictPrompt(
   ].join("\n");
 }
 
-/**
- * Check whether the response is exactly the PR_FINALIZED keyword.
- * Uses the strict verdict parser to reject extra commentary.
- */
-function hasFinalizationKeyword(text: string): boolean {
-  return (
-    parseVerdictKeyword(text, PR_FINALIZATION_KEYWORDS).keyword !== undefined
-  );
-}
-
 // ---- handler -----------------------------------------------------------------
 
 export function createReviewStageHandler(
@@ -497,7 +488,7 @@ export function createReviewStageHandler(
       if (currentStep === "review") {
         opts.onReviewProgress?.("review");
         const reviewPrompt = buildReviewPrompt(ctx, opts, round);
-        ctx.promptSinks?.b?.(reviewPrompt);
+        ctx.promptSinks?.b?.(reviewPrompt, "work");
         const reviewResult = await invokeOrResume(
           opts.agentB,
           ctx.savedAgentBSessionId,
@@ -539,7 +530,7 @@ export function createReviewStageHandler(
         if (agentBSessionId) {
           // Follow-up on review session (normal flow).
           const verdictPrompt = buildReviewVerdictPrompt();
-          ctx.promptSinks?.b?.(verdictPrompt);
+          ctx.promptSinks?.b?.(verdictPrompt, "verdict-followup");
           verdictResult = await sendFollowUp(
             opts.agentB,
             agentBSessionId,
@@ -566,7 +557,7 @@ export function createReviewStageHandler(
           // Invoke Agent B fresh to read its own review and provide
           // the verdict keyword.
           const resumePrompt = buildResumeVerdictPrompt(ctx, round);
-          ctx.promptSinks?.b?.(resumePrompt);
+          ctx.promptSinks?.b?.(resumePrompt, "verdict-followup");
           verdictResult = await invokeOrResume(
             opts.agentB,
             undefined,
@@ -589,6 +580,13 @@ export function createReviewStageHandler(
           verdictResult.responseText,
           REVIEW_VERDICT_KEYWORDS,
         );
+        if (reviewVerdict.keyword !== undefined) {
+          ctx.events?.emit("pipeline:verdict", {
+            agent: "b",
+            keyword: reviewVerdict.keyword,
+            raw: verdictResult.responseText,
+          });
+        }
 
         // Clarification retry if ambiguous, extra commentary, or
         // multiple valid keywords.
@@ -597,7 +595,7 @@ export function createReviewStageHandler(
             verdictResult.responseText,
             REVIEW_VERDICT_KEYWORDS,
           );
-          ctx.promptSinks?.b?.(clarifyPrompt);
+          ctx.promptSinks?.b?.(clarifyPrompt, "verdict-followup");
           const clarifySessionId = verdictResult.sessionId ?? agentBSessionId;
           let retryResult: AgentResult;
           if (clarifySessionId) {
@@ -636,6 +634,13 @@ export function createReviewStageHandler(
             verdictResult.responseText,
             REVIEW_VERDICT_KEYWORDS,
           );
+          if (reviewVerdict.keyword !== undefined) {
+            ctx.events?.emit("pipeline:verdict", {
+              agent: "b",
+              keyword: reviewVerdict.keyword,
+              raw: verdictResult.responseText,
+            });
+          }
         }
 
         // Post review verdict as a PR comment so it can be recovered.
@@ -731,7 +736,7 @@ export function createReviewStageHandler(
         // PR finalization: Agent A verifies issue reference and
         // "Not addressed" section before the pipeline advances.
         const finalizePrompt = buildPrFinalizationPrompt(ctx, opts);
-        ctx.promptSinks?.a?.(finalizePrompt);
+        ctx.promptSinks?.a?.(finalizePrompt, "work");
         const finalizeResult = await invokeOrResume(
           opts.agentA,
           ctx.savedAgentASessionId,
@@ -752,7 +757,7 @@ export function createReviewStageHandler(
 
         // Verdict follow-up: ask A for exactly PR_FINALIZED.
         const finalVerdictPrompt = buildPrFinalizationVerdictPrompt();
-        ctx.promptSinks?.a?.(finalVerdictPrompt);
+        ctx.promptSinks?.a?.(finalVerdictPrompt, "verdict-followup");
         let finalVerdictResult = await sendFollowUp(
           opts.agentA,
           finalizeResult.sessionId,
@@ -770,13 +775,25 @@ export function createReviewStageHandler(
           );
         }
 
-        if (!hasFinalizationKeyword(finalVerdictResult.responseText)) {
+        let finalKeyword = parseVerdictKeyword(
+          finalVerdictResult.responseText,
+          PR_FINALIZATION_KEYWORDS,
+        );
+        if (finalKeyword.keyword !== undefined) {
+          ctx.events?.emit("pipeline:verdict", {
+            agent: "a",
+            keyword: finalKeyword.keyword,
+            raw: finalVerdictResult.responseText,
+          });
+        }
+
+        if (finalKeyword.keyword === undefined) {
           // Clarification retry.
           const clarifyPrompt = buildClarificationPrompt(
             finalVerdictResult.responseText,
             PR_FINALIZATION_KEYWORDS,
           );
-          ctx.promptSinks?.a?.(clarifyPrompt);
+          ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
           const retryResult = await sendFollowUp(
             opts.agentA,
             finalVerdictResult.sessionId ?? finalizeResult.sessionId,
@@ -795,6 +812,17 @@ export function createReviewStageHandler(
           }
 
           finalVerdictResult = retryResult;
+          finalKeyword = parseVerdictKeyword(
+            finalVerdictResult.responseText,
+            PR_FINALIZATION_KEYWORDS,
+          );
+          if (finalKeyword.keyword !== undefined) {
+            ctx.events?.emit("pipeline:verdict", {
+              agent: "a",
+              keyword: finalKeyword.keyword,
+              raw: finalVerdictResult.responseText,
+            });
+          }
         }
 
         // If the keyword is still missing after the in-session retry,
@@ -809,7 +837,7 @@ export function createReviewStageHandler(
         // with the expected companion state:
         //   - Closes #N  → no "## Not addressed" (contradictory otherwise)
         //   - Part of #N → "## Not addressed" must be present
-        if (!hasFinalizationKeyword(finalVerdictResult.responseText)) {
+        if (finalKeyword.keyword === undefined) {
           const getPrBody = opts.getPrBody ?? defaultGetPrBody;
           const body = getPrBody(ctx.owner, ctx.repo, ctx.branch);
 
@@ -849,7 +877,7 @@ export function createReviewStageHandler(
         opts.onReviewProgress?.("author_fix", "NOT_APPROVED");
 
         const fixPrompt = buildAuthorFixPrompt(ctx, opts, round);
-        ctx.promptSinks?.a?.(fixPrompt);
+        ctx.promptSinks?.a?.(fixPrompt, "work");
         const fixResult = await invokeOrResume(
           opts.agentA,
           ctx.savedAgentASessionId,
@@ -871,7 +899,7 @@ export function createReviewStageHandler(
         // Completion check on Agent A (with clarification retry,
         // same pattern as stage 4 / stage 8).
         const authorCheckPrompt = buildAuthorCompletionCheckPrompt();
-        ctx.promptSinks?.a?.(authorCheckPrompt);
+        ctx.promptSinks?.a?.(authorCheckPrompt, "verdict-followup");
         let checkResult = await sendFollowUp(
           opts.agentA,
           fixResult.sessionId,
@@ -886,10 +914,15 @@ export function createReviewStageHandler(
           return mapAgentError(checkResult, "during author completion check");
         }
 
+        const authorVerdictCtx: VerdictContext | undefined = ctx.events
+          ? { events: ctx.events, agent: "a" }
+          : undefined;
+
         let checkMapped = mapResponseToResult(
           checkResult.responseText,
           undefined,
           AUTHOR_CHECK_KEYWORDS,
+          authorVerdictCtx,
         );
 
         if (checkMapped.outcome === "needs_clarification") {
@@ -897,7 +930,7 @@ export function createReviewStageHandler(
             checkResult.responseText,
             AUTHOR_CHECK_KEYWORDS,
           );
-          ctx.promptSinks?.a?.(retryPrompt);
+          ctx.promptSinks?.a?.(retryPrompt, "verdict-followup");
           const retryResult = await sendFollowUp(
             opts.agentA,
             checkResult.sessionId ?? fixResult.sessionId,
@@ -920,6 +953,7 @@ export function createReviewStageHandler(
             checkResult.responseText,
             undefined,
             AUTHOR_CHECK_KEYWORDS,
+            authorVerdictCtx,
           );
         }
 
@@ -1030,7 +1064,7 @@ async function handleUnresolvedSummary(
   const summaryPrompt = sessionId
     ? buildUnresolvedSummaryPrompt(round)
     : buildResumeUnresolvedSummaryPrompt(ctx, round);
-  promptSink?.(summaryPrompt);
+  promptSink?.(summaryPrompt, "summary");
 
   // If we have a session, resume; otherwise invoke fresh.
   let result: AgentResult;
@@ -1065,7 +1099,7 @@ async function handleUnresolvedSummary(
 
   // Verdict follow-up: ask for exactly NONE or COMPLETED.
   const verdictPrompt = buildUnresolvedVerdictPrompt();
-  promptSink?.(verdictPrompt);
+  promptSink?.(verdictPrompt, "verdict-followup");
   let verdictResult: AgentResult;
   const verdictSessionId = result.sessionId ?? sessionId;
 
@@ -1101,6 +1135,13 @@ async function handleUnresolvedSummary(
     verdictResult.responseText,
     UNRESOLVED_KEYWORDS,
   );
+  if (verdict.keyword !== undefined) {
+    ctx.events?.emit("pipeline:verdict", {
+      agent: "b",
+      keyword: verdict.keyword,
+      raw: verdictResult.responseText,
+    });
+  }
 
   // Clarification retry if the verdict is ambiguous or out-of-scope.
   if (verdict.keyword === undefined) {
@@ -1108,7 +1149,7 @@ async function handleUnresolvedSummary(
       verdictResult.responseText,
       UNRESOLVED_KEYWORDS,
     );
-    promptSink?.(clarifyPrompt);
+    promptSink?.(clarifyPrompt, "verdict-followup");
 
     const verdictSessionId2 = verdictResult.sessionId ?? sessionId;
     let retryResult: AgentResult;
@@ -1147,6 +1188,13 @@ async function handleUnresolvedSummary(
       retryResult.responseText,
       UNRESOLVED_KEYWORDS,
     );
+    if (verdict.keyword !== undefined) {
+      ctx.events?.emit("pipeline:verdict", {
+        agent: "b",
+        keyword: verdict.keyword,
+        raw: retryResult.responseText,
+      });
+    }
   }
 
   if (verdict.keyword?.toUpperCase() === "NONE") {

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -29,6 +29,7 @@ import {
   mapAgentError,
   mapFixOrDoneResponse,
   sendFollowUp,
+  type VerdictContext,
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
@@ -137,7 +138,7 @@ export function createSelfCheckStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send self-check prompt (resume if saved session).
       const checkPrompt = buildSelfCheckPrompt(ctx, opts);
-      ctx.promptSinks?.a?.(checkPrompt);
+      ctx.promptSinks?.a?.(checkPrompt, "work");
       const checkResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -158,7 +159,7 @@ export function createSelfCheckStageHandler(
 
       // Step 2: Send fix-or-done work prompt (resume the same session).
       const fixPrompt = buildFixOrDonePrompt();
-      ctx.promptSinks?.a?.(fixPrompt);
+      ctx.promptSinks?.a?.(fixPrompt, "work");
       const fixResult = await sendFollowUp(
         opts.agent,
         checkResult.sessionId,
@@ -175,7 +176,7 @@ export function createSelfCheckStageHandler(
 
       // Step 3: Verdict follow-up — ask for exactly FIXED or DONE.
       const verdictPrompt = buildFixOrDoneVerdictPrompt();
-      ctx.promptSinks?.a?.(verdictPrompt);
+      ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup");
       const verdictResult = await sendFollowUp(
         opts.agent,
         fixResult.sessionId,
@@ -190,10 +191,15 @@ export function createSelfCheckStageHandler(
         return mapAgentError(verdictResult, "during fix verdict");
       }
 
+      const verdictCtx: VerdictContext | undefined = ctx.events
+        ? { events: ctx.events, agent: "a" }
+        : undefined;
+
       let verdictCheckResult = verdictResult;
       let result = mapFixOrDoneResponse(
         verdictCheckResult.responseText,
         FIX_OR_DONE_KEYWORDS,
+        verdictCtx,
       );
 
       // Internal clarification retry (same pattern as other stages).
@@ -202,7 +208,7 @@ export function createSelfCheckStageHandler(
           verdictCheckResult.responseText,
           FIX_OR_DONE_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt);
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
         const retryResult = await sendFollowUp(
           opts.agent,
           verdictCheckResult.sessionId ?? fixResult.sessionId,
@@ -221,6 +227,7 @@ export function createSelfCheckStageHandler(
         result = mapFixOrDoneResponse(
           verdictCheckResult.responseText,
           FIX_OR_DONE_KEYWORDS,
+          verdictCtx,
         );
       }
 
@@ -237,7 +244,7 @@ export function createSelfCheckStageHandler(
       if (result.outcome === "completed" && verdictCheckResult.sessionId) {
         try {
           const syncPrompt = buildIssueSyncPrompt(ctx, opts);
-          ctx.promptSinks?.a?.(syncPrompt);
+          ctx.promptSinks?.a?.(syncPrompt, "work");
           const syncResult = await sendFollowUp(
             opts.agent,
             verdictCheckResult.sessionId,
@@ -251,7 +258,7 @@ export function createSelfCheckStageHandler(
           if (syncResult.status === "success") {
             // Verdict follow-up: ask for sync status report.
             const syncVerdictPrompt = buildIssueSyncVerdictPrompt();
-            ctx.promptSinks?.a?.(syncVerdictPrompt);
+            ctx.promptSinks?.a?.(syncVerdictPrompt, "verdict-followup");
             const syncVerdictResult = await sendFollowUp(
               opts.agent,
               syncResult.sessionId ?? verdictCheckResult.sessionId,
@@ -270,7 +277,7 @@ export function createSelfCheckStageHandler(
               // Clarification retry if the response was malformed.
               if (!parseResult.valid) {
                 const clarifyPrompt = buildIssueSyncClarificationPrompt();
-                ctx.promptSinks?.a?.(clarifyPrompt);
+                ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
                 const retryResult = await sendFollowUp(
                   opts.agent,
                   syncVerdictResult.sessionId ??

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -27,6 +27,7 @@ import {
   mapAgentError,
   mapResponseToResult,
   sendFollowUp,
+  type VerdictContext,
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 import { countBranchCommits as defaultCountBranchCommits } from "./worktree.js";
@@ -145,7 +146,7 @@ export function createSquashStageHandler(
 
       // Step 1: Send the squash prompt (resume if saved session).
       const prompt = buildSquashPrompt(ctx, opts);
-      ctx.promptSinks?.a?.(prompt);
+      ctx.promptSinks?.a?.(prompt, "work");
       const squashResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -167,7 +168,7 @@ export function createSquashStageHandler(
       // Step 2: Completion check (same internal-clarification pattern as
       // stage 4).
       const squashCheckPrompt = buildSquashCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(squashCheckPrompt);
+      ctx.promptSinks?.a?.(squashCheckPrompt, "verdict-followup");
       let checkResult = await sendFollowUp(
         opts.agent,
         squashResult.sessionId,
@@ -182,10 +183,15 @@ export function createSquashStageHandler(
         return mapAgentError(checkResult, "during squash completion check");
       }
 
+      const verdictCtx: VerdictContext | undefined = ctx.events
+        ? { events: ctx.events, agent: "a" }
+        : undefined;
+
       let result = mapResponseToResult(
         checkResult.responseText,
         undefined,
         SQUASH_CHECK_KEYWORDS,
+        verdictCtx,
       );
 
       if (result.outcome === "needs_clarification") {
@@ -193,7 +199,7 @@ export function createSquashStageHandler(
           checkResult.responseText,
           SQUASH_CHECK_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt);
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId ?? squashResult.sessionId,
@@ -216,6 +222,7 @@ export function createSquashStageHandler(
           checkResult.responseText,
           undefined,
           SQUASH_CHECK_KEYWORDS,
+          verdictCtx,
         );
       }
 

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -22,6 +22,7 @@ import {
   mapAgentError,
   mapFixOrDoneResponse,
   sendFollowUp,
+  type VerdictContext,
 } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
 
@@ -127,7 +128,7 @@ export function createTestPlanStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send verification prompt (resume if saved session).
       const verifyPrompt = buildTestPlanVerifyPrompt(ctx, opts);
-      ctx.promptSinks?.a?.(verifyPrompt);
+      ctx.promptSinks?.a?.(verifyPrompt, "work");
       const verifyResult = await invokeOrResume(
         opts.agent,
         ctx.savedAgentASessionId,
@@ -148,7 +149,7 @@ export function createTestPlanStageHandler(
 
       // Step 2: Send self-check work prompt (resume the same session).
       const selfCheckPrompt = buildTestPlanSelfCheckPrompt();
-      ctx.promptSinks?.a?.(selfCheckPrompt);
+      ctx.promptSinks?.a?.(selfCheckPrompt, "work");
       const checkResult = await sendFollowUp(
         opts.agent,
         verifyResult.sessionId,
@@ -165,7 +166,7 @@ export function createTestPlanStageHandler(
 
       // Step 3: Verdict follow-up — ask for exactly FIXED or DONE.
       const verdictPrompt = buildTestPlanVerdictPrompt();
-      ctx.promptSinks?.a?.(verdictPrompt);
+      ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup");
       const verdictResult = await sendFollowUp(
         opts.agent,
         checkResult.sessionId,
@@ -180,9 +181,14 @@ export function createTestPlanStageHandler(
         return mapAgentError(verdictResult, "during test plan verdict");
       }
 
+      const verdictCtx: VerdictContext | undefined = ctx.events
+        ? { events: ctx.events, agent: "a" }
+        : undefined;
+
       let result = mapFixOrDoneResponse(
         verdictResult.responseText,
         TEST_PLAN_VERDICT_KEYWORDS,
+        verdictCtx,
       );
 
       // Internal clarification retry (same pattern as other stages).
@@ -191,7 +197,7 @@ export function createTestPlanStageHandler(
           verdictResult.responseText,
           TEST_PLAN_VERDICT_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt);
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
         const retryResult = await sendFollowUp(
           opts.agent,
           verdictResult.sessionId ?? checkResult.sessionId,
@@ -212,6 +218,7 @@ export function createTestPlanStageHandler(
         result = mapFixOrDoneResponse(
           retryResult.responseText,
           TEST_PLAN_VERDICT_KEYWORDS,
+          verdictCtx,
         );
       }
 

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
+import { PipelineEventEmitter } from "./pipeline-events.js";
 import {
   buildDocConsistencyInstructions,
   invokeOrResume,
@@ -8,6 +9,7 @@ import {
   mapParsedStepToResult,
   mapResponseToResult,
   sendFollowUp,
+  type VerdictContext,
 } from "./stage-util.js";
 
 afterEach(() => {
@@ -453,6 +455,42 @@ describe("mapResponseToResult", () => {
     ]);
     expect(result.outcome).toBe("completed");
   });
+
+  test("emits pipeline:verdict when verdictCtx is provided", () => {
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+    const ctx: VerdictContext = { events, agent: "a" };
+
+    mapResponseToResult("COMPLETED", undefined, ["COMPLETED", "BLOCKED"], ctx);
+
+    expect(handler).toHaveBeenCalledWith({
+      agent: "a",
+      keyword: "COMPLETED",
+      raw: "COMPLETED",
+    });
+  });
+
+  test("does not emit pipeline:verdict without verdictCtx", () => {
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+
+    mapResponseToResult("COMPLETED", undefined, ["COMPLETED", "BLOCKED"]);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("does not emit pipeline:verdict when keyword is not parsed", () => {
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+    const ctx: VerdictContext = { events, agent: "a" };
+
+    mapResponseToResult("I did some work.", undefined, ["COMPLETED"], ctx);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
 });
 
 // ---- mapFixOrDoneResponse ---------------------------------------------------
@@ -557,6 +595,42 @@ describe("mapFixOrDoneResponse", () => {
       "DONE",
     ]);
     expect(result.outcome).toBe("needs_clarification");
+  });
+
+  test("emits pipeline:verdict when verdictCtx is provided", () => {
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+    const ctx: VerdictContext = { events, agent: "b" };
+
+    mapFixOrDoneResponse("FIXED", ["FIXED", "DONE"], ctx);
+
+    expect(handler).toHaveBeenCalledWith({
+      agent: "b",
+      keyword: "FIXED",
+      raw: "FIXED",
+    });
+  });
+
+  test("does not emit pipeline:verdict without verdictCtx", () => {
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+
+    mapFixOrDoneResponse("FIXED", ["FIXED", "DONE"]);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  test("does not emit pipeline:verdict when keyword is not parsed", () => {
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+    const ctx: VerdictContext = { events, agent: "a" };
+
+    mapFixOrDoneResponse("I looked at things.", ["FIXED", "DONE"], ctx);
+
+    expect(handler).not.toHaveBeenCalled();
   });
 });
 

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -11,6 +11,10 @@ import type {
 } from "./agent.js";
 import { t } from "./i18n/index.js";
 import type { StageOutcome, StageResult } from "./pipeline.js";
+import type {
+  AgentPromptKind,
+  PipelineEventEmitter,
+} from "./pipeline-events.js";
 import {
   type ParsedStep,
   parseStepStatus,
@@ -25,8 +29,11 @@ export type StreamSink = (chunk: string) => void;
 /**
  * Callback that receives the full prompt text before it is sent to the agent.
  * Used by the UI to display outgoing prompts in the agent's pane.
+ *
+ * The optional `kind` parameter classifies the prompt type so that
+ * diagnostic consumers can distinguish prompts without inspecting text.
  */
-export type PromptSink = (prompt: string) => void;
+export type PromptSink = (prompt: string, kind: AgentPromptKind) => void;
 
 /**
  * Callback that receives token usage data after an agent invocation completes.
@@ -364,6 +371,12 @@ export async function sendFollowUp(
   );
 }
 
+/** Context for emitting `pipeline:verdict` events from utility helpers. */
+export interface VerdictContext {
+  events: PipelineEventEmitter;
+  agent: "a" | "b";
+}
+
 /**
  * Convenience: parse response text and convert to a `StageResult` in one
  * call.
@@ -373,11 +386,15 @@ export async function sendFollowUp(
  * commentary.  Responses with multiple valid keywords, out-of-scope
  * keywords, or significant extra text are rejected as
  * `needs_clarification`.
+ *
+ * When `verdictCtx` is supplied, a `pipeline:verdict` event is emitted
+ * after a keyword is successfully parsed.
  */
 export function mapResponseToResult(
   responseText: string,
   overrides?: Partial<Record<ParsedStep["status"], StageOutcome>>,
   validKeywords?: readonly string[],
+  verdictCtx?: VerdictContext,
 ): StageResult {
   if (validKeywords && validKeywords.length > 0) {
     const verdict = parseVerdictKeyword(responseText, validKeywords);
@@ -388,6 +405,11 @@ export function mapResponseToResult(
         validVerdicts: validKeywords,
       };
     }
+    verdictCtx?.events.emit("pipeline:verdict", {
+      agent: verdictCtx.agent,
+      keyword: verdict.keyword,
+      raw: responseText,
+    });
     // Feed the matched keyword through parseStepStatus for status mapping.
     return mapParsedStepToResult(
       parseStepStatus(verdict.keyword),
@@ -455,10 +477,14 @@ export function buildDocConsistencyInstructions(indent = ""): string {
  * When `validKeywords` is provided, the strict verdict parser is used:
  * the response must contain exactly one valid keyword with no extra
  * commentary.
+ *
+ * When `verdictCtx` is supplied, a `pipeline:verdict` event is emitted
+ * after a keyword is successfully parsed.
  */
 export function mapFixOrDoneResponse(
   responseText: string,
   validKeywords?: readonly string[],
+  verdictCtx?: VerdictContext,
 ): StageResult {
   if (validKeywords && validKeywords.length > 0) {
     const verdict = parseVerdictKeyword(responseText, validKeywords);
@@ -469,6 +495,11 @@ export function mapFixOrDoneResponse(
         validVerdicts: validKeywords,
       };
     }
+    verdictCtx?.events.emit("pipeline:verdict", {
+      agent: verdictCtx.agent,
+      keyword: verdict.keyword,
+      raw: responseText,
+    });
     // Feed the matched keyword through parseStepStatus for status mapping.
     const parsed = parseStepStatus(verdict.keyword);
     if (parsed.status === "fixed" && parsed.keyword === "FIXED") {

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1837,6 +1837,7 @@ describe("viewport height constraint", () => {
         "Investigate the overflow in the real app layout.",
         "Keep the prompt block visible and clipped to the pane viewport.",
       ].join("\n"),
+      kind: "work",
     });
     await new Promise((r) => setTimeout(r, 50));
 
@@ -3080,7 +3081,11 @@ describe("AgentPane size-aware rendering", () => {
       </Box>,
     );
 
-    emitter.emit("agent:prompt", { agent: "a", prompt: "Do the task" });
+    emitter.emit("agent:prompt", {
+      agent: "a",
+      prompt: "Do the task",
+      kind: "work",
+    });
     await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame() ?? "";
@@ -3106,7 +3111,7 @@ describe("AgentPane size-aware rendering", () => {
       </Box>,
     );
 
-    emitter.emit("agent:prompt", { agent: "a", prompt: "hi" });
+    emitter.emit("agent:prompt", { agent: "a", prompt: "hi", kind: "work" });
     await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame() ?? "";

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -200,7 +200,7 @@ describe("agent:prompt integration with line accumulator", () => {
       stageName: "Implement",
       iteration: 0,
     });
-    emitter.emit("agent:prompt", { agent: "a", prompt: "hello" });
+    emitter.emit("agent:prompt", { agent: "a", prompt: "hello", kind: "work" });
 
     const lines = acc.getLines();
     expect(lines[0]).toBe("output");
@@ -220,7 +220,11 @@ describe("agent:prompt integration with line accumulator", () => {
     emitter.emit("agent:chunk", { agent: "a", chunk: "partial" });
     expect(acc.getBuffer()).toBe("partial");
 
-    emitter.emit("agent:prompt", { agent: "a", prompt: "question" });
+    emitter.emit("agent:prompt", {
+      agent: "a",
+      prompt: "question",
+      kind: "work",
+    });
 
     const lines = acc.getLines();
     expect(lines[0]).toBe("partial");
@@ -238,7 +242,7 @@ describe("agent:prompt integration with line accumulator", () => {
     const emitter = new PipelineEventEmitter();
     const acc = createLineAccumulator(emitter, "a");
 
-    emitter.emit("agent:prompt", { agent: "a", prompt: "hi" });
+    emitter.emit("agent:prompt", { agent: "a", prompt: "hi", kind: "work" });
 
     const lines = acc.getLines();
     expect(lines[0]).toEqual({
@@ -254,7 +258,11 @@ describe("agent:prompt integration with line accumulator", () => {
     const emitter = new PipelineEventEmitter();
     const acc = createLineAccumulator(emitter, "a");
 
-    emitter.emit("agent:prompt", { agent: "b", prompt: "not mine" });
+    emitter.emit("agent:prompt", {
+      agent: "b",
+      prompt: "not mine",
+      kind: "work",
+    });
 
     expect(acc.getLines()).toEqual([]);
 


### PR DESCRIPTION
## Summary

- Add three new event types to `PipelineEventMap`: `pipeline:verdict`, `pipeline:loop`, and `pipeline:ci-poll` with typed payloads and JSDoc documentation.
- Add `AgentPromptKind` type and required `kind` field to `AgentPromptEvent` to classify prompts (`"work"`, `"verdict-followup"`, `"ci-fix"`, `"summary"`). All prompt call sites across every stage handler are annotated.
- Emit `pipeline:verdict` at every `parseVerdictKeyword()` call site — both through the `stage-util.ts` helpers (`mapResponseToResult`, `mapFixOrDoneResponse`) and at direct calls in `rebase.ts` and `stage-review.ts`.
- Emit `pipeline:loop` in both the per-stage auto-loop and the restart path in `pipeline.ts`.
- Emit `pipeline:ci-poll` from inside the `waitForCi` polling loop (on each status check result), plus at start and done phases. Each `start` gets exactly one matching `done` immediately after `waitForCi()` completes — regardless of what happens next (timeout, clean pass, findings review, or fix loop). `pollCiAndFix` falls back to `ctx.events` when no explicit emitter is provided, so production callers get CI-poll events automatically.
- Add `events` field to `StageContext` so stage handlers can emit diagnostic events directly.

No user-visible behavior change — this is pure diagnostic infrastructure.

Closes #198

## Test plan

- [x] All new event types are typed in `PipelineEventMap` with JSDoc
- [x] `AgentPromptEvent.kind` is required and annotated at all prompt call sites
- [x] `pipeline:verdict` emitted after every `parseVerdictKeyword()` call — helpers and direct
- [x] `pipeline:loop` emitted in per-stage loop and restart path
- [x] `pipeline:ci-poll` start/status/done lifecycle events match 1:1 per polling round
- [x] `pollCiAndFix` falls back to `ctx.events` (covered by dedicated test)
- [x] `StageContext.events` field added for stage-handler-level event emission
- [x] Existing tests pass (`pnpm vitest run` — 1616 tests, 0 failures)
- [x] Type check passes (`pnpm tsc --noEmit`)
- [x] Lint passes (`pnpm biome check`)