### PR TITLE
Add single-commit squash suggestion path to stage 8 (#252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,80 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Stage 8 (Squash) now offers a single-commit suggestion path: when the agent
+  judges that one commit is appropriate, it writes the suggested title and
+  body into a marker-delimited block in the PR body instead of force-pushing.
+  The user can then either let the agent perform the squash (which reruns CI)
+  or apply the suggestion via GitHub's "Squash and merge" at merge time
+  (which avoids the extra CI cycle).
+- Stage 9 (Done) merge-confirm screen now prints the suggested squash title,
+  body, and PR URL inline when the squash stage finished via the
+  PR-body suggestion path, so the user can copy-paste without opening the
+  browser.
+
+### Changed
+
+- Stage 8 verdict keywords are now `SQUASHED_MULTI` / `SUGGESTED_SINGLE` /
+  `BLOCKED` (previously `COMPLETED` / `BLOCKED`).  When the verdict is
+  ambiguous after a clarification retry, the handler runs a deterministic
+  fallback chain — commit-count decrease, then PR-body marker presence,
+  then BLOCKED.
+- `RunState` now persists a `squashSubStep` field tracking progress through
+  the squash stage's substates so resume can re-enter at the correct point.
+  `RUN_STATE_VERSION` bumped from 2 to 3 (the new field defaults to
+  `undefined` for older state files; no destructive migration).
+- Stage 9 merge-confirm screen now includes a conditional one-line tip
+  (`pipeline.mergeConfirmSquashTip`) when a squash suggestion is live in
+  the PR body.
+
+### Fixed
+
+- Resuming Stage 8 from the `squashing` substate no longer re-sends the
+  full planning prompt.  The handler now checks whether the squash
+  already landed (commit count collapsed to 1) and jumps straight to
+  the CI poll, or re-sends only the follow-up squash prompt on the
+  saved session — avoiding a spurious second force-push / CI cycle
+  that defeated the purpose of this feature.
+- `RunState` migration from v2 to v3 no longer re-applies the v1 → v2
+  stage 7 / 8 swap, which would have remapped existing v2 runs
+  persisted at stage 7 or 8 to the wrong handler on upgrade.  The
+  swap is now guarded on the source version actually being v1 /
+  unversioned.
+- Stage 8 no longer silently routes a user's "agent squashes now"
+  choice to the "apply via GitHub" completion when no agent session
+  is available.  It fails closed with a clear message so the user is
+  not misled about what happened.
+- Stage 8 in-process retries now read the live persisted squash
+  sub-step and agent session id on each handler invocation instead
+  of the startup snapshot.  Previously, a transient `ci_poll`
+  failure followed by a retry could observe `squashSubStep ===
+  undefined` and, with the branch already collapsed to a single
+  commit, fall into the single-commit skip path — turning a
+  recoverable CI failure into a false successful completion.
+- Stage 8's deterministic fallback chain (commit-count /
+  marker-presence) now emits the `pipeline:verdict` event for the
+  derived verdict.  Previously the event was only emitted when the
+  agent response parsed into a concrete keyword, so the fallback
+  branch silently skipped telemetry.
+- Stage 8 now validates the squash suggestion block strictly before
+  accepting `SUGGESTED_SINGLE` / `applied_in_pr_body`.  A bare start
+  marker or a block missing `**Title:**` / the end marker is treated
+  as malformed and fails closed (or re-runs planning on resume)
+  instead of completing with `squash.messageAppended` and leaving
+  Stage 9 unable to render the inline preview.
+- Stage 8 now persists the verdict turn's session id before
+  transitioning to `awaiting_user_choice`.  Adapters can surface a
+  new session id on follow-up turns, so the verdict session is not
+  guaranteed to match the planning session that was persisted
+  earlier.  Without this, a resume where the user picks "agent
+  squashes now" could re-send the follow-up on the older planning
+  session rather than the exact conversation that drafted the
+  PR-body suggestion.
+
 ## [0.1.0] - 2026-04-18
 
 ### Added

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -92,7 +92,7 @@ Do not include any other commentary — just the keyword.
 | Test plan verdict | `FIXED` / `DONE` | `DONE` | `FIXED` → repeat |
 | PR creation check | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
 | CI findings review | _(no verdict keyword)_ | SHA unchanged | SHA changed → re-poll CI |
-| Squash check | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
+| Squash check | `SQUASHED_MULTI` / `SUGGESTED_SINGLE` / `BLOCKED` | `SQUASHED_MULTI` (CI poll), `SUGGESTED_SINGLE` (user choice) | `BLOCKED` → user chooses |
 | Reviewer verdict | `APPROVED` / `NOT_APPROVED` | `APPROVED` | `NOT_APPROVED` → repeat |
 | Author completion | `COMPLETED` / `BLOCKED` | `COMPLETED` | `BLOCKED` → user chooses |
 | Unresolved summary | `NONE` / `COMPLETED` | either | — |
