### PR TITLE
Update Claude Opus display name to 4.7

### DIFF
--- a/models.json
+++ b/models.json
@@ -1,6 +1,6 @@
 {
   "claude": [
-    { "name": "Claude Opus 4.6", "value": "opus" },
+    { "name": "Claude Opus 4.7", "value": "opus" },
     { "name": "Claude Sonnet 4.6", "value": "sonnet" }
   ],
   "codex": [


### PR DESCRIPTION
## Summary

- Update the Claude Opus entry's display label in `models.json` from `Claude Opus 4.6` to `Claude Opus 4.7`. The `opus` CLI alias value is unchanged.

Closes #248

## Test plan

- [x] `pnpm biome check models.json` — clean
- [x] Run `agentcoop` and verify the Claude model selector shows `Claude Opus 4.7` — verified indirectly: `loadModelsFile()` returns `claude[0].name === "Claude Opus 4.7"`, which `src/startup.ts:397-400` maps directly to the select choice, and `src/models.test.ts` (29 tests) passes.