### PR TITLE
Make CI check auto-iterations user-configurable (#235)

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Settings are stored in `~/.agentcoop/config.json`:
 | `language` | UI language (`en` or `ko`) | `en` |
 | `pipelineSettings.selfCheckAutoIterations` | Self-check budget | `5` |
 | `pipelineSettings.reviewAutoRounds` | Review budget | `5` |
+| `pipelineSettings.ciCheckAutoIterations` | CI check fix-attempt budget | `3` |
+| `pipelineSettings.ciCheckTimeoutMinutes` | CI poll timeout | `10` |
 | `pipelineSettings.inactivityTimeoutMinutes` | Silence timeout | `20` |
 | `pipelineSettings.autoResumeAttempts` | Max auto-resumes | `3` |
 | `notifications.bell` | Terminal bell on input wait | `true` |

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -566,8 +566,10 @@ Then commit and push the branch so a new CI run is triggered.
 ```
 
 **Loop behavior:** Each CI failure consumes one iteration from the
-auto-budget (default: 3). When the budget is exhausted, the user
-is asked whether to continue.
+auto-budget (default: 3, configurable via `ciCheckAutoIterations`).
+The stage polls for CI completion up to a configurable timeout
+(default: 10 minutes, configurable via `ciCheckTimeoutMinutes`).
+When the budget is exhausted, the user is asked whether to continue.
 
 #### CI findings review
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -40,6 +40,8 @@ describe("loadConfig", () => {
       pipelineSettings: {
         selfCheckAutoIterations: 5,
         reviewAutoRounds: 5,
+        ciCheckAutoIterations: 3,
+        ciCheckTimeoutMinutes: 10,
         inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
@@ -58,6 +60,8 @@ describe("loadConfig", () => {
       pipelineSettings: {
         selfCheckAutoIterations: 5,
         reviewAutoRounds: 5,
+        ciCheckAutoIterations: 3,
+        ciCheckTimeoutMinutes: 10,
         inactivityTimeoutMinutes: 20,
         autoResumeAttempts: 3,
       },
@@ -89,6 +93,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -236,6 +242,8 @@ describe("loadConfig", () => {
         pipelineSettings: {
           selfCheckAutoIterations: 5,
           reviewAutoRounds: 2,
+          ciCheckAutoIterations: 4,
+          ciCheckTimeoutMinutes: 15,
           inactivityTimeoutMinutes: 30,
           autoResumeAttempts: 1,
         },
@@ -245,6 +253,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 2,
+      ciCheckAutoIterations: 4,
+      ciCheckTimeoutMinutes: 15,
       inactivityTimeoutMinutes: 30,
       autoResumeAttempts: 1,
     });
@@ -267,6 +277,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -281,6 +293,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -333,6 +347,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -373,6 +389,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -396,6 +414,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -418,6 +438,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -432,6 +454,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -446,6 +470,8 @@ describe("loadConfig", () => {
     expect(config.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
@@ -537,6 +563,8 @@ describe("saveConfig", () => {
   const defaultPS = {
     selfCheckAutoIterations: 5,
     reviewAutoRounds: 5,
+    ciCheckAutoIterations: 3,
+    ciCheckTimeoutMinutes: 10,
     inactivityTimeoutMinutes: 20,
     autoResumeAttempts: 3,
   };

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,8 @@ import { dirname, join } from "node:path";
 export interface PipelineSettings {
   selfCheckAutoIterations: number;
   reviewAutoRounds: number;
+  ciCheckAutoIterations: number;
+  ciCheckTimeoutMinutes: number;
   inactivityTimeoutMinutes: number;
   autoResumeAttempts: number;
 }
@@ -12,6 +14,8 @@ export interface PipelineSettings {
 export const DEFAULT_PIPELINE_SETTINGS: PipelineSettings = {
   selfCheckAutoIterations: 5,
   reviewAutoRounds: 5,
+  ciCheckAutoIterations: 3,
+  ciCheckTimeoutMinutes: 10,
   inactivityTimeoutMinutes: 20,
   autoResumeAttempts: 3,
 };
@@ -103,6 +107,12 @@ function loadPipelineSettings(raw: unknown): PipelineSettings {
     reviewAutoRounds: isPositiveInt(r.reviewAutoRounds)
       ? r.reviewAutoRounds
       : d.reviewAutoRounds,
+    ciCheckAutoIterations: isPositiveInt(r.ciCheckAutoIterations)
+      ? r.ciCheckAutoIterations
+      : d.ciCheckAutoIterations,
+    ciCheckTimeoutMinutes: isPositiveInt(r.ciCheckTimeoutMinutes)
+      ? r.ciCheckTimeoutMinutes
+      : d.ciCheckTimeoutMinutes,
     inactivityTimeoutMinutes: isPositiveInt(r.inactivityTimeoutMinutes)
       ? r.inactivityTimeoutMinutes
       : d.inactivityTimeoutMinutes,
@@ -154,6 +164,27 @@ export function loadConfig(): Config {
       raw.executionMode === "auto" || raw.executionMode === "step"
         ? raw.executionMode
         : undefined,
+  };
+}
+
+/**
+ * Assembles the CI-check stage definition fragment from pipeline settings.
+ *
+ * Accepts a factory that builds the stage handler (so the caller can
+ * inject agent/issue context) and returns the handler spread with
+ * `autoBudget` set.  This keeps the minutes→ms conversion and the
+ * settings→stage wiring in one testable place, independent of the CLI
+ * entry point.
+ */
+export function assembleCiCheckStage<T>(
+  createHandler: (opts: { pollTimeoutMs: number }) => T,
+  settings: PipelineSettings,
+): T & { autoBudget: number } {
+  return {
+    ...createHandler({
+      pollTimeoutMs: settings.ciCheckTimeoutMinutes * 60_000,
+    }),
+    autoBudget: settings.ciCheckAutoIterations,
   };
 }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -34,6 +34,8 @@ export const en: Messages = {
   "startup.settingSelfCheck": "Self-check auto iterations",
   "startup.settingReviewRounds": "Review auto rounds",
   "startup.settingInactivityTimeout": "Inactivity timeout",
+  "startup.settingCiCheckIterations": "CI check auto iterations",
+  "startup.settingCiCheckTimeout": "CI check timeout",
   "startup.settingAutoResume": "Auto-resume attempts",
   "startup.settingSuffixMin": "min",
   "startup.adjustSettings": "Adjust any settings?",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -43,6 +43,9 @@ export const ko: Messages = {
     "\uB9AC\uBDF0 \uC790\uB3D9 \uBC18\uBCF5 \uD69F\uC218",
   "startup.settingInactivityTimeout":
     "\uBE44\uD65C\uC131 \uC2DC\uAC04 \uCD08\uACFC",
+  "startup.settingCiCheckIterations":
+    "CI \uAC80\uC0AC \uC790\uB3D9 \uBC18\uBCF5 \uD69F\uC218",
+  "startup.settingCiCheckTimeout": "CI \uAC80\uC0AC \uC2DC\uAC04 \uCD08\uACFC",
   "startup.settingAutoResume":
     "\uC790\uB3D9 \uC7AC\uAC1C \uC2DC\uB3C4 \uD69F\uC218",
   "startup.settingSuffixMin": "\uBD84",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -37,6 +37,8 @@ export interface Messages {
   "startup.settingSelfCheck": string;
   "startup.settingReviewRounds": string;
   "startup.settingInactivityTimeout": string;
+  "startup.settingCiCheckIterations": string;
+  "startup.settingCiCheckTimeout": string;
   "startup.settingAutoResume": string;
   "startup.settingSuffixMin": string;
   "startup.adjustSettings": string;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -181,9 +181,34 @@ describe("module exports", () => {
     expect(config.DEFAULT_PIPELINE_SETTINGS).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 20,
       autoResumeAttempts: 3,
     });
+  });
+
+  test("assembleCiCheckStage passes pollTimeoutMs to handler and sets autoBudget", async () => {
+    const { assembleCiCheckStage, DEFAULT_PIPELINE_SETTINGS } = await import(
+      "../dist/config.js"
+    );
+    // Use non-default values to prove the mapping, not just the defaults.
+    const settings = {
+      ...DEFAULT_PIPELINE_SETTINGS,
+      ciCheckAutoIterations: 7,
+      ciCheckTimeoutMinutes: 15,
+    };
+    let receivedOpts: { pollTimeoutMs: number } | undefined;
+    const handlerStub = { name: "CI check", number: 5, handler: () => {} };
+    const result = assembleCiCheckStage((opts: { pollTimeoutMs: number }) => {
+      receivedOpts = opts;
+      return handlerStub;
+    }, settings);
+    // The factory received the converted timeout.
+    expect(receivedOpts).toEqual({ pollTimeoutMs: 15 * 60_000 });
+    // The returned object spreads the handler and adds autoBudget.
+    expect(result.autoBudget).toBe(7);
+    expect(result.name).toBe("CI check");
   });
 
   test("github module exports listRepositories and getIssue", async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ import {
 } from "./cleanup-confirm.js";
 import { createCodexAdapter } from "./codex-adapter.js";
 import type { NotificationSettings, PipelineSettings } from "./config.js";
-import { loadConfig } from "./config.js";
+import { assembleCiCheckStage, loadConfig } from "./config.js";
 import { getGitHubUsername, getIssue } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
 import {
@@ -534,10 +534,15 @@ try {
     ...issueCtx,
   });
 
-  const ciCheckStage = createCiCheckStageHandler({
-    agent: agentA,
-    ...issueCtx,
-  });
+  const ciCheckStage = assembleCiCheckStage(
+    (opts) =>
+      createCiCheckStageHandler({
+        agent: agentA,
+        ...issueCtx,
+        ...opts,
+      }),
+    pipelineSettings,
+  );
 
   const testPlanStage = {
     ...createTestPlanStageHandler({
@@ -663,6 +668,8 @@ try {
     },
     selfCheckAutoIterations: pipelineSettings.selfCheckAutoIterations,
     reviewAutoRounds: pipelineSettings.reviewAutoRounds,
+    ciCheckAutoIterations: pipelineSettings.ciCheckAutoIterations,
+    ciCheckTimeoutMinutes: pipelineSettings.ciCheckTimeoutMinutes,
     inactivityTimeoutMinutes: pipelineSettings.inactivityTimeoutMinutes,
     autoResumeAttempts: pipelineSettings.autoResumeAttempts,
   });

--- a/src/run-log.test.ts
+++ b/src/run-log.test.ts
@@ -61,6 +61,8 @@ function meta(overrides?: Partial<RunLogMetadata>): RunLogMetadata {
     agentB: { cli: "claude", model: "sonnet" },
     selfCheckAutoIterations: 5,
     reviewAutoRounds: 5,
+    ciCheckAutoIterations: 3,
+    ciCheckTimeoutMinutes: 10,
     inactivityTimeoutMinutes: 20,
     autoResumeAttempts: 3,
     ...overrides,
@@ -106,6 +108,8 @@ describe("createRunLog", () => {
     expect(content).toContain("claude / sonnet");
     expect(content).toContain("self-check=5");
     expect(content).toContain("review=5");
+    expect(content).toContain("ci-check=3");
+    expect(content).toContain("ciCheck=10m");
     expect(content).toContain("inactivity=20m");
     expect(content).toContain("autoResume=3");
     expect(content).toContain("auto");

--- a/src/run-log.ts
+++ b/src/run-log.ts
@@ -35,6 +35,8 @@ export interface RunLogMetadata {
   agentB: RunLogAgentMeta;
   selfCheckAutoIterations: number;
   reviewAutoRounds: number;
+  ciCheckAutoIterations: number;
+  ciCheckTimeoutMinutes: number;
   inactivityTimeoutMinutes: number;
   autoResumeAttempts: number;
 }
@@ -177,10 +179,10 @@ export function createRunLog(
     write(`  context  : ${meta.agentB.contextWindow}`);
   if (meta.agentB.effortLevel) write(`  effort   : ${meta.agentB.effortLevel}`);
   write(
-    `Auto-budget: self-check=${meta.selfCheckAutoIterations}, review=${meta.reviewAutoRounds}`,
+    `Auto-budget: self-check=${meta.selfCheckAutoIterations}, review=${meta.reviewAutoRounds}, ci-check=${meta.ciCheckAutoIterations}`,
   );
   write(
-    `Timeouts   : inactivity=${meta.inactivityTimeoutMinutes}m, autoResume=${meta.autoResumeAttempts}`,
+    `Timeouts   : inactivity=${meta.inactivityTimeoutMinutes}m, ciCheck=${meta.ciCheckTimeoutMinutes}m, autoResume=${meta.autoResumeAttempts}`,
   );
   write("");
 

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -7,8 +7,10 @@
  * failure logs, sends them to the agent for a fix, and returns
  * `"not_approved"` so the engine loops back for another CI poll.
  *
- * The engine's default auto-budget (3) handles the "3 automatic /
- * 4th asks user" requirement for fix iterations.
+ * The engine's auto-budget (configurable via `ciCheckAutoIterations`,
+ * default 3) handles the fix iteration limit.  The poll timeout
+ * (configurable via `ciCheckTimeoutMinutes`, default 10) caps how
+ * long the stage waits for a pending CI run.
  */
 
 import type { AgentAdapter } from "./agent.js";

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -51,6 +51,8 @@ function defaultConfig(): Config {
     pipelineSettings: {
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 15,
       autoResumeAttempts: 3,
     },
@@ -126,6 +128,8 @@ describe("runStartup — happy path", () => {
     expect(result.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 15,
       autoResumeAttempts: 3,
     });
@@ -1071,6 +1075,8 @@ describe("runStartup — pipeline settings", () => {
     expect(result.pipelineSettings).toEqual({
       selfCheckAutoIterations: 3,
       reviewAutoRounds: 3,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
       inactivityTimeoutMinutes: 15,
       autoResumeAttempts: 3,
     });
@@ -1114,17 +1120,19 @@ describe("runStartup — pipeline settings", () => {
     expect(mockSaveConfig).toHaveBeenCalledOnce();
   });
 
-  test("presents all four settings as checkbox choices", async () => {
+  test("presents all six settings as checkbox choices", async () => {
     setupHappyPath();
     await runStartup();
 
     expect(mockCheckbox).toHaveBeenCalledTimes(2);
     const opts = mockCheckbox.mock.calls[0][0];
-    expect(opts.choices).toHaveLength(4);
+    expect(opts.choices).toHaveLength(6);
     const values = opts.choices.map((c: { value: string }) => c.value);
     expect(values).toEqual([
       "selfCheckAutoIterations",
       "reviewAutoRounds",
+      "ciCheckAutoIterations",
+      "ciCheckTimeoutMinutes",
       "inactivityTimeoutMinutes",
       "autoResumeAttempts",
     ]);
@@ -1132,8 +1140,10 @@ describe("runStartup — pipeline settings", () => {
     const names = opts.choices.map((c: { name: string }) => c.name);
     expect(names[0]).toBe("Self-check auto iterations: 3");
     expect(names[1]).toBe("Review auto rounds: 3");
-    expect(names[2]).toBe("Inactivity timeout: 15 min");
-    expect(names[3]).toBe("Auto-resume attempts: 3");
+    expect(names[2]).toBe("CI check auto iterations: 3");
+    expect(names[3]).toBe("CI check timeout: 10 min");
+    expect(names[4]).toBe("Inactivity timeout: 15 min");
+    expect(names[5]).toBe("Auto-resume attempts: 3");
   });
 
   test("displays current settings from config with unit suffix", async () => {
@@ -1145,6 +1155,9 @@ describe("runStartup — pipeline settings", () => {
     expect(logs).toContain("Pipeline settings");
     expect(logs).toContain("Self-check auto iterations");
     expect(logs).toContain("Review auto rounds");
+    expect(logs).toContain("CI check auto iterations");
+    expect(logs).toContain("CI check timeout");
+    expect(logs).toContain("10 min");
     expect(logs).toContain("Inactivity timeout");
     expect(logs).toContain("15 min");
     expect(logs).toContain("Auto-resume attempts");
@@ -1203,6 +1216,8 @@ describe("runStartup — pipeline settings", () => {
     const result = await runStartup();
     expect(result.pipelineSettings.selfCheckAutoIterations).toBe(10);
     expect(result.pipelineSettings.reviewAutoRounds).toBe(3);
+    expect(result.pipelineSettings.ciCheckAutoIterations).toBe(3);
+    expect(result.pipelineSettings.ciCheckTimeoutMinutes).toBe(10);
     expect(result.pipelineSettings.inactivityTimeoutMinutes).toBe(15);
     expect(result.pipelineSettings.autoResumeAttempts).toBe(3);
   });
@@ -1238,13 +1253,15 @@ describe("runStartup — pipeline settings", () => {
     expect(result.pipelineSettings.reviewAutoRounds).toBe(5);
   });
 
-  test("adjusting all four settings works correctly", async () => {
+  test("adjusting all six settings works correctly", async () => {
     setupHappyPath();
     mockCheckbox
       .mockReset()
       .mockResolvedValueOnce([
         "selfCheckAutoIterations",
         "reviewAutoRounds",
+        "ciCheckAutoIterations",
+        "ciCheckTimeoutMinutes",
         "inactivityTimeoutMinutes",
         "autoResumeAttempts",
       ])
@@ -1253,6 +1270,8 @@ describe("runStartup — pipeline settings", () => {
     mockInput
       .mockResolvedValueOnce("5") // selfCheckAutoIterations
       .mockResolvedValueOnce("7") // reviewAutoRounds
+      .mockResolvedValueOnce("4") // ciCheckAutoIterations
+      .mockResolvedValueOnce("15") // ciCheckTimeoutMinutes
       .mockResolvedValueOnce("30") // inactivityTimeoutMinutes
       .mockResolvedValueOnce("2"); // autoResumeAttempts
     mockConfirm.mockReset().mockResolvedValueOnce(true); // save
@@ -1262,6 +1281,8 @@ describe("runStartup — pipeline settings", () => {
     expect(result.pipelineSettings).toEqual({
       selfCheckAutoIterations: 5,
       reviewAutoRounds: 7,
+      ciCheckAutoIterations: 4,
+      ciCheckTimeoutMinutes: 15,
       inactivityTimeoutMinutes: 30,
       autoResumeAttempts: 2,
     });
@@ -1271,6 +1292,8 @@ describe("runStartup — pipeline settings", () => {
         pipelineSettings: {
           selfCheckAutoIterations: 5,
           reviewAutoRounds: 7,
+          ciCheckAutoIterations: 4,
+          ciCheckTimeoutMinutes: 15,
           inactivityTimeoutMinutes: 30,
           autoResumeAttempts: 2,
         },

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -443,20 +443,26 @@ function settingLabels(): Record<SettingKey, string> {
   return {
     selfCheckAutoIterations: m["startup.settingSelfCheck"],
     reviewAutoRounds: m["startup.settingReviewRounds"],
+    ciCheckAutoIterations: m["startup.settingCiCheckIterations"],
+    ciCheckTimeoutMinutes: m["startup.settingCiCheckTimeout"],
     inactivityTimeoutMinutes: m["startup.settingInactivityTimeout"],
     autoResumeAttempts: m["startup.settingAutoResume"],
   };
 }
 
 function settingSuffixes(): Partial<Record<SettingKey, string>> {
+  const m = t();
   return {
-    inactivityTimeoutMinutes: t()["startup.settingSuffixMin"],
+    ciCheckTimeoutMinutes: m["startup.settingSuffixMin"],
+    inactivityTimeoutMinutes: m["startup.settingSuffixMin"],
   };
 }
 
 const SETTING_KEYS: SettingKey[] = [
   "selfCheckAutoIterations",
   "reviewAutoRounds",
+  "ciCheckAutoIterations",
+  "ciCheckTimeoutMinutes",
   "inactivityTimeoutMinutes",
   "autoResumeAttempts",
 ];

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -89,7 +89,9 @@ export function renderPromptRows(block: PromptBlock, width: number): string[] {
  * `[HH:MM:SS] Pipeline: <message>`
  */
 export function renderDiagnosticRow(block: DiagnosticBlock): string {
-  return `[${block.timestamp}] Pipeline: ${block.message}`;
+  const suffix =
+    block.count != null && block.count > 1 ? ` x${block.count}` : "";
+  return `[${block.timestamp}] Pipeline: ${block.message}${suffix}`;
 }
 
 /** A single terminal row tagged with display metadata. */

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -3180,6 +3180,35 @@ describe("renderDiagnosticRow", () => {
     });
     expect(row).toBe("[00:00:00] Pipeline: ");
   });
+
+  test("appends count suffix when count > 1", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "06:41:08",
+      message: "CI poll status: pending",
+      count: 3,
+    });
+    expect(row).toBe("[06:41:08] Pipeline: CI poll status: pending x3");
+  });
+
+  test("omits count suffix when count is 1", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "01:00:00",
+      message: "some message",
+      count: 1,
+    });
+    expect(row).toBe("[01:00:00] Pipeline: some message");
+  });
+
+  test("omits count suffix when count is undefined", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "01:00:00",
+      message: "some message",
+    });
+    expect(row).toBe("[01:00:00] Pipeline: some message");
+  });
 });
 
 describe("AgentPane diagnostic rendering", () => {

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -49,20 +49,42 @@ function createLineAccumulator(
   }
 
   function pushDiagnostic(message: string) {
-    const block: DiagnosticBlock = {
-      kind: "diagnostic",
-      timestamp: "00:00:00",
-      message,
-    };
     // Flush any pending partial line before inserting the diagnostic
     // so it appears in the correct chronological position (mirrors
     // the real hook's pushDiagnostic logic).
     if (buffer) {
       const pending = buffer;
       buffer = "";
+      const block: DiagnosticBlock = {
+        kind: "diagnostic",
+        timestamp: "00:00:00",
+        message,
+      };
       const next: LineEntry[] = [...lines, pending, block];
       lines = next.length > maxLines ? next.slice(-maxLines) : next;
     } else {
+      // Deduplicate consecutive identical diagnostics (mirrors
+      // the real hook's deduplication logic).
+      const last = lines.length > 0 ? lines[lines.length - 1] : undefined;
+      if (
+        last != null &&
+        typeof last !== "string" &&
+        last.kind === "diagnostic" &&
+        last.message === message
+      ) {
+        const updated: DiagnosticBlock = {
+          ...last,
+          timestamp: "00:00:00",
+          count: (last.count ?? 1) + 1,
+        };
+        lines = [...lines.slice(0, -1), updated];
+        return;
+      }
+      const block: DiagnosticBlock = {
+        kind: "diagnostic",
+        timestamp: "00:00:00",
+        message,
+      };
       push(block);
     }
   }
@@ -748,6 +770,76 @@ describe("diagnostic event routing", () => {
       message: 'Reviewer verdict parsed as "APPROVED"',
     });
     expect(acc.getBuffer()).toBe("");
+
+    acc.cleanup();
+  });
+
+  test("consecutive identical diagnostics are collapsed with count", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    // Emit three identical CI poll status events.
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+
+    const lines = acc.getLines();
+    // Should collapse to a single diagnostic entry with count 3.
+    expect(lines).toHaveLength(1);
+    const diag = lines[0] as DiagnosticBlock;
+    expect(diag.kind).toBe("diagnostic");
+    expect(diag.message).toBe("CI poll status: pending");
+    expect(diag.count).toBe(3);
+
+    acc.cleanup();
+  });
+
+  test("non-consecutive identical diagnostics are not collapsed", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+    emitter.emit("agent:chunk", { agent: "a", chunk: "some output\n" });
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+
+    const diags = diagnostics(acc.getLines());
+    // Separated by a chunk line, so they should be two distinct entries.
+    expect(diags).toHaveLength(2);
+    expect(diags[0].count).toBeUndefined();
+    expect(diags[1].count).toBeUndefined();
+
+    acc.cleanup();
+  });
+
+  test("different consecutive diagnostics are not collapsed", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pass" });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(2);
+    expect(diags[0].message).toBe("CI poll status: pending");
+    expect(diags[1].message).toBe("CI poll status: pass");
+
+    acc.cleanup();
+  });
+
+  test("deduplication after partial chunk flush produces separate entries", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+    // Emit a partial chunk then an identical diagnostic — the flush
+    // breaks the consecutive sequence, so they should not be collapsed.
+    emitter.emit("agent:chunk", { agent: "a", chunk: "partial" });
+    emitter.emit("pipeline:ci-poll", { action: "status", verdict: "pending" });
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(2);
+    expect(diags[0].count).toBeUndefined();
+    expect(diags[1].count).toBeUndefined();
 
     acc.cleanup();
   });

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -31,6 +31,8 @@ export interface DiagnosticBlock {
   timestamp: string;
   /** Human-readable diagnostic message. */
   message: string;
+  /** Number of consecutive occurrences (omitted or 1 for the first). */
+  count?: number;
 }
 
 /** A line buffer entry: plain text, a prompt block, or a diagnostic line. */
@@ -151,17 +153,18 @@ export function useAgentLines(
   }, [maxLines]);
 
   const pushDiagnostic = useRef((message: string) => {
-    const block: DiagnosticBlock = {
-      kind: "diagnostic",
-      timestamp: hhmmss(),
-      message,
-    };
+    const now = hhmmss();
     // Flush any pending partial line before inserting the diagnostic
     // so it appears in the correct chronological position.
     if (bufferRef.current) {
       const pending = bufferRef.current;
       bufferRef.current = "";
       setPendingLine("");
+      const block: DiagnosticBlock = {
+        kind: "diagnostic",
+        timestamp: now,
+        message,
+      };
       setLines((prev) => {
         const next: LineEntry[] = [...prev, pending, block];
         return next.length > maxLinesRef.current
@@ -170,6 +173,29 @@ export function useAgentLines(
       });
     } else {
       setLines((prev) => {
+        // Deduplicate: if the last entry is a diagnostic with the same
+        // message, update it in place with an incremented count and
+        // the latest timestamp.
+        const last = prev.length > 0 ? prev[prev.length - 1] : undefined;
+        if (
+          last != null &&
+          typeof last !== "string" &&
+          last.kind === "diagnostic" &&
+          last.message === message
+        ) {
+          const updated: DiagnosticBlock = {
+            ...last,
+            timestamp: now,
+            count: (last.count ?? 1) + 1,
+          };
+          const next: LineEntry[] = [...prev.slice(0, -1), updated];
+          return next;
+        }
+        const block: DiagnosticBlock = {
+          kind: "diagnostic",
+          timestamp: now,
+          message,
+        };
         const next: LineEntry[] = [...prev, block];
         return next.length > maxLinesRef.current
           ? next.slice(-maxLinesRef.current)


### PR DESCRIPTION
## Summary

- Add `ciCheckAutoIterations` and `ciCheckTimeoutMinutes` to `PipelineSettings` with defaults matching current hardcoded values (3 iterations, 10 min timeout)
- Wire both through config loading, settings UI, run log metadata, and `ciCheckStage` construction
- Collapse consecutive identical diagnostics in agent panes (e.g. "CI poll status: pending x12") by deduplicating in `pushDiagnostic` with an in-place count
- Add i18n keys (en + ko), update JSDoc in stage-cicheck, and update all relevant tests

Closes #235

## Test plan

- [x] `pnpm vitest run` — all 1679 tests pass
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm biome check` — no lint issues
- [x] `src/config.test.ts` — covers loading and defaulting of ciCheckAutoIterations and ciCheckTimeoutMinutes
- [x] `src/startup.test.ts` — covers display and editing of new settings in the UI (6 settings instead of 4)
- [x] `src/index.test.ts` — verifies new settings in DEFAULT_PIPELINE_SETTINGS toEqual check, and `assembleCiCheckStage` test proves the handler factory receives `pollTimeoutMs` and the assembled stage gets `autoBudget` from settings
- [x] `src/run-log.test.ts` — verifies new fields in metadata and header string
- [x] `src/ui/useEventEmitter.test.ts` — consecutive identical diagnostics collapsed with count; non-consecutive not collapsed
- [x] `src/ui/components.test.tsx` — renderDiagnosticRow appends ` x{count}` when count > 1, omits otherwise