@@ -135,6 +135,18 @@ The standard PR sync instructions appear in stages 5 through 8:
 > does. If the description is outdated or inaccurate, update it
 > using `gh pr edit --body "..."`. Keep the issue reference
 > (Closes #N or Part of #N) in the body.
+
+The squash stage extends this contract with a marker-delimited
+**squash suggestion block**.  When a single commit is the right
+shape for the branch, the agent writes the proposed title and body
+into the PR description between the markers
+`<!-- agentcoop:squash-suggestion:start -->` and
+`<!-- agentcoop:squash-suggestion:end -->` instead of force-pushing.
+The block is idempotent — re-runs replace any prior block between
+the same markers rather than stacking duplicates.  The Stage 9
+merge-confirm screen reads this block back so the user can apply
+the message via GitHub's "Squash and merge" without opening the
+browser.
 
 ### Issue-implementation reconciliation
 
@@ -1212,69 +1224,165 @@ avoiding re-execution of already-completed work within a round.
 ### Stage 8: Squash commits
 
 **Agent:** A\
-**Purpose:** Consolidate branch commits into one or a few
-meaningful commits. Skipped automatically if the branch has only
-one commit.
+**Purpose:** Decide whether the branch is best presented as a
+single squash commit (in which case the agent writes the suggested
+message into the PR body and lets GitHub's "Squash and merge"
+apply it at merge time) or several meaningful commits (rewrite
+history and force-push).  Skipped automatically if the branch has
+only one commit.
+
+The single-commit suggestion path was added to avoid wasting an
+extra CI cycle on a force-push that GitHub's "Squash and merge"
+button would perform anyway.
 
 **Prompt:**
 
-```text
-You are squashing commits for the following GitHub issue.
+The work prompt asks the agent to:
 
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {worktree_path}
-
-## Issue #{number}: {title}
-
-{issue_body}
-
-## Instructions
-
-1. Before pushing, check whether the PR description still accurately
-   reflects the current code changes.  Run
-   `gh pr view --json body --jq .body` to read the current
-   description, then compare it against what the branch actually does.
-   If the description is outdated or inaccurate, update it using
-   `gh pr edit --body "..."`.  Keep the issue reference
-   (Closes #{number} or Part of #{number}) in the body.
-2. Review the commits after the base commit `{baseSha}` and
-   consolidate them into one or a few meaningful commits.  Only
-   commits introduced on this branch should be touched — do not
-   include commits from the base branch.  Use
-   `git reset --soft {baseSha}` followed by `git commit`, or an
-   interactive rebase — whichever is simpler.
-3. Write clear, concise commit messages that summarise the changes.
-   Do not include issue or PR numbers in the commit title.
-   Instead, reference the issue in the commit body using
-   `Closes #N` or `Part of #N`.
-4. Force-push the branch (`git push --force-with-lease`).
-```
+1. Sync the PR description (standard PR-sync instructions).
+2. Decide whether the work belongs in **one** commit or **several**.
+3. Branch on that decision:
+   - **Single commit appropriate:** do not rewrite history.  Draft
+     the squash title and body, then write them into the PR body
+     between the markers
+     `<!-- agentcoop:squash-suggestion:start -->` and
+     `<!-- agentcoop:squash-suggestion:end -->` (replacing any prior
+     block between the same markers).  Do not force-push.
+   - **Multiple commits appropriate:** consolidate the branch
+     commits — using `git reset --soft {baseSha}` + `git commit` or
+     interactive rebase — write clear messages, and force-push
+     (`git push --force-with-lease`).
 
 **Completion check:**
 
 ```text
-You have finished your squash attempt.  Please evaluate the result
-and respond with exactly one of the following keywords:
+You have finished your squash decision.  Respond with exactly one
+of the following keywords:
 
-- COMPLETED — if the commits were squashed and force-pushed
-- BLOCKED — if you could not squash and need user intervention
+- SQUASHED_MULTI — if you rewrote history into multiple meaningful
+  commits and force-pushed
+- SUGGESTED_SINGLE — if a single commit is appropriate and you
+  wrote the suggested title/body into the PR body marker block
+  (no force-push)
+- BLOCKED — if you could not complete either path and need user
+  intervention
 
 Do not include any other commentary — just the keyword.
 ```
 
-**Ambiguous response handling:** Same internal clarification
-retry pattern as stage 4 (Create PR).  If clarification also fails,
-the handler re-checks the branch commit count to verify whether the
-squash actually happened.  If the count decreased, the stage
-completes; otherwise it reports `BLOCKED`.
+The handler calls `parseVerdictKeyword` directly with these three
+keywords (rather than feeding them through the shared `KEYWORD_MAP`)
+because the three-way distinction is squash-specific.
 
-**Post-squash CI:** After a successful squash and force-push, the
-orchestrator polls CI and invokes Agent A to fix failures if
-needed (up to 3 internal fix attempts). The stage only completes
-when CI passes.
+**Verdict handling:**
+
+- `SQUASHED_MULTI` → poll CI after the force-push (existing
+  behaviour, up to 3 internal fix attempts) and finish with
+  `squash.completed` when CI passes.
+- `SUGGESTED_SINGLE` → verify a fully parseable suggestion block is
+  present in the PR body before asking the user.  "Parseable" means
+  both markers are present **and** `parseSquashSuggestionBlock`
+  succeeds (the block contains a `**Title:**` line).  A bare start
+  marker or a block missing `**Title:**`/the end marker fails
+  closed with `blocked` rather than completing as if the suggestion
+  were valid — Stage 9 reads the same block via
+  `parseSquashSuggestionBlock` to render the inline preview, so a
+  malformed block would leave the merge-confirm screen blank.  Once
+  validated, ask the user via `chooseSquashApplyMode`:
+  - **"Agent squashes now"** → send a follow-up prompt on the
+    same session telling the agent to perform the squash using
+    the message it already drafted, then run the post-squash CI
+    poll loop.
+  - **"Apply via GitHub"** → finish the stage with
+    `squash.messageAppended` and persist
+    `squashSubStep === "applied_in_pr_body"` so Stage 9 surfaces
+    the suggestion in the merge-confirm screen.  No CI rerun.
+- `BLOCKED` → existing blocked flow.
+
+**Ambiguous response handling:** Same internal clarification
+retry pattern as stage 4 (Create PR).  If clarification also
+fails, the handler runs a **deterministic fallback chain**:
+
+1. If the branch commit count **decreased** relative to the
+   snapshot taken at stage entry, treat as `SQUASHED_MULTI` (the
+   force-push has already happened — that hard-to-undo side
+   effect must be detected first).
+2. Else, fetch the PR body and check for a fully parseable
+   suggestion block (markers present **and**
+   `parseSquashSuggestionBlock` returns a value).  If present,
+   treat as `SUGGESTED_SINGLE`; a malformed block (e.g. only the
+   start marker) is treated as missing.
+3. Else, treat as `BLOCKED`.
+
+The order matters: checking the commit count first prevents a
+completed squash from being misclassified as a SINGLE suggestion
+when an earlier run left a stale marker block in the PR body.
+
+The derived verdict is emitted as a `pipeline:verdict` event just
+like a parsed-keyword verdict, so telemetry consumers see every
+verdict regardless of whether it came from the agent response or
+the fallback chain.
+
+**`SquashSubStep` state machine:**
+
+```text
+planning → verdict
+        ├── (SQUASHED_MULTI)   → ci_poll → done
+        ├── (SUGGESTED_SINGLE) → awaiting_user_choice
+        │       ├── (agent)  → squashing → ci_poll → done
+        │       └── (github) → applied_in_pr_body (stage done)
+        └── (BLOCKED)         → user chooses
+```
+
+`RunState.squashSubStep` persists the current substate so resume
+re-enters at the correct point:
+
+- `applied_in_pr_body` → stage already done; advance to Stage 9.
+- `awaiting_user_choice` → re-verify a parseable suggestion block is
+  still in the PR body (same strict check as the verdict path); if
+  present, re-present the user choice without re-invoking the agent.
+  If absent or malformed, fall back to `planning` rather than
+  re-presenting a choice the user could not act on.  If
+  the user then picks "agent squashes now" but no agent session is
+  available (neither the saved run state nor the current verdict
+  produced a session ID), the stage fails closed with `blocked`
+  rather than silently completing as if the user had picked
+  "github" — the user's choice must not be misrepresented.
+- `ci_poll` → resume the post-squash CI poll loop directly.
+- `squashing` → the user picked "agent squashes now" and the
+  follow-up prompt was sent, but we were interrupted before the
+  transition to `ci_poll`.  Resume runs a deterministic check
+  before doing anything expensive:
+  1. Re-count the branch commits.  If it collapsed to 1, the
+     squash already landed — jump straight to `ci_poll`.  This is
+     the common case and avoids a second force-push / CI cycle.
+  2. Otherwise, if a saved session is available, re-send **only**
+     the follow-up squash prompt on that session so the agent
+     continues the same conversation rather than restarting
+     planning.
+  3. As a last resort (no session persisted), fall back to a
+     fresh planning run.
+- `planning` (or absent) → run the agent prompt fresh (the work
+  prompt is idempotent — the agent will redo or confirm the same
+  decision).
+
+The stage reads the sub-step and the persisted agent-A session id
+via live getters on each handler invocation, so an in-process
+retry (e.g. after a transient `ci_poll` error) observes the
+values the previous iteration persisted rather than the startup
+snapshot.  Without this, a retry from `ci_poll` after the branch
+had already collapsed could fall into the single-commit skip path
+and falsely complete the stage.
+
+The stage also persists the **verdict turn's** session id (the one
+returned by `resolveVerdict`) before transitioning to
+`awaiting_user_choice`.  Adapters can surface a new session id on
+a follow-up turn, so the verdict session is not guaranteed to
+equal the planning session.  Persisting it ensures that a resume
+from `awaiting_user_choice` — where the user picks "agent
+squashes now" — re-sends the follow-up on the exact conversation
+that drafted the PR-body suggestion, rather than the earlier
+planning session.
 
 **Outcome handling:** `requiresArtifact: true` — if `BLOCKED`,
 only **Instruct** and **Halt** are offered.

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -141,6 +141,12 @@ export const en: Messages = {
     `Pipeline for ${owner}/${repo}#${issue} completed.`,
   "pipeline.mergeConfirm":
     "Has the PR been merged? Confirm to clean up the worktree.",
+  "pipeline.mergeConfirmSquashTip":
+    "If this repo allows 'Squash and merge', the suggested commit " +
+    "message is in the PR body.",
+  "pipeline.suggestedSquashTitle": (title) => `Suggested title: ${title}`,
+  "pipeline.suggestedSquashBody": "Suggested body:",
+  "pipeline.prUrl": (url) => `PR: ${url}`,
   "pipeline.worktreeCleanedUp": "Worktree cleaned up.",
   "pipeline.worktreePreserved": "Worktree preserved (merge not confirmed).",
   "pipeline.conflictsDetected":
@@ -249,6 +255,20 @@ export const en: Messages = {
   "ci.agentError": (detail) => `Agent error during CI fix: ${detail}`,
   "squash.completed": "Commits squashed and CI passed.",
   "squash.singleCommitSkip": "Single commit — skipping squash.",
+  "squash.messageAppended":
+    "Suggested squash commit message written to PR body. " +
+    "Apply it via GitHub's 'Squash and merge' at merge time.",
+  "squash.singleChoicePrompt":
+    "A single squash commit looks appropriate. " +
+    "How should the suggested message be applied?",
+  "squash.singleChoiceAgent":
+    "Let agent squash now (force-push, runs CI again)",
+  "squash.singleChoiceGithub":
+    "Apply via GitHub 'Squash and merge' at merge time (no CI rerun)",
+  "squash.agentChoiceMissingSession":
+    "Cannot perform the squash: the agent session required to continue " +
+    "the conversation was lost. Re-run stage 8 or apply the suggestion " +
+    "via GitHub's 'Squash and merge' at merge time.",
   "review.approved": (round) => `Review approved at round ${round}.`,
   "review.unresolvedItems": (base, summary) =>
     `${base}\n\nUnresolved items:\n${summary}`,

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -176,6 +176,11 @@ export const ko: Messages = {
     `${owner}/${repo}#${issue} \uD30C\uC774\uD504\uB77C\uC778\uC774 \uC644\uB8CC\uB418\uC5C8\uC2B5\uB2C8\uB2E4.`,
   "pipeline.mergeConfirm":
     "PR이 병합되었습니까? 확인하면 워크트리를 정리합니다.",
+  "pipeline.mergeConfirmSquashTip":
+    "이 저장소가 'Squash and merge'를 허용한다면, 제안된 커밋 메시지가 PR 본문에 있습니다.",
+  "pipeline.suggestedSquashTitle": (title) => `제안 제목: ${title}`,
+  "pipeline.suggestedSquashBody": "제안 본문:",
+  "pipeline.prUrl": (url) => `PR: ${url}`,
   "pipeline.worktreeCleanedUp": "워크트리가 정리되었습니다.",
   "pipeline.worktreePreserved": "워크트리가 보존되었습니다 (병합 미확인).",
   "pipeline.conflictsDetected":
@@ -291,6 +296,18 @@ export const ko: Messages = {
   "ci.agentError": (detail) => `CI 수정 중 에이전트 오류: ${detail}`,
   "squash.completed": "커밋이 스쿼시되고 CI를 통과했습니다.",
   "squash.singleCommitSkip": "커밋이 하나뿐이므로 스쿼시를 건너뜁니다.",
+  "squash.messageAppended":
+    "제안된 스쿼시 커밋 메시지가 PR 본문에 기록되었습니다. " +
+    "병합 시 GitHub의 'Squash and merge'로 적용하세요.",
+  "squash.singleChoicePrompt":
+    "단일 스쿼시 커밋이 적합해 보입니다. 제안 메시지를 어떻게 적용할까요?",
+  "squash.singleChoiceAgent": "에이전트가 지금 스쿼시 (강제 푸시, CI 재실행)",
+  "squash.singleChoiceGithub":
+    "병합 시 GitHub 'Squash and merge'로 적용 (CI 재실행 없음)",
+  "squash.agentChoiceMissingSession":
+    "스쿼시를 수행할 수 없습니다: 대화를 이어갈 에이전트 세션이 유실되었습니다. " +
+    "스테이지 8을 다시 실행하거나, 병합 시 GitHub의 'Squash and merge'로 " +
+    "제안을 적용하세요.",
   "review.approved": (round) => `${round}라운드에서 리뷰가 승인되었습니다.`,
   "review.unresolvedItems": (base, summary) =>
     `${base}\n\n미해결 항목:\n${summary}`,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -137,6 +137,10 @@ export interface Messages {
     issue: number,
   ) => string;
   "pipeline.mergeConfirm": string;
+  "pipeline.mergeConfirmSquashTip": string;
+  "pipeline.suggestedSquashTitle": (title: string) => string;
+  "pipeline.suggestedSquashBody": string;
+  "pipeline.prUrl": (url: string) => string;
   "pipeline.worktreeCleanedUp": string;
   "pipeline.worktreePreserved": string;
   "pipeline.conflictsDetected": string;
@@ -241,6 +245,11 @@ export interface Messages {
   "ci.agentError": (detail: string) => string;
   "squash.completed": string;
   "squash.singleCommitSkip": string;
+  "squash.messageAppended": string;
+  "squash.singleChoicePrompt": string;
+  "squash.singleChoiceAgent": string;
+  "squash.singleChoiceGithub": string;
+  "squash.agentChoiceMissingSession": string;
   "review.approved": (round: number) => string;
   "review.unresolvedItems": (base: string, summary: string) => string;
   "review.fixesApplied": (round: number) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ import type {
 } from "./pipeline.js";
 import { createDoneStageHandler } from "./pipeline.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
-import { checkMergeable, findPrNumber } from "./pr.js";
+import { checkMergeable, findPrNumber, getPrBody } from "./pr.js";
 import {
   fetchPrComments,
   type PrComment,
@@ -60,7 +60,10 @@ import { createCreatePrStageHandler } from "./stage-createpr.js";
 import { createImplementStageHandler } from "./stage-implement.js";
 import { createReviewStageHandler } from "./stage-review.js";
 import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
-import { createSquashStageHandler } from "./stage-squash.js";
+import {
+  createSquashStageHandler,
+  parseSquashSuggestionBlock,
+} from "./stage-squash.js";
 import { createTestPlanStageHandler } from "./stage-testplan.js";
 import type { AgentConfig } from "./startup.js";
 import { modelDisplayName, runStartup, selectTarget } from "./startup.js";
@@ -571,6 +574,27 @@ try {
         agent: agentA,
         ...issueCtx,
         defaultBranch,
+        chooseSquashApplyMode: async (msg) => {
+          if (tuiPrompt) return tuiPrompt.chooseSquashApplyMode(msg);
+          return "agent";
+        },
+        onSquashSubStep: (subStep) => {
+          runState.squashSubStep = subStep;
+          saveRunState(runState);
+        },
+        // Getter form — reads live persisted state on each handler
+        // invocation so that an in-process retry (e.g. after a
+        // ci_poll error) sees the sub-step the previous iteration
+        // persisted, not the startup snapshot.  Without this, a
+        // retry from ci_poll would see `undefined` and fall into the
+        // single-commit skip path once the branch has collapsed.
+        savedSquashSubStep: () => runState.squashSubStep,
+        // Same live-read pattern for the agent-A session id so the
+        // retry can re-use the conversation Stage 8 just persisted.
+        // `ctx.savedAgentASessionId` is cleared after the first
+        // iteration of the stage's inner loop and cannot be relied on
+        // for retries by itself.
+        getSavedAgentSessionId: () => runState.agentA.sessionId,
         ...opts,
       }),
     pipelineSettings,
@@ -621,6 +645,7 @@ try {
     selfCheckCount: 0,
     reviewCount: 0,
     reviewSubStep: undefined,
+    squashSubStep: undefined,
     lastVerdict: undefined,
     executionMode,
     agentA: {
@@ -654,6 +679,7 @@ try {
         handleUnknownMergeable: UserPrompt["handleUnknownMergeable"];
         waitForManualResolve: UserPrompt["waitForManualResolve"];
         confirmCleanup: UserPrompt["confirmCleanup"];
+        chooseSquashApplyMode: UserPrompt["chooseSquashApplyMode"];
       }
     | undefined;
 
@@ -730,6 +756,21 @@ try {
       }
     },
     hasRunningServices: () => hasDockerComposeRunning(wt.path),
+    getSquashMergeHint: () => {
+      if (runState.squashSubStep !== "applied_in_pr_body") return undefined;
+      const body = getPrBody(owner, repo, wt.branch);
+      const suggestion = parseSquashSuggestionBlock(body);
+      const prNum = runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
+      const prUrl =
+        prNum !== undefined
+          ? `https://github.com/${owner}/${repo}/pull/${prNum}`
+          : undefined;
+      return {
+        title: suggestion?.title,
+        body: suggestion?.body,
+        prUrl,
+      };
+    },
     onNotMerged: async (signal) => {
       if (!tuiPrompt) return;
       const m = t();

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1119,6 +1119,50 @@ describe("createDoneStageHandler", () => {
     expect(stage.name).toBe("Done");
   });
 
+  test("MERGEABLE: includes squash suggestion hint in confirmMerge message", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => ({
+        title: "Fix widget rendering",
+        body: "Body line\n\nCloses #5",
+        prUrl: "https://github.com/org/repo/pull/123",
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    expect(confirmMerge).toHaveBeenCalledOnce();
+    const message = confirmMerge.mock.calls[0][0] as string;
+    expect(message).toContain("Squash and merge");
+    expect(message).toContain("Fix widget rendering");
+    expect(message).toContain("Closes #5");
+    expect(message).toContain("https://github.com/org/repo/pull/123");
+  });
+
+  test("MERGEABLE: omits hint when getSquashMergeHint returns undefined", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => undefined,
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    const message = confirmMerge.mock.calls[0][0] as string;
+    expect(message).not.toContain("Squash and merge");
+  });
+
   test("MERGEABLE: confirms merge, stops services, then cleans up", async () => {
     const opts = makeDoneOpts();
     const stage = createDoneStageHandler(opts);

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -235,6 +235,15 @@ export interface UserPrompt {
    * worktree).  Used in stage 9 "not merged" path.
    */
   confirmCleanup(message: string): Promise<boolean>;
+
+  /**
+   * Ask the user how to apply a single-commit squash suggestion that
+   * the agent has written to the PR body.  Returns `"agent"` to ask
+   * the agent to perform the squash now (force-push, runs CI again),
+   * or `"github"` to leave it for GitHub's "Squash and merge" at
+   * merge time (no CI rerun).
+   */
+  chooseSquashApplyMode(message: string): Promise<"agent" | "github">;
 }
 
 // ---- loop control --------------------------------------------------------
@@ -896,6 +905,23 @@ export interface DoneStageOptions {
    * can bail out early on cancellation.
    */
   onNotMerged: (signal?: AbortSignal) => Promise<void>;
+  /**
+   * When the squash stage finished via the SUGGESTED_SINGLE / GitHub
+   * path, this returns a small bundle to render in the merge-confirm
+   * screen so the user can copy-paste the suggested squash message
+   * without opening the browser.  All fields are optional; missing
+   * fields are simply omitted from the output.
+   */
+  getSquashMergeHint?: () =>
+    | {
+        /** Suggested squash commit title parsed from the PR body. */
+        title?: string;
+        /** Suggested squash commit body parsed from the PR body. */
+        body?: string;
+        /** Hyperlink-friendly PR URL. */
+        prUrl?: string;
+      }
+    | undefined;
 }
 
 /**
@@ -1102,9 +1128,24 @@ export function createDoneStageHandler(
   ): Promise<StageResult> {
     const m = t();
     for (;;) {
-      const choice = await options.prompt.confirmMerge(
-        `${summary}\n\n${m["pipeline.mergeConfirm"]}`,
-      );
+      const hint = options.getSquashMergeHint?.();
+      const sections: string[] = [summary];
+      if (hint) {
+        const tipLines: string[] = [m["pipeline.mergeConfirmSquashTip"]];
+        if (hint.title) {
+          tipLines.push(m["pipeline.suggestedSquashTitle"](hint.title));
+        }
+        if (hint.body) {
+          tipLines.push(m["pipeline.suggestedSquashBody"]);
+          tipLines.push(hint.body);
+        }
+        if (hint.prUrl) {
+          tipLines.push(m["pipeline.prUrl"](hint.prUrl));
+        }
+        sections.push(tipLines.join("\n"));
+      }
+      sections.push(m["pipeline.mergeConfirm"]);
+      const choice = await options.prompt.confirmMerge(sections.join("\n\n"));
       if (ctx.signal?.aborted) {
         return { outcome: "completed", message: "" };
       }

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -52,6 +52,7 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
     },
     issueSyncStatus: "skipped",
     issueChanges: [],
+    squashSubStep: undefined,
     ...overrides,
   };
 }
@@ -244,6 +245,67 @@ describe("loadRunState — migration from v1 (unversioned)", () => {
     saveRunState(makeRunState({ currentStage: 7 }));
     const loaded = loadRunState("org", "repo", 42);
     expect(loaded?.currentStage).toBe(7);
+  });
+});
+
+describe("loadRunState — migration from v2", () => {
+  /**
+   * Write a raw v2 state (post-stage-swap, pre-squashSubStep) to disk.
+   * v2 files already have stages 7=review and 8=squash; the upgrade
+   * to v3 must not re-apply the v1→v2 swap.
+   */
+  function writeV2State(overrides: Record<string, unknown> = {}) {
+    const { squashSubStep: _, ...rest } = makeRunState();
+    const raw = { ...rest, version: 2, ...overrides };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+  }
+
+  test("preserves stage 7 across v2 → v3 upgrade", () => {
+    writeV2State({ currentStage: 7 });
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.currentStage).toBe(7);
+    expect(loaded?.version).toBe(RUN_STATE_VERSION);
+  });
+
+  test("preserves stage 8 across v2 → v3 upgrade", () => {
+    writeV2State({ currentStage: 8 });
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.currentStage).toBe(8);
+    expect(loaded?.version).toBe(RUN_STATE_VERSION);
+  });
+
+  test("backfills squashSubStep as undefined on v2 → v3 upgrade", () => {
+    writeV2State({ currentStage: 8 });
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.squashSubStep).toBeUndefined();
+  });
+});
+
+describe("squashSubStep persistence", () => {
+  test("round-trips squashSubStep", () => {
+    const state = makeRunState({
+      currentStage: 8,
+      squashSubStep: "applied_in_pr_body",
+    });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.squashSubStep).toBe("applied_in_pr_body");
+  });
+
+  test("defaults to undefined for old state files without squashSubStep", () => {
+    const { squashSubStep: _, ...raw } = makeRunState();
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded).toBeDefined();
+    expect(loaded?.squashSubStep).toBeUndefined();
   });
 });
 

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -33,6 +33,19 @@ export type ReviewSubStep =
   | "author_fix"
   | "ci_poll";
 
+/**
+ * Sub-step within stage 8 (squash).  Tracks the three-way decision
+ * the agent makes (one big commit suggestion vs. a real squash) so
+ * resume can re-enter at the correct point without re-running
+ * side-effectful work.
+ */
+export type SquashSubStep =
+  | "planning"
+  | "awaiting_user_choice"
+  | "squashing"
+  | "ci_poll"
+  | "applied_in_pr_body";
+
 export interface AgentState {
   cli: string;
   model: string;
@@ -49,8 +62,9 @@ export interface AgentState {
  * History:
  *  1 — original order (stages 7=squash, 8=review)
  *  2 — swapped stages 7↔8 (7=review, 8=squash)
+ *  3 — added `squashSubStep` for stage 8 single-commit suggestion flow
  */
-export const RUN_STATE_VERSION = 2;
+export const RUN_STATE_VERSION = 3;
 
 export interface RunState {
   version: number;
@@ -71,6 +85,8 @@ export interface RunState {
   reviewCount: number;
   /** Current sub-step within a review round.  Undefined outside stage 7. */
   reviewSubStep: ReviewSubStep | undefined;
+  /** Current sub-step within stage 8 (squash).  Undefined outside stage 8. */
+  squashSubStep: SquashSubStep | undefined;
   /** Last known review verdict for the current round. */
   lastVerdict: "APPROVED" | "NOT_APPROVED" | undefined;
   executionMode: "auto" | "step";
@@ -147,6 +163,7 @@ function isValidRunState(
     (r.selfCheckCount === undefined || typeof r.selfCheckCount === "number") &&
     (r.reviewCount === undefined || typeof r.reviewCount === "number") &&
     (r.reviewSubStep === undefined || typeof r.reviewSubStep === "string") &&
+    (r.squashSubStep === undefined || typeof r.squashSubStep === "string") &&
     (r.lastVerdict === undefined ||
       r.lastVerdict === "APPROVED" ||
       r.lastVerdict === "NOT_APPROVED") &&
@@ -163,22 +180,33 @@ function isValidRunState(
 }
 
 /**
- * Migrate a legacy (v1 / unversioned) run-state to the current version.
+ * Migrate a legacy run-state to the current version.
  *
- * v1 → v2: stages 7 (squash) and 8 (review) were swapped.  If
- * `currentStage` is one of those two, remap it so the run resumes
- * into the correct handler.
+ * Each step is applied only when the source version predates it,
+ * so an already-migrated state is never re-remapped on a later
+ * upgrade.
+ *
+ *  v1 / unversioned → v2: stages 7 (squash) and 8 (review) were
+ *                          swapped.  Remap `currentStage` so the run
+ *                          resumes into the correct handler.
+ *  v2 → v3:                added `squashSubStep`.  No remap required
+ *                          (`loadRunState` already backfills
+ *                          `undefined`), just bump the version tag.
  */
 function migrateRunState(state: RunState): RunState {
   if (state.version >= RUN_STATE_VERSION) return state;
 
   const migrated = { ...state };
 
-  // v1 → v2: swap stages 7 ↔ 8
-  if (migrated.currentStage === 7) {
-    migrated.currentStage = 8;
-  } else if (migrated.currentStage === 8) {
-    migrated.currentStage = 7;
+  // v1 → v2: swap stages 7 ↔ 8.  Must be skipped for v2+ states so
+  // that a v2 run persisted at stage 7 or 8 is not remapped to the
+  // wrong handler during the v2 → v3 upgrade.
+  if (migrated.version < 2) {
+    if (migrated.currentStage === 7) {
+      migrated.currentStage = 8;
+    } else if (migrated.currentStage === 8) {
+      migrated.currentStage = 7;
+    }
   }
 
   migrated.version = RUN_STATE_VERSION;
@@ -212,6 +240,7 @@ export function loadRunState(
     selfCheckCount: (r.selfCheckCount as number | undefined) ?? 0,
     reviewCount: (r.reviewCount as number | undefined) ?? 0,
     reviewSubStep: (r.reviewSubStep as ReviewSubStep | undefined) ?? undefined,
+    squashSubStep: (r.squashSubStep as SquashSubStep | undefined) ?? undefined,
     lastVerdict:
       (r.lastVerdict as "APPROVED" | "NOT_APPROVED" | undefined) ?? undefined,
     issueSyncStatus:

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -90,6 +90,8 @@ function makePrompt(overrides: Partial<UserPrompt> = {}): UserPrompt {
     handleConflict: vi.fn().mockResolvedValue("manual"),
     handleUnknownMergeable: vi.fn().mockResolvedValue("exit"),
     waitForManualResolve: vi.fn().mockResolvedValue(undefined),
+    confirmCleanup: vi.fn().mockResolvedValue(true),
+    chooseSquashApplyMode: vi.fn().mockResolvedValue("agent"),
     ...overrides,
   };
 }
@@ -1674,7 +1676,9 @@ describe("Stage 8 (Squash) through pipeline", () => {
         ),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const stage = createSquashStageHandler({
@@ -1746,7 +1750,9 @@ describe("Stage 8 (Squash) baseSha integration", () => {
       }),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const stage = createSquashStageHandler({
@@ -1781,7 +1787,9 @@ describe("Stage 8 (Squash) baseSha integration", () => {
       }),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const stage = createSquashStageHandler({
@@ -2305,7 +2313,9 @@ describe("Stages 7+8 (Review + Squash) through pipeline", () => {
         ),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const agentA: AgentAdapter = {

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -2,10 +2,14 @@ import { describe, expect, test, vi } from "vitest";
 import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import type { CiRun, CiStatus, CiVerdict } from "./ci.js";
 import type { StageContext } from "./pipeline.js";
+import { PipelineEventEmitter } from "./pipeline-events.js";
 import {
   buildSquashCompletionCheckPrompt,
   buildSquashPrompt,
   createSquashStageHandler,
+  parseSquashSuggestionBlock,
+  SQUASH_SUGGESTION_END_MARKER,
+  SQUASH_SUGGESTION_START_MARKER,
   type SquashStageOptions,
 } from "./stage-squash.js";
 
@@ -14,7 +18,7 @@ import {
 function makeResult(overrides: Partial<AgentResult> = {}): AgentResult {
   return {
     sessionId: "sess-1",
-    responseText: "COMPLETED",
+    responseText: "SQUASHED_MULTI",
     status: "success",
     errorType: undefined,
     stderrText: "",
@@ -73,7 +77,9 @@ function makeOpts(
       ),
     resume: vi
       .fn()
-      .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+      .mockReturnValue(
+        makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+      ),
   };
 
   return {
@@ -89,6 +95,8 @@ function makeOpts(
     pollTimeoutMs: 1000,
     emptyRunsGracePeriodMs: 0,
     countBranchCommits: vi.fn().mockReturnValue(2),
+    getPrBody: vi.fn().mockReturnValue(""),
+    chooseSquashApplyMode: vi.fn().mockResolvedValue("agent"),
     ...overrides,
   };
 }
@@ -105,10 +113,13 @@ describe("buildSquashPrompt", () => {
     expect(prompt).toContain("The widget is broken.");
   });
 
-  test("includes squash and force-push instructions", () => {
+  test("includes both squash paths and the marker block contract", () => {
     const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("consolidate them into one");
+    expect(prompt).toContain("If a single commit is appropriate");
+    expect(prompt).toContain("If multiple commits are appropriate");
     expect(prompt).toContain("Force-push the branch");
+    expect(prompt).toContain("agentcoop:squash-suggestion:start");
+    expect(prompt).toContain("agentcoop:squash-suggestion:end");
   });
 
   test("includes PR description sync instructions", () => {
@@ -141,14 +152,21 @@ describe("buildSquashPrompt", () => {
     expect(prompt).toContain("Review all commits on this branch");
     expect(prompt).not.toContain("git reset --soft");
   });
+
+  test("includes the three-way decision instruction", () => {
+    const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
+    expect(prompt).toContain("single logical change");
+    expect(prompt).toContain("genuinely independent");
+  });
 });
 
 // ---- buildSquashCompletionCheckPrompt ----------------------------------------
 
 describe("buildSquashCompletionCheckPrompt", () => {
-  test("mentions COMPLETED and BLOCKED keywords", () => {
+  test("mentions all three verdict keywords", () => {
     const prompt = buildSquashCompletionCheckPrompt();
-    expect(prompt).toContain("COMPLETED");
+    expect(prompt).toContain("SQUASHED_MULTI");
+    expect(prompt).toContain("SUGGESTED_SINGLE");
     expect(prompt).toContain("BLOCKED");
   });
 });
@@ -276,7 +294,9 @@ describe("createSquashStageHandler", () => {
       invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const opts = makeOpts({
@@ -317,7 +337,9 @@ describe("createSquashStageHandler", () => {
       invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
@@ -405,7 +427,7 @@ describe("createSquashStageHandler", () => {
         }),
       ),
       // Second resume: clarified
-      makeStream(makeResult({ responseText: "COMPLETED" })),
+      makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
     ];
 
     const agent: AgentAdapter = {
@@ -439,7 +461,7 @@ describe("createSquashStageHandler", () => {
       // 1st resume: ambiguous completion check (no sessionId)
       makeStream(ambiguousCheck),
       // 2nd resume: clarification retry via fallback session
-      makeStream(makeResult({ responseText: "COMPLETED" })),
+      makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
     ];
 
     const agent: AgentAdapter = {
@@ -537,7 +559,9 @@ describe("createSquashStageHandler", () => {
       invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
@@ -681,7 +705,9 @@ describe("createSquashStageHandler", () => {
       invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
       resume: vi
         .fn()
-        .mockReturnValue(makeStream(makeResult({ responseText: "COMPLETED" }))),
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
     };
 
     const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });
@@ -690,5 +716,747 @@ describe("createSquashStageHandler", () => {
 
     expect(result.outcome).toBe("error");
     expect(result.message).toContain("agent crash");
+  });
+
+  // -- SUGGESTED_SINGLE: user picks "agent" ----------------------------------
+
+  test("SUGGESTED_SINGLE + user picks agent → follow-up + CI poll runs", async () => {
+    const prBodyWithMarker = `Hello\n${SQUASH_SUGGESTION_START_MARKER}\n## Suggested squash commit\n\n**Title:** My title\n\n**Body:**\nLine\n${SQUASH_SUGGESTION_END_MARKER}`;
+    let resumeCall = 0;
+    const resumeResults = [
+      makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+      makeStream(
+        makeResult({
+          sessionId: "sess-followup",
+          responseText: "Squashed and pushed.",
+        }),
+      ),
+    ];
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+          ),
+        ),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+    };
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const onSquashSubStep = vi.fn();
+    const opts = makeOpts({
+      agent,
+      chooseSquashApplyMode,
+      getPrBody,
+      onSquashSubStep,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("CI passed");
+    expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+    expect(agent.resume).toHaveBeenCalledTimes(2); // verdict + follow-up
+    expect(opts.getCiStatus).toHaveBeenCalled();
+    const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+    expect(states).toContain("planning");
+    expect(states).toContain("awaiting_user_choice");
+    expect(states).toContain("squashing");
+    expect(states).toContain("ci_poll");
+  });
+
+  // -- SUGGESTED_SINGLE: user picks "github" ---------------------------------
+
+  test("SUGGESTED_SINGLE + user picks github → no CI poll, applied_in_pr_body", async () => {
+    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+        ),
+    };
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const onSquashSubStep = vi.fn();
+    const getCiStatus = vi.fn();
+    const opts = makeOpts({
+      agent,
+      chooseSquashApplyMode,
+      getPrBody,
+      onSquashSubStep,
+      getCiStatus,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("Squash and merge");
+    expect(getCiStatus).not.toHaveBeenCalled();
+    const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+    expect(states[states.length - 1]).toBe("applied_in_pr_body");
+  });
+
+  // -- SUGGESTED_SINGLE missing marker → BLOCKED -----------------------------
+
+  test("SUGGESTED_SINGLE with missing marker block → blocked", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+        ),
+    };
+    const opts = makeOpts({
+      agent,
+      getPrBody: vi.fn().mockReturnValue("body without any marker"),
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+  });
+
+  // -- Post-clarification fallback ordering ----------------------------------
+
+  describe("post-clarification fallback ordering", () => {
+    function makeAmbiguousAgent(): AgentAdapter {
+      let resumeCall = 0;
+      const resumeResults = [
+        makeStream(
+          makeResult({
+            sessionId: "sess-2",
+            responseText: "I think it's done.",
+          }),
+        ),
+        makeStream(makeResult({ responseText: "Still vague." })),
+      ];
+      return {
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-squash",
+              responseText: "Worked on it.",
+            }),
+          ),
+        ),
+        resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+      };
+    }
+
+    test("count decreased AND marker present → SQUASHED_MULTI (count wins)", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** stale\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        countBranchCommits: vi
+          .fn()
+          .mockReturnValueOnce(3)
+          .mockReturnValueOnce(1),
+        getPrBody: vi.fn().mockReturnValue(prBody),
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("CI passed");
+    });
+
+    test("count unchanged AND marker present → SUGGESTED_SINGLE", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** suggested\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        countBranchCommits: vi.fn().mockReturnValue(2),
+        getPrBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+      expect(result.outcome).toBe("completed");
+      expect(chooseSquashApplyMode).toHaveBeenCalled();
+    });
+
+    test("neither → BLOCKED", async () => {
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        countBranchCommits: vi.fn().mockReturnValue(2),
+        getPrBody: vi.fn().mockReturnValue(""),
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+      expect(result.outcome).toBe("blocked");
+    });
+  });
+
+  // -- resume on each substate -----------------------------------------------
+
+  describe("resume on saved substate", () => {
+    test("applied_in_pr_body → returns completed without invoking agent", async () => {
+      const opts = makeOpts({ savedSquashSubStep: "applied_in_pr_body" });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+      expect(result.outcome).toBe("completed");
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      expect(opts.agent.resume).not.toHaveBeenCalled();
+    });
+
+    test("ci_poll → skips planning, runs CI poll only", async () => {
+      const opts = makeOpts({ savedSquashSubStep: "ci_poll" });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+      expect(result.outcome).toBe("completed");
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      expect(opts.getCiStatus).toHaveBeenCalled();
+    });
+
+    test("awaiting_user_choice with marker present → re-presents user choice", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+      const opts = makeOpts({
+        savedSquashSubStep: "awaiting_user_choice",
+        getPrBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+      expect(result.outcome).toBe("completed");
+      expect(chooseSquashApplyMode).toHaveBeenCalled();
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+    });
+
+    // Regression: a user who picks "agent" when no session is
+    // available must be blocked, not silently routed to the github
+    // completion message (which would misrepresent what happened).
+    test("awaiting_user_choice + user picks agent + no session → blocked", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+      const onSquashSubStep = vi.fn();
+      const getCiStatus = vi.fn();
+      const opts = makeOpts({
+        savedSquashSubStep: "awaiting_user_choice",
+        getPrBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode,
+        onSquashSubStep,
+        getCiStatus,
+      });
+      const stage = createSquashStageHandler(opts);
+      // No savedAgentASessionId on the ctx.
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.message).toContain("session");
+      expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      expect(opts.agent.resume).not.toHaveBeenCalled();
+      expect(getCiStatus).not.toHaveBeenCalled();
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states).not.toContain("applied_in_pr_body");
+      expect(states).not.toContain("ci_poll");
+    });
+
+    test("awaiting_user_choice with marker missing → falls back to fresh planning run", async () => {
+      const opts = makeOpts({
+        savedSquashSubStep: "awaiting_user_choice",
+        getPrBody: vi.fn().mockReturnValue(""),
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler(BASE_CTX);
+      expect(opts.agent.invoke).toHaveBeenCalled();
+    });
+
+    // Regression for issue #252 review feedback: resuming from
+    // "squashing" must not re-send the full planning prompt.
+    test("squashing with commit count collapsed to 1 → jumps straight to CI poll", async () => {
+      const countBranchCommits = vi.fn().mockReturnValue(1);
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        savedSquashSubStep: "squashing",
+        countBranchCommits,
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler({
+        ...BASE_CTX,
+        savedAgentASessionId: "sess-squash",
+      });
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("CI passed");
+      // No agent turns at all — the squash already happened.
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      expect(opts.agent.resume).not.toHaveBeenCalled();
+      expect(opts.getCiStatus).toHaveBeenCalled();
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states).not.toContain("planning");
+      expect(states).toContain("ci_poll");
+    });
+
+    test("squashing with count still > 1 and session available → re-sends follow-up only", async () => {
+      const resume = vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      );
+      const agent: AgentAdapter = {
+        invoke: vi.fn(),
+        resume,
+      };
+      const promptSink = vi.fn();
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        agent,
+        savedSquashSubStep: "squashing",
+        countBranchCommits: vi.fn().mockReturnValue(3),
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler({
+        ...BASE_CTX,
+        savedAgentASessionId: "sess-squash",
+        promptSinks: { a: promptSink },
+      });
+      expect(result.outcome).toBe("completed");
+      expect(agent.invoke).not.toHaveBeenCalled();
+      expect(resume).toHaveBeenCalledTimes(1);
+      const [resumedSession, resumedPrompt] = resume.mock.calls[0];
+      expect(resumedSession).toBe("sess-squash");
+      expect(resumedPrompt).toContain("user chose to have you perform");
+      // The planning prompt must NOT be sent again.
+      const sentPrompts = promptSink.mock.calls.map((c) => c[0]);
+      expect(
+        sentPrompts.some((p: string) => p.includes("Decide whether the work")),
+      ).toBe(false);
+      expect(opts.getCiStatus).toHaveBeenCalled();
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states).not.toContain("planning");
+      expect(states).toContain("ci_poll");
+    });
+
+    test("squashing with count still > 1 but no saved session → falls back to fresh planning run", async () => {
+      const opts = makeOpts({
+        savedSquashSubStep: "squashing",
+        countBranchCommits: vi.fn().mockReturnValue(3),
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler(BASE_CTX);
+      // Last-resort fallback: planning prompt is sent via invoke.
+      expect(opts.agent.invoke).toHaveBeenCalled();
+    });
+  });
+
+  // -- live sub-step/session on retry (issue #252 review round 3) -------------
+
+  describe("live sub-step / session on in-process retry", () => {
+    // Regression: after SUGGESTED_SINGLE → agent → ci_poll, a ci_poll
+    // error triggers a fresh handler invocation.  The handler must
+    // read the live persisted sub-step (via the getter form) rather
+    // than the startup snapshot — otherwise the branch has already
+    // collapsed to one commit and the single-commit skip path returns
+    // a false successful completion instead of resuming CI polling.
+    test("ci_poll resume re-enters via live getter after branch collapsed to 1", async () => {
+      // Simulate: startup snapshot was undefined; a previous iteration
+      // then transitioned to "ci_poll" and persisted it.  The retry
+      // must observe that persisted value.
+      const liveSubStep = vi.fn(() => "ci_poll" as const);
+      // Branch already has one commit — single-commit skip WOULD fire
+      // if the live sub-step getter were ignored.
+      const countBranchCommits = vi.fn().mockReturnValue(1);
+      const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pass"));
+      const opts = makeOpts({
+        savedSquashSubStep: liveSubStep,
+        countBranchCommits,
+        getCiStatus,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(liveSubStep).toHaveBeenCalled();
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("CI passed");
+      expect(result.message).not.toContain("Single commit");
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      expect(getCiStatus).toHaveBeenCalled();
+    });
+
+    // Regression: the getter for the persisted agent-A session id
+    // allows the handler to re-use the saved conversation on retry
+    // even though the pipeline's one-shot `ctx.savedAgentASessionId`
+    // was cleared after the first iteration.
+    test("resume from squashing reuses session via getSavedAgentSessionId when ctx session is absent", async () => {
+      const resume = vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      );
+      const agent: AgentAdapter = { invoke: vi.fn(), resume };
+      const opts = makeOpts({
+        agent,
+        savedSquashSubStep: () => "squashing",
+        countBranchCommits: vi.fn().mockReturnValue(3),
+        getSavedAgentSessionId: () => "sess-persisted",
+      });
+      const stage = createSquashStageHandler(opts);
+      // Mimic an in-process retry: ctx.savedAgentASessionId is
+      // undefined because the pipeline already cleared it.
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(agent.invoke).not.toHaveBeenCalled();
+      expect(resume).toHaveBeenCalledTimes(1);
+      expect(resume.mock.calls[0][0]).toBe("sess-persisted");
+    });
+  });
+
+  // -- verdict session id persistence (issue #252 review round 5) -----------
+  //
+  // `resolveVerdict()` may surface a session id that differs from the
+  // planning turn's (adapters can update the id on follow-up turns).
+  // Stage 8 must persist the latest verdict session id via
+  // `ctx.onSessionId` BEFORE entering `awaiting_user_choice`, so that a
+  // resume + user "agent" choice continues the exact conversation that
+  // drafted the PR-body suggestion — not the older planning session.
+  describe("verdict session id persistence", () => {
+    test("SUGGESTED_SINGLE persists verdict session (distinct from planning) before awaiting choice", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const invoke = vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-planning",
+            responseText: "Drafted suggestion.",
+          }),
+        ),
+      );
+      // Verdict turn surfaces a different session id.
+      const resume = vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-verdict",
+              responseText: "SUGGESTED_SINGLE",
+            }),
+          ),
+        )
+        // Later follow-up for the agent squash path.
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-followup",
+              responseText: "Squashed and pushed.",
+            }),
+          ),
+        );
+      const agent: AgentAdapter = { invoke, resume };
+
+      const sessionCalls: Array<[string, string]> = [];
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+      const opts = makeOpts({
+        agent,
+        getPrBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode,
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler({
+        ...BASE_CTX,
+        onSessionId: (a, sid) => sessionCalls.push([a, sid]),
+      });
+
+      const persisted = sessionCalls.map(([, sid]) => sid);
+      // The verdict session id must have been persisted before the
+      // user-choice prompt.  It must also precede the follow-up turn,
+      // so a resume after that point would pick the correct session.
+      const verdictIndex = persisted.indexOf("sess-verdict");
+      expect(verdictIndex).toBeGreaterThanOrEqual(0);
+
+      // chooseSquashApplyMode was called exactly once, and for "agent"
+      // the follow-up resume was sent on the verdict session id.
+      expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+      // resume calls: 0 = verdict check, 1 = agent squash follow-up.
+      expect(resume.mock.calls[1][0]).toBe("sess-verdict");
+    });
+
+    test("resume from awaiting_user_choice + user picks agent resumes the verdict session id via getSavedAgentSessionId", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const resume = vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      );
+      const agent: AgentAdapter = { invoke: vi.fn(), resume };
+
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+      const opts = makeOpts({
+        agent,
+        savedSquashSubStep: "awaiting_user_choice",
+        getPrBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode,
+        // The persisted session id is the VERDICT session, not the
+        // planning session — proving the Round 5 fix wires the
+        // follow-up to the verdict conversation on resume.
+        getSavedAgentSessionId: () => "sess-verdict",
+      });
+      const stage = createSquashStageHandler(opts);
+      // Clear ctx.savedAgentASessionId to force the getter path.
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+      expect(resume).toHaveBeenCalledTimes(1);
+      expect(resume.mock.calls[0][0]).toBe("sess-verdict");
+      expect(agent.invoke).not.toHaveBeenCalled();
+    });
+  });
+
+  // -- pipeline:verdict telemetry on fallback chain (issue #252 review round 3)
+  // The deterministic fallback chain derives the verdict from commit
+  // count and PR body when both agent responses are ambiguous.  That
+  // derived keyword must still be surfaced as a pipeline:verdict event
+  // so telemetry consumers see every verdict, not just the parsed ones.
+  describe("pipeline:verdict emission from deterministic fallback", () => {
+    function makeAmbiguousAgent(): AgentAdapter {
+      let resumeCall = 0;
+      const resumeResults = [
+        makeStream(
+          makeResult({
+            sessionId: "sess-2",
+            responseText: "I think it's done.",
+          }),
+        ),
+        makeStream(makeResult({ responseText: "Still vague." })),
+      ];
+      return {
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-squash",
+              responseText: "Worked on it.",
+            }),
+          ),
+        ),
+        resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+      };
+    }
+
+    test("emits SQUASHED_MULTI when commit count decreased", async () => {
+      const events = new PipelineEventEmitter();
+      const handler = vi.fn();
+      events.on("pipeline:verdict", handler);
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        countBranchCommits: vi
+          .fn()
+          .mockReturnValueOnce(3)
+          .mockReturnValueOnce(1),
+        getPrBody: vi.fn().mockReturnValue(""),
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler({ ...BASE_CTX, events });
+
+      const keywords = handler.mock.calls.map((c) => c[0].keyword);
+      expect(keywords).toContain("SQUASHED_MULTI");
+    });
+
+    test("emits SUGGESTED_SINGLE when marker block is present", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** s\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const events = new PipelineEventEmitter();
+      const handler = vi.fn();
+      events.on("pipeline:verdict", handler);
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        countBranchCommits: vi.fn().mockReturnValue(2),
+        getPrBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode: vi.fn().mockResolvedValue("github"),
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler({ ...BASE_CTX, events });
+
+      const keywords = handler.mock.calls.map((c) => c[0].keyword);
+      expect(keywords).toContain("SUGGESTED_SINGLE");
+    });
+
+    test("emits BLOCKED when neither signal is present", async () => {
+      const events = new PipelineEventEmitter();
+      const handler = vi.fn();
+      events.on("pipeline:verdict", handler);
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        countBranchCommits: vi.fn().mockReturnValue(2),
+        getPrBody: vi.fn().mockReturnValue(""),
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler({ ...BASE_CTX, events });
+
+      const keywords = handler.mock.calls.map((c) => c[0].keyword);
+      expect(keywords).toContain("BLOCKED");
+    });
+  });
+
+  // -- malformed suggestion block (marker present, parser fails) -------------
+  //
+  // Stage 9 reads the block via `parseSquashSuggestionBlock` to render
+  // the inline preview, so Stage 8 must reject any block the parser
+  // cannot handle (start marker only, missing end marker, missing
+  // `**Title:**`).  Otherwise the SUGGESTED_SINGLE path completes with
+  // `applied_in_pr_body` and Stage 9 has nothing to show.
+  describe("malformed suggestion block", () => {
+    function makeMalformedBodies(): Array<{ name: string; body: string }> {
+      return [
+        {
+          name: "start marker only (no end marker)",
+          body: `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n**Body:**\nB`,
+        },
+        {
+          name: "both markers but no Title line",
+          body: `${SQUASH_SUGGESTION_START_MARKER}\nNo title here\n${SQUASH_SUGGESTION_END_MARKER}`,
+        },
+      ];
+    }
+
+    test.each(
+      makeMalformedBodies(),
+    )("verdict SUGGESTED_SINGLE + $name → blocked, no user choice", async ({
+      body,
+    }) => {
+      const agent: AgentAdapter = {
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-squash",
+              responseText: "Plan.",
+            }),
+          ),
+        ),
+        resume: vi
+          .fn()
+          .mockReturnValue(
+            makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+          ),
+      };
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        agent,
+        getPrBody: vi.fn().mockReturnValue(body),
+        chooseSquashApplyMode,
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("blocked");
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states).not.toContain("applied_in_pr_body");
+      expect(states).not.toContain("awaiting_user_choice");
+    });
+
+    test.each(
+      makeMalformedBodies(),
+    )("fallback chain + $name → BLOCKED (not SUGGESTED_SINGLE)", async ({
+      body,
+    }) => {
+      let resumeCall = 0;
+      const resumeResults = [
+        makeStream(
+          makeResult({
+            sessionId: "sess-2",
+            responseText: "I think it's done.",
+          }),
+        ),
+        makeStream(makeResult({ responseText: "Still vague." })),
+      ];
+      const agent: AgentAdapter = {
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-squash",
+              responseText: "Worked on it.",
+            }),
+          ),
+        ),
+        resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+      };
+      const events = new PipelineEventEmitter();
+      const handler = vi.fn();
+      events.on("pipeline:verdict", handler);
+      const opts = makeOpts({
+        agent,
+        countBranchCommits: vi.fn().mockReturnValue(2),
+        getPrBody: vi.fn().mockReturnValue(body),
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler({ ...BASE_CTX, events });
+
+      expect(result.outcome).toBe("blocked");
+      const keywords = handler.mock.calls.map((c) => c[0].keyword);
+      expect(keywords).toContain("BLOCKED");
+      expect(keywords).not.toContain("SUGGESTED_SINGLE");
+    });
+
+    test.each(
+      makeMalformedBodies(),
+    )("resume awaiting_user_choice + $name → re-runs planning, no user choice", async ({
+      body,
+    }) => {
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+      const opts = makeOpts({
+        savedSquashSubStep: "awaiting_user_choice",
+        getPrBody: vi.fn().mockReturnValue(body),
+        chooseSquashApplyMode,
+      });
+      const stage = createSquashStageHandler(opts);
+      await stage.handler(BASE_CTX);
+
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      expect(opts.agent.invoke).toHaveBeenCalled();
+    });
+  });
+});
+
+// ---- parseSquashSuggestionBlock --------------------------------------------
+
+describe("parseSquashSuggestionBlock", () => {
+  test("parses title and body from a well-formed block", () => {
+    const body = `noise\n${SQUASH_SUGGESTION_START_MARKER}\n## Suggested squash commit\n\n**Title:** Fix widget rendering\n\n**Body:**\nFirst line.\n\nCloses #42\n${SQUASH_SUGGESTION_END_MARKER}\nmore noise`;
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Fix widget rendering",
+      body: "First line.\n\nCloses #42",
+    });
+  });
+
+  test("returns undefined when markers are missing", () => {
+    expect(parseSquashSuggestionBlock("no markers here")).toBeUndefined();
+  });
+
+  test("returns undefined for empty input", () => {
+    expect(parseSquashSuggestionBlock(undefined)).toBeUndefined();
+    expect(parseSquashSuggestionBlock("")).toBeUndefined();
+  });
+
+  test("returns undefined when title line is absent", () => {
+    const body = `${SQUASH_SUGGESTION_START_MARKER}\nNo title here\n${SQUASH_SUGGESTION_END_MARKER}`;
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
   });
 });

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -1,15 +1,25 @@
 /**
  * Stage 8 — Squash commits.
  *
- * Two-step flow + internal CI polling:
- *   1. Send a squash prompt to Agent A instructing it to squash all
- *      branch commits into one and force-push.
- *   2. Resume the session with a completion check (COMPLETED/BLOCKED).
- *   3. Poll CI after force-push.  If CI fails, the agent is invoked
- *      to fix the issue and CI is re-polled (internal loop, max 3).
+ * Three-way verdict: the agent decides whether the branch is best
+ * consolidated into one commit (write the suggested message into the
+ * PR body and let GitHub's "Squash and merge" apply it at merge
+ * time, avoiding an extra CI cycle) or several meaningful commits
+ * (rewrite history and force-push as before).
  *
- * `requiresArtifact` is true because the squash must succeed before
- * the pipeline proceeds to Done.
+ *   1. Send the squash prompt instructing the agent to choose between
+ *      the SUGGESTED_SINGLE and SQUASHED_MULTI paths.
+ *   2. Resume the session with a verdict prompt
+ *      (SQUASHED_MULTI / SUGGESTED_SINGLE / BLOCKED).
+ *   3. Branch on the verdict:
+ *        - SQUASHED_MULTI    → poll CI after force-push.
+ *        - SUGGESTED_SINGLE  → ask the user how to apply the
+ *                              suggestion (agent squash now, or
+ *                              GitHub "Squash and merge" later).
+ *        - BLOCKED           → existing blocked flow.
+ *
+ * `requiresArtifact` is true because the squash decision must succeed
+ * before the pipeline proceeds to Done.
  */
 
 import type { AgentAdapter } from "./agent.js";
