### PR TITLE
Display inline pipeline diagnostics in agent panes (#200)

### DIFF
--- a/src/pipeline-events.test.ts
+++ b/src/pipeline-events.test.ts
@@ -179,6 +179,7 @@ describe("PipelineEventEmitter", () => {
       stageNumber: 2,
       stageName: "Implement",
       remaining: 1,
+      budget: 3,
       exhausted: false,
     };
     emitter.emit("pipeline:loop", event);

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -28,8 +28,10 @@ export interface ReviewPostedEvent {
 export interface AgentInvokeEvent {
   agent: "a" | "b";
   type: "invoke" | "resume";
-  /** Type of prompt being sent (when available). */
-  promptKind?: AgentPromptKind;
+  /** Prompt kind so the diagnostic can show orchestrator context. */
+  kind?: AgentPromptKind;
+  /** Review round (1-based) for review-stage invocations. */
+  round?: number;
 }
 
 /**
@@ -37,12 +39,14 @@ export interface AgentInvokeEvent {
  * consumers to inspect prompt text.
  *
  * - `"work"` — primary stage prompt
+ * - `"review"` — reviewer stage prompt (Agent B reviewing Agent A's work)
  * - `"verdict-followup"` — verdict clarification prompt
  * - `"ci-fix"` — CI failure fix prompt
  * - `"summary"` — unresolved summary request
  */
 export type AgentPromptKind =
   | "work"
+  | "review"
   | "verdict-followup"
   | "ci-fix"
   | "summary";
@@ -82,8 +86,12 @@ export interface PipelineLoopEvent {
   stageName: string;
   /** Auto-iterations remaining after this advance. */
   remaining: number;
+  /** Total auto-budget for the loop. */
+  budget: number;
   /** `true` when the auto-budget has been exhausted. */
   exhausted: boolean;
+  /** Primary agent for the looping stage (used for pane routing). */
+  agent?: "a" | "b";
 }
 
 /**

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -86,6 +86,11 @@ export interface StageDefinition {
    * the CI check before re-entering verification.
    */
   restartFromStage?: number;
+  /**
+   * The agent that primarily drives this stage.  Used by the UI to
+   * route loop diagnostics to the correct pane.
+   */
+  primaryAgent?: "a" | "b";
 }
 
 /**
@@ -512,7 +517,9 @@ export async function runPipeline(
         stageNumber: stage.number,
         stageName: stage.name,
         remaining: lc.autoRemaining,
+        budget: lc.budget,
         exhausted: !canContinue,
+        agent: stage.primaryAgent,
       });
       if (!canContinue) {
         const approved = await prompt.confirmContinueLoop(
@@ -631,22 +638,26 @@ async function runStage(
         a: (
           prompt: string,
           kind: import("./pipeline-events.js").AgentPromptKind,
+          meta?: import("./stage-util.js").PromptSinkMeta,
         ) => {
           events.emit("agent:invoke", {
             agent: "a",
-            type: "invoke",
-            promptKind: kind,
+            type: meta?.resume ? "resume" : "invoke",
+            kind,
+            round: meta?.round,
           });
           events.emit("agent:prompt", { agent: "a", prompt, kind });
         },
         b: (
           prompt: string,
           kind: import("./pipeline-events.js").AgentPromptKind,
+          meta?: import("./stage-util.js").PromptSinkMeta,
         ) => {
           events.emit("agent:invoke", {
             agent: "b",
-            type: "invoke",
-            promptKind: kind,
+            type: meta?.resume ? "resume" : "invoke",
+            kind,
+            round: meta?.round,
           });
           events.emit("agent:prompt", { agent: "b", prompt, kind });
         },
@@ -800,7 +811,9 @@ async function runStage(
       stageNumber: stage.number,
       stageName: stage.name,
       remaining: lc.autoRemaining,
+      budget: lc.budget,
       exhausted: !canContinue,
+      agent: stage.primaryAgent,
     });
     // Notify caller after loop counter change for persistence.
     onStageTransition?.(stage.number, lc.iteration);
@@ -907,6 +920,7 @@ export function createDoneStageHandler(
   return {
     name: t()["stage.done"],
     number: 9,
+    primaryAgent: "a",
     handler: async (ctx) => {
       const m = t();
       const summary = m["pipeline.pipelineCompleted"](

--- a/src/rebase.ts
+++ b/src/rebase.ts
@@ -104,7 +104,7 @@ export function createRebaseHandler(
 
     // Verdict follow-up: ask for exactly COMPLETED or BLOCKED.
     const verdictPrompt = buildRebaseVerdictPrompt();
-    ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup");
+    ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup", { resume: true });
     let verdictResult = await sendFollowUp(
       agent,
       result.sessionId,
@@ -138,7 +138,7 @@ export function createRebaseHandler(
         verdictResult.responseText,
         REBASE_KEYWORDS,
       );
-      ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+      ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", { resume: true });
       const retryResult = await sendFollowUp(
         agent,
         verdictResult.sessionId ?? result.sessionId,

--- a/src/run-log.test.ts
+++ b/src/run-log.test.ts
@@ -147,7 +147,7 @@ describe("createRunLog", () => {
     emitter.emit("agent:invoke", {
       agent: "a",
       type: "invoke",
-      promptKind: "work",
+      kind: "work",
     });
 
     // Enter a stage so subsequent "work" prompts include stage context.
@@ -160,12 +160,12 @@ describe("createRunLog", () => {
     emitter.emit("agent:invoke", {
       agent: "b",
       type: "invoke",
-      promptKind: "work",
+      kind: "work",
     });
     emitter.emit("agent:invoke", {
       agent: "a",
       type: "invoke",
-      promptKind: "ci-fix",
+      kind: "ci-fix",
     });
     emitter.emit("agent:invoke", { agent: "b", type: "invoke" });
     await log.close();
@@ -177,7 +177,7 @@ describe("createRunLog", () => {
     expect(content).toContain("[Pipeline] Invoking Agent B (work: Implement)");
     // Non-work kinds are unchanged.
     expect(content).toContain("[Pipeline] Invoking Agent A (ci-fix)");
-    // Without promptKind, no parenthetical suffix.
+    // Without kind, no parenthetical suffix.
     expect(content).toMatch(/Invoking Agent B\n/);
   });
 
@@ -375,7 +375,7 @@ describe("createRunLog", () => {
     emitter.emit("agent:invoke", {
       agent: "a",
       type: "invoke",
-      promptKind: "work",
+      kind: "work",
     });
 
     // Restore to "Done".
@@ -384,7 +384,7 @@ describe("createRunLog", () => {
     emitter.emit("agent:invoke", {
       agent: "a",
       type: "invoke",
-      promptKind: "work",
+      kind: "work",
     });
 
     await log.close();

--- a/src/run-log.ts
+++ b/src/run-log.ts
@@ -215,10 +215,10 @@ export function createRunLog(
   emitter.on("agent:invoke", (ev) => {
     const label = ev.agent === "a" ? "Agent A" : "Agent B";
     let suffix = "";
-    if (ev.promptKind === "work" && currentStageName) {
+    if (ev.kind === "work" && currentStageName) {
       suffix = ` (work: ${currentStageName})`;
-    } else if (ev.promptKind) {
-      suffix = ` (${ev.promptKind})`;
+    } else if (ev.kind) {
+      suffix = ` (${ev.kind})`;
     }
     write(`${ts()} [Pipeline] Invoking ${label}${suffix}`);
   });

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -312,6 +312,7 @@ export function createCiCheckStageHandler(
   return {
     name: t()["stage.ciCheck"],
     number: 5,
+    primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // ---- poll for CI completion ------------------------------------------
 

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -108,6 +108,7 @@ export function createCreatePrStageHandler(
   return {
     name: t()["stage.createPr"],
     number: 4,
+    primaryAgent: "a",
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the PR creation prompt (resume if saved session).
@@ -136,7 +137,7 @@ export function createCreatePrStageHandler(
       // session, because re-entering the handler would re-run the
       // side-effectful PR creation step.
       const prCheckPrompt = buildPrCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(prCheckPrompt, "verdict-followup");
+      ctx.promptSinks?.a?.(prCheckPrompt, "verdict-followup", { resume: true });
       let checkResult = await sendFollowUp(
         opts.agent,
         prResult.sessionId,
@@ -167,7 +168,9 @@ export function createCreatePrStageHandler(
           checkResult.responseText,
           PR_CHECK_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+          resume: true,
+        });
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId ?? prResult.sessionId,

--- a/src/stage-implement.test.ts
+++ b/src/stage-implement.test.ts
@@ -415,6 +415,54 @@ describe("createImplementStageHandler", () => {
     });
   });
 
+  test("prompt sink receives resume: true for completion check", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const checkResult = makeResult({ responseText: "COMPLETED" });
+    const agent = makeAgent(implResult, checkResult);
+    const promptSink = vi.fn();
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      promptSinks: { a: promptSink },
+    };
+    await stage.handler(ctx);
+
+    // First call: implementation prompt (no resume meta).
+    expect(promptSink).toHaveBeenCalledTimes(2);
+    expect(promptSink.mock.calls[0][2]).toBeUndefined();
+    // Second call: completion check (resume: true).
+    expect(promptSink.mock.calls[1][2]).toEqual({ resume: true });
+  });
+
+  test("prompt sink receives resume: true for clarification retry", async () => {
+    const implResult = makeResult({ sessionId: "sess-impl" });
+    const ambiguousCheck = makeResult({
+      sessionId: "sess-check",
+      responseText: "I think so",
+    });
+    const clarifiedCheck = makeResult({ responseText: "COMPLETED" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(implResult)),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(ambiguousCheck))
+        .mockReturnValueOnce(makeStream(clarifiedCheck)),
+    };
+    const promptSink = vi.fn();
+    const stage = createImplementStageHandler(makeOpts({ agent }));
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      promptSinks: { a: promptSink },
+    };
+    await stage.handler(ctx);
+
+    // 3 calls: impl prompt, check prompt, clarification prompt.
+    expect(promptSink).toHaveBeenCalledTimes(3);
+    // Both the check and clarification calls pass resume: true.
+    expect(promptSink.mock.calls[1][2]).toEqual({ resume: true });
+    expect(promptSink.mock.calls[2][2]).toEqual({ resume: true });
+  });
+
   test("falls back to invoke when saved session fails", async () => {
     const errorResult = makeResult({
       status: "error",

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -85,6 +85,7 @@ export function createImplementStageHandler(
   return {
     name: t()["stage.implement"],
     number: 2,
+    primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the implementation prompt (resume if saved session).
       const prompt = buildImplementPrompt(ctx, opts);
@@ -109,7 +110,7 @@ export function createImplementStageHandler(
 
       // Step 2: Resume the session and ask for completion status.
       const checkPrompt = buildCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(checkPrompt, "verdict-followup");
+      ctx.promptSinks?.a?.(checkPrompt, "verdict-followup", { resume: true });
       const checkResult = await sendFollowUp(
         opts.agent,
         implResult.sessionId,
@@ -141,7 +142,9 @@ export function createImplementStageHandler(
           checkResult.responseText,
           IMPLEMENT_CHECK_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+          resume: true,
+        });
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId ?? implResult.sessionId,

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -443,6 +443,7 @@ export function createReviewStageHandler(
   return {
     name: t()["stage.review"],
     number: 7,
+    primaryAgent: "b",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       const round = ctx.iteration + 1; // 1-based for display
 
@@ -488,7 +489,7 @@ export function createReviewStageHandler(
       if (currentStep === "review") {
         opts.onReviewProgress?.("review");
         const reviewPrompt = buildReviewPrompt(ctx, opts, round);
-        ctx.promptSinks?.b?.(reviewPrompt, "work");
+        ctx.promptSinks?.b?.(reviewPrompt, "review", { round });
         const reviewResult = await invokeOrResume(
           opts.agentB,
           ctx.savedAgentBSessionId,
@@ -530,7 +531,9 @@ export function createReviewStageHandler(
         if (agentBSessionId) {
           // Follow-up on review session (normal flow).
           const verdictPrompt = buildReviewVerdictPrompt();
-          ctx.promptSinks?.b?.(verdictPrompt, "verdict-followup");
+          ctx.promptSinks?.b?.(verdictPrompt, "verdict-followup", {
+            resume: true,
+          });
           verdictResult = await sendFollowUp(
             opts.agentB,
             agentBSessionId,
@@ -757,7 +760,9 @@ export function createReviewStageHandler(
 
         // Verdict follow-up: ask A for exactly PR_FINALIZED.
         const finalVerdictPrompt = buildPrFinalizationVerdictPrompt();
-        ctx.promptSinks?.a?.(finalVerdictPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(finalVerdictPrompt, "verdict-followup", {
+          resume: true,
+        });
         let finalVerdictResult = await sendFollowUp(
           opts.agentA,
           finalizeResult.sessionId,
@@ -793,7 +798,9 @@ export function createReviewStageHandler(
             finalVerdictResult.responseText,
             PR_FINALIZATION_KEYWORDS,
           );
-          ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+          ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+            resume: true,
+          });
           const retryResult = await sendFollowUp(
             opts.agentA,
             finalVerdictResult.sessionId ?? finalizeResult.sessionId,
@@ -899,7 +906,9 @@ export function createReviewStageHandler(
         // Completion check on Agent A (with clarification retry,
         // same pattern as stage 4 / stage 8).
         const authorCheckPrompt = buildAuthorCompletionCheckPrompt();
-        ctx.promptSinks?.a?.(authorCheckPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(authorCheckPrompt, "verdict-followup", {
+          resume: true,
+        });
         let checkResult = await sendFollowUp(
           opts.agentA,
           fixResult.sessionId,
@@ -930,7 +939,9 @@ export function createReviewStageHandler(
             checkResult.responseText,
             AUTHOR_CHECK_KEYWORDS,
           );
-          ctx.promptSinks?.a?.(retryPrompt, "verdict-followup");
+          ctx.promptSinks?.a?.(retryPrompt, "verdict-followup", {
+            resume: true,
+          });
           const retryResult = await sendFollowUp(
             opts.agentA,
             checkResult.sessionId ?? fixResult.sessionId,

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -135,6 +135,7 @@ export function createSelfCheckStageHandler(
   return {
     name: t()["stage.selfCheck"],
     number: 3,
+    primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send self-check prompt (resume if saved session).
       const checkPrompt = buildSelfCheckPrompt(ctx, opts);
@@ -159,7 +160,7 @@ export function createSelfCheckStageHandler(
 
       // Step 2: Send fix-or-done work prompt (resume the same session).
       const fixPrompt = buildFixOrDonePrompt();
-      ctx.promptSinks?.a?.(fixPrompt, "work");
+      ctx.promptSinks?.a?.(fixPrompt, "work", { resume: true });
       const fixResult = await sendFollowUp(
         opts.agent,
         checkResult.sessionId,
@@ -176,7 +177,7 @@ export function createSelfCheckStageHandler(
 
       // Step 3: Verdict follow-up — ask for exactly FIXED or DONE.
       const verdictPrompt = buildFixOrDoneVerdictPrompt();
-      ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup");
+      ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup", { resume: true });
       const verdictResult = await sendFollowUp(
         opts.agent,
         fixResult.sessionId,
@@ -208,7 +209,9 @@ export function createSelfCheckStageHandler(
           verdictCheckResult.responseText,
           FIX_OR_DONE_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+          resume: true,
+        });
         const retryResult = await sendFollowUp(
           opts.agent,
           verdictCheckResult.sessionId ?? fixResult.sessionId,
@@ -244,7 +247,7 @@ export function createSelfCheckStageHandler(
       if (result.outcome === "completed" && verdictCheckResult.sessionId) {
         try {
           const syncPrompt = buildIssueSyncPrompt(ctx, opts);
-          ctx.promptSinks?.a?.(syncPrompt, "work");
+          ctx.promptSinks?.a?.(syncPrompt, "work", { resume: true });
           const syncResult = await sendFollowUp(
             opts.agent,
             verdictCheckResult.sessionId,
@@ -258,7 +261,9 @@ export function createSelfCheckStageHandler(
           if (syncResult.status === "success") {
             // Verdict follow-up: ask for sync status report.
             const syncVerdictPrompt = buildIssueSyncVerdictPrompt();
-            ctx.promptSinks?.a?.(syncVerdictPrompt, "verdict-followup");
+            ctx.promptSinks?.a?.(syncVerdictPrompt, "verdict-followup", {
+              resume: true,
+            });
             const syncVerdictResult = await sendFollowUp(
               opts.agent,
               syncResult.sessionId ?? verdictCheckResult.sessionId,
@@ -277,7 +282,9 @@ export function createSelfCheckStageHandler(
               // Clarification retry if the response was malformed.
               if (!parseResult.valid) {
                 const clarifyPrompt = buildIssueSyncClarificationPrompt();
-                ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+                ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+                  resume: true,
+                });
                 const retryResult = await sendFollowUp(
                   opts.agent,
                   syncVerdictResult.sessionId ??

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -130,6 +130,7 @@ export function createSquashStageHandler(
   return {
     name: t()["stage.squash"],
     number: 8,
+    primaryAgent: "a",
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Skip squash when the branch has only one commit.
@@ -168,7 +169,9 @@ export function createSquashStageHandler(
       // Step 2: Completion check (same internal-clarification pattern as
       // stage 4).
       const squashCheckPrompt = buildSquashCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(squashCheckPrompt, "verdict-followup");
+      ctx.promptSinks?.a?.(squashCheckPrompt, "verdict-followup", {
+        resume: true,
+      });
       let checkResult = await sendFollowUp(
         opts.agent,
         squashResult.sessionId,
@@ -199,7 +202,9 @@ export function createSquashStageHandler(
           checkResult.responseText,
           SQUASH_CHECK_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+          resume: true,
+        });
         const retryResult = await sendFollowUp(
           opts.agent,
           checkResult.sessionId ?? squashResult.sessionId,

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -125,6 +125,7 @@ export function createTestPlanStageHandler(
   return {
     name: t()["stage.testPlan"],
     number: 6,
+    primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send verification prompt (resume if saved session).
       const verifyPrompt = buildTestPlanVerifyPrompt(ctx, opts);
@@ -149,7 +150,7 @@ export function createTestPlanStageHandler(
 
       // Step 2: Send self-check work prompt (resume the same session).
       const selfCheckPrompt = buildTestPlanSelfCheckPrompt();
-      ctx.promptSinks?.a?.(selfCheckPrompt, "work");
+      ctx.promptSinks?.a?.(selfCheckPrompt, "work", { resume: true });
       const checkResult = await sendFollowUp(
         opts.agent,
         verifyResult.sessionId,
@@ -166,7 +167,7 @@ export function createTestPlanStageHandler(
 
       // Step 3: Verdict follow-up — ask for exactly FIXED or DONE.
       const verdictPrompt = buildTestPlanVerdictPrompt();
-      ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup");
+      ctx.promptSinks?.a?.(verdictPrompt, "verdict-followup", { resume: true });
       const verdictResult = await sendFollowUp(
         opts.agent,
         checkResult.sessionId,
@@ -197,7 +198,9 @@ export function createTestPlanStageHandler(
           verdictResult.responseText,
           TEST_PLAN_VERDICT_KEYWORDS,
         );
-        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup");
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+          resume: true,
+        });
         const retryResult = await sendFollowUp(
           opts.agent,
           verdictResult.sessionId ?? checkResult.sessionId,

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -26,14 +26,27 @@ import {
  */
 export type StreamSink = (chunk: string) => void;
 
+/** Extra context forwarded through the prompt sink to diagnostic events. */
+export interface PromptSinkMeta {
+  /** Review round (1-based) for review-stage invocations. */
+  round?: number;
+  /** True when the prompt resumes an existing session (sendFollowUp). */
+  resume?: boolean;
+}
+
 /**
  * Callback that receives the full prompt text before it is sent to the agent.
  * Used by the UI to display outgoing prompts in the agent's pane.
  *
  * The optional `kind` parameter classifies the prompt type so that
  * diagnostic consumers can distinguish prompts without inspecting text.
+ * The optional `meta` parameter carries additional context (e.g. round).
  */
-export type PromptSink = (prompt: string, kind: AgentPromptKind) => void;
+export type PromptSink = (
+  prompt: string,
+  kind: AgentPromptKind,
+  meta?: PromptSinkMeta,
+) => void;
 
 /**
  * Callback that receives token usage data after an agent invocation completes.

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -7,6 +7,7 @@ import type {
   StageEnterEvent,
 } from "../pipeline-events.js";
 import {
+  type DiagnosticBlock,
   type LineEntry,
   PROMPT_LINE_PREFIX,
   PROMPT_SEPARATOR_CHAR,
@@ -83,10 +84,19 @@ export function renderPromptRows(block: PromptBlock, width: number): string[] {
   return result;
 }
 
+/**
+ * Render a diagnostic block as a single formatted line:
+ * `[HH:MM:SS] Pipeline: <message>`
+ */
+export function renderDiagnosticRow(block: DiagnosticBlock): string {
+  return `[${block.timestamp}] Pipeline: ${block.message}`;
+}
+
 /** A single terminal row tagged with display metadata. */
 interface RowEntry {
   text: string;
   isPrompt: boolean;
+  isDiagnostic: boolean;
   /** Index of the parent logical line in allLines. */
   lineIdx: number;
 }
@@ -161,12 +171,28 @@ export function AgentPane({
         entry.startsWith(PROMPT_LINE_PREFIX) ||
         entry.startsWith(PROMPT_SEPARATOR_CHAR);
       for (const row of splitIntoRows(entry, contentWidth)) {
-        allRows.push({ text: row, isPrompt, lineIdx: i });
+        allRows.push({ text: row, isPrompt, isDiagnostic: false, lineIdx: i });
+      }
+    } else if (entry.kind === "diagnostic") {
+      // DiagnosticBlock: single formatted row.
+      const text = renderDiagnosticRow(entry);
+      for (const row of splitIntoRows(text, contentWidth)) {
+        allRows.push({
+          text: row,
+          isPrompt: false,
+          isDiagnostic: true,
+          lineIdx: i,
+        });
       }
     } else {
       // PromptBlock: render size-aware with current content width.
       for (const row of renderPromptRows(entry, contentWidth)) {
-        allRows.push({ text: row, isPrompt: true, lineIdx: i });
+        allRows.push({
+          text: row,
+          isPrompt: true,
+          isDiagnostic: false,
+          lineIdx: i,
+        });
       }
     }
   }
@@ -276,12 +302,15 @@ export function AgentPane({
     linesAbove = startRow > 0 ? allRows[startRow].lineIdx : 0;
   }
 
-  const hasOutput = allLines.length > 0;
+  // Diagnostic-only panes should still show the placeholder message.
+  const hasOutput = allLines.some(
+    (l) => typeof l === "string" || l.kind !== "diagnostic",
+  );
 
   let placeholder: string | undefined;
-  if (visibleRowEntries.length === 0 && effectiveOffset === 0) {
+  if (effectiveOffset === 0 && (!hasOutput || visibleRowEntries.length === 0)) {
     const m = t();
-    if (hasOutput) {
+    if (hasOutput && visibleRowEntries.length === 0) {
       placeholder = m["agentPane.tooSmall"];
     } else if (
       agent === "b" &&
@@ -333,14 +362,13 @@ export function AgentPane({
         flexShrink={1}
         overflow="hidden"
       >
-        {placeholder !== undefined ? (
-          <Text dimColor>{placeholder}</Text>
-        ) : (
+        {placeholder !== undefined && <Text dimColor>{placeholder}</Text>}
+        {(placeholder === undefined || !hasOutput) && (
           <>
             {topIndicator && <Text dimColor>{topIndicator}</Text>}
             {visibleRowEntries.map((row, i) => (
               // biome-ignore lint/suspicious/noArrayIndexKey: rows are derived without stable IDs
-              <Text key={i} dimColor={row.isPrompt}>
+              <Text key={i} dimColor={row.isPrompt || row.isDiagnostic}>
                 {row.text}
               </Text>
             ))}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -14,7 +14,12 @@ import {
   type AgentInvokeEvent,
   PipelineEventEmitter,
 } from "../pipeline-events.js";
-import { AgentPane, renderPromptRows, splitIntoRows } from "./AgentPane.js";
+import {
+  AgentPane,
+  renderDiagnosticRow,
+  renderPromptRows,
+  splitIntoRows,
+} from "./AgentPane.js";
 import {
   computeLayoutWidth,
   computeVisibilityFlags,
@@ -1764,7 +1769,8 @@ describe("viewport height constraint", () => {
 
     const emitter = new PipelineEventEmitter();
     const viewportWidth = 80;
-    const viewportHeight = 16;
+    // Extra height to accommodate inline diagnostic rows from stage:enter.
+    const viewportHeight = 18;
     const labelA = "Agent A (author)";
     const labelB = "Agent B (reviewer)";
     const flags = computeVisibilityFlags(viewportHeight, 1, true, "row", {
@@ -3151,5 +3157,99 @@ describe("AgentPane size-aware rendering", () => {
     const frame = lastFrame() ?? "";
     // The frame must fit within 8 rows.
     expect(frame.split("\n").length).toBeLessThanOrEqual(8);
+  });
+});
+
+describe("renderDiagnosticRow", () => {
+  test("formats timestamp and message with Pipeline prefix", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "01:03:15",
+      message: 'Reviewer verdict parsed as "APPROVED"',
+    });
+    expect(row).toBe(
+      '[01:03:15] Pipeline: Reviewer verdict parsed as "APPROVED"',
+    );
+  });
+
+  test("handles empty message", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "00:00:00",
+      message: "",
+    });
+    expect(row).toBe("[00:00:00] Pipeline: ");
+  });
+});
+
+describe("AgentPane diagnostic rendering", () => {
+  test("renders diagnostic lines inline with agent output", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={12}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "output line\n" });
+    emitter.emit("pipeline:verdict", {
+      agent: "a",
+      keyword: "APPROVED",
+      raw: "APPROVED",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("output line");
+    expect(frame).toContain("Pipeline:");
+    expect(frame).toContain("APPROVED");
+  });
+
+  test("diagnostic-only pane shows placeholder and diagnostics together", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={10}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // Placeholder and diagnostic lines should both be visible.
+    expect(frame).toContain("waiting for output");
+    expect(frame).toContain("Pipeline:");
+    expect(frame).toContain("Implement");
+  });
+
+  test("diagnostic after partial chunk preserves chronological order", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={12}>
+        <AgentPane label="Agent A" agent="a" emitter={emitter} color="blue" />
+      </Box>,
+    );
+
+    // Emit a partial (unterminated) chunk, then a diagnostic.
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial text" });
+    emitter.emit("pipeline:verdict", {
+      agent: "a",
+      keyword: "APPROVED",
+      raw: "APPROVED",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    // The partial text should appear before the diagnostic line.
+    const partialIdx = frame.indexOf("partial text");
+    const diagnosticIdx = frame.indexOf("Pipeline:");
+    expect(partialIdx).toBeGreaterThanOrEqual(0);
+    expect(diagnosticIdx).toBeGreaterThanOrEqual(0);
+    expect(partialIdx).toBeLessThan(diagnosticIdx);
   });
 });

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -5,8 +5,20 @@
  * PipelineEventEmitter events and accumulate chunks into lines.
  */
 import { describe, expect, test } from "vitest";
+import type {
+  AgentInvokeEvent,
+  PipelineCiPollEvent,
+  PipelineLoopEvent,
+  PipelineVerdictEvent,
+  StageEnterEvent,
+  StageExitEvent,
+} from "../pipeline-events.js";
 import { PipelineEventEmitter } from "../pipeline-events.js";
-import type { LineEntry, PromptBlock } from "./useEventEmitter.js";
+import type {
+  DiagnosticBlock,
+  LineEntry,
+  PromptBlock,
+} from "./useEventEmitter.js";
 
 // ---- line accumulation logic (mirrors useAgentLines) -------------------------
 
@@ -23,8 +35,39 @@ function createLineAccumulator(
   let buffer = "";
   let lines: LineEntry[] = [];
   let stageName: string | undefined;
+  const handlers: Array<{ event: string; fn: (...args: unknown[]) => void }> =
+    [];
 
-  const chunkHandler = (ev: { agent: "a" | "b"; chunk: string }) => {
+  function on<T>(event: string, fn: (ev: T) => void) {
+    emitter.on(event as "agent:chunk", fn as never);
+    handlers.push({ event, fn: fn as (...args: unknown[]) => void });
+  }
+
+  function push(block: DiagnosticBlock | PromptBlock) {
+    const next: LineEntry[] = [...lines, block];
+    lines = next.length > maxLines ? next.slice(-maxLines) : next;
+  }
+
+  function pushDiagnostic(message: string) {
+    const block: DiagnosticBlock = {
+      kind: "diagnostic",
+      timestamp: "00:00:00",
+      message,
+    };
+    // Flush any pending partial line before inserting the diagnostic
+    // so it appears in the correct chronological position (mirrors
+    // the real hook's pushDiagnostic logic).
+    if (buffer) {
+      const pending = buffer;
+      buffer = "";
+      const next: LineEntry[] = [...lines, pending, block];
+      lines = next.length > maxLines ? next.slice(-maxLines) : next;
+    } else {
+      push(block);
+    }
+  }
+
+  on<{ agent: "a" | "b"; chunk: string }>("agent:chunk", (ev) => {
     if (ev.agent !== agent) return;
     buffer += ev.chunk;
     const parts = buffer.split("\n");
@@ -32,9 +75,9 @@ function createLineAccumulator(
     if (parts.length === 0) return;
     const next: LineEntry[] = [...lines, ...parts];
     lines = next.length > maxLines ? next.slice(-maxLines) : next;
-  };
+  });
 
-  const promptHandler = (ev: { agent: "a" | "b"; prompt: string }) => {
+  on<{ agent: "a" | "b"; prompt: string }>("agent:prompt", (ev) => {
     if (ev.agent !== agent) return;
     const block: PromptBlock = { kind: "prompt", prompt: ev.prompt, stageName };
     if (buffer) {
@@ -43,26 +86,96 @@ function createLineAccumulator(
       const next: LineEntry[] = [...lines, pending, block];
       lines = next.length > maxLines ? next.slice(-maxLines) : next;
     } else {
-      const next: LineEntry[] = [...lines, block];
-      lines = next.length > maxLines ? next.slice(-maxLines) : next;
+      push(block);
     }
-  };
+  });
 
-  const stageHandler = (ev: { stageName: string }) => {
+  // Buffer exit events and merge with the following enter to produce a
+  // single transition line (mirrors the real hook's pendingExitRef logic).
+  let pendingExit: {
+    stageNumber: number;
+    stageName: string | undefined;
+    outcome: string;
+  } | null = null;
+
+  on<StageExitEvent>("stage:exit", (ev) => {
+    pendingExit = {
+      stageNumber: ev.stageNumber,
+      stageName,
+      outcome: ev.outcome,
+    };
+  });
+
+  on<StageEnterEvent>("stage:enter", (ev) => {
+    const pending = pendingExit;
+    pendingExit = null;
+    if (pending) {
+      const from = pending.stageName
+        ? `Stage ${pending.stageNumber} (${pending.stageName})`
+        : `Stage ${pending.stageNumber}`;
+      pushDiagnostic(
+        `${from} → Stage ${ev.stageNumber} (${ev.stageName}) [outcome: ${pending.outcome}]`,
+      );
+    } else {
+      pushDiagnostic(`Entering Stage ${ev.stageNumber} (${ev.stageName})`);
+    }
     stageName = ev.stageName;
-  };
+  });
 
-  emitter.on("agent:chunk", chunkHandler);
-  emitter.on("agent:prompt", promptHandler);
-  emitter.on("stage:enter", stageHandler);
+  on<PipelineVerdictEvent>("pipeline:verdict", (ev) => {
+    if (ev.agent !== agent) return;
+    pushDiagnostic(`Reviewer verdict parsed as "${ev.keyword}"`);
+  });
+
+  on<PipelineLoopEvent>("pipeline:loop", (ev) => {
+    if (ev.agent !== undefined && ev.agent !== agent) return;
+    if (ev.exhausted) {
+      pushDiagnostic(`${ev.stageName} auto-budget exhausted`);
+    } else {
+      pushDiagnostic(
+        `${ev.stageName} auto-budget ${ev.remaining}/${ev.budget} remaining`,
+      );
+    }
+  });
+
+  on<PipelineCiPollEvent>("pipeline:ci-poll", (ev) => {
+    if (agent !== "a") return;
+    if (ev.action === "start") {
+      const sha = ev.sha ? ` (SHA: ${ev.sha.slice(0, 7)})` : "";
+      pushDiagnostic(`CI polling started${sha}`);
+    } else if (ev.action === "status") {
+      const verdict = ev.verdict ? `: ${ev.verdict}` : "";
+      pushDiagnostic(`CI poll status${verdict}`);
+    } else {
+      const verdict = ev.verdict ? `: ${ev.verdict}` : "";
+      pushDiagnostic(`CI polling done${verdict}`);
+    }
+  });
+
+  on<AgentInvokeEvent>("agent:invoke", (ev) => {
+    if (ev.agent !== agent) return;
+    const kindLabels: Record<string, string> = {
+      work: "work prompt",
+      review: "review prompt",
+      "verdict-followup": "verdict follow-up",
+      "ci-fix": "CI fix prompt",
+      summary: "summary request",
+    };
+    const label = agent === "a" ? "Agent A" : "Agent B";
+    const action = ev.type === "invoke" ? "Invoking" : "Resuming";
+    const kindLabel = ev.kind ? (kindLabels[ev.kind] ?? ev.kind) : "";
+    const roundSuffix = ev.round != null ? ` (round ${ev.round})` : "";
+    const context = kindLabel ? ` with ${kindLabel}${roundSuffix}` : "";
+    pushDiagnostic(`${action} ${label}${context}`);
+  });
 
   return {
     getLines: () => lines,
     getBuffer: () => buffer,
     cleanup: () => {
-      emitter.off("agent:chunk", chunkHandler);
-      emitter.off("agent:prompt", promptHandler);
-      emitter.off("stage:enter", stageHandler);
+      for (const { event, fn } of handlers) {
+        emitter.off(event as "agent:chunk", fn as never);
+      }
     },
   };
 }
@@ -204,7 +317,9 @@ describe("agent:prompt integration with line accumulator", () => {
 
     const lines = acc.getLines();
     expect(lines[0]).toBe("output");
-    expect(lines[1]).toEqual({
+    // stage:enter also produces a diagnostic block
+    expect(lines[1]).toMatchObject({ kind: "diagnostic" });
+    expect(lines[2]).toEqual({
       kind: "prompt",
       prompt: "hello",
       stageName: "Implement",
@@ -312,5 +427,328 @@ describe("event subscription patterns", () => {
 
     accA.cleanup();
     accB.cleanup();
+  });
+});
+
+describe("diagnostic event routing", () => {
+  function diagnostics(lines: LineEntry[]): DiagnosticBlock[] {
+    return lines.filter(
+      (l): l is DiagnosticBlock =>
+        typeof l !== "string" && l.kind === "diagnostic",
+    );
+  }
+
+  test("pipeline:verdict routes to the agent that produced it", () => {
+    const emitter = new PipelineEventEmitter();
+    const accA = createLineAccumulator(emitter, "a");
+    const accB = createLineAccumulator(emitter, "b");
+
+    emitter.emit("pipeline:verdict", {
+      agent: "b",
+      keyword: "APPROVED",
+      raw: "APPROVED",
+    });
+
+    expect(diagnostics(accA.getLines())).toEqual([]);
+    const bDiags = diagnostics(accB.getLines());
+    expect(bDiags).toHaveLength(1);
+    expect(bDiags[0].message).toBe('Reviewer verdict parsed as "APPROVED"');
+
+    accA.cleanup();
+    accB.cleanup();
+  });
+
+  test("stage:enter and stage:exit combine into a single transition line", () => {
+    const emitter = new PipelineEventEmitter();
+    const accA = createLineAccumulator(emitter, "a");
+    const accB = createLineAccumulator(emitter, "b");
+
+    emitter.emit("stage:enter", {
+      stageNumber: 7,
+      stageName: "Review",
+      iteration: 0,
+    });
+    emitter.emit("stage:exit", { stageNumber: 7, outcome: "completed" });
+    emitter.emit("stage:enter", {
+      stageNumber: 8,
+      stageName: "Squash",
+      iteration: 0,
+    });
+
+    for (const acc of [accA, accB]) {
+      const diags = diagnostics(acc.getLines());
+      expect(diags).toHaveLength(2);
+      expect(diags[0].message).toBe("Entering Stage 7 (Review)");
+      expect(diags[1].message).toBe(
+        "Stage 7 (Review) → Stage 8 (Squash) [outcome: completed]",
+      );
+    }
+
+    accA.cleanup();
+    accB.cleanup();
+  });
+
+  test("pipeline:loop shows remaining/total budget in the owning pane", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "b");
+
+    emitter.emit("pipeline:loop", {
+      stageNumber: 7,
+      stageName: "Review",
+      remaining: 4,
+      budget: 5,
+      exhausted: false,
+      agent: "b",
+    });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("Review auto-budget 4/5 remaining");
+
+    acc.cleanup();
+  });
+
+  test("pipeline:loop shows exhausted message", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "b");
+
+    emitter.emit("pipeline:loop", {
+      stageNumber: 7,
+      stageName: "Review",
+      remaining: 0,
+      budget: 5,
+      exhausted: true,
+      agent: "b",
+    });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("Review auto-budget exhausted");
+
+    acc.cleanup();
+  });
+
+  test("pipeline:loop does not appear in the non-owning pane", () => {
+    const emitter = new PipelineEventEmitter();
+    const accA = createLineAccumulator(emitter, "a");
+    const accB = createLineAccumulator(emitter, "b");
+
+    emitter.emit("pipeline:loop", {
+      stageNumber: 7,
+      stageName: "Review",
+      remaining: 3,
+      budget: 5,
+      exhausted: false,
+      agent: "b",
+    });
+
+    // Agent B owns the loop — should receive the diagnostic.
+    expect(diagnostics(accB.getLines())).toHaveLength(1);
+    // Agent A should not receive it.
+    expect(diagnostics(accA.getLines())).toHaveLength(0);
+
+    accA.cleanup();
+    accB.cleanup();
+  });
+
+  test("pipeline:ci-poll routes only to agent A", () => {
+    const emitter = new PipelineEventEmitter();
+    const accA = createLineAccumulator(emitter, "a");
+    const accB = createLineAccumulator(emitter, "b");
+
+    emitter.emit("pipeline:ci-poll", {
+      action: "start",
+      sha: "abc1234567890",
+    });
+
+    const aDiags = diagnostics(accA.getLines());
+    expect(aDiags).toHaveLength(1);
+    expect(aDiags[0].message).toBe("CI polling started (SHA: abc1234)");
+
+    // Agent B should not receive ci-poll diagnostics
+    const bDiags = diagnostics(accB.getLines());
+    expect(bDiags).toHaveLength(0);
+
+    accA.cleanup();
+    accB.cleanup();
+  });
+
+  test("pipeline:ci-poll status includes verdict when present", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", {
+      action: "status",
+      verdict: "pending",
+    });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("CI poll status: pending");
+
+    acc.cleanup();
+  });
+
+  test("pipeline:ci-poll status without verdict", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", { action: "status" });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("CI poll status");
+
+    acc.cleanup();
+  });
+
+  test("pipeline:ci-poll start without SHA", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", { action: "start" });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("CI polling started");
+
+    acc.cleanup();
+  });
+
+  test("pipeline:ci-poll done includes verdict", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", {
+      action: "done",
+      sha: "abc",
+      verdict: "pass",
+    });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("CI polling done: pass");
+
+    acc.cleanup();
+  });
+
+  test("agent:invoke routes to the target agent's pane with kind context", () => {
+    const emitter = new PipelineEventEmitter();
+    const accA = createLineAccumulator(emitter, "a");
+    const accB = createLineAccumulator(emitter, "b");
+
+    emitter.emit("agent:invoke", {
+      agent: "b",
+      type: "invoke",
+      kind: "work",
+    });
+
+    const aDiags = diagnostics(accA.getLines());
+    expect(aDiags).toHaveLength(0);
+
+    const bDiags = diagnostics(accB.getLines());
+    expect(bDiags).toHaveLength(1);
+    expect(bDiags[0].message).toBe("Invoking Agent B with work prompt");
+
+    accA.cleanup();
+    accB.cleanup();
+  });
+
+  test("agent:invoke resume produces correct message with kind", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:invoke", {
+      agent: "a",
+      type: "resume",
+      kind: "verdict-followup",
+    });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("Resuming Agent A with verdict follow-up");
+
+    acc.cleanup();
+  });
+
+  test("agent:invoke review kind includes round", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "b");
+
+    emitter.emit("agent:invoke", {
+      agent: "b",
+      type: "invoke",
+      kind: "review",
+      round: 2,
+    });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe(
+      "Invoking Agent B with review prompt (round 2)",
+    );
+
+    acc.cleanup();
+  });
+
+  test("agent:invoke without kind falls back to generic message", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "b");
+
+    emitter.emit("agent:invoke", { agent: "b", type: "invoke" });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toBe("Invoking Agent B");
+
+    acc.cleanup();
+  });
+
+  test("diagnostic blocks are capped by maxLines", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a", 2);
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "line1\n" });
+    emitter.emit("pipeline:verdict", {
+      agent: "a",
+      keyword: "BLOCKED",
+      raw: "BLOCKED",
+    });
+    emitter.emit("pipeline:verdict", {
+      agent: "a",
+      keyword: "APPROVED",
+      raw: "APPROVED",
+    });
+
+    // maxLines = 2: should keep only the last two entries
+    expect(acc.getLines()).toHaveLength(2);
+
+    acc.cleanup();
+  });
+
+  test("diagnostic arriving mid-chunk flushes the partial buffer first", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial" });
+    expect(acc.getBuffer()).toBe("partial");
+
+    emitter.emit("pipeline:verdict", {
+      agent: "a",
+      keyword: "APPROVED",
+      raw: "APPROVED",
+    });
+
+    const lines = acc.getLines();
+    // The partial text should be flushed as a plain string line
+    // before the diagnostic block.
+    expect(lines[0]).toBe("partial");
+    expect(lines[1]).toMatchObject({
+      kind: "diagnostic",
+      message: 'Reviewer verdict parsed as "APPROVED"',
+    });
+    expect(acc.getBuffer()).toBe("");
+
+    acc.cleanup();
   });
 });

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -1,5 +1,21 @@
 import { useEffect, useRef, useState } from "react";
