### PR TITLE
Decouple model list from source code (#240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,18 @@ Settings are stored in `~/.agentcoop/config.json`:
 | `pipelineSettings.autoResumeAttempts` | Max auto-resumes | `3` |
 | `notifications.bell` | Terminal bell on input wait | `true` |
 | `notifications.desktop` | Desktop notification | `false` |
+| `customModels.claude` | Extra Claude model entries | _(none)_ |
+| `customModels.codex` | Extra Codex/GPT model entries | _(none)_ |
 
 Agent presets (CLI, model, context window, effort level) are also
 saved per agent slot.
+
+**Custom models**: During agent setup, choose "Enter custom model..."
+to register a model not in the default list. You are prompted for a
+model identifier (the `--model` CLI argument) and an optional display
+name. The entry is saved under `customModels` and appears in the
+model picker on subsequent runs. Default models are defined in
+`models.json` at the repository root.
 
 ## Notifications
 

--- a/models.json
+++ b/models.json
@@ -1,0 +1,10 @@
+{
+  "claude": [
+    { "name": "Claude Opus 4.6", "value": "opus" },
+    { "name": "Claude Sonnet 4.6", "value": "sonnet" }
+  ],
+  "codex": [
+    { "name": "GPT-5.4", "value": "gpt-5.4" },
+    { "name": "GPT-5.3-Codex", "value": "gpt-5.3-codex" }
+  ]
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -553,6 +553,138 @@ describe("loadConfig", () => {
     const config2 = loadConfig();
     expect(config2.notifications.bell).toBe(true);
   });
+
+  // ---- customModels -----------------------------------------------------------
+
+  test("default config has no customModels", () => {
+    const config = loadConfig();
+    expect(config.customModels).toBeUndefined();
+  });
+
+  test("reads valid customModels with both CLIs", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        customModels: {
+          claude: [{ name: "Claude Opus 4.7", value: "claude-opus-4-7" }],
+          codex: [{ name: "GPT-6", value: "gpt-6" }],
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.customModels).toEqual({
+      claude: [{ name: "Claude Opus 4.7", value: "claude-opus-4-7" }],
+      codex: [{ name: "GPT-6", value: "gpt-6" }],
+    });
+  });
+
+  test("reads customModels with only one CLI key", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        customModels: {
+          claude: [{ name: "My Model", value: "my-model" }],
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.customModels?.claude).toEqual([
+      { name: "My Model", value: "my-model" },
+    ]);
+    expect(config.customModels?.codex).toBeUndefined();
+  });
+
+  test("filters out malformed entries in customModels arrays", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        customModels: {
+          claude: [
+            { name: "Valid", value: "valid" },
+            { name: 42, value: "bad-name" },
+            { name: "Missing Value" },
+            "not-an-object",
+            null,
+            { name: "Also Valid", value: "also-valid" },
+          ],
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.customModels?.claude).toEqual([
+      { name: "Valid", value: "valid" },
+      { name: "Also Valid", value: "also-valid" },
+    ]);
+  });
+
+  test("returns undefined customModels when all entries are invalid", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        customModels: {
+          claude: [{ bad: true }, null],
+          codex: ["not-object"],
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.customModels).toBeUndefined();
+  });
+
+  test("returns undefined customModels when value is not an object", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], customModels: "invalid" }),
+    );
+    const config = loadConfig();
+    expect(config.customModels).toBeUndefined();
+  });
+
+  test("returns undefined customModels when value is null", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], customModels: null }),
+    );
+    const config = loadConfig();
+    expect(config.customModels).toBeUndefined();
+  });
+
+  test("returns undefined customModels when value is an array", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({ owners: [], customModels: [1, 2] }),
+    );
+    const config = loadConfig();
+    expect(config.customModels).toBeUndefined();
+  });
+
+  test("returns undefined customModels when CLI key is not an array", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        customModels: { claude: "not-array", codex: 42 },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.customModels).toBeUndefined();
+  });
+
+  test("customModels roundtrips with saveConfig", () => {
+    const config = loadConfig();
+    config.customModels = {
+      claude: [{ name: "Test Model", value: "test-model" }],
+    };
+    saveConfig(config);
+    const reloaded = loadConfig();
+    expect(reloaded.customModels).toEqual({
+      claude: [{ name: "Test Model", value: "test-model" }],
+    });
+  });
 });
 
 describe("saveConfig", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,10 @@ export interface Config {
   agentA?: SavedAgentConfig;
   agentB?: SavedAgentConfig;
   executionMode?: "auto" | "step";
+  customModels?: {
+    claude?: Array<{ name: string; value: string }>;
+    codex?: Array<{ name: string; value: string }>;
+  };
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -80,6 +84,36 @@ function loadSavedAgentConfig(raw: unknown): SavedAgentConfig | undefined {
       typeof r.contextWindow === "string" ? r.contextWindow : undefined,
     effortLevel: typeof r.effortLevel === "string" ? r.effortLevel : undefined,
   };
+}
+
+function loadModelEntries(
+  raw: unknown,
+): Array<{ name: string; value: string }> {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(
+      (e): e is { name: string; value: string } =>
+        typeof e === "object" &&
+        e !== null &&
+        !Array.isArray(e) &&
+        typeof (e as Record<string, unknown>).name === "string" &&
+        typeof (e as Record<string, unknown>).value === "string",
+    )
+    .map((e) => ({ name: e.name, value: e.value }));
+}
+
+function loadCustomModels(raw: unknown): Config["customModels"] | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+  const r = raw as Record<string, unknown>;
+  const claude = loadModelEntries(r.claude);
+  const codex = loadModelEntries(r.codex);
+  if (claude.length === 0 && codex.length === 0) return undefined;
+  const result: NonNullable<Config["customModels"]> = {};
+  if (claude.length > 0) result.claude = claude;
+  if (codex.length > 0) result.codex = codex;
+  return result;
 }
 
 function loadNotificationSettings(raw: unknown): NotificationSettings {
@@ -164,6 +198,7 @@ export function loadConfig(): Config {
       raw.executionMode === "auto" || raw.executionMode === "step"
         ? raw.executionMode
         : undefined,
+    customModels: loadCustomModels(raw.customModels),
   };
 }
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -49,6 +49,22 @@ export const en: Messages = {
   "startup.proceedWithIssue": "Proceed with this issue?",
   "startup.issueNotConfirmed": "Issue not confirmed. Aborting.",
 
+  // ---- custom model entry --------------------------------------------------
+
+  "startup.customModelOption": "Enter custom model...",
+  "startup.customModelValue": "Model identifier (passed to --model):",
+  "startup.customModelName": "Display name (leave blank to use identifier):",
+  "startup.customModelInvalidClaude":
+    "Must match: opus, sonnet, haiku, or claude-<name> (lowercase alphanumeric and hyphens)",
+  "startup.customModelInvalidCodex":
+    "Must match: gpt-<name> or o<number>[-<name>] (lowercase alphanumeric, hyphens, dots)",
+  "startup.customModelDuplicate": (name) => `Already exists as "${name}"`,
+
+  // ---- model registry ------------------------------------------------------
+
+  "models.loadFailed": (detail) =>
+    `Failed to load model definitions: ${detail}`,
+
   // ---- resume / run state ------------------------------------------------
 
   "resume.savedStateFound": "  Saved run state found:",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -65,6 +65,26 @@ export const ko: Messages = {
   "startup.issueNotConfirmed":
     "\uC774\uC288\uAC00 \uD655\uC778\uB418\uC9C0 \uC54A\uC558\uC2B5\uB2C8\uB2E4. \uC911\uB2E8\uD569\uB2C8\uB2E4.",
 
+  // ---- custom model entry --------------------------------------------------
+
+  "startup.customModelOption":
+    "\uC0AC\uC6A9\uC790 \uC815\uC758 \uBAA8\uB378 \uC785\uB825...",
+  "startup.customModelValue":
+    "\uBAA8\uB378 \uC2DD\uBCC4\uC790 (--model\uC5D0 \uC804\uB2EC\uB428):",
+  "startup.customModelName":
+    "\uD45C\uC2DC \uC774\uB984 (\uBE44\uC6CC\uB450\uBA74 \uC2DD\uBCC4\uC790 \uC0AC\uC6A9):",
+  "startup.customModelInvalidClaude":
+    "\uD615\uC2DD: opus, sonnet, haiku \uB610\uB294 claude-<\uC774\uB984> (\uC18C\uBB38\uC790 \uC601\uC22B\uC790 \uBC0F \uD558\uC774\uD508)",
+  "startup.customModelInvalidCodex":
+    "\uD615\uC2DD: gpt-<\uC774\uB984> \uB610\uB294 o<\uC22B\uC790>[-<\uC774\uB984>] (\uC18C\uBB38\uC790 \uC601\uC22B\uC790, \uD558\uC774\uD508, \uC810)",
+  "startup.customModelDuplicate": (name) =>
+    `\uC774\uBBF8 "${name}"(\uC73C)\uB85C \uC874\uC7AC\uD569\uB2C8\uB2E4`,
+
+  // ---- model registry ------------------------------------------------------
+
+  "models.loadFailed": (detail) =>
+    `\uBAA8\uB378 \uC815\uC758 \uB85C\uB4DC \uC2E4\uD328: ${detail}`,
+
   // ---- resume / run state ------------------------------------------------
 
   "resume.savedStateFound":

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -52,6 +52,19 @@ export interface Messages {
   "startup.proceedWithIssue": string;
   "startup.issueNotConfirmed": string;
 
+  // ---- custom model entry (startup.ts) -------------------------------------
+
+  "startup.customModelOption": string;
+  "startup.customModelValue": string;
+  "startup.customModelName": string;
+  "startup.customModelInvalidClaude": string;
+  "startup.customModelInvalidCodex": string;
+  "startup.customModelDuplicate": (existingName: string) => string;
+
+  // ---- model registry (models.ts / index.ts) --------------------------------
+
+  "models.loadFailed": (detail: string) => string;
+
   // ---- resume / run state (index.ts) -------------------------------------
 
   "resume.savedStateFound": string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   type IssueChange,
   type IssueSyncStatus,
 } from "./issue-sync.js";
+import { initModels, ModelsLoadError, setCustomModels } from "./models.js";
 import type {
   PipelineOptions,
   PipelineResult,
@@ -308,6 +309,9 @@ const bootConfig = loadConfig();
 await initI18n(bootConfig.language);
 
 try {
+  initModels();
+  setCustomModels(bootConfig.customModels);
+
   // Phase 1: select target (owner / repo / issue).
   const target = await selectTarget();
   const { owner, repo, issueNumber } = target;
@@ -382,8 +386,10 @@ try {
     const result = await runStartup(target);
     // Re-initialise i18n if the user changed language during startup.
     await initI18n(result.language);
-    // Reload config to pick up any notification changes made during startup.
+    // Reload config to pick up any notification or custom-model changes
+    // made during startup.
     const freshConfig = loadConfig();
+    setCustomModels(freshConfig.customModels);
     return {
       agentAConfig: result.agentA,
       agentBConfig: result.agentB,
@@ -948,6 +954,10 @@ try {
     error.message.includes("User force closed the prompt")
   ) {
     process.exit(130);
+  }
+  if (error instanceof ModelsLoadError) {
+    console.error(t()["models.loadFailed"](error.message));
+    process.exit(1);
   }
   console.error(error instanceof Error ? error.message : error);
   process.exit(1);

--- a/src/models.test.ts
+++ b/src/models.test.ts
@@ -1,0 +1,311 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  getModelDisplayName,
+  getModels,
+  initModels,
+  isOpusModel,
+  loadModelsFile,
+  ModelsLoadError,
+  setCustomModels,
+} from "./models.js";
+
+const tmpDir = join(import.meta.dirname, "..", ".tmp-test-models");
+
+function tmpPath(name = "models.json"): string {
+  return join(tmpDir, name);
+}
+
+function writeModels(data: unknown, name = "models.json"): string {
+  const path = tmpPath(name);
+  writeFileSync(path, JSON.stringify(data));
+  return path;
+}
+
+// ---- loadModelsFile ---------------------------------------------------------
+
+describe("loadModelsFile", () => {
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("parses valid models.json", () => {
+    const path = writeModels({
+      claude: [{ name: "Claude Opus 4.6", value: "opus" }],
+      codex: [{ name: "GPT-5.4", value: "gpt-5.4" }],
+    });
+    const result = loadModelsFile(path);
+    expect(result.claude).toEqual([{ name: "Claude Opus 4.6", value: "opus" }]);
+    expect(result.codex).toEqual([{ name: "GPT-5.4", value: "gpt-5.4" }]);
+  });
+
+  test("parses multiple entries per CLI", () => {
+    const path = writeModels({
+      claude: [
+        { name: "Claude Opus 4.6", value: "opus" },
+        { name: "Claude Sonnet 4.6", value: "sonnet" },
+      ],
+      codex: [
+        { name: "GPT-5.4", value: "gpt-5.4" },
+        { name: "GPT-5.3-Codex", value: "gpt-5.3-codex" },
+      ],
+    });
+    const result = loadModelsFile(path);
+    expect(result.claude).toHaveLength(2);
+    expect(result.codex).toHaveLength(2);
+  });
+
+  test("throws ModelsLoadError when file is missing", () => {
+    expect(() => loadModelsFile(join(tmpDir, "nonexistent.json"))).toThrow(
+      ModelsLoadError,
+    );
+  });
+
+  test("throws ModelsLoadError on invalid JSON", () => {
+    const path = tmpPath();
+    writeFileSync(path, "{ broken json");
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+    expect(() => loadModelsFile(path)).toThrow("invalid JSON");
+  });
+
+  test("throws ModelsLoadError when root is not an object", () => {
+    const path = writeModels([1, 2, 3]);
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+    expect(() => loadModelsFile(path)).toThrow("must contain an object");
+  });
+
+  test("throws ModelsLoadError when root is null", () => {
+    const path = tmpPath();
+    writeFileSync(path, "null");
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+  });
+
+  test("throws ModelsLoadError when claude key is not an array", () => {
+    const path = writeModels({
+      claude: "not-an-array",
+      codex: [],
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+    expect(() => loadModelsFile(path)).toThrow('"claude" must be an array');
+  });
+
+  test("throws ModelsLoadError when codex key is not an array", () => {
+    const path = writeModels({
+      claude: [],
+      codex: { foo: "bar" },
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+    expect(() => loadModelsFile(path)).toThrow('"codex" must be an array');
+  });
+
+  test("throws ModelsLoadError when claude key is missing", () => {
+    const path = writeModels({
+      codex: [{ name: "GPT-5.4", value: "gpt-5.4" }],
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+  });
+
+  test("throws ModelsLoadError when entry is missing name", () => {
+    const path = writeModels({
+      claude: [{ value: "opus" }],
+      codex: [],
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+    expect(() => loadModelsFile(path)).toThrow('string "name" and "value"');
+  });
+
+  test("throws ModelsLoadError when entry is missing value", () => {
+    const path = writeModels({
+      claude: [{ name: "Claude Opus 4.6" }],
+      codex: [],
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+  });
+
+  test("throws ModelsLoadError when entry has non-string name", () => {
+    const path = writeModels({
+      claude: [{ name: 42, value: "opus" }],
+      codex: [],
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+  });
+
+  test("throws ModelsLoadError when entry is a primitive", () => {
+    const path = writeModels({
+      claude: ["not-an-object"],
+      codex: [],
+    });
+    expect(() => loadModelsFile(path)).toThrow(ModelsLoadError);
+    expect(() => loadModelsFile(path)).toThrow("must be objects");
+  });
+
+  test("accepts empty arrays", () => {
+    const path = writeModels({ claude: [], codex: [] });
+    const result = loadModelsFile(path);
+    expect(result.claude).toEqual([]);
+    expect(result.codex).toEqual([]);
+  });
+});
+
+// ---- initModels + getModels -------------------------------------------------
+
+describe("getModels", () => {
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+    const path = writeModels({
+      claude: [
+        { name: "Claude Opus 4.6", value: "opus" },
+        { name: "Claude Sonnet 4.6", value: "sonnet" },
+      ],
+      codex: [{ name: "GPT-5.4", value: "gpt-5.4" }],
+    });
+    initModels(path);
+    setCustomModels({});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns defaults when no customs", () => {
+    const models = getModels("claude");
+    expect(models).toEqual([
+      { name: "Claude Opus 4.6", value: "opus" },
+      { name: "Claude Sonnet 4.6", value: "sonnet" },
+    ]);
+  });
+
+  test("returns codex defaults", () => {
+    expect(getModels("codex")).toEqual([{ name: "GPT-5.4", value: "gpt-5.4" }]);
+  });
+
+  test("merges customs after defaults", () => {
+    setCustomModels({
+      claude: [{ name: "Claude Opus 4.7", value: "claude-opus-4-7" }],
+    });
+    const models = getModels("claude");
+    expect(models).toEqual([
+      { name: "Claude Opus 4.6", value: "opus" },
+      { name: "Claude Sonnet 4.6", value: "sonnet" },
+      { name: "Claude Opus 4.7", value: "claude-opus-4-7" },
+    ]);
+  });
+
+  test("defaults win over customs with same value", () => {
+    setCustomModels({
+      claude: [{ name: "My Custom Opus", value: "opus" }],
+    });
+    const models = getModels("claude");
+    expect(models).toHaveLength(2);
+    expect(models[0]).toEqual({ name: "Claude Opus 4.6", value: "opus" });
+  });
+
+  test("custom codex models append after defaults", () => {
+    setCustomModels({
+      codex: [{ name: "GPT-6", value: "gpt-6" }],
+    });
+    expect(getModels("codex")).toEqual([
+      { name: "GPT-5.4", value: "gpt-5.4" },
+      { name: "GPT-6", value: "gpt-6" },
+    ]);
+  });
+
+  test("missing CLI key in customs treated as empty", () => {
+    setCustomModels({ claude: [{ name: "New", value: "new" }] });
+    // codex should still return just defaults
+    expect(getModels("codex")).toEqual([{ name: "GPT-5.4", value: "gpt-5.4" }]);
+  });
+
+  test("setCustomModels with undefined resets customs", () => {
+    setCustomModels({
+      claude: [{ name: "X", value: "x" }],
+    });
+    expect(getModels("claude")).toHaveLength(3);
+    setCustomModels(undefined);
+    expect(getModels("claude")).toHaveLength(2);
+  });
+
+  test("deduplicates within customs", () => {
+    setCustomModels({
+      claude: [
+        { name: "A", value: "custom-a" },
+        { name: "A duplicate", value: "custom-a" },
+      ],
+    });
+    const models = getModels("claude");
+    const customA = models.filter((m) => m.value === "custom-a");
+    expect(customA).toHaveLength(1);
+    expect(customA[0].name).toBe("A");
+  });
+});
+
+// ---- isOpusModel ------------------------------------------------------------
+
+describe("isOpusModel", () => {
+  test("recognises the short alias", () => {
+    expect(isOpusModel("opus")).toBe(true);
+  });
+
+  test("recognises explicit Opus IDs", () => {
+    expect(isOpusModel("claude-opus-4-6")).toBe(true);
+    expect(isOpusModel("claude-opus-4-7")).toBe(true);
+    expect(isOpusModel("claude-opus-5-0")).toBe(true);
+  });
+
+  test("rejects non-Opus models", () => {
+    expect(isOpusModel("sonnet")).toBe(false);
+    expect(isOpusModel("haiku")).toBe(false);
+    expect(isOpusModel("claude-sonnet-4-6")).toBe(false);
+    expect(isOpusModel("claude-haiku-4-5")).toBe(false);
+    expect(isOpusModel("gpt-5.4")).toBe(false);
+  });
+
+  test("rejects partial matches", () => {
+    expect(isOpusModel("opus-extra")).toBe(false);
+    expect(isOpusModel("my-opus")).toBe(false);
+    expect(isOpusModel("claude-opus")).toBe(false);
+  });
+});
+
+// ---- getModelDisplayName ----------------------------------------------------
+
+describe("getModelDisplayName", () => {
+  beforeEach(() => {
+    mkdirSync(tmpDir, { recursive: true });
+    const path = writeModels({
+      claude: [{ name: "Claude Opus 4.6", value: "opus" }],
+      codex: [{ name: "GPT-5.4", value: "gpt-5.4" }],
+    });
+    initModels(path);
+    setCustomModels({});
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns display name for known model", () => {
+    expect(getModelDisplayName("claude", "opus")).toBe("Claude Opus 4.6");
+    expect(getModelDisplayName("codex", "gpt-5.4")).toBe("GPT-5.4");
+  });
+
+  test("falls back to raw value for unknown model", () => {
+    expect(getModelDisplayName("claude", "claude-opus-4-7")).toBe(
+      "claude-opus-4-7",
+    );
+  });
+
+  test("resolves custom model display name", () => {
+    setCustomModels({
+      claude: [{ name: "Claude Opus 4.7", value: "claude-opus-4-7" }],
+    });
+    expect(getModelDisplayName("claude", "claude-opus-4-7")).toBe(
+      "Claude Opus 4.7",
+    );
+  });
+});

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,172 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface ModelEntry {
+  name: string;
+  value: string;
+}
+
+export type CliType = "claude" | "codex";
+
+interface ModelsFile {
+  claude: ModelEntry[];
+  codex: ModelEntry[];
+}
+
+/**
+ * Thrown when `models.json` cannot be loaded or has an invalid shape.
+ *
+ * The entry point catches this and treats it as a startup-blocking
+ * failure — `models.json` ships with the release and must be present.
+ */
+export class ModelsLoadError extends Error {
+  constructor(detail: string) {
+    super(detail);
+    this.name = "ModelsLoadError";
+  }
+}
+
+// ---- module state -----------------------------------------------------------
+
+let defaults: ModelsFile | undefined;
+let customs: Record<CliType, ModelEntry[]> = { claude: [], codex: [] };
+
+// ---- loading & validation ---------------------------------------------------
+
+function parseModelArray(raw: unknown, key: string): ModelEntry[] {
+  if (!Array.isArray(raw)) {
+    throw new ModelsLoadError(`"${key}" must be an array`);
+  }
+  const result: ModelEntry[] = [];
+  for (const entry of raw) {
+    if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+      throw new ModelsLoadError(`entries in "${key}" must be objects`);
+    }
+    const e = entry as Record<string, unknown>;
+    if (typeof e.name !== "string" || typeof e.value !== "string") {
+      throw new ModelsLoadError(
+        `entries in "${key}" must have string "name" and "value"`,
+      );
+    }
+    result.push({ name: e.name, value: e.value });
+  }
+  return result;
+}
+
+/**
+ * Read and validate `models.json`.
+ *
+ * @param filePath  Explicit path; defaults to `../models.json` relative
+ *                  to this compiled module (i.e. repo root).
+ */
+export function loadModelsFile(filePath?: string): ModelsFile {
+  const path =
+    filePath ??
+    join(dirname(fileURLToPath(import.meta.url)), "..", "models.json");
+  let content: string;
+  try {
+    content = readFileSync(path, "utf-8");
+  } catch (err) {
+    throw new ModelsLoadError(
+      `Cannot read models.json at ${path}: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(content);
+  } catch {
+    throw new ModelsLoadError("models.json contains invalid JSON");
+  }
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new ModelsLoadError("models.json must contain an object");
+  }
+  const obj = raw as Record<string, unknown>;
+  return {
+    claude: parseModelArray(obj.claude, "claude"),
+    codex: parseModelArray(obj.codex, "codex"),
+  };
+}
+
+// ---- registry lifecycle -----------------------------------------------------
+
+/**
+ * Load `models.json` and store the repo-shipped defaults.
+ *
+ * Must be called once at startup before any `getModels` /
+ * `getModelDisplayName` calls.
+ *
+ * @throws {ModelsLoadError} when the file is missing, unreadable,
+ *         contains invalid JSON, or has a shape mismatch.
+ */
+export function initModels(modelsJsonPath?: string): void {
+  defaults = loadModelsFile(modelsJsonPath);
+}
+
+/**
+ * Replace the user-defined custom models used for merging.
+ *
+ * Call after `initModels` whenever the config is (re)loaded or a new
+ * custom model is persisted.
+ */
+export function setCustomModels(custom?: {
+  claude?: ModelEntry[];
+  codex?: ModelEntry[];
+}): void {
+  customs = {
+    claude: custom?.claude ?? [],
+    codex: custom?.codex ?? [],
+  };
+}
+
+// ---- queries ----------------------------------------------------------------
+
+function mergeModels(base: ModelEntry[], extra: ModelEntry[]): ModelEntry[] {
+  const seen = new Set<string>();
+  const result: ModelEntry[] = [];
+  for (const entry of base) {
+    if (!seen.has(entry.value)) {
+      seen.add(entry.value);
+      result.push(entry);
+    }
+  }
+  for (const entry of extra) {
+    if (!seen.has(entry.value)) {
+      seen.add(entry.value);
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+/**
+ * Return the merged model list for a CLI (repo defaults + user customs).
+ *
+ * Repo defaults appear first; user customs are appended.  Duplicate
+ * `value` entries keep the first occurrence (repo defaults win).
+ */
+export function getModels(cli: CliType): ModelEntry[] {
+  if (!defaults) {
+    throw new Error("Model registry not initialized — call initModels() first");
+  }
+  return mergeModels(defaults[cli], customs[cli]);
+}
+
+/**
+ * Return `true` when the model value refers to a Claude Opus variant.
+ *
+ * Recognises the short alias (`"opus"`) and explicit IDs that follow
+ * the `claude-opus-*` naming convention (e.g. `claude-opus-4-7`).
+ */
+export function isOpusModel(value: string): boolean {
+  return value === "opus" || value.startsWith("claude-opus-");
+}
+
+/**
+ * Look up the display name for a model value, falling back to the raw
+ * value when not found.
+ */
+export function getModelDisplayName(cli: CliType, value: string): string {
+  const models = getModels(cli);
+  return models.find((m) => m.value === value)?.name ?? value;
+}

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { Config } from "./config.js";
 import type { Issue } from "./github.js";
 import { initI18n } from "./i18n/index.js";
@@ -36,9 +36,54 @@ vi.mock("./github.js", () => ({
   getIssue: (...args: unknown[]) => mockGetIssue(...args),
 }));
 
+const mockGetModels = vi.fn();
+const mockGetModelDisplayName = vi.fn();
+const mockIsOpusModel = vi.fn();
+const mockSetCustomModels = vi.fn();
+
+vi.mock("./models.js", () => ({
+  getModels: (...args: unknown[]) => mockGetModels(...args),
+  getModelDisplayName: (...args: unknown[]) => mockGetModelDisplayName(...args),
+  isOpusModel: (...args: unknown[]) => mockIsOpusModel(...args),
+  setCustomModels: (...args: unknown[]) => mockSetCustomModels(...args),
+}));
+
 const { runStartup, selectTarget, modelDisplayName } = await import(
   "./startup.js"
 );
+
+// ---------------------------------------------------------------------------
+// Model mock setup
+// ---------------------------------------------------------------------------
+
+const CLAUDE_TEST_MODELS = [
+  { name: "Claude Opus 4.6", value: "opus" },
+  { name: "Claude Sonnet 4.6", value: "sonnet" },
+];
+
+const CODEX_TEST_MODELS = [
+  { name: "GPT-5.4", value: "gpt-5.4" },
+  { name: "GPT-5.3-Codex", value: "gpt-5.3-codex" },
+];
+
+const MODEL_DISPLAY_NAMES: Record<string, string> = {
+  opus: "Claude Opus 4.6",
+  sonnet: "Claude Sonnet 4.6",
+  "gpt-5.4": "GPT-5.4",
+  "gpt-5.3-codex": "GPT-5.3-Codex",
+};
+
+function setupModelMocks() {
+  mockGetModels.mockImplementation((cli: string) =>
+    cli === "claude" ? [...CLAUDE_TEST_MODELS] : [...CODEX_TEST_MODELS],
+  );
+  mockGetModelDisplayName.mockImplementation(
+    (_cli: string, value: string) => MODEL_DISPLAY_NAMES[value] ?? value,
+  );
+  mockIsOpusModel.mockImplementation(
+    (value: string) => value === "opus" || value.startsWith("claude-opus-"),
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -94,6 +139,10 @@ function setupHappyPath() {
   mockGetIssue.mockReturnValue(defaultIssue());
   mockConfirm.mockResolvedValueOnce(true); // confirm issue
 }
+
+beforeEach(() => {
+  setupModelMocks();
+});
 
 afterEach(async () => {
   vi.resetAllMocks();
@@ -518,11 +567,13 @@ describe("runStartup — model selection", () => {
       (c: { value: string }) => c.value,
     );
     // Agent A selected "claude" CLI, so only Claude models are shown
+    // plus the "Enter custom model..." sentinel
     expect(values).toContain("opus");
     expect(values).toContain("sonnet");
+    expect(values).toContain("__custom__");
     expect(values).not.toContain("gpt-5.4");
     expect(values).not.toContain("gpt-5.3-codex");
-    expect(values).toHaveLength(2);
+    expect(values).toHaveLength(3);
   });
 
   test("switching CLI seeds defaults from CLI_DEFAULTS", async () => {
@@ -638,6 +689,35 @@ describe("runStartup — effort level choices", () => {
     expect(result.agentA.effortLevel).toBe("max");
     expect(result.agentB.effortLevel).toBe("high");
   });
+
+  test("offers max effort for explicit Opus ID (claude-opus-4-7)", async () => {
+    setupHappyPath();
+    mockSelect
+      .mockReset()
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("claude") // agent A CLI
+      .mockResolvedValueOnce("claude-opus-4-7") // agent A model — explicit ID
+      .mockResolvedValueOnce("200k") // agent A context window
+      .mockResolvedValueOnce("max") // agent A effort
+      .mockResolvedValueOnce("codex") // agent B CLI
+      .mockResolvedValueOnce("gpt-5.4") // agent B model
+      .mockResolvedValueOnce("high") // agent B effort
+      .mockResolvedValueOnce("auto") // execution mode
+      .mockResolvedValueOnce("en"); // language
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+
+    // Effort prompt for an explicit Opus ID should include "max"
+    // index: 0=owner, 1=CLI, 2=model, 3=context, 4=effort
+    const agentAEffortCall = mockSelect.mock.calls[4][0];
+    const agentAValues = agentAEffortCall.choices.map(
+      (c: { value: string }) => c.value,
+    );
+    expect(agentAValues).toContain("max");
+    expect(agentAValues).toEqual(["low", "medium", "high", "max"]);
+    expect(result.agentA.effortLevel).toBe("max");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -652,6 +732,16 @@ describe("modelDisplayName", () => {
       effortLevel: "max",
     });
     expect(name).toBe("Claude Opus 4.6 (1M) / Max");
+  });
+
+  test("shows Max label for explicit Opus ID with max effort", () => {
+    const name = modelDisplayName({
+      cli: "claude",
+      model: "claude-opus-4-7",
+      contextWindow: "1m",
+      effortLevel: "max",
+    });
+    expect(name).toBe("claude-opus-4-7 (1M) / Max");
   });
 
   test("shows High label for Sonnet with high effort", () => {
@@ -1716,5 +1806,240 @@ describe("runStartup — quick-start", () => {
     const result = await runStartup();
 
     expect(result.executionMode).toBe("auto");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom model entry
+// ---------------------------------------------------------------------------
+describe("runStartup — custom model entry", () => {
+  test("custom model flow prompts for value and name, persists to config", async () => {
+    const config = defaultConfig();
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("claude") // agent A CLI
+      .mockResolvedValueOnce("__custom__") // agent A model → custom sentinel
+      .mockResolvedValueOnce("200k") // agent A context window
+      .mockResolvedValueOnce("high") // agent A effort
+      .mockResolvedValueOnce("codex") // agent B CLI
+      .mockResolvedValueOnce("gpt-5.4") // agent B model
+      .mockResolvedValueOnce("high") // agent B effort
+      .mockResolvedValueOnce("auto") // execution mode
+      .mockResolvedValueOnce("en"); // language
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput
+      .mockResolvedValueOnce("42") // issue number
+      .mockResolvedValueOnce("claude-opus-4-7") // custom model value
+      .mockResolvedValueOnce("Claude Opus 4.7"); // custom model display name
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+    expect(result.agentA.model).toBe("claude-opus-4-7");
+    expect(result.agentA.cli).toBe("claude");
+
+    // Config should have been saved with the custom model.
+    expect(mockSaveConfig).toHaveBeenCalled();
+    expect(config.customModels?.claude).toEqual([
+      { name: "Claude Opus 4.7", value: "claude-opus-4-7" },
+    ]);
+    // Registry should have been refreshed.
+    expect(mockSetCustomModels).toHaveBeenCalledWith(config.customModels);
+  });
+
+  test("custom model display name defaults to value when left blank", async () => {
+    const config = defaultConfig();
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("codex") // agent A CLI
+      .mockResolvedValueOnce("__custom__") // agent A model → custom sentinel
+      .mockResolvedValueOnce("high") // agent A effort
+      .mockResolvedValueOnce("claude") // agent B CLI
+      .mockResolvedValueOnce("opus") // agent B model
+      .mockResolvedValueOnce("200k") // agent B context window
+      .mockResolvedValueOnce("high") // agent B effort
+      .mockResolvedValueOnce("auto") // execution mode
+      .mockResolvedValueOnce("en"); // language
+    mockSearch.mockResolvedValueOnce("agentcoop");
+    mockInput
+      .mockResolvedValueOnce("42") // issue number
+      .mockResolvedValueOnce("gpt-6") // custom model value
+      .mockResolvedValueOnce(""); // blank → defaults to value
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+    expect(result.agentA.model).toBe("gpt-6");
+    expect(config.customModels?.codex).toEqual([
+      { name: "gpt-6", value: "gpt-6" },
+    ]);
+  });
+
+  test("custom model validates regex for Claude", async () => {
+    const config = defaultConfig();
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers") // owner
+      .mockResolvedValueOnce("claude") // agent A CLI
+      .mockResolvedValueOnce("__custom__") // custom sentinel
+      .mockResolvedValueOnce("200k") // agent A context window
+      .mockResolvedValueOnce("high") // agent A effort
+      .mockResolvedValueOnce("codex") // agent B CLI
+      .mockResolvedValueOnce("gpt-5.4") // agent B model
+      .mockResolvedValueOnce("high") // agent B effort
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("en");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+
+    let valueCallDone = false;
+    mockInput.mockImplementation(
+      async (opts: {
+        message: string;
+        validate?: (v: string) => string | true;
+        default?: string;
+      }) => {
+        if (opts.message === "Issue number:") return "42";
+        if (!valueCallDone && opts.validate) {
+          valueCallDone = true;
+          // Invalid values should be rejected
+          expect(opts.validate("INVALID")).not.toBe(true);
+          expect(opts.validate("some spaces")).not.toBe(true);
+          expect(opts.validate("")).not.toBe(true);
+          // Valid values should pass (only non-duplicate ones)
+          expect(opts.validate("haiku")).toBe(true);
+          expect(opts.validate("claude-opus-4-7")).toBe(true);
+          expect(opts.validate("claude-haiku-4-5")).toBe(true);
+          return "claude-haiku-4-5";
+        }
+        // Display name prompt
+        return "Claude Haiku 4.5";
+      },
+    );
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+    expect(result.agentA.model).toBe("claude-haiku-4-5");
+  });
+
+  test("custom model validates regex for Codex", async () => {
+    const config = defaultConfig();
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers")
+      .mockResolvedValueOnce("codex") // agent A CLI
+      .mockResolvedValueOnce("__custom__")
+      .mockResolvedValueOnce("high") // agent A effort
+      .mockResolvedValueOnce("claude") // agent B CLI
+      .mockResolvedValueOnce("opus")
+      .mockResolvedValueOnce("200k")
+      .mockResolvedValueOnce("high")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("en");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+
+    let valueCallDone = false;
+    mockInput.mockImplementation(
+      async (opts: {
+        message: string;
+        validate?: (v: string) => string | true;
+        default?: string;
+      }) => {
+        if (opts.message === "Issue number:") return "42";
+        if (!valueCallDone && opts.validate) {
+          valueCallDone = true;
+          expect(opts.validate("INVALID")).not.toBe(true);
+          expect(opts.validate("claude-opus-4-7")).not.toBe(true);
+          // Valid Codex values
+          expect(opts.validate("gpt-6")).toBe(true);
+          expect(opts.validate("gpt-5.5-turbo")).toBe(true);
+          expect(opts.validate("o3-mini")).toBe(true);
+          return "gpt-6";
+        }
+        return "GPT-6";
+      },
+    );
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true);
+
+    const result = await runStartup();
+    expect(result.agentA.model).toBe("gpt-6");
+  });
+
+  test("custom model rejects duplicate values", async () => {
+    const config = defaultConfig();
+    mockLoadConfig.mockReturnValue(config);
+    mockSelect
+      .mockResolvedValueOnce("aicers")
+      .mockResolvedValueOnce("claude")
+      .mockResolvedValueOnce("__custom__")
+      .mockResolvedValueOnce("200k")
+      .mockResolvedValueOnce("high")
+      .mockResolvedValueOnce("codex")
+      .mockResolvedValueOnce("gpt-5.4")
+      .mockResolvedValueOnce("high")
+      .mockResolvedValueOnce("auto")
+      .mockResolvedValueOnce("en");
+    mockSearch.mockResolvedValueOnce("agentcoop");
+
+    let valueCallDone = false;
+    mockInput.mockImplementation(
+      async (opts: {
+        message: string;
+        validate?: (v: string) => string | true;
+        default?: string;
+      }) => {
+        if (opts.message === "Issue number:") return "42";
+        if (!valueCallDone && opts.validate) {
+          valueCallDone = true;
+          // "opus" already exists in the merged list via mockGetModels
+          const result = opts.validate("opus");
+          expect(result).not.toBe(true);
+          expect(result).toContain("Already exists");
+          // A truly new value should pass
+          expect(opts.validate("claude-opus-4-7")).toBe(true);
+          return "claude-opus-4-7";
+        }
+        return "Claude Opus 4.7";
+      },
+    );
+    mockCheckbox.mockResolvedValueOnce([]).mockResolvedValueOnce(["bell"]);
+    mockListRepositories.mockReturnValue([
+      { name: "agentcoop", description: "" },
+    ]);
+    mockGetIssue.mockReturnValue(defaultIssue());
+    mockConfirm.mockResolvedValueOnce(true);
+
+    await runStartup();
+  });
+
+  test("model selector includes custom model option", async () => {
+    setupHappyPath();
+    await runStartup();
+
+    // Agent A model selection is the 3rd select call (index 2)
+    const agentAModelCall = mockSelect.mock.calls[2][0];
+    const lastChoice =
+      agentAModelCall.choices[agentAModelCall.choices.length - 1];
+    expect(lastChoice.name).toBe("Enter custom model...");
+    expect(lastChoice.value).toBe("__custom__");
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -8,6 +8,12 @@ import { loadConfig, saveConfig } from "./config.js";
 import type { Issue } from "./github.js";
 import { getIssue, listRepositories } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
+import {
+  getModelDisplayName,
+  getModels,
+  isOpusModel,
+  setCustomModels,
+} from "./models.js";
 
 export interface TargetResult {
   owner: string;
@@ -42,17 +48,14 @@ const CLI_CHOICES = [
   { name: "Codex", value: "codex" as const },
 ];
 
-// ---- Model choices per CLI -----------------------------------------------
+// ---- Custom model sentinel value -----------------------------------------
 
-const CLAUDE_MODELS = [
-  { name: "Claude Opus 4.6", value: "opus" },
-  { name: "Claude Sonnet 4.6", value: "sonnet" },
-];
+const CUSTOM_MODEL_SENTINEL = "__custom__";
 
-const CODEX_MODELS = [
-  { name: "GPT-5.4", value: "gpt-5.4" },
-  { name: "GPT-5.3-Codex", value: "gpt-5.3-codex" },
-];
+// ---- Model validation patterns -------------------------------------------
+
+const CLAUDE_MODEL_PATTERN = /^(opus|sonnet|haiku|claude-[a-z0-9-]+)$/;
+const CODEX_MODEL_PATTERN = /^(gpt-[a-z0-9.-]+|o[0-9]+(-[a-z0-9]+)?)$/;
 
 // ---- Context window variants ---------------------------------------------
 
@@ -75,7 +78,7 @@ const CLAUDE_OPUS_EFFORT_LEVELS = [
 ];
 
 function claudeEffortChoices(model: string) {
-  return model === "opus" ? CLAUDE_OPUS_EFFORT_LEVELS : CLAUDE_EFFORT_LEVELS;
+  return isOpusModel(model) ? CLAUDE_OPUS_EFFORT_LEVELS : CLAUDE_EFFORT_LEVELS;
 }
 
 const CODEX_REASONING_LEVELS = [
@@ -88,9 +91,7 @@ const CODEX_REASONING_LEVELS = [
 // ---- Display name helpers ------------------------------------------------
 
 function modelDisplayName(config: AgentConfig): string {
-  const modelChoices = config.cli === "claude" ? CLAUDE_MODELS : CODEX_MODELS;
-  const modelName =
-    modelChoices.find((m) => m.value === config.model)?.name ?? config.model;
+  const modelName = getModelDisplayName(config.cli, config.model);
   const parts = [modelName];
   if (config.contextWindow) {
     parts[0] = `${modelName} (${config.contextWindow.toUpperCase()})`;
@@ -218,13 +219,18 @@ export async function runStartup(
   const agentA = await selectAgent(
     t()["agent.labelARole"],
     config.agentA ?? DEFAULT_AGENT_A,
+    config,
   );
   // Smart default: opposite CLI for agent B
   const defaultBCli = agentA.cli === "claude" ? "codex" : "claude";
   const agentBDefaults: Partial<AgentConfig> = config.agentB
     ? config.agentB
     : CLI_DEFAULTS[defaultBCli];
-  const agentB = await selectAgent(t()["agent.labelBRole"], agentBDefaults);
+  const agentB = await selectAgent(
+    t()["agent.labelBRole"],
+    agentBDefaults,
+    config,
+  );
   const executionMode = await selectExecutionMode(config.executionMode);
 
   const { language, dirty: langDirty } = await selectLanguage(config);
@@ -362,6 +368,7 @@ const DEFAULT_AGENT_A = CLI_DEFAULTS.claude;
 async function selectAgent(
   label: string,
   defaults?: Partial<AgentConfig>,
+  config?: Config,
 ): Promise<AgentConfig> {
   const m = t();
 
@@ -376,12 +383,54 @@ async function selectAgent(
   // of landing on the first choice.
   const effective = defaults?.cli === cli ? defaults : CLI_DEFAULTS[cli];
 
-  const models = cli === "claude" ? CLAUDE_MODELS : CODEX_MODELS;
-  const model = await select({
+  const models = getModels(cli);
+  const modelChoices = [
+    ...models.map((m) => ({ name: m.name, value: m.value })),
+    { name: m["startup.customModelOption"], value: CUSTOM_MODEL_SENTINEL },
+  ];
+  let model = await select({
     message: m["startup.agentModel"](label),
-    choices: models,
+    choices: modelChoices,
     default: effective.model,
   });
+
+  if (model === CUSTOM_MODEL_SENTINEL) {
+    const pattern =
+      cli === "claude" ? CLAUDE_MODEL_PATTERN : CODEX_MODEL_PATTERN;
+    const invalidMsg =
+      cli === "claude"
+        ? m["startup.customModelInvalidClaude"]
+        : m["startup.customModelInvalidCodex"];
+
+    const rawValue = await input({
+      message: m["startup.customModelValue"],
+      validate: (v) => {
+        const trimmed = v.trim();
+        if (!pattern.test(trimmed)) return invalidMsg;
+        const existing = getModels(cli).find((e) => e.value === trimmed);
+        if (existing) return m["startup.customModelDuplicate"](existing.name);
+        return true;
+      },
+    });
+    const value = rawValue.trim();
+
+    const rawName = await input({
+      message: m["startup.customModelName"],
+      default: value,
+    });
+    const displayName = rawName.trim() || value;
+
+    // Persist to config.
+    if (config) {
+      if (!config.customModels) config.customModels = {};
+      if (!config.customModels[cli]) config.customModels[cli] = [];
+      config.customModels[cli].push({ name: displayName, value });
+      saveConfig(config);
+      setCustomModels(config.customModels);
+    }
+
+    model = value;
+  }
 
   let contextWindow: string | undefined;
   if (cli === "claude") {


### PR DESCRIPTION
## Summary

- Extract hardcoded `CLAUDE_MODELS` / `CODEX_MODELS` arrays from `src/startup.ts` into a repo-shipped `models.json` and a new registry module (`src/models.ts`).
- Add `customModels` field to `Config` so users can register models at runtime via an "Enter custom model..." option in the agent selector, with regex validation and duplicate-value rejection.
- Migrate `modelDisplayName()` to use the registry so custom models render display names correctly in the quick-start summary.
- Centralise the Opus-family check into `isOpusModel()` in the registry, so explicit Opus IDs (e.g. `claude-opus-4-7`) get `Max` effort without code changes.
- Surface `models.json` load failures as startup-blocking errors (new `ModelsLoadError` class caught in `src/index.ts`).
- Add i18n keys (en + ko) for custom-model prompts, validation messages, and load-failure errors.
- Update README configuration table to document `customModels`.

Part of #240

## Not addressed

- **Phase 2: Edit/remove submenu for custom models** — deferred per the issue's phasing plan. The current `selectAgent()` is a linear prompt flow and inserting a submenu is a larger UI/test shape change.

## Test plan

- [x] `src/models.test.ts` — `loadModelsFile` parsing: valid JSON, multiple entries, empty arrays
- [x] `src/models.test.ts` — `loadModelsFile` errors: missing file, invalid JSON, non-object root, missing/malformed keys and entries all throw `ModelsLoadError`
- [x] `src/models.test.ts` — `getModels` merge: defaults-only, customs appended, defaults win on duplicate values, deduplication within customs, `setCustomModels(undefined)` resets
- [x] `src/models.test.ts` — `getModelDisplayName`: known model returns display name, unknown falls back to raw value, custom model resolved
- [x] `src/models.test.ts` — `isOpusModel`: recognises alias and explicit IDs, rejects non-Opus models and partial matches
- [x] `src/config.test.ts` — `customModels` loading: valid with both CLIs, single CLI key, filters malformed entries, undefined on invalid shapes (non-object, null, array, non-array CLI keys)
- [x] `src/config.test.ts` — `customModels` roundtrips through `saveConfig` / `loadConfig`
- [x] `src/startup.test.ts` — model selector includes "Enter custom model..." sentinel as last choice
- [x] `src/startup.test.ts` — custom model flow: prompts for value and name, persists to config, refreshes registry
- [x] `src/startup.test.ts` — display name defaults to value when left blank
- [x] `src/startup.test.ts` — regex validation rejects invalid Claude and Codex patterns, accepts valid ones
- [x] `src/startup.test.ts` — duplicate-value rejection returns "Already exists" error naming the conflicting entry
- [x] `src/startup.test.ts` — explicit Opus ID (`claude-opus-4-7`) gets `Max` effort option end-to-end
- [x] `src/startup.test.ts` — `modelDisplayName` renders `Max` correctly for explicit Opus IDs
- [x] All 1729 tests pass, type-check clean, Biome clean