@@ -22,17 +32,32 @@ import { type CiPollResult, pollCiAndFix } from "./ci-poll.js";
 import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
+import { getPrBody as defaultGetPrBody } from "./pr.js";
+import type { SquashSubStep } from "./run-state.js";
 import {
   invokeOrResume,
   mapAgentError,
-  mapResponseToResult,
   sendFollowUp,
   type VerdictContext,
 } from "./stage-util.js";
-import { buildClarificationPrompt } from "./step-parser.js";
+import {
+  buildClarificationPrompt,
+  parseVerdictKeyword,
+} from "./step-parser.js";
 import { countBranchCommits as defaultCountBranchCommits } from "./worktree.js";
 
 // ---- public types ------------------------------------------------------------
+
+/** Marker block delimiters used in the PR body for the SUGGESTED_SINGLE path. */
+export const SQUASH_SUGGESTION_START_MARKER =
+  "<!-- agentcoop:squash-suggestion:start -->";
+export const SQUASH_SUGGESTION_END_MARKER =
+  "<!-- agentcoop:squash-suggestion:end -->";
+
+export interface SquashSuggestion {
+  title: string;
+  body: string;
+}
 
 export interface SquashStageOptions {
   agent: AgentAdapter;
@@ -56,6 +81,45 @@ export interface SquashStageOptions {
   delay?: (ms: number) => Promise<void>;
   /** Injected for testability. Defaults to `worktree.countBranchCommits`. */
   countBranchCommits?: (cwd: string, baseBranch: string) => number;
+  /** Injected for testability. Defaults to `pr.getPrBody`. */
+  getPrBody?: (
+    owner: string,
+    repo: string,
+    branch: string,
+  ) => string | undefined;
+  /**
+   * Ask the user how to apply a single-commit squash suggestion.
+   * Required for the SUGGESTED_SINGLE path; if absent the stage
+   * conservatively defaults to "agent".
+   */
+  chooseSquashApplyMode?: (message: string) => Promise<"agent" | "github">;
+  /**
+   * Persist the current squash sub-step so resume can re-enter at
+   * the correct point.  Optional — when omitted, sub-step transitions
+   * are not persisted (used by tests).
+   */
+  onSquashSubStep?: (subStep: SquashSubStep | undefined) => void;
+  /**
+   * Restored sub-step from a prior run.  When set, the handler skips
+   * earlier sub-steps and re-enters at the saved point.
+   *
+   * May be a value (snapshot at resume time) or a getter (reads live
+   * persisted state on each retry).  The getter form is required for
+   * in-process retries after the handler has already transitioned the
+   * sub-step — e.g. `ci_poll` failing and triggering a fresh handler
+   * invocation.  Without the live read, the retry would see the
+   * startup snapshot (`undefined`) and fall into the single-commit
+   * skip path instead of resuming CI polling.
+   */
+  savedSquashSubStep?: SquashSubStep | (() => SquashSubStep | undefined);
+  /**
+   * Getter for the persisted agent-A session id.  Read on each handler
+   * invocation so that in-process retries see the session the stage
+   * persisted during a previous iteration.  The pipeline-supplied
+   * `ctx.savedAgentASessionId` is one-shot — cleared after the first
+   * iteration — so it cannot be relied on for retries alone.
+   */
+  getSavedAgentSessionId?: () => string | undefined;
 }
 
 // ---- prompt builders ---------------------------------------------------------
@@ -80,25 +144,65 @@ export function buildSquashPrompt(
     `## Instructions`,
     ``,
     `1. ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `2. Decide whether the work on this branch is best presented as`,
+    `   **one** commit or as **several** meaningful commits.  Inspect the`,
+    `   existing commits' scope, file overlap, and intent.`,
+    ``,
+    `   - **One commit is appropriate** when all changes belong to a`,
+    `     single logical change (typical small fix or feature).`,
+    `   - **Multiple commits are appropriate** when the branch contains`,
+    `     genuinely independent changes that benefit from separate`,
+    `     history (e.g. a refactor preceding a feature).`,
+    ``,
+    `3. Branch on your decision:`,
+    ``,
+    `   **If a single commit is appropriate:**`,
+    `   - Do NOT rewrite history.  Do NOT force-push.`,
+    `   - Draft the commit title and body that should be used when the`,
+    `     PR is squash-merged.  The title must not include issue or PR`,
+    `     numbers; reference the issue in the body using \`Closes #N\``,
+    `     or \`Part of #N\`.`,
+    `   - Update the PR body to include a marker-delimited block`,
+    `     containing the suggestion.  The block must be idempotent —`,
+    `     replace any existing block between the same markers, do not`,
+    `     stack duplicates.  Use exactly these markers:`,
+    ``,
+    `     \`\`\`text`,
+    `     ${SQUASH_SUGGESTION_START_MARKER}`,
+    `     ## Suggested squash commit`,
+    ``,
+    `     **Title:** <your title>`,
+    ``,
+    `     **Body:**`,
+    `     <your body — may include \`Closes #N\` / \`Part of #N\`>`,
+    `     ${SQUASH_SUGGESTION_END_MARKER}`,
+    `     \`\`\``,
+    ``,
+    `     Read the current body with`,
+    `     \`gh pr view --json body --jq .body\`, replace any prior`,
+    `     suggestion block, and write the result back via`,
+    `     \`gh pr edit --body "..."\`.`,
+    ``,
+    `   **If multiple commits are appropriate:**`,
     ...(ctx.baseSha
       ? [
-          `2. Review the commits after the base commit \`${ctx.baseSha}\` and`,
-          `   consolidate them into one or a few meaningful commits.  Only`,
-          `   commits introduced on this branch should be touched — do not`,
-          `   include commits from the base branch.  Use`,
-          `   \`git reset --soft ${ctx.baseSha}\` followed by \`git commit\`, or`,
-          `   an interactive rebase — whichever is simpler.`,
+          `   - Review the commits after the base commit \`${ctx.baseSha}\``,
+          `     and consolidate them into a few meaningful commits.  Only`,
+          `     commits introduced on this branch should be touched — do not`,
+          `     include commits from the base branch.  Use`,
+          `     \`git reset --soft ${ctx.baseSha}\` followed by \`git commit\`,`,
+          `     or an interactive rebase — whichever is simpler.`,
         ]
       : [
-          `2. Review all commits on this branch and consolidate them into one`,
-          `   or a few meaningful commits.  Use an interactive rebase or`,
-          `   reset-based approach — whichever is simpler.`,
+          `   - Review all commits on this branch and consolidate them into`,
+          `     a few meaningful commits.  Use an interactive rebase or`,
+          `     reset-based approach — whichever is simpler.`,
         ]),
-    `3. Write clear, concise commit messages that summarise the changes.`,
-    `   Do not include issue or PR numbers in the commit title.`,
-    `   Instead, reference the issue in the commit body using`,
-    `   \`Closes #N\` or \`Part of #N\`.`,
-    `4. Force-push the branch (\`git push --force-with-lease\`).`,
+    `   - Write clear, concise commit messages that summarise the changes.`,
+    `     Do not include issue or PR numbers in the commit title.`,
+    `     Instead, reference the issue in the commit body using`,
+    `     \`Closes #N\` or \`Part of #N\`.`,
+    `   - Force-push the branch (\`git push --force-with-lease\`).`,
   ];
 
   if (ctx.userInstruction) {
@@ -108,21 +212,199 @@ export function buildSquashPrompt(
   return lines.join("\n");
 }
 
-export const SQUASH_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
+/**
+ * Three-way verdict keywords for the squash stage.  Kept out of the
+ * shared `KEYWORD_MAP` / `StepStatus` enum because they are
+ * squash-specific; the handler branches on the raw keyword from
+ * `parseVerdictKeyword` instead.
+ */
+export const SQUASH_CHECK_KEYWORDS = [
+  "SQUASHED_MULTI",
+  "SUGGESTED_SINGLE",
+  "BLOCKED",
+] as const;
+
+export type SquashVerdict = (typeof SQUASH_CHECK_KEYWORDS)[number];
 
 export function buildSquashCompletionCheckPrompt(): string {
   return [
-    `You have finished your squash attempt.  Please evaluate the result`,
-    `and respond with exactly one of the following keywords:`,
+    `You have finished your squash decision.  Respond with exactly one`,
+    `of the following keywords:`,
     ``,
-    `- COMPLETED — if the commits were squashed and force-pushed`,
-    `- BLOCKED — if you could not squash and need user intervention`,
+    `- SQUASHED_MULTI — if you rewrote history into multiple meaningful`,
+    `  commits and force-pushed`,
+    `- SUGGESTED_SINGLE — if a single commit is appropriate and you`,
+    `  wrote the suggested title/body into the PR body marker block`,
+    `  (no force-push)`,
+    `- BLOCKED — if you could not complete either path and need user`,
+    `  intervention`,
     ``,
     `Do not include any other commentary — just the keyword.`,
   ].join("\n");
 }
 
+/**
+ * Follow-up prompt sent on the same session when the user picks
+ * "agent squashes now" after a SUGGESTED_SINGLE verdict.  The agent
+ * already drafted the message in the PR body, so this just asks it
+ * to perform the squash with the same message.
+ */
+export function buildAgentSquashFollowupPrompt(): string {
+  return [
+    `The user chose to have you perform the squash now using the title`,
+    `and body you wrote into the PR body marker block.`,
+    ``,
+    `Squash the branch into a single commit using that exact title and`,
+    `body, then force-push (\`git push --force-with-lease\`).  You may`,
+    `leave the marker block in the PR body — it does not interfere with`,
+    `merging.`,
+  ].join("\n");
+}
+
+// ---- marker block parsing ----------------------------------------------------
+
+/**
+ * Extract the title and body from the squash suggestion marker block
+ * in `prBody`.  Returns `undefined` when the markers are missing or
+ * the block does not contain a parseable title.
+ */
+export function parseSquashSuggestionBlock(
+  prBody: string | undefined,
+): SquashSuggestion | undefined {
+  if (!prBody) return undefined;
+  const startIdx = prBody.indexOf(SQUASH_SUGGESTION_START_MARKER);
+  const endIdx = prBody.indexOf(SQUASH_SUGGESTION_END_MARKER);
+  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return undefined;
+
+  const inner = prBody
+    .slice(startIdx + SQUASH_SUGGESTION_START_MARKER.length, endIdx)
+    .trim();
+
+  // Match `**Title:** <title>` on its own line.
+  const titleMatch = inner.match(/\*\*Title:\*\*\s*(.+?)\s*$/m);
+  if (!titleMatch) return undefined;
+  const title = titleMatch[1].trim();
+
+  // Body starts after `**Body:**`.
+  const bodyMarker = "**Body:**";
+  const bodyStart = inner.indexOf(bodyMarker);
+  let body = "";
+  if (bodyStart !== -1) {
+    body = inner.slice(bodyStart + bodyMarker.length).trim();
+  }
+
+  return { title, body };
+}
+
+/**
+ * True when `prBody` contains a fully parseable squash suggestion
+ * block (start + end markers AND a `**Title:**` line that
+ * `parseSquashSuggestionBlock` can extract).
+ *
+ * Stage 8 must use this strict check rather than a marker-presence
+ * check because Stage 9 reads the same block via
+ * `parseSquashSuggestionBlock` to render the inline preview.  If
+ * Stage 8 accepted a malformed block (e.g. only the start marker, or
+ * a block missing `**Title:**`/the end marker), the SUGGESTED_SINGLE
+ * path could complete with `applied_in_pr_body` while leaving Stage 9
+ * with nothing to show.
+ */
+function hasValidSuggestionBlock(prBody: string | undefined): boolean {
+  return parseSquashSuggestionBlock(prBody) !== undefined;
+}
+
 // ---- handler -----------------------------------------------------------------
+
+interface VerdictHandle {
+  verdict: SquashVerdict | undefined;
+  responseText: string;
+  sessionId: string | undefined;
+}
+
+/**
+ * Run the verdict prompt + one clarification retry.  Returns the
+ * resolved verdict (or `undefined` when both attempts were ambiguous)
+ * along with the latest response text and session id.
+ */
+async function resolveVerdict(
+  agent: AgentAdapter,
+  squashSessionId: string | undefined,
+  ctx: StageContext,
+  verdictCtx: VerdictContext | undefined,
+  worktreePath: string,
+): Promise<VerdictHandle | StageResult> {
+  const checkPrompt = buildSquashCompletionCheckPrompt();
+  ctx.promptSinks?.a?.(checkPrompt, "verdict-followup", { resume: true });
+  let checkResult = await sendFollowUp(
+    agent,
+    squashSessionId,
+    checkPrompt,
+    worktreePath,
+    ctx.streamSinks?.a,
+    undefined,
+    ctx.usageSinks?.a,
+  );
+
+  if (checkResult.status === "error") {
+    return mapAgentError(checkResult, "during squash completion check");
+  }
+
+  let verdict = parseVerdictKeyword(
+    checkResult.responseText,
+    SQUASH_CHECK_KEYWORDS,
+  ).keyword as SquashVerdict | undefined;
+
+  if (verdict !== undefined) {
+    verdictCtx?.events.emit("pipeline:verdict", {
+      agent: verdictCtx.agent,
+      keyword: verdict,
+      raw: checkResult.responseText,
+    });
+    return {
+      verdict,
+      responseText: checkResult.responseText,
+      sessionId: checkResult.sessionId ?? squashSessionId,
+    };
+  }
+
+  // Single clarification retry.
+  const clarifyPrompt = buildClarificationPrompt(
+    checkResult.responseText,
+    SQUASH_CHECK_KEYWORDS,
+  );
+  ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", { resume: true });
+  const retryResult = await sendFollowUp(
+    agent,
+    checkResult.sessionId ?? squashSessionId,
+    clarifyPrompt,
+    worktreePath,
+    ctx.streamSinks?.a,
+    undefined,
+    ctx.usageSinks?.a,
+  );
+
+  if (retryResult.status === "error") {
+    return mapAgentError(retryResult, "during squash completion clarification");
+  }
+
+  checkResult = retryResult;
+  verdict = parseVerdictKeyword(checkResult.responseText, SQUASH_CHECK_KEYWORDS)
+    .keyword as SquashVerdict | undefined;
+
+  if (verdict !== undefined) {
+    verdictCtx?.events.emit("pipeline:verdict", {
+      agent: verdictCtx.agent,
+      keyword: verdict,
+      raw: checkResult.responseText,
+    });
+  }
+
+  return {
+    verdict,
+    responseText: checkResult.responseText,
+    sessionId: checkResult.sessionId ?? squashSessionId,
+  };
+}
 
 export function createSquashStageHandler(
   opts: SquashStageOptions,
@@ -133,24 +415,119 @@ export function createSquashStageHandler(
     primaryAgent: "a",
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
+      const countCommits = opts.countBranchCommits ?? defaultCountBranchCommits;
+      const getPrBody = opts.getPrBody ?? defaultGetPrBody;
+
+      // Read the persisted agent-A session id (live) with a fallback
+      // to the one-shot pipeline value, so in-process retries can
+      // resume the same conversation.
+      const resolveSavedSessionId = (): string | undefined =>
+        opts.getSavedAgentSessionId?.() ?? ctx.savedAgentASessionId;
+
+      // ---- resume routing -------------------------------------------------
+      //
+      // Handle known post-planning substates FIRST so that the
+      // single-commit skip check below cannot mask a completed squash
+      // (where the branch now has only one commit because the agent
+      // already force-pushed).
+      //
+      // Resolve the saved sub-step through the getter (if supplied)
+      // so in-process retries see the live persisted value instead of
+      // a startup snapshot.
+      const saved =
+        typeof opts.savedSquashSubStep === "function"
+          ? opts.savedSquashSubStep()
+          : opts.savedSquashSubStep;
+
+      if (saved === "applied_in_pr_body") {
+        // Stage already finished via the SUGGESTED_SINGLE / github path.
+        return {
+          outcome: "completed",
+          message: t()["squash.messageAppended"],
+        };
+      }
+
+      if (saved === "ci_poll") {
+        return runCiPollAndFinish(ctx, opts);
+      }
+
+      if (saved === "squashing") {
+        // The user picked "agent squashes now" and the follow-up
+        // prompt was sent, but we were interrupted before
+        // transitioning to `ci_poll`.  Falling through to a fresh
+        // planning run would re-send the entire decision prompt and
+        // potentially trigger another force-push / CI cycle — the
+        // exact waste this feature is meant to avoid.
+        //
+        // Detect a completed squash deterministically (commit count
+        // collapsed to 1) and jump to CI polling.  Otherwise, reuse
+        // the saved session to re-send just the follow-up squash
+        // prompt so the agent continues the same conversation.
+        const resumeCount = countCommits(ctx.worktreePath, opts.defaultBranch);
+        if (resumeCount <= 1) {
+          return runCiPollAndFinish(ctx, opts);
+        }
+
+        const sessionId = resolveSavedSessionId();
+        if (sessionId !== undefined) {
+          const followupPrompt = buildAgentSquashFollowupPrompt();
+          ctx.promptSinks?.a?.(followupPrompt, "work", { resume: true });
+          const followup = await sendFollowUp(
+            opts.agent,
+            sessionId,
+            followupPrompt,
+            ctx.worktreePath,
+            ctx.streamSinks?.a,
+            undefined,
+            ctx.usageSinks?.a,
+          );
+
+          if (followup.sessionId) {
+            ctx.onSessionId?.("a", followup.sessionId);
+          }
+
+          if (followup.status === "error") {
+            return mapAgentError(
+              followup,
+              "during resumed agent squash follow-up",
+            );
+          }
+
+          return runCiPollAndFinish(ctx, opts);
+        }
+        // No session available — fall through to a fresh planning run
+        // as a last resort.  This should be rare: the session id is
+        // persisted alongside `squashSubStep`.
+      }
+
+      if (saved === "awaiting_user_choice") {
+        const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
+        if (hasValidSuggestionBlock(prBody)) {
+          return askUserAndApply(ctx, opts, undefined);
+        }
+        // Suggestion block missing or malformed — fall back to a
+        // fresh planning run rather than re-presenting a choice that
+        // the user could not act on.
+      }
+
       // Skip squash when the branch has only one commit.
-      const count = (opts.countBranchCommits ?? defaultCountBranchCommits)(
-        ctx.worktreePath,
-        opts.defaultBranch,
-      );
-      if (count <= 1) {
+      const initialCount = countCommits(ctx.worktreePath, opts.defaultBranch);
+      if (initialCount <= 1) {
+        opts.onSquashSubStep?.(undefined);
         return {
           outcome: "completed",
           message: t()["squash.singleCommitSkip"],
         };
       }
 
-      // Step 1: Send the squash prompt (resume if saved session).
+      // ---- planning: send the squash work prompt --------------------------
+      opts.onSquashSubStep?.("planning");
+
       const prompt = buildSquashPrompt(ctx, opts);
       ctx.promptSinks?.a?.(prompt, "work");
       const squashResult = await invokeOrResume(
         opts.agent,
-        ctx.savedAgentASessionId,
+        resolveSavedSessionId(),
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
@@ -166,122 +543,206 @@ export function createSquashStageHandler(
         return mapAgentError(squashResult, "during squash");
       }
 
-      // Step 2: Completion check (same internal-clarification pattern as
-      // stage 4).
-      const squashCheckPrompt = buildSquashCompletionCheckPrompt();
-      ctx.promptSinks?.a?.(squashCheckPrompt, "verdict-followup", {
-        resume: true,
-      });
-      let checkResult = await sendFollowUp(
-        opts.agent,
-        squashResult.sessionId,
-        squashCheckPrompt,
-        ctx.worktreePath,
-        ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
-      );
-
-      if (checkResult.status === "error") {
-        return mapAgentError(checkResult, "during squash completion check");
-      }
-
+      // ---- verdict --------------------------------------------------------
       const verdictCtx: VerdictContext | undefined = ctx.events
         ? { events: ctx.events, agent: "a" }
         : undefined;
 
-      let result = mapResponseToResult(
-        checkResult.responseText,
-        undefined,
-        SQUASH_CHECK_KEYWORDS,
+      const handle = await resolveVerdict(
+        opts.agent,
+        squashResult.sessionId,
+        ctx,
         verdictCtx,
+        ctx.worktreePath,
       );
 
-      if (result.outcome === "needs_clarification") {
-        const clarifyPrompt = buildClarificationPrompt(
-          checkResult.responseText,
-          SQUASH_CHECK_KEYWORDS,
-        );
-        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
-          resume: true,
-        });
-        const retryResult = await sendFollowUp(
-          opts.agent,
-          checkResult.sessionId ?? squashResult.sessionId,
-          clarifyPrompt,
-          ctx.worktreePath,
-          ctx.streamSinks?.a,
-          undefined,
-          ctx.usageSinks?.a,
-        );
-
-        if (retryResult.status === "error") {
-          return mapAgentError(
-            retryResult,
-            "during squash completion clarification",
-          );
-        }
-
-        checkResult = retryResult;
-        result = mapResponseToResult(
-          checkResult.responseText,
-          undefined,
-          SQUASH_CHECK_KEYWORDS,
-          verdictCtx,
-        );
+      if ("outcome" in handle) {
+        // Agent error inside resolveVerdict — already a StageResult.
+        return handle;
       }
 
-      // If still ambiguous after the in-session retry, verify
-      // the squash actually happened by checking whether the
-      // commit count decreased.
-      if (result.outcome === "needs_clarification") {
-        const postCount = (
-          opts.countBranchCommits ?? defaultCountBranchCommits
-        )(ctx.worktreePath, opts.defaultBranch);
-        if (postCount < count) {
-          result = { outcome: "completed", message: result.message };
+      let verdict: SquashVerdict | undefined = handle.verdict;
+      const verdictResponseText = handle.responseText;
+      const verdictSessionId = handle.sessionId;
+
+      // Persist the latest session id from the verdict turn before
+      // potentially entering `awaiting_user_choice`.  Adapters may
+      // surface a new session id on follow-up turns (see
+      // `src/claude-adapter.ts`), so the verdict session can differ
+      // from the planning session that was persisted earlier at
+      // `squashResult.sessionId`.  Without this, a resume from
+      // `awaiting_user_choice` that routes the user's "agent" choice
+      // back to the older planning session would not continue the
+      // exact conversation that drafted the PR-body suggestion.
+      if (verdictSessionId) {
+        ctx.onSessionId?.("a", verdictSessionId);
+      }
+
+      // ---- post-clarification deterministic fallback chain -----------------
+      // Order matters: a completed force-push is the hard-to-undo side
+      // effect, so detect it first.  Only then check the suggestion
+      // block, because an earlier run may have left a stale block in
+      // the PR body that would otherwise be misclassified.  The block
+      // must be fully parseable (markers + `**Title:**`) — a malformed
+      // block is treated as missing because Stage 9 cannot render a
+      // preview from it.
+      if (verdict === undefined) {
+        const postCount = countCommits(ctx.worktreePath, opts.defaultBranch);
+        if (postCount < initialCount) {
+          verdict = "SQUASHED_MULTI";
         } else {
-          result = {
+          const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
+          if (hasValidSuggestionBlock(prBody)) {
+            verdict = "SUGGESTED_SINGLE";
+          } else {
+            verdict = "BLOCKED";
+          }
+        }
+        // The verdict was derived deterministically rather than parsed
+        // from the agent response, but telemetry consumers still need
+        // the `pipeline:verdict` event so the stage outcome is
+        // attributable.  The raw text is the last clarification
+        // response — the best signal we have for "what the agent said
+        // before we overrode it".
+        verdictCtx?.events.emit("pipeline:verdict", {
+          agent: verdictCtx.agent,
+          keyword: verdict,
+          raw: verdictResponseText,
+        });
+      }
+
+      // Branch on the resolved verdict.
+      if (verdict === "BLOCKED") {
+        opts.onSquashSubStep?.(undefined);
+        return {
+          outcome: "blocked",
+          message: `${squashResult.responseText}\n\n---\n\n${verdictResponseText}`,
+        };
+      }
+
+      if (verdict === "SUGGESTED_SINGLE") {
+        // Verify the PR body holds a fully parseable suggestion block
+        // before asking the user.  A bare start marker or a block
+        // missing `**Title:**`/the end marker would let the stage
+        // complete with `applied_in_pr_body` but leave Stage 9 unable
+        // to render the inline preview, so fail closed instead.
+        const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
+        if (!hasValidSuggestionBlock(prBody)) {
+          opts.onSquashSubStep?.(undefined);
+          return {
             outcome: "blocked",
-            message: `${squashResult.responseText}\n\n---\n\n${checkResult.responseText}`,
+            message: `${squashResult.responseText}\n\n---\n\n${verdictResponseText}`,
           };
         }
+        return askUserAndApply(ctx, opts, verdictSessionId);
       }
 
-      if (result.outcome === "blocked") {
-        result.message = `${squashResult.responseText}\n\n---\n\n${checkResult.responseText}`;
-        return result;
-      }
-
-      if (result.outcome !== "completed") {
-        return result;
-      }
-
-      // Step 3: Poll CI after force-push.
-      const ciResult: CiPollResult = await pollCiAndFix({
-        ctx,
-        agent: opts.agent,
-        issueTitle: opts.issueTitle,
-        issueBody: opts.issueBody,
-        getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
-        collectFailureLogs:
-          opts.collectFailureLogs ?? defaultCollectFailureLogs,
-        getHeadSha: opts.getHeadSha,
-        emptyRunsGracePeriodMs: opts.emptyRunsGracePeriodMs,
-        pollIntervalMs: opts.pollIntervalMs,
-        pollTimeoutMs: opts.pollTimeoutMs,
-        maxFixAttempts: opts.maxFixAttempts,
-        delay: opts.delay,
-      });
-
-      if (!ciResult.passed) {
-        return { outcome: "error", message: ciResult.message };
-      }
-
-      return {
-        outcome: "completed",
-        message: t()["squash.completed"],
-      };
+      // SQUASHED_MULTI — proceed with the existing CI poll path.
+      return runCiPollAndFinish(ctx, opts);
     },
+  };
+}
+
+/**
+ * Present the user with the SUGGESTED_SINGLE choice and dispatch.
+ * `verdictSessionId` is the session that just produced the verdict;
+ * it is needed when the user picks "agent" so the follow-up prompt
+ * is sent on the same conversation.
+ */
+async function askUserAndApply(
+  ctx: StageContext,
+  opts: SquashStageOptions,
+  verdictSessionId: string | undefined,
+): Promise<StageResult> {
+  opts.onSquashSubStep?.("awaiting_user_choice");
+
+  const choice = opts.chooseSquashApplyMode
+    ? await opts.chooseSquashApplyMode(t()["squash.singleChoicePrompt"])
+    : "agent";
+
+  if (choice === "github") {
+    opts.onSquashSubStep?.("applied_in_pr_body");
+    return {
+      outcome: "completed",
+      message: t()["squash.messageAppended"],
+    };
+  }
+
+  // User picked "agent" — send the follow-up squash prompt and run CI.
+  opts.onSquashSubStep?.("squashing");
+
+  const sessionId =
+    verdictSessionId ??
+    opts.getSavedAgentSessionId?.() ??
+    ctx.savedAgentASessionId;
+  if (sessionId === undefined) {
+    // Without a session we cannot ask the agent to continue.  The
+    // user explicitly chose "agent", so silently completing as if
+    // they had picked "github" would misrepresent what happened.
+    // Fail closed and let the user retry or switch paths.  This
+    // should be rare: both invoke and verdict normally produce
+    // session IDs that get persisted alongside `squashSubStep`.
+    opts.onSquashSubStep?.(undefined);
+    return {
+      outcome: "blocked",
+      message: t()["squash.agentChoiceMissingSession"],
+    };
+  }
+
+  const followupPrompt = buildAgentSquashFollowupPrompt();
+  ctx.promptSinks?.a?.(followupPrompt, "work", { resume: true });
+  const followup = await sendFollowUp(
+    opts.agent,
+    sessionId,
+    followupPrompt,
+    ctx.worktreePath,
+    ctx.streamSinks?.a,
+    undefined,
+    ctx.usageSinks?.a,
+  );
+
+  if (followup.sessionId) {
+    ctx.onSessionId?.("a", followup.sessionId);
+  }
+
+  if (followup.status === "error") {
+    return mapAgentError(followup, "during agent squash follow-up");
+  }
+
+  return runCiPollAndFinish(ctx, opts);
+}
+
+/**
+ * Poll CI after a force-push and return the final stage result.
+ */
+async function runCiPollAndFinish(
+  ctx: StageContext,
+  opts: SquashStageOptions,
+): Promise<StageResult> {
+  opts.onSquashSubStep?.("ci_poll");
+
+  const ciResult: CiPollResult = await pollCiAndFix({
+    ctx,
+    agent: opts.agent,
+    issueTitle: opts.issueTitle,
+    issueBody: opts.issueBody,
+    getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
+    collectFailureLogs: opts.collectFailureLogs ?? defaultCollectFailureLogs,
+    getHeadSha: opts.getHeadSha,
+    emptyRunsGracePeriodMs: opts.emptyRunsGracePeriodMs,
+    pollIntervalMs: opts.pollIntervalMs,
+    pollTimeoutMs: opts.pollTimeoutMs,
+    maxFixAttempts: opts.maxFixAttempts,
+    delay: opts.delay,
+  });
+
+  if (!ciResult.passed) {
+    return { outcome: "error", message: ciResult.message };
+  }
+
+  opts.onSquashSubStep?.(undefined);
+  return {
+    outcome: "completed",
+    message: t()["squash.completed"],
   };
 }

--- a/src/step-parser.test.ts
+++ b/src/step-parser.test.ts
@@ -344,4 +344,45 @@ describe("parseVerdictKeyword", () => {
       keyword: "NOT_APPROVED",
     });
   });
+
+  // -- squash three-way verdict ---------------------------------------------
+  describe("squash three-way verdict", () => {
+    const squashKw = ["SQUASHED_MULTI", "SUGGESTED_SINGLE", "BLOCKED"] as const;
+
+    test("returns SQUASHED_MULTI on exact match", () => {
+      expect(parseVerdictKeyword("SQUASHED_MULTI", squashKw)).toEqual({
+        keyword: "SQUASHED_MULTI",
+      });
+    });
+
+    test("returns SUGGESTED_SINGLE on exact match", () => {
+      expect(parseVerdictKeyword("SUGGESTED_SINGLE", squashKw)).toEqual({
+        keyword: "SUGGESTED_SINGLE",
+      });
+    });
+
+    test("rejects when both SQUASHED_MULTI and SUGGESTED_SINGLE appear", () => {
+      expect(
+        parseVerdictKeyword(
+          "I started with SQUASHED_MULTI but then chose SUGGESTED_SINGLE",
+          squashKw,
+        ),
+      ).toEqual({ keyword: undefined });
+    });
+
+    test("rejects when SUGGESTED_SINGLE appears with extra commentary", () => {
+      expect(
+        parseVerdictKeyword(
+          "SUGGESTED_SINGLE — wrote the marker block",
+          squashKw,
+        ),
+      ).toEqual({ keyword: undefined });
+    });
+
+    test("ignores out-of-scope COMPLETED for squash keywords", () => {
+      expect(parseVerdictKeyword("COMPLETED", squashKw)).toEqual({
+        keyword: undefined,
+      });
+    });
+  });
 });

--- a/src/ui/TuiUserPrompt.ts
+++ b/src/ui/TuiUserPrompt.ts
@@ -169,5 +169,17 @@ export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
       });
       return response === "yes";
     },
