### PR TITLE
Add persistent run log file (#199)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ import {
   reconcileWithPr,
 } from "./pr-comments.js";
 import { createRebaseHandler } from "./rebase.js";
+import { createRunLog, type RunLogWriter } from "./run-log.js";
 import {
   deleteRunState,
   loadRunState,
@@ -641,6 +642,31 @@ try {
     }
   });
 
+  // Persistent run log for post-mortem debugging.
+  const runLog: RunLogWriter = createRunLog(emitter, {
+    owner,
+    repo,
+    issueNumber,
+    worktreePath: wt.path,
+    executionMode,
+    agentA: {
+      cli: agentAConfig.cli,
+      model: agentAConfig.model,
+      contextWindow: agentAConfig.contextWindow,
+      effortLevel: agentAConfig.effortLevel,
+    },
+    agentB: {
+      cli: agentBConfig.cli,
+      model: agentBConfig.model,
+      contextWindow: agentBConfig.contextWindow,
+      effortLevel: agentBConfig.effortLevel,
+    },
+    selfCheckAutoIterations: pipelineSettings.selfCheckAutoIterations,
+    reviewAutoRounds: pipelineSettings.reviewAutoRounds,
+    inactivityTimeoutMinutes: pipelineSettings.inactivityTimeoutMinutes,
+    autoResumeAttempts: pipelineSettings.autoResumeAttempts,
+  });
+
   const doneStage = createDoneStageHandler({
     events: emitter,
     checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
@@ -804,7 +830,8 @@ try {
     const { unmount } = renderApp({
       emitter,
       pipelineOptions: pipelineOpts,
-      onExit: (result: PipelineResult) => {
+      onExit: async (result: PipelineResult) => {
+        await runLog.close();
         unmount();
         resolve(result);
       },

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -28,6 +28,8 @@ export interface ReviewPostedEvent {
 export interface AgentInvokeEvent {
   agent: "a" | "b";
   type: "invoke" | "resume";
+  /** Type of prompt being sent (when available). */
+  promptKind?: AgentPromptKind;
 }
 
 /**

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -632,14 +632,22 @@ async function runStage(
           prompt: string,
           kind: import("./pipeline-events.js").AgentPromptKind,
         ) => {
-          events.emit("agent:invoke", { agent: "a", type: "invoke" });
+          events.emit("agent:invoke", {
+            agent: "a",
+            type: "invoke",
+            promptKind: kind,
+          });
           events.emit("agent:prompt", { agent: "a", prompt, kind });
         },
         b: (
           prompt: string,
           kind: import("./pipeline-events.js").AgentPromptKind,
         ) => {
-          events.emit("agent:invoke", { agent: "b", type: "invoke" });
+          events.emit("agent:invoke", {
+            agent: "b",
+            type: "invoke",
+            promptKind: kind,
+          });
           events.emit("agent:prompt", { agent: "b", prompt, kind });
         },
       }

--- a/src/run-log.test.ts
+++ b/src/run-log.test.ts
@@ -1,0 +1,414 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  type WriteStream,
+} from "node:fs";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { PipelineEventEmitter } from "./pipeline-events.js";
+import { createRunLog, logFilePath, type RunLogMetadata } from "./run-log.js";
+
+// Redirect homedir() to a temp directory so tests don't pollute the
+// user's home.  vi.hoisted runs before imports, so we use require.
+const { TEST_HOME, streamControl } = vi.hoisted(() => {
+  const os = require("node:os");
+  const path = require("node:path");
+  return {
+    TEST_HOME: path.join(os.tmpdir(), `agentcoop-run-log-test-${process.pid}`),
+    /** Captures created WriteStreams so tests can manipulate them. */
+    streamControl: { streams: [] as WriteStream[] },
+  };
+});
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    homedir: () => TEST_HOME,
+  };
+});
+
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    createWriteStream: (
+      ...args: Parameters<typeof actual.createWriteStream>
+    ) => {
+      const stream = (actual.createWriteStream as (...a: never) => unknown)(
+        ...args,
+      );
+      streamControl.streams.push(stream as WriteStream);
+      return stream;
+    },
+  };
+});
+
+function meta(overrides?: Partial<RunLogMetadata>): RunLogMetadata {
+  return {
+    owner: "acme",
+    repo: "widget",
+    issueNumber: 42,
+    worktreePath: "/tmp/wt",
+    executionMode: "auto",
+    agentA: {
+      cli: "claude",
+      model: "opus",
+      contextWindow: "200k",
+      effortLevel: "high",
+    },
+    agentB: { cli: "claude", model: "sonnet" },
+    selfCheckAutoIterations: 5,
+    reviewAutoRounds: 5,
+    inactivityTimeoutMinutes: 20,
+    autoResumeAttempts: 3,
+    ...overrides,
+  };
+}
+
+describe("logFilePath", () => {
+  test("produces expected file name", () => {
+    const date = new Date("2026-03-15T09:05:07.000Z");
+    const p = logFilePath("acme", "widget", 42, date);
+    expect(p).toContain("acme-widget-#42-");
+    expect(p).toMatch(/\.log$/);
+  });
+});
+
+describe("createRunLog", () => {
+  beforeEach(() => {
+    mkdirSync(TEST_HOME, { recursive: true });
+  });
+
+  afterEach(() => {
+    streamControl.streams = [];
+    rmSync(TEST_HOME, { recursive: true, force: true });
+  });
+
+  function readLog(path: string): string {
+    return readFileSync(path, "utf-8");
+  }
+
+  test("creates log file with header", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+    await log.close();
+
+    expect(existsSync(log.path)).toBe(true);
+    const content = readLog(log.path);
+    expect(content).toContain("=== AgentCoop Run Log ===");
+    expect(content).toContain("acme/widget");
+    expect(content).toContain("#42");
+    expect(content).toContain("claude / opus");
+    expect(content).toContain("context  : 200k");
+    expect(content).toContain("effort   : high");
+    expect(content).toContain("claude / sonnet");
+    expect(content).toContain("self-check=5");
+    expect(content).toContain("review=5");
+    expect(content).toContain("inactivity=20m");
+    expect(content).toContain("autoResume=3");
+    expect(content).toContain("auto");
+  });
+
+  test("logs agent:chunk events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "hello world" });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("[Agent A] hello world");
+  });
+
+  test("logs agent:prompt events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("agent:prompt", {
+      agent: "b",
+      prompt: "Fix the bug",
+      kind: "ci-fix",
+    });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("[Agent B:prompt] --- prompt start (ci-fix) ---");
+    expect(content).toContain("[Agent B:prompt] Fix the bug");
+    expect(content).toContain("[Agent B:prompt] --- prompt end ---");
+  });
+
+  test("logs agent:invoke events with prompt kind and stage context", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    // "work" before any stage:enter — falls back to generic "work".
+    emitter.emit("agent:invoke", {
+      agent: "a",
+      type: "invoke",
+      promptKind: "work",
+    });
+
+    // Enter a stage so subsequent "work" prompts include stage context.
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+
+    emitter.emit("agent:invoke", {
+      agent: "b",
+      type: "invoke",
+      promptKind: "work",
+    });
+    emitter.emit("agent:invoke", {
+      agent: "a",
+      type: "invoke",
+      promptKind: "ci-fix",
+    });
+    emitter.emit("agent:invoke", { agent: "b", type: "invoke" });
+    await log.close();
+
+    const content = readLog(log.path);
+    // Before stage:enter, "work" has no stage context.
+    expect(content).toContain("[Pipeline] Invoking Agent A (work)");
+    // After stage:enter, "work" includes stage name.
+    expect(content).toContain("[Pipeline] Invoking Agent B (work: Implement)");
+    // Non-work kinds are unchanged.
+    expect(content).toContain("[Pipeline] Invoking Agent A (ci-fix)");
+    // Without promptKind, no parenthetical suffix.
+    expect(content).toMatch(/Invoking Agent B\n/);
+  });
+
+  test("logs stage:enter and stage:exit events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    emitter.emit("stage:exit", { stageNumber: 2, outcome: "completed" });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain(
+      "[Pipeline] Stage 2 (Implement) → enter (iteration 0)",
+    );
+    expect(content).toContain(
+      "[Pipeline] Stage 2 (Implement) → exit (completed)",
+    );
+  });
+
+  test("logs pipeline:verdict events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("pipeline:verdict", {
+      agent: "a",
+      keyword: "APPROVED",
+      raw: "Looks good.\n\nAPPROVED",
+    });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain(
+      '[Pipeline] Agent A verdict parsed as "APPROVED"',
+    );
+  });
+
+  test("logs pipeline:loop events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("pipeline:loop", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      remaining: 4,
+      exhausted: false,
+    });
+    emitter.emit("pipeline:loop", {
+      stageNumber: 3,
+      stageName: "Self-check",
+      remaining: 0,
+      exhausted: true,
+    });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain(
+      "[Pipeline] Auto-budget 4 remaining for stage 3 (Self-check)",
+    );
+    expect(content).toContain(
+      "[Pipeline] Auto-budget exhausted for stage 3 (Self-check)",
+    );
+  });
+
+  test("logs pipeline:ci-poll events", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("pipeline:ci-poll", { action: "start", sha: "abc1234" });
+    emitter.emit("pipeline:ci-poll", {
+      action: "status",
+      verdict: "pending",
+    });
+    emitter.emit("pipeline:ci-poll", {
+      action: "done",
+      sha: "abc1234",
+      verdict: "pass",
+    });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("[Pipeline] CI polling started (SHA: abc1234)");
+    expect(content).toContain("[Pipeline] CI polling status: pending");
+    expect(content).toContain("[Pipeline] CI polling done (verdict: pass)");
+  });
+
+  test("timestamps are present on event lines", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "tick" });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toMatch(/\[\d{2}:\d{2}:\d{2}\] \[Agent A\] tick/);
+  });
+
+  test("returns no-op writer when log directory cannot be created", async () => {
+    // Point homedir at a path that cannot be created (a file, not a dir).
+    const fs = require("node:fs");
+    const blockerPath = `${TEST_HOME}/.agentcoop/logs`;
+    fs.mkdirSync(`${TEST_HOME}/.agentcoop`, { recursive: true });
+    fs.writeFileSync(blockerPath, "block");
+
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    // Should return a no-op writer (empty path, close is safe to call).
+    expect(log.path).toBe("");
+    await log.close(); // must not throw
+
+    fs.rmSync(blockerPath);
+  });
+
+  test("close writes footer", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("[Pipeline] Log closed");
+  });
+
+  test("disables itself on write failure", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+    expect(log.path).not.toBe("");
+
+    // Destroy the underlying stream to simulate a disk I/O error.
+    const stream = streamControl.streams.at(-1) as WriteStream;
+    const closed = new Promise<void>((resolve) =>
+      stream.once("close", resolve),
+    );
+    stream.destroy(new Error("simulated disk error"));
+    await closed;
+
+    // Subsequent emits must not throw — the writer is disabled.
+    expect(() => {
+      emitter.emit("agent:chunk", { agent: "a", chunk: "should not crash" });
+    }).not.toThrow();
+
+    // close() must not throw.
+    await log.close();
+  });
+
+  test("avoids filename collision with exclusive create", async () => {
+    const fs = require("node:fs");
+
+    // Freeze time so both createRunLog calls produce the same timestamp,
+    // deterministically forcing the EEXIST retry path.
+    vi.useFakeTimers({ now: new Date("2026-06-01T12:00:00.000Z") });
+    try {
+      const emitter1 = new PipelineEventEmitter();
+      const emitter2 = new PipelineEventEmitter();
+
+      const log1 = createRunLog(emitter1, meta());
+      expect(log1.path).not.toBe("");
+
+      // The unsuffixed path is now taken; the second log must get a
+      // collision on "wx" and retry with the "-1" suffix.
+      const log2 = createRunLog(emitter2, meta());
+      expect(log2.path).not.toBe("");
+      expect(log2.path).not.toBe(log1.path);
+      expect(log2.path).toMatch(/-1\.log$/);
+
+      await log1.close();
+      await log2.close();
+
+      expect(fs.existsSync(log1.path)).toBe(true);
+      expect(fs.existsSync(log2.path)).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("stage:name-override updates context for subsequent agent:invoke", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    // Enter the Done stage.
+    emitter.emit("stage:enter", {
+      stageNumber: 9,
+      stageName: "Done",
+      iteration: 0,
+    });
+
+    // Override to "Rebase" (as the pipeline does before invoking the rebase agent).
+    emitter.emit("stage:name-override", { stageName: "Rebase" });
+
+    // A "work" invoke should now show "Rebase", not "Done".
+    emitter.emit("agent:invoke", {
+      agent: "a",
+      type: "invoke",
+      promptKind: "work",
+    });
+
+    // Restore to "Done".
+    emitter.emit("stage:name-override", { stageName: "Done" });
+
+    emitter.emit("agent:invoke", {
+      agent: "a",
+      type: "invoke",
+      promptKind: "work",
+    });
+
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("[Pipeline] Stage name override → Rebase");
+    expect(content).toContain("[Pipeline] Invoking Agent A (work: Rebase)");
+    expect(content).toContain("[Pipeline] Stage name override → Done");
+    expect(content).toContain("[Pipeline] Invoking Agent A (work: Done)");
+  });
+
+  test("multiline chunks produce separate prefixed lines", async () => {
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+
+    emitter.emit("agent:chunk", {
+      agent: "b",
+      chunk: "line1\nline2\nline3",
+    });
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("[Agent B] line1");
+    expect(content).toContain("[Agent B] line2");
+    expect(content).toContain("[Agent B] line3");
+  });
+});

