### PR TITLE
Prepare 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.1.0] - 2026-04-18
+
+First public release.
+
+### Added
+
+- **Pipeline** — 8-stage pipeline (stages 2–9) orchestrating two AI agents
+  (author and reviewer) through implementation, self-check, PR creation, CI
+  fix, test plan verification, code review, commit squash, and merge
+  preparation.
+- **Agent adapters** — Support for Claude and Codex as agent CLIs, each
+  running in non-interactive mode with full filesystem and tool access.
+- **Terminal UI** — Split-pane Ink-based TUI with real-time streamed agent
+  output, token usage bar, status bar (elapsed time, stage, base commit),
+  and horizontal/vertical layout toggle.
+- **Run state persistence** — Pipeline state is saved to
+  `~/.agentcoop/runs/{owner}/{repo}/{issueNumber}.json` so interrupted runs
+  can resume from the last completed stage.
+- **Repository isolation** — Bare clone at
+  `~/.agentcoop/repos/{owner}/{repo}.git` with per-issue git worktrees at
+  `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`.
+- **CI integration** — Waits for GitHub Actions and check runs; agent fixes
+  failures automatically; CodeQL findings are triaged via the code scanning
+  API.
+- **Review loop** — Author and reviewer communicate through labelled PR
+  comments (`[Reviewer Round N]`, `[Author Round N]`, `[Review Verdict Round
+  N]`); state is reconciled from PR comments on resume.
+- **Configurable pipeline settings** — Loop budgets, CI timeout, inactivity
+  timeout, and agent defaults are persisted in `~/.agentcoop/config.json`.
+- **Custom model support** — Models are loaded from `models.json`; users can
+  add, edit, and remove custom model entries through the startup wizard.
+- **i18n** — UI strings available in English and Korean.
+- **Notifications** — Desktop and terminal-bell notifications on macOS when
+  user input is required.
+- **Run log** — Persistent JSONL run log written alongside run state for
+  post-mortem inspection.
+- **Inline diagnostics** — Pipeline diagnostic events are displayed directly
+  in the agent panes.
+- **Step mode** — Optional step-by-step execution where the user confirms
+  before each pipeline stage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [0.1.0] - 2026-04-18
 
-First public release.
-
 ### Added
 
 - **Pipeline** — 8-stage pipeline (stages 2–9) orchestrating two AI agents

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,39 +8,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **Pipeline** — 8-stage pipeline (stages 2–9) orchestrating two AI agents
-  (author and reviewer) through implementation, self-check, PR creation, CI
-  fix, test plan verification, code review, commit squash, and merge
-  preparation.
-- **Agent adapters** — Support for Claude and Codex as agent CLIs, each
-  running in non-interactive mode with full filesystem and tool access.
-- **Terminal UI** — Split-pane Ink-based TUI with real-time streamed agent
-  output, token usage bar, status bar (elapsed time, stage, base commit),
-  and horizontal/vertical layout toggle.
-- **Run state persistence** — Pipeline state is saved to
-  `~/.agentcoop/runs/{owner}/{repo}/{issueNumber}.json` so interrupted runs
-  can resume from the last completed stage.
-- **Repository isolation** — Bare clone at
-  `~/.agentcoop/repos/{owner}/{repo}.git` with per-issue git worktrees at
-  `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`.
-- **CI integration** — Waits for GitHub Actions and check runs; agent fixes
-  failures automatically; CodeQL findings are triaged via the code scanning
-  API.
-- **Review loop** — Author and reviewer communicate through labelled PR
-  comments (`[Reviewer Round N]`, `[Author Round N]`, `[Review Verdict Round
-  N]`); state is reconciled from PR comments on resume.
-- **Configurable pipeline settings** — Loop budgets, CI timeout, inactivity
-  timeout, and agent defaults are persisted in `~/.agentcoop/config.json`.
-- **Custom model support** — Models are loaded from `models.json`; users can
-  add, edit, and remove custom model entries through the startup wizard.
-- **i18n** — UI strings available in English and Korean.
-- **Notifications** — Desktop and terminal-bell notifications on macOS when
-  user input is required.
-- **Run log** — Persistent JSONL run log written alongside run state for
-  post-mortem inspection.
-- **Inline diagnostics** — Pipeline diagnostic events are displayed directly
-  in the agent panes.
-- **Step mode** — Optional step-by-step execution where the user confirms
-  before each pipeline stage.
+- Initial public release of AgentCoop.
 
 [0.1.0]: https://github.com/aicers/agentcoop/tree/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.1.0] - 2026-04-18
 
 First public release.
@@ -47,5 +45,4 @@ First public release.
 - **Step mode** — Optional step-by-step execution where the user confirms
   before each pipeline stage.
 
-[Unreleased]: https://github.com/aicers/agentcoop/compare/0.1.0...main
 [0.1.0]: https://github.com/aicers/agentcoop/tree/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+This file documents recent notable changes to this project. The format of this
+file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
+this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+## [Unreleased]
 
 ## [0.1.0] - 2026-04-18
 
@@ -44,3 +46,6 @@ First public release.
   in the agent panes.
 - **Step mode** — Optional step-by-step execution where the user confirms
   before each pipeline stage.
+
+[Unreleased]: https://github.com/aicers/agentcoop/compare/0.1.0...main
+[0.1.0]: https://github.com/aicers/agentcoop/tree/0.1.0

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ tokens consumed.
 
 Agents run with full filesystem and tool access:
 `--permission-mode bypassPermissions` for Claude,
-`--dangerously-bypass-approvals-and-sandbox` for Codex. There is no
+`-s danger-full-access` for Codex. There is no
 interactive permission prompt flow.
 
 This is necessary, not merely convenient. Agents run in
@@ -236,7 +236,7 @@ to reuse it, clean up and recreate, or halt.
 
 ## Prerequisites
 
-- Node.js 24+
+- Node.js 24.x
 - pnpm
 - `claude` and/or `codex` CLI installed and authenticated
 - `gh` CLI authenticated


### PR DESCRIPTION
## Summary

- Fix wrong Codex permission flag in README (`--dangerously-bypass-approvals-and-sandbox` → `-s danger-full-access`)
- Clarify Node.js version requirement from `24+` to `24.x` to match the `package.json` engine constraint (`>=24.0.0 <25.0.0`)
- Add `CHANGELOG.md` with 0.1.0 release entry

Part of #246