+
+    async chooseSquashApplyMode(message: string): Promise<"agent" | "github"> {
+      const m = t();
+      const response = await dispatch({
+        message,
+        choices: [
+          { label: m["squash.singleChoiceAgent"], value: "agent" },
+          { label: m["squash.singleChoiceGithub"], value: "github" },
+        ],
+      });
+      return response === "agent" ? "agent" : "github";
+    },
   };
 }


### PR DESCRIPTION
## Summary

When stage 8 (Squash) judges that the branch should be consolidated into a single commit, it no longer rewrites history and force-pushes. Instead, the agent writes the suggested title and body into a marker-delimited block in the PR body and the user is asked whether to:

- let the agent squash now (runs CI again), or
- apply the suggestion via GitHub's "Squash and merge" at merge time (no CI rerun).

The multi-commit path (`SQUASHED_MULTI`) is unchanged. Stage 8's verdict keywords change from `COMPLETED` / `BLOCKED` to `SQUASHED_MULTI` / `SUGGESTED_SINGLE` / `BLOCKED`. The squash handler parses the keyword directly rather than going through `mapResponseToResult`, keeping the three-way distinction out of the shared `StepStatus`. When the clarification retry still returns an ambiguous keyword, a deterministic fallback chain runs — commit-count decrease (detects a completed force-push), then PR-body suggestion-block presence, then `BLOCKED` — so a completed squash is never misclassified as a suggestion. The derived verdict is also emitted as a `pipeline:verdict` event so telemetry consumers see every verdict, not just parsed ones.

