### PR TITLE
Fix squash/review stages ignoring ciCheckTimeoutMinutes (#242)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -223,6 +223,40 @@ export function assembleCiCheckStage<T>(
   };
 }
 
+/**
+ * Assembles the squash stage definition fragment from pipeline settings.
+ *
+ * Keeps the minutes→ms conversion in one testable place, matching the
+ * pattern used by {@link assembleCiCheckStage}.
+ */
+export function assembleSquashStage<T>(
+  createHandler: (opts: { pollTimeoutMs: number }) => T,
+  settings: PipelineSettings,
+): T {
+  return createHandler({
+    pollTimeoutMs: settings.ciCheckTimeoutMinutes * 60_000,
+  });
+}
+
+/**
+ * Assembles the review stage definition fragment from pipeline settings.
+ *
+ * Converts `ciCheckTimeoutMinutes` to `pollTimeoutMs` and maps
+ * `reviewAutoRounds` to `autoBudget`, keeping the settings→stage wiring
+ * in one testable place.
+ */
+export function assembleReviewStage<T>(
+  createHandler: (opts: { pollTimeoutMs: number }) => T,
+  settings: PipelineSettings,
+): T & { autoBudget: number } {
+  return {
+    ...createHandler({
+      pollTimeoutMs: settings.ciCheckTimeoutMinutes * 60_000,
+    }),
+    autoBudget: settings.reviewAutoRounds,
+  };
+}
+
 export function saveConfig(config: Config): void {
   const path = configPath();
   mkdirSync(dirname(path), { recursive: true });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -211,6 +211,44 @@ describe("module exports", () => {
     expect(result.name).toBe("CI check");
   });
 
+  test("assembleSquashStage passes pollTimeoutMs to handler", async () => {
+    const { assembleSquashStage, DEFAULT_PIPELINE_SETTINGS } = await import(
+      "../dist/config.js"
+    );
+    const settings = {
+      ...DEFAULT_PIPELINE_SETTINGS,
+      ciCheckTimeoutMinutes: 20,
+    };
+    let receivedOpts: { pollTimeoutMs: number } | undefined;
+    const handlerStub = { name: "Squash", number: 8, handler: () => {} };
+    const result = assembleSquashStage((opts: { pollTimeoutMs: number }) => {
+      receivedOpts = opts;
+      return handlerStub;
+    }, settings);
+    expect(receivedOpts).toEqual({ pollTimeoutMs: 20 * 60_000 });
+    expect(result.name).toBe("Squash");
+  });
+
+  test("assembleReviewStage passes pollTimeoutMs to handler and sets autoBudget", async () => {
+    const { assembleReviewStage, DEFAULT_PIPELINE_SETTINGS } = await import(
+      "../dist/config.js"
+    );
+    const settings = {
+      ...DEFAULT_PIPELINE_SETTINGS,
+      ciCheckTimeoutMinutes: 25,
+      reviewAutoRounds: 3,
+    };
+    let receivedOpts: { pollTimeoutMs: number } | undefined;
+    const handlerStub = { name: "Review", number: 7, handler: () => {} };
+    const result = assembleReviewStage((opts: { pollTimeoutMs: number }) => {
+      receivedOpts = opts;
+      return handlerStub;
+    }, settings);
+    expect(receivedOpts).toEqual({ pollTimeoutMs: 25 * 60_000 });
+    expect(result.autoBudget).toBe(3);
+    expect(result.name).toBe("Review");
+  });
+
   test("github module exports listRepositories and getIssue", async () => {
     const github = await import("../dist/github.js");
     expect(typeof github.listRepositories).toBe("function");

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,12 @@ import {
 } from "./cleanup-confirm.js";
 import { createCodexAdapter } from "./codex-adapter.js";
 import type { NotificationSettings, PipelineSettings } from "./config.js";
-import { assembleCiCheckStage, loadConfig } from "./config.js";
+import {
+  assembleCiCheckStage,
+  assembleReviewStage,
+  assembleSquashStage,
+  loadConfig,
+} from "./config.js";
 import { getGitHubUsername, getIssue } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
 import {
@@ -558,38 +563,45 @@ try {
     restartFromStage: 5,
   };
 
-  const squashStage = createSquashStageHandler({
-    agent: agentA,
-    ...issueCtx,
-    defaultBranch,
-  });
+  const squashStage = assembleSquashStage(
+    (opts) =>
+      createSquashStageHandler({
+        agent: agentA,
+        ...issueCtx,
+        defaultBranch,
+        ...opts,
+      }),
+    pipelineSettings,
+  );
 
-  const reviewStage = {
-    ...createReviewStageHandler({
-      agentA,
-      agentB,
-      ...issueCtx,
-      getPrNumber: () => runState.prNumber,
-      onReviewProgress: (subStep, verdict) => {
-        runState.reviewSubStep = subStep;
-        if (verdict !== undefined) {
-          runState.lastVerdict = verdict;
-        } else if (subStep === "review" || subStep === "verdict") {
-          // Entering a pre-verdict step for a (possibly new) round —
-          // clear the stale verdict from the previous round so that
-          // reconciliation does not falsely invalidate sessions.
-          runState.lastVerdict = undefined;
-        }
-        saveRunState(runState);
-      },
-      onReviewPosted: (round) => {
-        runState.reviewCount = round;
-        saveRunState(runState);
-        emitter.emit("review:posted", { round });
-      },
-    }),
-    autoBudget: pipelineSettings.reviewAutoRounds,
-  };
+  const reviewStage = assembleReviewStage(
+    (opts) =>
+      createReviewStageHandler({
+        agentA,
+        agentB,
+        ...issueCtx,
+        ...opts,
+        getPrNumber: () => runState.prNumber,
+        onReviewProgress: (subStep, verdict) => {
+          runState.reviewSubStep = subStep;
+          if (verdict !== undefined) {
+            runState.lastVerdict = verdict;
+          } else if (subStep === "review" || subStep === "verdict") {
+            // Entering a pre-verdict step for a (possibly new) round —
+            // clear the stale verdict from the previous round so that
+            // reconciliation does not falsely invalidate sessions.
+            runState.lastVerdict = undefined;
+          }
+          saveRunState(runState);
+        },
+        onReviewPosted: (round) => {
+          runState.reviewCount = round;
+          saveRunState(runState);
+          emitter.emit("review:posted", { round });
+        },
+      }),
+    pipelineSettings,
+  );
 
   // Mutable run state for persistence.
   const runState: RunState = savedState ?? {

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -18,8 +18,8 @@
  *         the next review round.
  *
  * The pipeline engine's auto-budget manages the 3-automatic /
- * 4th-asks-user contract.  `autoBudget` should be set from the
- * `reviewAutoRounds` config value in `index.ts`.
+ * 4th-asks-user contract.  `autoBudget` is wired from the
+ * `reviewAutoRounds` config value via `assembleReviewStage`.
  */
 
 import type { AgentAdapter, AgentResult } from "./agent.js";


### PR DESCRIPTION
## Summary

- Extract `assembleSquashStage` and `assembleReviewStage` helpers in `src/config.ts`, following the existing `assembleCiCheckStage` pattern, to keep the `ciCheckTimeoutMinutes` → `pollTimeoutMs` conversion in one testable place.
- Wire stages 7 (review) and 8 (squash) through these helpers in `src/index.ts` so they respect the user's configured timeout instead of silently falling back to the hardcoded 600 s default.
- Add unit tests for both new assembly functions, verifying that a non-default `ciCheckTimeoutMinutes` reaches the handlers.

Closes #242

## Test plan

- [x] `assembleSquashStage` test: non-default `ciCheckTimeoutMinutes` is converted and passed to the handler factory.
- [x] `assembleReviewStage` test: non-default `ciCheckTimeoutMinutes` is converted and passed to the handler factory; `reviewAutoRounds` maps to `autoBudget`.
- [x] Existing `assembleCiCheckStage` test still passes.
- [x] Full test suite passes (1746 tests).