### PR TITLE
Fix E2BIG crash when CI failure logs are large (#234)

### DIFF
--- a/src/claude-adapter.test.ts
+++ b/src/claude-adapter.test.ts
@@ -709,12 +709,11 @@ describe("ClaudeStreamTransformer", () => {
 // buildClaudeArgs
 // ---------------------------------------------------------------------------
 describe("buildClaudeArgs", () => {
-  test("builds basic args with bypassPermissions and --verbose", () => {
-    const args = buildClaudeArgs("do something", {});
+  test("builds basic args with -p, bypassPermissions, and --verbose", () => {
+    const args = buildClaudeArgs({});
 
     expect(args).toEqual([
       "-p",
-      "do something",
       "--output-format",
       "stream-json",
       "--verbose",
@@ -723,20 +722,27 @@ describe("buildClaudeArgs", () => {
     ]);
   });
 
+  test("does not include prompt text in args (prompt goes via stdin)", () => {
+    const args = buildClaudeArgs({});
+    // -p is a flag only; no prompt text follows it
+    expect(args[0]).toBe("-p");
+    expect(args[1]).toBe("--output-format");
+  });
+
   test("always includes --verbose (required by stream-json)", () => {
-    const args = buildClaudeArgs("prompt", {});
+    const args = buildClaudeArgs({});
     expect(args).toContain("--verbose");
   });
 
   test("always passes bypassPermissions", () => {
-    const args = buildClaudeArgs("prompt", {});
+    const args = buildClaudeArgs({});
 
     expect(args).toContain("--permission-mode");
     expect(args).toContain("bypassPermissions");
   });
 
   test("includes --model when model is specified", () => {
-    const args = buildClaudeArgs("prompt", {
+    const args = buildClaudeArgs({
       model: "opus",
     });
 
@@ -745,13 +751,13 @@ describe("buildClaudeArgs", () => {
   });
 
   test("omits --model when model is undefined", () => {
-    const args = buildClaudeArgs("prompt", {});
+    const args = buildClaudeArgs({});
 
     expect(args).not.toContain("--model");
   });
 
   test("includes --effort when effortLevel is set", () => {
-    const args = buildClaudeArgs("prompt", {
+    const args = buildClaudeArgs({
       effortLevel: "high",
     });
 
@@ -760,7 +766,7 @@ describe("buildClaudeArgs", () => {
   });
 
   test("includes --effort max for Opus max effort", () => {
-    const args = buildClaudeArgs("prompt", {
+    const args = buildClaudeArgs({
       model: "opus",
       effortLevel: "max",
     });
@@ -770,13 +776,13 @@ describe("buildClaudeArgs", () => {
   });
 
   test("omits --effort when effortLevel is undefined", () => {
-    const args = buildClaudeArgs("prompt", {});
+    const args = buildClaudeArgs({});
 
     expect(args).not.toContain("--effort");
   });
 
   test("appends [1m] to model when contextWindow is 1m", () => {
-    const args = buildClaudeArgs("prompt", {
+    const args = buildClaudeArgs({
       model: "opus",
       contextWindow: "1m",
     });
@@ -785,7 +791,7 @@ describe("buildClaudeArgs", () => {
   });
 
   test("does not modify model when contextWindow is 200k", () => {
-    const args = buildClaudeArgs("prompt", {
+    const args = buildClaudeArgs({
       model: "opus",
       contextWindow: "200k",
     });
@@ -795,28 +801,23 @@ describe("buildClaudeArgs", () => {
   });
 
   test("includes --resume when sessionId is given", () => {
-    const args = buildClaudeArgs("continue", {}, "sess-123");
+    const args = buildClaudeArgs({}, "sess-123");
 
     expect(args).toContain("--resume");
     expect(args).toContain("sess-123");
   });
 
   test("omits --resume when sessionId is undefined", () => {
-    const args = buildClaudeArgs("prompt", {});
+    const args = buildClaudeArgs({});
 
     expect(args).not.toContain("--resume");
   });
 
   test("combines all options together", () => {
-    const args = buildClaudeArgs(
-      "full prompt",
-      { model: "sonnet" },
-      "sess-xyz",
-    );
+    const args = buildClaudeArgs({ model: "sonnet" }, "sess-xyz");
 
     expect(args).toEqual([
       "-p",
-      "full prompt",
       "--output-format",
       "stream-json",
       "--verbose",

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -207,7 +207,6 @@ export interface ClaudeAdapterOptions {
 }
 
 export function buildClaudeArgs(
-  prompt: string,
   opts: {
     model?: string;
     effortLevel?: ClaudeEffortLevel;
@@ -216,7 +215,8 @@ export function buildClaudeArgs(
   sessionId?: string,
 ): string[] {
   // --verbose is required for --output-format stream-json.
-  const args = ["-p", prompt, "--output-format", "stream-json", "--verbose"];
+  // -p without a following positional argument causes Claude to read from stdin.
+  const args = ["-p", "--output-format", "stream-json", "--verbose"];
   if (opts.model) {
     // Append context window variant as a bracketed suffix (e.g. opus[1m])
     // when the extended 1M window is selected.
@@ -297,7 +297,7 @@ export function createClaudeAdapter(
       if (options?.onUsage) transformer.onUsage = options.onUsage;
       return spawnAgent({
         command: "claude",
-        args: buildClaudeArgs(prompt, {
+        args: buildClaudeArgs({
           model,
           effortLevel,
           contextWindow,
@@ -306,6 +306,7 @@ export function createClaudeAdapter(
         parseResult: parseClaudeOutput,
         chunkTransformer: transformer,
         inactivityTimeoutMs,
+        stdin: prompt,
       });
     },
     resume(sessionId, prompt, options?: InvokeOptions) {
@@ -313,15 +314,12 @@ export function createClaudeAdapter(
       if (options?.onUsage) transformer.onUsage = options.onUsage;
       return spawnAgent({
         command: "claude",
-        args: buildClaudeArgs(
-          prompt,
-          { model, effortLevel, contextWindow },
-          sessionId,
-        ),
+        args: buildClaudeArgs({ model, effortLevel, contextWindow }, sessionId),
         cwd: options?.cwd,
         parseResult: parseClaudeOutput,
         chunkTransformer: transformer,
         inactivityTimeoutMs,
+        stdin: prompt,
       });
     },
   };

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -700,60 +700,54 @@ describe("CodexStreamTransformer", () => {
 // buildCodexInvokeArgs
 // ---------------------------------------------------------------------------
 describe("buildCodexInvokeArgs", () => {
-  test("builds invoke args with default options", () => {
-    const args = buildCodexInvokeArgs("do something", {});
+  test("builds invoke args with '-' placeholder for stdin", () => {
+    const args = buildCodexInvokeArgs({});
 
-    expect(args).toEqual([
-      "exec",
-      "-s",
-      "danger-full-access",
-      "--json",
-      "do something",
-    ]);
+    expect(args).toEqual(["exec", "-s", "danger-full-access", "--json", "-"]);
   });
 
   test("includes -m when model is specified", () => {
-    const args = buildCodexInvokeArgs("prompt", { model: "gpt-5.4" });
+    const args = buildCodexInvokeArgs({ model: "gpt-5.4" });
 
     expect(args).toContain("-m");
     expect(args).toContain("gpt-5.4");
-    // prompt comes after model
-    expect(args.indexOf("gpt-5.4")).toBeLessThan(args.indexOf("prompt"));
+    // '-' comes after model
+    expect(args.indexOf("gpt-5.4")).toBeLessThan(args.indexOf("-"));
   });
 
   test("omits -m when model is undefined", () => {
-    const args = buildCodexInvokeArgs("prompt", {});
+    const args = buildCodexInvokeArgs({});
     expect(args).not.toContain("-m");
     expect(args).not.toContain("--model");
   });
 
   test("does not include -a flag (not supported by CLI)", () => {
-    const args = buildCodexInvokeArgs("prompt", {});
+    const args = buildCodexInvokeArgs({});
     expect(args).not.toContain("-a");
     expect(args).not.toContain("never");
   });
 
   test("includes -c reasoning effort when specified", () => {
-    const args = buildCodexInvokeArgs("prompt", {
+    const args = buildCodexInvokeArgs({
       reasoningEffort: "high",
     });
 
     expect(args).toContain("-c");
     expect(args).toContain("model_reasoning_effort=high");
-    // -c value comes before the prompt
+    // -c value comes before the '-' placeholder
     expect(args.indexOf("model_reasoning_effort=high")).toBeLessThan(
-      args.indexOf("prompt"),
+      args.indexOf("-"),
     );
   });
 
   test("omits reasoning effort when undefined", () => {
-    const args = buildCodexInvokeArgs("prompt", {});
+    const args = buildCodexInvokeArgs({});
     const reArgs = args.filter((a) => a.includes("model_reasoning_effort"));
     expect(reArgs).toHaveLength(0);
   });
 
   test("passes xhigh reasoning effort through to CLI", () => {
-    const args = buildCodexInvokeArgs("prompt", {
+    const args = buildCodexInvokeArgs({
       reasoningEffort: "xhigh",
     });
 
@@ -766,19 +760,19 @@ describe("buildCodexInvokeArgs", () => {
 // ---------------------------------------------------------------------------
 describe("buildCodexResumeArgs", () => {
   test("always includes -c sandbox_mode=danger-full-access", () => {
-    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+    const args = buildCodexResumeArgs("sess-abc", {});
 
     expect(args).toContain("-c");
     expect(args).toContain("sandbox_mode=danger-full-access");
   });
 
   test("does not include --json (resume outputs plain text)", () => {
-    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+    const args = buildCodexResumeArgs("sess-abc", {});
     expect(args).not.toContain("--json");
   });
 
   test("includes -c model override when model is specified", () => {
-    const args = buildCodexResumeArgs("sess-abc", "continue", {
+    const args = buildCodexResumeArgs("sess-abc", {
       model: "gpt-5.3-codex",
     });
 
@@ -787,40 +781,40 @@ describe("buildCodexResumeArgs", () => {
   });
 
   test("omits model override when model is undefined", () => {
-    const args = buildCodexResumeArgs("sess-abc", "continue", {});
+    const args = buildCodexResumeArgs("sess-abc", {});
 
     const modelArgs = args.filter((a) => a.startsWith('model="'));
     expect(modelArgs).toHaveLength(0);
   });
 
-  test("places session ID and prompt after config flags", () => {
-    const args = buildCodexResumeArgs("sess-abc", "continue", {
+  test("places session ID and '-' after config flags", () => {
+    const args = buildCodexResumeArgs("sess-abc", {
       model: "gpt-5.4",
     });
 
     const sessIdx = args.indexOf("sess-abc");
-    const promptIdx = args.indexOf("continue");
+    const dashIdx = args.lastIndexOf("-");
     expect(sessIdx).toBeGreaterThan(0);
-    expect(promptIdx).toBe(sessIdx + 1);
+    expect(dashIdx).toBe(sessIdx + 1);
     // Both should come after all -c flags
     const lastCIdx = args.lastIndexOf("-c");
     expect(sessIdx).toBeGreaterThan(lastCIdx + 1);
   });
 
   test("does not include -s flag (uses -c for sandbox instead)", () => {
-    const args = buildCodexResumeArgs("sess-1", "prompt", {});
+    const args = buildCodexResumeArgs("sess-1", {});
     expect(args).not.toContain("-s");
   });
 
   test("does not include -m flag (uses -c for model instead)", () => {
-    const args = buildCodexResumeArgs("sess-1", "prompt", {
+    const args = buildCodexResumeArgs("sess-1", {
       model: "gpt-5.4",
     });
     expect(args).not.toContain("-m");
   });
 
   test("includes -c reasoning effort when specified", () => {
-    const args = buildCodexResumeArgs("sess-1", "prompt", {
+    const args = buildCodexResumeArgs("sess-1", {
       reasoningEffort: "medium",
     });
 
@@ -828,13 +822,13 @@ describe("buildCodexResumeArgs", () => {
   });
 
   test("omits reasoning effort when undefined", () => {
-    const args = buildCodexResumeArgs("sess-1", "prompt", {});
+    const args = buildCodexResumeArgs("sess-1", {});
     const reArgs = args.filter((a) => a.includes("model_reasoning_effort"));
     expect(reArgs).toHaveLength(0);
   });
 
   test("passes xhigh reasoning effort through to CLI", () => {
-    const args = buildCodexResumeArgs("sess-1", "prompt", {
+    const args = buildCodexResumeArgs("sess-1", {
       reasoningEffort: "xhigh",
     });
 

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -360,10 +360,10 @@ export interface CodexAdapterOptions {
   inactivityTimeoutMs?: number;
 }
 
-export function buildCodexInvokeArgs(
-  prompt: string,
-  opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
-): string[] {
+export function buildCodexInvokeArgs(opts: {
+  model?: string;
+  reasoningEffort?: CodexReasoningEffort;
+}): string[] {
   const args = ["exec", "-s", "danger-full-access", "--json"];
   if (opts.model) {
     args.push("-m", opts.model);
@@ -371,13 +371,12 @@ export function buildCodexInvokeArgs(
   if (opts.reasoningEffort) {
     args.push("-c", `model_reasoning_effort=${opts.reasoningEffort}`);
   }
-  args.push(prompt);
+  args.push("-");
   return args;
 }
 
 export function buildCodexResumeArgs(
   sessionId: string,
-  prompt: string,
   opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
 ): string[] {
   // Note: `codex exec resume` does not support --json; output is plain text.
@@ -388,7 +387,7 @@ export function buildCodexResumeArgs(
   if (opts.reasoningEffort) {
     args.push("-c", `model_reasoning_effort=${opts.reasoningEffort}`);
   }
-  args.push(sessionId, prompt);
+  args.push(sessionId, "-");
   return args;
 }
 
@@ -494,17 +493,18 @@ export function createCodexAdapter(
       }
       const stream = spawnAgent({
         command: "codex",
-        args: buildCodexInvokeArgs(prompt, { model, reasoningEffort }),
+        args: buildCodexInvokeArgs({ model, reasoningEffort }),
         cwd: options?.cwd,
         parseResult: parseCodexInvokeOutput,
         chunkTransformer: makeTransformer(),
         inactivityTimeoutMs,
+        stdin: prompt,
       });
       if (reasoningEffort !== "xhigh") return stream;
       return withXhighFallback(stream, () =>
         spawnAgent({
           command: "codex",
-          args: buildCodexInvokeArgs(prompt, {
+          args: buildCodexInvokeArgs({
             model,
             reasoningEffort: "high",
           }),
@@ -512,6 +512,7 @@ export function createCodexAdapter(
           parseResult: parseCodexInvokeOutput,
           chunkTransformer: makeTransformer(),
           inactivityTimeoutMs,
+          stdin: prompt,
         }),
       );
     },
@@ -533,7 +534,7 @@ export function createCodexAdapter(
       // codex exec resume outputs plain text, not JSONL.
       const stream = spawnAgent({
         command: "codex",
-        args: buildCodexResumeArgs(sessionId, prompt, {
+        args: buildCodexResumeArgs(sessionId, {
           model,
           reasoningEffort,
         }),
@@ -542,18 +543,20 @@ export function createCodexAdapter(
         // No chunkTransformer for resume — plain text is already
         // human-readable and can go directly to the UI.
         inactivityTimeoutMs,
+        stdin: prompt,
       });
       if (reasoningEffort !== "xhigh") return stream;
       return withXhighFallback(stream, () =>
         spawnAgent({
           command: "codex",
-          args: buildCodexResumeArgs(sessionId, prompt, {
+          args: buildCodexResumeArgs(sessionId, {
             model,
             reasoningEffort: "high",
           }),
           cwd: options?.cwd,
           parseResult: parseResume,
           inactivityTimeoutMs,
+          stdin: prompt,
         }),
       );
     },

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -17,8 +17,8 @@ function createMockChild(): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
   child.stdout = new PassThrough();
   child.stderr = new PassThrough();
-  child.stdin = null;
-  child.stdio = [null, child.stdout, child.stderr, null, null];
+  child.stdin = new PassThrough();
+  child.stdio = [child.stdin, child.stdout, child.stderr, null, null];
   child.pid = 12345;
   child.connected = false;
   child.signalCode = null;
@@ -73,7 +73,7 @@ describe("spawnAgent", () => {
 
     expect(mockSpawn).toHaveBeenCalledWith("test-cli", ["--flag", "value"], {
       cwd: "/some/dir",
-      stdio: ["ignore", "pipe", "pipe"],
+      stdio: ["pipe", "pipe", "pipe"],
     });
   });
 
@@ -207,7 +207,7 @@ describe("spawnAgent", () => {
     });
   });
 
-  test("rejects on non-ENOENT spawn error", async () => {
+  test("resolves execution_error on non-ENOENT spawn error", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
@@ -227,7 +227,141 @@ describe("spawnAgent", () => {
     err.code = "EACCES";
     child.emit("error", err);
 
-    await expect(stream.result).rejects.toThrow("permission denied");
+    const result = await stream.result;
+    expect(result).toMatchObject({
+      sessionId: undefined,
+      responseText: "permission denied",
+      status: "error",
+      errorType: "execution_error",
+      stderrText: "",
+    });
+  });
+
+  test("resolves execution_error on E2BIG spawn error (async event)", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const err = new Error("spawn E2BIG") as NodeJS.ErrnoException;
+    err.code = "E2BIG";
+    child.emit("error", err);
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("execution_error");
+    expect(result.responseText).toBe("spawn E2BIG");
+  });
+
+  test("resolves execution_error when spawn() throws E2BIG synchronously", async () => {
+    const err = new Error("spawn E2BIG") as NodeJS.ErrnoException;
+    err.code = "E2BIG";
+    mockSpawn.mockImplementation(() => {
+      throw err;
+    });
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("execution_error");
+    expect(result.responseText).toBe("spawn E2BIG");
+  });
+
+  test("resolves execution_error when spawn() throws EACCES synchronously", async () => {
+    const err = new Error("spawn EACCES") as NodeJS.ErrnoException;
+    err.code = "EACCES";
+    mockSpawn.mockImplementation(() => {
+      throw err;
+    });
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("execution_error");
+    expect(result.responseText).toBe("spawn EACCES");
+  });
+
+  test("resolves cli_not_found when spawn() throws ENOENT synchronously", async () => {
+    const err = new Error("spawn ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    mockSpawn.mockImplementation(() => {
+      throw err;
+    });
+
+    const stream = spawnAgent({
+      command: "nonexistent",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("cli_not_found");
+    expect(result.responseText).toBe("nonexistent CLI not found");
+  });
+
+  test("synchronous spawn throw returns empty async iterator", async () => {
+    const err = new Error("spawn E2BIG") as NodeJS.ErrnoException;
+    err.code = "E2BIG";
+    mockSpawn.mockImplementation(() => {
+      throw err;
+    });
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const chunks: string[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([]);
   });
 
   test("passes only stdout to parseResult output param", async () => {
@@ -307,6 +441,116 @@ describe("spawnAgent", () => {
     const result = await stream.result;
     expect(result.responseText).toBe("");
     expect(result.status).toBe("success");
+  });
+
+  test("writes stdin option to child process stdin", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+    const stdinData: string[] = [];
+    (child.stdin as PassThrough).on("data", (chunk: Buffer) => {
+      stdinData.push(chunk.toString());
+    });
+
+    spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => ({
+        sessionId: undefined,
+        responseText: output,
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      stdin: "hello from stdin",
+    });
+
+    // Allow the write to flush.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stdinData.join("")).toBe("hello from stdin");
+  });
+
+  test("closes stdin when no stdin option provided", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    // stdin should be ended (writable finished).
+    expect((child.stdin as PassThrough).writableEnded).toBe(true);
+  });
+
+  test("silently ignores EPIPE on stdin", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    // Replace stdin with one that emits EPIPE on write.
+    const fakeStdin = new PassThrough();
+    child.stdin = fakeStdin;
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (output) => ({
+        sessionId: undefined,
+        responseText: output,
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      stdin: "prompt data",
+    });
+
+    // Simulate EPIPE error on stdin.
+    const epipe = new Error("write EPIPE") as NodeJS.ErrnoException;
+    epipe.code = "EPIPE";
+    fakeStdin.emit("error", epipe);
+
+    // Process should still resolve normally.
+    child.emit("close", 0);
+    const result = await stream.result;
+    expect(result.status).toBe("success");
+  });
+
+  test("silently ignores non-EPIPE stdin errors (no uncaught exception)", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const fakeStdin = new PassThrough();
+    child.stdin = fakeStdin;
+
+    const stream = spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: (_output, code) => ({
+        sessionId: undefined,
+        responseText: "",
+        status: code === 0 ? "success" : "error",
+        errorType: code === 0 ? undefined : "execution_error",
+        stderrText: "",
+      }),
+      stdin: "prompt data",
+    });
+
+    // Simulate a non-EPIPE stdin error — should not throw.
+    const err = new Error("write ECONNRESET") as NodeJS.ErrnoException;
+    err.code = "ECONNRESET";
+    fakeStdin.emit("error", err);
+
+    // Child exits with error; the close handler produces a structured result.
+    child.emit("close", 1);
+    const result = await stream.result;
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("execution_error");
   });
 });
 
@@ -706,9 +950,13 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
     return events.map((e) => JSON.stringify(e)).join("\n");
   }
 
-  test("invoke sends correct args and returns parsed result", async () => {
+  test("invoke passes prompt via stdin, not in args", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
+    const stdinData: string[] = [];
+    (child.stdin as PassThrough).on("data", (chunk: Buffer) => {
+      stdinData.push(chunk.toString());
+    });
 
     const adapter = createClaudeAdapter({
       model: "opus",
@@ -716,19 +964,16 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
 
     const stream = adapter.invoke("write tests");
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      "claude",
-      expect.arrayContaining([
-        "-p",
-        "write tests",
-        "--output-format",
-        "stream-json",
-        "--verbose",
-        "--model",
-        "opus",
-      ]),
-      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
-    );
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("-p");
+    expect(spawnArgs).not.toContain("write tests");
+    expect(spawnArgs).toContain("--output-format");
+    expect(spawnArgs).toContain("--model");
+    expect(spawnArgs).toContain("opus");
+
+    // Verify prompt was delivered via stdin.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stdinData.join("")).toBe("write tests");
 
     const output = streamJsonl([
       { type: "system", subtype: "init", session_id: "sess-new" },
@@ -749,23 +994,27 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
     expect(result.status).toBe("success");
   });
 
-  test("resume includes --resume flag with session ID", () => {
+  test("resume passes prompt via stdin and includes --resume flag", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
+    const stdinData: string[] = [];
+    (child.stdin as PassThrough).on("data", (chunk: Buffer) => {
+      stdinData.push(chunk.toString());
+    });
 
     const adapter = createClaudeAdapter();
     adapter.resume("sess-prev", "continue working");
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      "claude",
-      expect.arrayContaining([
-        "--resume",
-        "sess-prev",
-        "--permission-mode",
-        "bypassPermissions",
-      ]),
-      expect.anything(),
-    );
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("--resume");
+    expect(spawnArgs).toContain("sess-prev");
+    expect(spawnArgs).toContain("--permission-mode");
+    expect(spawnArgs).toContain("bypassPermissions");
+    expect(spawnArgs).not.toContain("continue working");
+
+    // Verify prompt was delivered via stdin.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stdinData.join("")).toBe("continue working");
   });
 
   test("invoke with cwd passes working directory", () => {
@@ -888,27 +1137,28 @@ describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {
 // E2E: Codex adapter full flow
 // ---------------------------------------------------------------------------
 describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
-  test("invoke sends correct args and returns parsed JSONL result", async () => {
+  test("invoke passes prompt via stdin with '-' in args", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
+    const stdinData: string[] = [];
+    (child.stdin as PassThrough).on("data", (chunk: Buffer) => {
+      stdinData.push(chunk.toString());
+    });
 
     const adapter = createCodexAdapter({ model: "gpt-5.4" });
     const stream = adapter.invoke("fix the bug");
 
-    expect(mockSpawn).toHaveBeenCalledWith(
-      "codex",
-      expect.arrayContaining([
-        "exec",
-        "-s",
-        "danger-full-access",
-        "--json",
-        "-m",
-        "gpt-5.4",
-        "-c",
-        "model_reasoning_effort=high",
-      ]),
-      expect.objectContaining({ stdio: ["ignore", "pipe", "pipe"] }),
-    );
+    const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    expect(spawnArgs).toContain("-");
+    expect(spawnArgs).not.toContain("fix the bug");
+    expect(spawnArgs).toContain("exec");
+    expect(spawnArgs).toContain("--json");
+    expect(spawnArgs).toContain("-m");
+    expect(spawnArgs).toContain("gpt-5.4");
+
+    // Verify prompt was delivered via stdin.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stdinData.join("")).toBe("fix the bug");
 
     const jsonl = [
       JSON.stringify({
@@ -981,9 +1231,13 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(spawnArgs).toContain("model_reasoning_effort=medium");
   });
 
-  test("resume uses plain text parsing without --json flag", async () => {
+  test("resume passes prompt via stdin with '-' in args", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
+    const stdinData: string[] = [];
+    (child.stdin as PassThrough).on("data", (chunk: Buffer) => {
+      stdinData.push(chunk.toString());
+    });
 
     const adapter = createCodexAdapter({ model: "gpt-5.3-codex" });
     const stream = adapter.resume("sess-prev", "keep going");
@@ -991,6 +1245,12 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
     expect(spawnArgs).toContain("resume");
     expect(spawnArgs).toContain("sess-prev");
+    expect(spawnArgs).toContain("-");
+    expect(spawnArgs).not.toContain("keep going");
+
+    // Verify prompt was delivered via stdin.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(stdinData.join("")).toBe("keep going");
     expect(spawnArgs).toContain("-c");
     expect(spawnArgs).toContain("sandbox_mode=danger-full-access");
     expect(spawnArgs).toContain('model="gpt-5.3-codex"');

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -1,4 +1,6 @@
+import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
+import EventEmitter from "node:events";
 import type { AgentResult, AgentStream, ChunkTransformer } from "./agent.js";
 
 export interface SpawnAgentOptions {
@@ -21,13 +23,65 @@ export interface SpawnAgentOptions {
    * Omit or pass 0 to disable.
    */
   inactivityTimeoutMs?: number;
+  /**
+   * When provided, this text is written to the child's stdin and the
+   * stream is closed.  This avoids placing large prompts on the command
+   * line where they can hit the OS `ARG_MAX` limit.
+   */
+  stdin?: string;
 }
 
 export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
-  const child = spawn(opts.command, opts.args, {
-    cwd: opts.cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(opts.command, opts.args, {
+      cwd: opts.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+  } catch (err) {
+    // spawn() can throw synchronously for errors like E2BIG (argument
+    // list too long) or EACCES.  Convert these into a structured result
+    // so callers never see an unhandled exception.
+    const errno = (err as NodeJS.ErrnoException).code;
+    const errorResult: AgentResult =
+      errno === "ENOENT"
+        ? {
+            sessionId: undefined,
+            responseText: `${opts.command} CLI not found`,
+            status: "error",
+            errorType: "cli_not_found",
+            stderrText: "",
+          }
+        : {
+            sessionId: undefined,
+            responseText: (err as Error).message,
+            status: "error",
+            errorType: "execution_error",
+            stderrText: "",
+          };
+    const stubChild = new EventEmitter() as ChildProcess;
+    stubChild.kill = () => false;
+    return {
+      async *[Symbol.asyncIterator]() {},
+      result: Promise.resolve(errorResult),
+      child: stubChild,
+    };
+  }
+
+  // Write prompt to stdin when provided, avoiding ARG_MAX limits.
+  if (opts.stdin != null) {
+    child.stdin?.on("error", () => {
+      // EPIPE means the child closed its stdin before we finished
+      // writing — harmless.  Other errors (e.g. ECONNRESET) will
+      // surface as a non-zero exit code from the child, which the
+      // `close` handler resolves as a structured AgentResult.
+      // Throwing from an event callback would bypass structured error
+      // handling and produce an uncaught exception.
+    });
+    child.stdin?.end(opts.stdin);
+  } else {
+    child.stdin?.end();
+  }
 
   const { stdout, stderr } = child;
   const stdoutChunks: string[] = [];
@@ -84,7 +138,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
     stderrChunks.push(data.toString());
   });
 
-  const result = new Promise<AgentResult>((resolve, reject) => {
+  const result = new Promise<AgentResult>((resolve) => {
     child.on("error", (err) => {
       if (inactivityTimer) clearTimeout(inactivityTimer);
       if ("code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -96,7 +150,13 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
           stderrText: "",
         });
       } else {
-        reject(err);
+        resolve({
+          sessionId: undefined,
+          responseText: err.message,
+          status: "error",
+          errorType: "execution_error",
+          stderrText: "",
+        });
       }
     });
 


### PR DESCRIPTION
## Summary

- Pass agent prompts via stdin instead of positional CLI arguments to avoid hitting the OS `ARG_MAX` limit (~1 MB on macOS) when CI failure logs are large.
- Wrap the `spawn()` call in a try/catch so that synchronous throws (e.g. `E2BIG` on macOS) are converted into a structured `AgentResult` with `status: "error"` and `errorType: "execution_error"`, preventing unhandled exceptions.
- Resolve all non-`ENOENT` spawn errors emitted as async `"error"` events the same way.
- Silently ignore all stdin write errors (not just `EPIPE`) to avoid uncaught exceptions from async event callbacks; other failures surface via the child's exit code.

Closes #234

## Test plan

- [x] `spawnAgent` writes `stdin` option to child process stdin and closes the stream
- [x] `spawnAgent` closes stdin immediately when no `stdin` option is provided
- [x] `spawnAgent` silently ignores `EPIPE` errors on stdin
- [x] `spawnAgent` silently ignores non-`EPIPE` stdin errors (no uncaught exception)
- [x] `spawnAgent` resolves `execution_error` for non-`ENOENT` spawn errors via async error event (e.g. `EACCES`, `E2BIG`)
- [x] `spawnAgent` resolves `execution_error` when `spawn()` throws `E2BIG` synchronously
- [x] `spawnAgent` resolves `execution_error` when `spawn()` throws `EACCES` synchronously
- [x] `spawnAgent` resolves `cli_not_found` when `spawn()` throws `ENOENT` synchronously
- [x] `spawnAgent` returns empty async iterator on synchronous spawn failure
- [x] `buildClaudeArgs` no longer includes prompt text in the args array
- [x] Claude adapter `invoke()` passes prompt via `stdin`, not in args — verified via child.stdin content
- [x] Claude adapter `resume()` passes prompt via `stdin`, not in args — verified via child.stdin content
- [x] `buildCodexInvokeArgs` includes `"-"` placeholder instead of prompt text
- [x] `buildCodexResumeArgs` includes `"-"` placeholder instead of prompt text
- [x] Codex adapter `invoke()` passes prompt via `stdin` — verified via child.stdin content
- [x] Codex adapter `resume()` passes prompt via `stdin` — verified via child.stdin content
- [x] All tests pass (`pnpm vitest run`)
- [x] Biome lint clean, TypeScript type-check passes