-import type { PipelineEventEmitter } from "../pipeline-events.js";
+import type {
+  AgentInvokeEvent,
+  PipelineCiPollEvent,
+  PipelineEventEmitter,
+  PipelineLoopEvent,
+  PipelineVerdictEvent,
+  StageEnterEvent,
+  StageExitEvent,
+} from "../pipeline-events.js";
+
+/** Return a HH:MM:SS timestamp string for the current time. */
+function hhmmss(): string {
+  const d = new Date();
+  return [d.getHours(), d.getMinutes(), d.getSeconds()]
+    .map((n) => String(n).padStart(2, "0"))
+    .join(":");
+}
 
 /** A structured prompt block stored for size-aware rendering. */
 export interface PromptBlock {
@@ -8,8 +24,17 @@ export interface PromptBlock {
   stageName?: string;
 }
 
-/** A line buffer entry: either a plain text line or a deferred prompt block. */
-export type LineEntry = string | PromptBlock;
+/** An inline diagnostic line from the pipeline orchestrator. */
+export interface DiagnosticBlock {
+  kind: "diagnostic";
+  /** HH:MM:SS timestamp. */
+  timestamp: string;
+  /** Human-readable diagnostic message. */
+  message: string;
+}
+
+/** A line buffer entry: plain text, a prompt block, or a diagnostic line. */
+export type LineEntry = string | PromptBlock | DiagnosticBlock;
 
 export interface AgentLinesResult {
   /** Completed (newline-terminated) lines and prompt blocks. */
@@ -116,6 +141,160 @@ export function useAgentLines(
       emitter.off("agent:prompt", handler);
     };
   }, [emitter, agent, maxLines]);