`RunState` gains an explicit `squashSubStep` (`planning` / `awaiting_user_choice` / `squashing` / `ci_poll` / `applied_in_pr_body`) so resume re-enters the stage at the correct sub-state. `RUN_STATE_VERSION` is bumped from 2 to 3 with a non-destructive default for older state files. Stage 9's merge-confirm screen prints a conditional tip, the suggested title and body, and the PR URL inline when the suggestion path is live.

Resuming from `squashing` no longer falls through to a fresh planning run: if the commit count has already collapsed to 1 the handler jumps straight to the CI poll; otherwise it re-sends only the follow-up squash prompt on the saved session. This prevents the extra force-push / CI cycle the feature was designed to avoid.

In-process retries read the persisted squash sub-step and agent-A session id through live getters, not the one-shot snapshots the pipeline passes through `StageContext`. Without that, a transient `ci_poll` failure followed by a retry could see `squashSubStep === undefined` and, with the branch already collapsed to a single commit, fall into the single-commit skip path — turning a recoverable CI failure into a false successful completion.

The SUGGESTED_SINGLE / `applied_in_pr_body` paths now validate the PR-body block strictly via `parseSquashSuggestionBlock` (markers present **and** a `**Title:**` line). A bare start marker or a block missing `**Title:**` / the end marker fails closed with `blocked` (or re-runs planning on resume) instead of completing with `squash.messageAppended` and leaving Stage 9 unable to render the inline preview from the same parser.