--- a/src/run-log.ts
+++ b/src/run-log.ts
@@ -1,0 +1,297 @@
+/**
+ * Persistent run log — writes all pipeline events to a log file for
+ * post-mortem debugging.
+ *
+ * Log files live at `~/.agentcoop/logs/<org>-<repo>-#<issue>-<timestamp>.log`.
+ */
+
+import {
+  createWriteStream,
+  mkdirSync,
+  openSync,
+  type WriteStream,
+} from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { PipelineEventEmitter } from "./pipeline-events.js";
+
+// ---- public types --------------------------------------------------------
+
+export interface RunLogAgentMeta {
+  cli: string;
+  model: string;
+  contextWindow?: string;
+  effortLevel?: string;
+}
+
+export interface RunLogMetadata {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  worktreePath: string;
+  executionMode: "auto" | "step";
+  agentA: RunLogAgentMeta;
+  agentB: RunLogAgentMeta;
+  selfCheckAutoIterations: number;
+  reviewAutoRounds: number;
+  inactivityTimeoutMinutes: number;
+  autoResumeAttempts: number;
+}
+
+// ---- helpers -------------------------------------------------------------
+
+function logsDir(): string {
+  return join(homedir(), ".agentcoop", "logs");
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+function formatTimestamp(date: Date): string {
+  return `${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+}
+
+function fileTimestamp(date: Date): string {
+  const y = date.getFullYear();
+  const mo = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  const h = pad(date.getHours());
+  const mi = pad(date.getMinutes());
+  const s = pad(date.getSeconds());
+  return `${y}${mo}${d}-${h}${mi}${s}`;
+}
+
+/** Build the log file path for a run (without collision suffix). */
+export function logFilePath(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  startTime: Date,
+  suffix?: number,
+): string {
+  const base = `${owner}-${repo}-#${issueNumber}-${fileTimestamp(startTime)}`;
+  const name = suffix ? `${base}-${suffix}.log` : `${base}.log`;
+  return join(logsDir(), name);
+}
+
+// ---- writer --------------------------------------------------------------
+
+export interface RunLogWriter {
+  /** Absolute path to the log file. */
+  path: string;
+  /** Flush and close the log file. */
+  close(): Promise<void>;
+}
+
+/** A no-op writer used when the log file cannot be created. */
+function noopWriter(): RunLogWriter {
+  return { path: "", close: () => Promise.resolve() };
+}
+
+/**
+ * Create a run log writer that subscribes to the given emitter and
+ * writes all events to a log file.
+ *
+ * If the log file cannot be created (permissions, full disk, etc.)
+ * this returns a no-op writer so the pipeline is not blocked.
+ */
+export function createRunLog(
+  emitter: PipelineEventEmitter,
+  meta: RunLogMetadata,
+): RunLogWriter {
+  const startTime = new Date();
+
+  let fd = -1;
+  let filePath = "";
+  try {
+    mkdirSync(logsDir(), { recursive: true });
+
+    // Use exclusive create ("wx") to avoid silently truncating a log
+    // from another run that started in the same second.  Retry with
+    // an incrementing suffix on collision.
+    const MAX_RETRIES = 10;
+    let opened = false;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      filePath = logFilePath(
+        meta.owner,
+        meta.repo,
+        meta.issueNumber,
+        startTime,
+        attempt === 0 ? undefined : attempt,
+      );
+      try {
+        fd = openSync(filePath, "wx");
+        opened = true;
+        break;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          "code" in err &&
+          (err as NodeJS.ErrnoException).code === "EEXIST"
+        ) {
+          continue;
+        }
+        throw err; // non-collision error → let the outer catch handle it
+      }
+    }
+    if (!opened) return noopWriter();
+  } catch {
+    return noopWriter();
+  }
+
+  // Wrap the fd in a buffered write stream so event-listener writes
+  // do not block the event loop.
+  const stream: WriteStream = createWriteStream("", { fd });
+
+  // Track whether the writer has been disabled due to a write error.
+  let disabled = false;
+  stream.on("error", () => {
+    disabled = true;
+  });
+
+  function write(line: string): void {
+    if (disabled) return;
+    try {
+      stream.write(`${line}\n`);
+    } catch {
+      disabled = true;
+    }
+  }
+
+  // ---- header block ------------------------------------------------------
+
+  write("=== AgentCoop Run Log ===");
+  write(`Start time : ${startTime.toISOString()}`);
+  write(`Repository : ${meta.owner}/${meta.repo}`);
+  write(`Issue      : #${meta.issueNumber}`);
+  write(`Worktree   : ${meta.worktreePath}`);
+  write(`Mode       : ${meta.executionMode}`);
+  write(`Agent A    : ${meta.agentA.cli} / ${meta.agentA.model}`);
+  if (meta.agentA.contextWindow)
+    write(`  context  : ${meta.agentA.contextWindow}`);
+  if (meta.agentA.effortLevel) write(`  effort   : ${meta.agentA.effortLevel}`);
+  write(`Agent B    : ${meta.agentB.cli} / ${meta.agentB.model}`);
+  if (meta.agentB.contextWindow)
+    write(`  context  : ${meta.agentB.contextWindow}`);
+  if (meta.agentB.effortLevel) write(`  effort   : ${meta.agentB.effortLevel}`);
+  write(
+    `Auto-budget: self-check=${meta.selfCheckAutoIterations}, review=${meta.reviewAutoRounds}`,
+  );
+  write(
+    `Timeouts   : inactivity=${meta.inactivityTimeoutMinutes}m, autoResume=${meta.autoResumeAttempts}`,
+  );
+  write("");
+
+  // ---- event subscriptions -----------------------------------------------
+
+  /** Map stage number → name, populated by stage:enter events. */
+  const stageNames = new Map<number, string>();
+
+  /** Most recently entered stage — used to add context to "work" invocations. */
+  let currentStageName: string | null = null;
+
+  function ts(): string {
+    return `[${formatTimestamp(new Date())}]`;
+  }
+
+  emitter.on("agent:chunk", (ev) => {
+    const label = ev.agent === "a" ? "Agent A" : "Agent B";
+    for (const line of ev.chunk.split("\n")) {
+      write(`${ts()} [${label}] ${line}`);
+    }
+  });
+
+  emitter.on("agent:prompt", (ev) => {
+    const label = ev.agent === "a" ? "Agent A" : "Agent B";
+    write(`${ts()} [${label}:prompt] --- prompt start (${ev.kind}) ---`);
+    for (const line of ev.prompt.split("\n")) {
+      write(`${ts()} [${label}:prompt] ${line}`);
+    }
+    write(`${ts()} [${label}:prompt] --- prompt end ---`);
+  });
+
+  emitter.on("agent:invoke", (ev) => {
+    const label = ev.agent === "a" ? "Agent A" : "Agent B";
+    let suffix = "";
+    if (ev.promptKind === "work" && currentStageName) {
+      suffix = ` (work: ${currentStageName})`;
+    } else if (ev.promptKind) {
+      suffix = ` (${ev.promptKind})`;
+    }
+    write(`${ts()} [Pipeline] Invoking ${label}${suffix}`);
+  });
+
+  emitter.on("stage:enter", (ev) => {
+    currentStageName = ev.stageName;
+    stageNames.set(ev.stageNumber, ev.stageName);
+    write(
+      `${ts()} [Pipeline] Stage ${ev.stageNumber} (${ev.stageName}) → enter (iteration ${ev.iteration})`,
+    );
+  });
+
+  emitter.on("stage:name-override", (ev) => {
+    currentStageName = ev.stageName;
+    write(`${ts()} [Pipeline] Stage name override → ${ev.stageName}`);
+  });
+
+  emitter.on("stage:exit", (ev) => {
+    const name = stageNames.get(ev.stageNumber);
+    const label = name
+      ? `Stage ${ev.stageNumber} (${name})`
+      : `Stage ${ev.stageNumber}`;
+    write(`${ts()} [Pipeline] ${label} → exit (${ev.outcome})`);
+  });
+
+  emitter.on("pipeline:verdict", (ev) => {
+    const label = ev.agent === "a" ? "Agent A" : "Agent B";
+    write(`${ts()} [Pipeline] ${label} verdict parsed as "${ev.keyword}"`);
+  });
+
+  emitter.on("pipeline:loop", (ev) => {
+    if (ev.exhausted) {
+      write(
+        `${ts()} [Pipeline] Auto-budget exhausted for stage ${ev.stageNumber} (${ev.stageName})`,
+      );
+    } else {
+      write(
+        `${ts()} [Pipeline] Auto-budget ${ev.remaining} remaining for stage ${ev.stageNumber} (${ev.stageName})`,
+      );
+    }
+  });
+
+  emitter.on("pipeline:ci-poll", (ev) => {
+    if (ev.action === "start") {
+      write(
+        `${ts()} [Pipeline] CI polling started (SHA: ${ev.sha ?? "unknown"})`,
+      );
+    } else if (ev.action === "status") {
+      write(`${ts()} [Pipeline] CI polling status: ${ev.verdict ?? "pending"}`);
+    } else {
+      write(
+        `${ts()} [Pipeline] CI polling done (verdict: ${ev.verdict ?? "unknown"})`,
+      );
+    }
+  });
+
+  // ---- close -------------------------------------------------------------
+
+  return {
+    path: filePath,
+    close(): Promise<void> {
+      return new Promise<void>((resolve) => {
+        if (disabled || stream.destroyed) {
+          if (!stream.destroyed) stream.destroy();
+          resolve();
+          return;
+        }
+        write("");
+        write(`${ts()} [Pipeline] Log closed`);
+        disabled = true;
+        stream.once("error", () => resolve());
+        stream.end(() => resolve());
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add `src/run-log.ts` — a log file writer that subscribes to `PipelineEventEmitter` and writes all diagnostic events to `~/.agentcoop/logs/<org>-<repo>-#<issue>-<timestamp>.log` with a header block containing resolved run configuration (agent models, context windows, effort levels, auto-budgets, timeouts) and timestamped event entries.
- Writes use a buffered `fs.createWriteStream` so event-listener writes do not block the TUI event loop. The file is opened with `openSync("wx")` for collision safety, then wrapped in a write stream for async I/O.
- Integrate the log writer in `src/index.ts`: instantiated after the emitter is created, closed (with `await`) on pipeline exit before `unmount()`.
- Log creation is best-effort: filesystem failures at any point (open, write, or close) degrade to a no-op writer instead of aborting the pipeline. The writer disables itself on the first write error so a mid-run filesystem failure cannot propagate out of an event listener.
- `agent:invoke` log lines include stage-specific context for `"work"` prompts (e.g. `Invoking Agent A (work: Implement)`) so different stages are distinguishable at a glance.
- Track `stage:name-override` events so the effective stage name (e.g. "Rebase" during the Done → Rebase subflow) is reflected in subsequent `agent:invoke` log lines, matching what the TUI displays.
- Add comprehensive tests in `src/run-log.test.ts` covering every event type, the header block, timestamps, multiline handling, close footer, no-op fallback, write failure resilience, filename collision avoidance, and stage name override tracking.

Closes #199

## Test plan

- [x] Running a pipeline produces a log file at `~/.agentcoop/logs/<org>-<repo>-#<issue>-<timestamp>.log`
- [x] Log file contains the header block with resolved config (agent models, contextWindow, effortLevel, inactivityTimeoutMinutes, autoResumeAttempts)
- [x] All event types are logged: `agent:chunk`, `agent:prompt`, `agent:invoke`, `stage:enter`, `stage:exit`, `stage:name-override`, `pipeline:verdict`, `pipeline:loop`, `pipeline:ci-poll`
- [x] `agent:invoke` with `"work"` kind includes current stage name when available
- [x] `stage:name-override` updates the effective stage name used by `agent:invoke`
- [x] Log lines have `[HH:MM:SS]` timestamps that are monotonically increasing
- [x] Multiline chunks produce separate prefixed lines
- [x] Log file is closed with a footer on pipeline exit
- [x] `~/.agentcoop/logs/` directory is created if it does not exist
- [x] Filesystem failures degrade to no-op writer (tested for both open and write failures)
- [x] Concurrent runs for the same issue don't overwrite each other (collision test)
- [x] Existing tests pass (`pnpm vitest run`)
- [x] No user-visible behavior change in the TUI