+
+  // Helper: push a DiagnosticBlock into the line buffer.
+  // Store maxLines in a ref so the callback always sees the latest value
+  // without duplicating the function body.
+  const maxLinesRef = useRef(maxLines);
+  useEffect(() => {
+    maxLinesRef.current = maxLines;
+  }, [maxLines]);
+
+  const pushDiagnostic = useRef((message: string) => {
+    const block: DiagnosticBlock = {
+      kind: "diagnostic",
+      timestamp: hhmmss(),
+      message,
+    };
+    // Flush any pending partial line before inserting the diagnostic
+    // so it appears in the correct chronological position.
+    if (bufferRef.current) {
+      const pending = bufferRef.current;
+      bufferRef.current = "";
+      setPendingLine("");
+      setLines((prev) => {
+        const next: LineEntry[] = [...prev, pending, block];
+        return next.length > maxLinesRef.current
+          ? next.slice(-maxLinesRef.current)
+          : next;
+      });
+    } else {
+      setLines((prev) => {
+        const next: LineEntry[] = [...prev, block];
+        return next.length > maxLinesRef.current
+          ? next.slice(-maxLinesRef.current)
+          : next;
+      });
+    }
+  });
+
+  // --- Diagnostic event subscriptions ---
+
+  // pipeline:verdict → route to the agent that produced the verdict.
+  useEffect(() => {
+    const handler = (ev: PipelineVerdictEvent) => {
+      if (ev.agent !== agent) return;
+      pushDiagnostic.current(`Reviewer verdict parsed as "${ev.keyword}"`);
+    };
+    emitter.on("pipeline:verdict", handler);
+    return () => {
+      emitter.off("pipeline:verdict", handler);
+    };
+  }, [emitter, agent]);
+
+  // stage:enter / stage:exit → show combined stage transitions in both panes.
+  // Buffer exit events and merge with the following enter to produce a single
+  // transition line like "Stage 7 (Review) → Stage 8 (Squash) [outcome: completed]".
+  const pendingExitRef = useRef<{
+    stageNumber: number;
+    stageName: string | undefined;
+    outcome: string;
+  } | null>(null);
+
+  useEffect(() => {
+    const exitHandler = (ev: StageExitEvent) => {
+      pendingExitRef.current = {
+        stageNumber: ev.stageNumber,
+        stageName: stageNameRef.current,
+        outcome: ev.outcome,
+      };
+    };
+    const enterHandler = (ev: StageEnterEvent) => {
+      const pending = pendingExitRef.current;
+      pendingExitRef.current = null;
+      if (pending) {
+        const from = pending.stageName
+          ? `Stage ${pending.stageNumber} (${pending.stageName})`
+          : `Stage ${pending.stageNumber}`;
+        pushDiagnostic.current(
+          `${from} → Stage ${ev.stageNumber} (${ev.stageName}) [outcome: ${pending.outcome}]`,
+        );
+      } else {
+        pushDiagnostic.current(
+          `Entering Stage ${ev.stageNumber} (${ev.stageName})`,
+        );
+      }
+    };
+    emitter.on("stage:exit", exitHandler);
+    emitter.on("stage:enter", enterHandler);
+    return () => {
+      emitter.off("stage:exit", exitHandler);
+      emitter.off("stage:enter", enterHandler);
+    };
+  }, [emitter]);
+
+  // pipeline:loop → route to the looping stage's primary agent pane.
+  useEffect(() => {
+    const handler = (ev: PipelineLoopEvent) => {
+      if (ev.agent !== undefined && ev.agent !== agent) return;
+      if (ev.exhausted) {
+        pushDiagnostic.current(`${ev.stageName} auto-budget exhausted`);
+      } else {
+        pushDiagnostic.current(
+          `${ev.stageName} auto-budget ${ev.remaining}/${ev.budget} remaining`,
+        );
+      }
+    };
+    emitter.on("pipeline:loop", handler);
+    return () => {
+      emitter.off("pipeline:loop", handler);
+    };
+  }, [emitter, agent]);
+
+  // pipeline:ci-poll → route to Agent A pane (CI fixes run on A).
+  useEffect(() => {
+    if (agent !== "a") return;
+    const handler = (ev: PipelineCiPollEvent) => {
+      if (ev.action === "start") {
+        const sha = ev.sha ? ` (SHA: ${ev.sha.slice(0, 7)})` : "";
+        pushDiagnostic.current(`CI polling started${sha}`);
+      } else if (ev.action === "status") {
+        const verdict = ev.verdict ? `: ${ev.verdict}` : "";
+        pushDiagnostic.current(`CI poll status${verdict}`);
+      } else {
+        const verdict = ev.verdict ? `: ${ev.verdict}` : "";
+        pushDiagnostic.current(`CI polling done${verdict}`);
+      }
+    };
+    emitter.on("pipeline:ci-poll", handler);
+    return () => {
+      emitter.off("pipeline:ci-poll", handler);
+    };
+  }, [emitter, agent]);
+
+  // agent:invoke → route to the target agent's pane.
+  useEffect(() => {
+    const kindLabels: Record<string, string> = {
+      work: "work prompt",
+      review: "review prompt",
+      "verdict-followup": "verdict follow-up",
+      "ci-fix": "CI fix prompt",
+      summary: "summary request",
+    };
+    const handler = (ev: AgentInvokeEvent) => {
+      if (ev.agent !== agent) return;
+      const label = agent === "a" ? "Agent A" : "Agent B";
+      const action = ev.type === "invoke" ? "Invoking" : "Resuming";
+      const kindLabel = ev.kind ? (kindLabels[ev.kind] ?? ev.kind) : "";
+      const roundSuffix = ev.round != null ? ` (round ${ev.round})` : "";
+      const context = kindLabel ? ` with ${kindLabel}${roundSuffix}` : "";
+      pushDiagnostic.current(`${action} ${label}${context}`);
+    };
+    emitter.on("agent:invoke", handler);
+    return () => {
+      emitter.off("agent:invoke", handler);
+    };
+  }, [emitter, agent]);
 
   return { lines, pendingLine };
 }