Stage 8 also persists the verdict turn's session id via `ctx.onSessionId` before transitioning to `awaiting_user_choice`. Adapters may surface a new session id on follow-up turns, so the verdict session is not guaranteed to match the planning session persisted earlier. Without persisting it, a resume where the user picks "agent squashes now" could re-send the follow-up on the older planning session rather than the exact conversation that drafted the PR-body suggestion.

New i18n keys: `squash.messageAppended`, `squash.singleChoicePrompt`, `squash.singleChoiceAgent`, `squash.singleChoiceGithub`, `squash.agentChoiceMissingSession`, `pipeline.mergeConfirmSquashTip`, `pipeline.suggestedSquashTitle`, `pipeline.suggestedSquashBody`, `pipeline.prUrl` (English + Korean). `docs/pipeline.md` is rewritten for Stage 8, including the new keyword contracts, the `SquashSubStep` state machine, the marker block contract, the post-clarification fallback chain, and the live-getter resume story. `CHANGELOG.md` gains an `[Unreleased]` section.

Closes #252

## Test plan

- [x] `pnpm run check` passes (Biome)
- [x] `pnpm run test` passes (1790 tests)
- [x] `pnpm run build` succeeds (tsc)
- [x] Stage 8 `SQUASHED_MULTI` path: agent force-pushes, CI poll runs, stage completes with `squash.completed`
- [x] Stage 8 `SUGGESTED_SINGLE` + user picks "agent": follow-up prompt is sent, force-push + CI poll run, stage completes with `squash.completed`
- [x] Stage 8 `SUGGESTED_SINGLE` + user picks "github": stage completes with `squash.messageAppended`, no CI poll, `squashSubStep === "applied_in_pr_body"`
- [x] Stage 8 `SUGGESTED_SINGLE` with missing marker block falls back to `BLOCKED`
- [x] Stage 8 `SUGGESTED_SINGLE` with malformed marker block (start marker only / missing `**Title:**`) fails closed without prompting the user
- [x] Stage 8 fallback chain treats malformed block as missing → `BLOCKED` (not `SUGGESTED_SINGLE`)
- [x] Resume from `awaiting_user_choice` with malformed block re-runs planning instead of re-presenting the user choice
- [x] Post-clarification fallback ordering: commit-count decrease wins over marker presence
- [x] Post-clarification fallback emits `pipeline:verdict` for the derived keyword (SQUASHED_MULTI / SUGGESTED_SINGLE / BLOCKED)
- [x] Resume in `awaiting_user_choice` re-presents the user choice without re-running the agent
- [x] Resume in `ci_poll` resumes the poll loop
- [x] Resume in `applied_in_pr_body` advances straight to Stage 9
- [x] Resume in `squashing` with commit count collapsed to 1 jumps straight to CI poll (no agent invocation)
- [x] Resume in `squashing` with count still > 1 and a saved session re-sends only the follow-up prompt (no planning prompt)
- [x] Resume in `squashing` with count still > 1 and no saved session falls back to a fresh planning run
- [x] In-process retry: live `savedSquashSubStep` getter re-enters `ci_poll` instead of falsely completing via single-commit skip
- [x] In-process retry: live `getSavedAgentSessionId` getter re-uses the persisted session even when `ctx.savedAgentASessionId` was cleared
- [x] Stage 8 `BLOCKED` path unchanged
- [x] \`parseVerdictKeyword\` disambiguates `SQUASHED_MULTI` vs `SUGGESTED_SINGLE` (single-keyword matches resolve; both-present resolves to ambiguous)
- [x] Stage 9 merge-confirm screen shows the conditional tip, inline title/body, and PR URL when `squashSubStep === "applied_in_pr_body"`
- [x] `RunState` migration: state files without `squashSubStep` load cleanly as `undefined`
- [x] Stage 8 persists the verdict turn's session id before `awaiting_user_choice`; resume + user "agent" choice uses the verdict session (not the planning session) for the follow-up