### PR TITLE
Harden Dependabot config against unwanted major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,11 @@ updates:
           - version-update:semver-major
         versions:
           - ">= 25"
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+        versions:
+          - ">= 6"
 
   - package-ecosystem: github-actions
     directory: /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24
@@ -46,7 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - name: Enable corepack
+        run: corepack enable pnpm
       - uses: actions/setup-node@v6
         with:
           node-version: 24


### PR DESCRIPTION
## Summary

- Replace `pnpm/action-setup@v5` with corepack in `.github/workflows/ci.yml` so a bump to v6 cannot break CI via the npm-installed pnpm + `actions/setup-node` lockfile-rewrite interaction.
- Add a Dependabot `ignore` rule for `typescript` major versions in `.github/dependabot.yml` so TypeScript 6 bump PRs stop being opened.

Closes #225.

## Test plan

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] CI workflow succeeds on this PR (verifies corepack path works)