### PR TITLE
Render stage transitions as divider lines (#237)

### DIFF
--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -85,12 +85,20 @@ export function renderPromptRows(block: PromptBlock, width: number): string[] {
 }
 
 /**
- * Render a diagnostic block as a single formatted line:
+ * Render a diagnostic block as a single formatted line.
+ *
+ * Global (stage-transition) diagnostics use a divider style:
+ * `── Stage 4 (Create PR) → Stage 5 (CI check) [outcome: completed] ──`
+ *
+ * Agent-specific diagnostics keep the activity-log style:
  * `[HH:MM:SS] Pipeline: <message>`
  */
 export function renderDiagnosticRow(block: DiagnosticBlock): string {
   const suffix =
     block.count != null && block.count > 1 ? ` x${block.count}` : "";
+  if (block.global) {
+    return `\u2500\u2500 ${block.message}${suffix} \u2500\u2500`;
+  }
   return `[${block.timestamp}] Pipeline: ${block.message}${suffix}`;
 }
 

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -3209,6 +3209,32 @@ describe("renderDiagnosticRow", () => {
     });
     expect(row).toBe("[01:00:00] Pipeline: some message");
   });
+
+  test("renders global diagnostic as divider line", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "07:04:28",
+      message:
+        "Stage 4 (Create PR) \u2192 Stage 5 (CI check) [outcome: completed]",
+      global: true,
+    });
+    expect(row).toBe(
+      "\u2500\u2500 Stage 4 (Create PR) \u2192 Stage 5 (CI check) [outcome: completed] \u2500\u2500",
+    );
+  });
+
+  test("renders global diagnostic with count suffix", () => {
+    const row = renderDiagnosticRow({
+      kind: "diagnostic",
+      timestamp: "00:00:00",
+      message: "Entering Stage 1 (Implement)",
+      count: 2,
+      global: true,
+    });
+    expect(row).toBe(
+      "\u2500\u2500 Entering Stage 1 (Implement) x2 \u2500\u2500",
+    );
+  });
 });
 
 describe("AgentPane diagnostic rendering", () => {
@@ -3251,8 +3277,9 @@ describe("AgentPane diagnostic rendering", () => {
 
     const frame = lastFrame() ?? "";
     // Placeholder and diagnostic lines should both be visible.
+    // Stage transitions render as divider lines (no "Pipeline:" prefix).
     expect(frame).toContain("waiting for output");
-    expect(frame).toContain("Pipeline:");
+    expect(frame).toContain("\u2500\u2500");
     expect(frame).toContain("Implement");
   });
 

--- a/src/ui/useEventEmitter.test.ts
+++ b/src/ui/useEventEmitter.test.ts
@@ -48,19 +48,20 @@ function createLineAccumulator(
     lines = next.length > maxLines ? next.slice(-maxLines) : next;
   }
 
-  function pushDiagnostic(message: string) {
+  function pushDiagnostic(message: string, global?: boolean) {
     // Flush any pending partial line before inserting the diagnostic
     // so it appears in the correct chronological position (mirrors
     // the real hook's pushDiagnostic logic).
+    const base: DiagnosticBlock = {
+      kind: "diagnostic",
+      timestamp: "00:00:00",
+      message,
+      ...(global ? { global: true } : {}),
+    };
     if (buffer) {
       const pending = buffer;
       buffer = "";
-      const block: DiagnosticBlock = {
-        kind: "diagnostic",
-        timestamp: "00:00:00",
-        message,
-      };
-      const next: LineEntry[] = [...lines, pending, block];
+      const next: LineEntry[] = [...lines, pending, base];
       lines = next.length > maxLines ? next.slice(-maxLines) : next;
     } else {
       // Deduplicate consecutive identical diagnostics (mirrors
@@ -70,7 +71,8 @@ function createLineAccumulator(
         last != null &&
         typeof last !== "string" &&
         last.kind === "diagnostic" &&
-        last.message === message
+        last.message === message &&
+        (last.global ?? false) === (global ?? false)
       ) {
         const updated: DiagnosticBlock = {
           ...last,
@@ -80,12 +82,7 @@ function createLineAccumulator(
         lines = [...lines.slice(0, -1), updated];
         return;
       }
-      const block: DiagnosticBlock = {
-        kind: "diagnostic",
-        timestamp: "00:00:00",
-        message,
-      };
-      push(block);
+      push(base);
     }
   }
 
@@ -137,9 +134,13 @@ function createLineAccumulator(
         : `Stage ${pending.stageNumber}`;
       pushDiagnostic(
         `${from} → Stage ${ev.stageNumber} (${ev.stageName}) [outcome: ${pending.outcome}]`,
+        true,
       );
     } else {
-      pushDiagnostic(`Entering Stage ${ev.stageNumber} (${ev.stageName})`);
+      pushDiagnostic(
+        `Entering Stage ${ev.stageNumber} (${ev.stageName})`,
+        true,
+      );
     }
     stageName = ev.stageName;
   });
@@ -194,6 +195,7 @@ function createLineAccumulator(
   return {
     getLines: () => lines,
     getBuffer: () => buffer,
+    pushDiagnostic,
     cleanup: () => {
       for (const { event, fn } of handlers) {
         emitter.off(event as "agent:chunk", fn as never);
@@ -501,9 +503,11 @@ describe("diagnostic event routing", () => {
       const diags = diagnostics(acc.getLines());
       expect(diags).toHaveLength(2);
       expect(diags[0].message).toBe("Entering Stage 7 (Review)");
+      expect(diags[0].global).toBe(true);
       expect(diags[1].message).toBe(
         "Stage 7 (Review) → Stage 8 (Squash) [outcome: completed]",
       );
+      expect(diags[1].global).toBe(true);
     }
 
     accA.cleanup();
@@ -822,6 +826,26 @@ describe("diagnostic event routing", () => {
     expect(diags).toHaveLength(2);
     expect(diags[0].message).toBe("CI poll status: pending");
     expect(diags[1].message).toBe("CI poll status: pass");
+
+    acc.cleanup();
+  });
+
+  test("global and non-global diagnostics with same message are not collapsed", () => {
+    const emitter = new PipelineEventEmitter();
+    const acc = createLineAccumulator(emitter, "a");
+
+    // Push a global diagnostic, then a non-global one with the exact
+    // same message text.  The dedup condition at useEventEmitter.ts:188
+    // must keep them as separate entries.
+    acc.pushDiagnostic("same message", true);
+    acc.pushDiagnostic("same message");
+
+    const diags = diagnostics(acc.getLines());
+    expect(diags).toHaveLength(2);
+    expect(diags[0].global).toBe(true);
+    expect(diags[0].count).toBeUndefined();
+    expect(diags[1].global).toBeUndefined();
+    expect(diags[1].count).toBeUndefined();
 
     acc.cleanup();
   });

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -33,6 +33,8 @@ export interface DiagnosticBlock {
   message: string;
   /** Number of consecutive occurrences (omitted or 1 for the first). */
   count?: number;
+  /** Whether this is a global (cross-pane) diagnostic like stage transitions. */
+  global?: boolean;
 }
 
 /** A line buffer entry: plain text, a prompt block, or a diagnostic line. */
@@ -152,21 +154,22 @@ export function useAgentLines(
     maxLinesRef.current = maxLines;
   }, [maxLines]);
 
-  const pushDiagnostic = useRef((message: string) => {
+  const pushDiagnostic = useRef((message: string, global?: boolean) => {
     const now = hhmmss();
+    const base: DiagnosticBlock = {
+      kind: "diagnostic",
+      timestamp: now,
+      message,
+      ...(global ? { global: true } : {}),
+    };
     // Flush any pending partial line before inserting the diagnostic
     // so it appears in the correct chronological position.
     if (bufferRef.current) {
       const pending = bufferRef.current;
       bufferRef.current = "";
       setPendingLine("");
-      const block: DiagnosticBlock = {
-        kind: "diagnostic",
-        timestamp: now,
-        message,
-      };
       setLines((prev) => {
-        const next: LineEntry[] = [...prev, pending, block];
+        const next: LineEntry[] = [...prev, pending, base];
         return next.length > maxLinesRef.current
           ? next.slice(-maxLinesRef.current)
           : next;
@@ -174,14 +177,15 @@ export function useAgentLines(
     } else {
       setLines((prev) => {
         // Deduplicate: if the last entry is a diagnostic with the same
-        // message, update it in place with an incremented count and
-        // the latest timestamp.
+        // message and global flag, update it in place with an
+        // incremented count and the latest timestamp.
         const last = prev.length > 0 ? prev[prev.length - 1] : undefined;
         if (
           last != null &&
           typeof last !== "string" &&
           last.kind === "diagnostic" &&
-          last.message === message
+          last.message === message &&
+          (last.global ?? false) === (global ?? false)
         ) {
           const updated: DiagnosticBlock = {
             ...last,
@@ -191,12 +195,7 @@ export function useAgentLines(
           const next: LineEntry[] = [...prev.slice(0, -1), updated];
           return next;
         }
-        const block: DiagnosticBlock = {
-          kind: "diagnostic",
-          timestamp: now,
-          message,
-        };
-        const next: LineEntry[] = [...prev, block];
+        const next: LineEntry[] = [...prev, base];
         return next.length > maxLinesRef.current
           ? next.slice(-maxLinesRef.current)
           : next;
@@ -244,10 +243,12 @@ export function useAgentLines(
           : `Stage ${pending.stageNumber}`;
         pushDiagnostic.current(
           `${from} → Stage ${ev.stageNumber} (${ev.stageName}) [outcome: ${pending.outcome}]`,
+          true,
         );
       } else {
         pushDiagnostic.current(
           `Entering Stage ${ev.stageNumber} (${ev.stageName})`,
+          true,
         );
       }
     };


### PR DESCRIPTION
## Summary

- Adds a `global` boolean flag to `DiagnosticBlock` to distinguish cross-pane stage-transition diagnostics from agent-specific ones
- Stage-transition messages (`stage:enter` / `stage:exit`) now render as divider lines (`── Stage 4 (Create PR) → Stage 5 (CI check) [outcome: completed] ──`) instead of timestamped activity-log lines
- Agent-specific diagnostics remain unchanged (`[HH:MM:SS] Pipeline: <message>`)
- Deduplication logic respects the `global` flag so global and agent-specific diagnostics with identical text are not collapsed together

Closes #237

## Test plan

- [x] `renderDiagnosticRow` returns divider format (`── … ──`) when `global: true`
- [x] `renderDiagnosticRow` returns activity-log format (`[HH:MM:SS] Pipeline: …`) when `global` is absent or false
- [x] Global diagnostics with `count > 1` include the `xN` suffix inside the divider
- [x] `stage:enter` and `stage:exit` events produce diagnostics with `global: true`
- [x] Deduplication treats global and non-global diagnostics with the same message as distinct entries
- [x] AgentPane renders stage-transition lines without the `Pipeline:` prefix