### PR TITLE
Add xhigh effort level for Claude Opus 4.7 (#250)

### DIFF
--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -197,7 +197,7 @@ export class ClaudeStreamTransformer extends JsonlLineTransformer {
 // Adapter options + args builder
 // ---------------------------------------------------------------------------
 
-export type ClaudeEffortLevel = "low" | "medium" | "high" | "max";
+export type ClaudeEffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
 export interface ClaudeAdapterOptions {
   model?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,8 @@ function createAdapter(
         | "low"
         | "medium"
         | "high"
+        | "xhigh"
+        | "max"
         | undefined,
       contextWindow: agentConfig.contextWindow,
       inactivityTimeoutMs,

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -680,7 +680,7 @@ describe("runStartup — effort level choices", () => {
       (c: { value: string }) => c.value,
     );
     expect(agentAValues).toContain("max");
-    expect(agentAValues).toEqual(["low", "medium", "high", "max"]);
+    expect(agentAValues).toEqual(["low", "medium", "high", "xhigh", "max"]);
 
     // Agent B (Sonnet) effort prompt should NOT include "max"
     // index: 5=agentB CLI, 6=agentB model, 7=agentB context, 8=agentB effort
@@ -720,7 +720,7 @@ describe("runStartup — effort level choices", () => {
       (c: { value: string }) => c.value,
     );
     expect(agentAValues).toContain("max");
-    expect(agentAValues).toEqual(["low", "medium", "high", "max"]);
+    expect(agentAValues).toEqual(["low", "medium", "high", "xhigh", "max"]);
     expect(result.agentA.effortLevel).toBe("max");
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -77,6 +77,7 @@ const CLAUDE_EFFORT_LEVELS = [
 
 const CLAUDE_OPUS_EFFORT_LEVELS = [
   ...CLAUDE_EFFORT_LEVELS,
+  { name: "Extra high", value: "xhigh" },
   { name: "Max", value: "max" },
 ];
 


### PR DESCRIPTION
## Summary

Claude CLI 2.1.113 added a new `xhigh` effort level between `high` and `max`, shown in Claude Desktop as **Extra high**. agentcoop didn't expose it, so users on Opus 4.7 couldn't select the new value.

- Extend `ClaudeEffortLevel` in `src/claude-adapter.ts` with `"xhigh"`.
- Add `{ name: "Extra high", value: "xhigh" }` between `High` and `Max` in `CLAUDE_OPUS_EFFORT_LEVELS` (`src/startup.ts`). Scoped to Opus for now, matching how `max` is Opus-only; Sonnet/Haiku keep the base three levels until per-model applicability is confirmed.
- Update `src/index.ts` effort-level union to include `"xhigh"` (and `"max"`) so the cast stays accurate.
- Update the startup tests that assert the full Opus effort list.

No i18n strings needed — the level names are defined inline in `startup.ts`, not in `src/i18n/`.

Closes #250

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes on the changed files
- [x] `pnpm vitest run` passes (all 1746 tests)
- [x] `pnpm build` succeeds
- [x] Manual: on Claude CLI 2.1.113 with Opus 4.7 selected, the effort picker shows `Low / Medium / High / Extra high / Max` and passing `--effort xhigh` is accepted
- [x] Manual: with Sonnet/Haiku selected, the effort picker still shows only `Low / Medium / High`