### PR DESCRIPTION
## Summary

- Add `DiagnosticBlock` type to `useEventEmitter.ts` alongside the existing `PromptBlock`, with `kind: "diagnostic"`, `timestamp`, and `message` fields.
- Subscribe to all five diagnostic event categories in `useAgentLines()` and route them to the correct agent pane: `pipeline:verdict` to the producing agent, `stage:enter`/`stage:exit` to both panes, `pipeline:loop` to the looping stage's primary agent pane, `pipeline:ci-poll` to Agent A only, and `agent:invoke` to the target agent.
- Add `primaryAgent` field to `StageDefinition` so loop events carry the owning agent for accurate pane routing.
- Thread `AgentPromptKind` into `agent:invoke` diagnostics so messages include orchestrator context (e.g. "Invoking Agent B with review prompt (round 2)").
- Add `"review"` variant to `AgentPromptKind` and `round` field to `AgentInvokeEvent` so the review stage emits round-specific diagnostics instead of the generic "work prompt" label.
- Extend `PromptSink` with an optional `PromptSinkMeta` parameter so stage handlers can forward extra context (e.g. round number, resume flag) through the prompt sink to diagnostic events.
- Emit `type: "resume"` in `agent:invoke` events for all unconditional `sendFollowUp()` paths so the UI can truthfully distinguish fresh invocations from session resumptions.
- Combine `stage:exit` and `stage:enter` into a single transition diagnostic line (e.g. "Stage 7 (Review) → Stage 8 (Squash) [outcome: completed]") instead of two separate lines, reducing noise and surfacing the destination stage.
- Add `budget` field to `PipelineLoopEvent` and display loop diagnostics as "Review auto-budget 4/5 remaining" so users can gauge how close the auto-budget is to exhaustion.
- Render diagnostic lines in `AgentPane.tsx` with dimmed color and a `[HH:MM:SS] Pipeline:` prefix, scrolling inline with other pane content.
- Diagnostic-only panes show both the "waiting for output" placeholder and diagnostic lines, so users can trace pipeline decisions even before the agent produces real output.
- Flush the partial-output buffer before inserting diagnostics to preserve chronological ordering when a diagnostic arrives mid-chunk.

Closes #200

## Test plan

- [x] `pipeline:verdict` events appear only in the pane of the agent that produced the verdict
- [x] `stage:enter` and `stage:exit` combine into a single transition line in both panes
- [x] `pipeline:loop` events show remaining/total budget (e.g. "4/5 remaining") in the owning pane
- [x] `pipeline:ci-poll` events appear only in Agent A's pane
- [x] `agent:invoke` events appear in the target agent's pane with prompt kind context
- [x] `agent:invoke` review events include round number (e.g. "review prompt (round 2)")
- [x] `agent:invoke` resume events render as "Resuming" (production-path tested)
- [x] Diagnostic lines are visually distinct (dimmed) from agent output and prompts
- [x] Pane scrolling works correctly with diagnostic lines mixed in
- [x] Diagnostic-only panes show placeholder alongside diagnostic rows
- [x] Diagnostic after partial chunk preserves chronological order
- [x] Test helper `pushDiagnostic` flushes partial buffer (matches real hook)
- [x] All existing tests pass (`pnpm vitest run` — 1645 tests passing)
- [x] Lint and type checks pass (`pnpm biome check`, `pnpm tsc --noEmit`)