### PR TITLE
Fix TokenBar text collapse in vertical layout (#256)

### DIFF
--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -139,12 +139,14 @@ export function TokenBar({
       : textB;
 
   const boxHeight = contentWidth !== undefined ? 3 : undefined;
+  // In column layout, flexBasis={0}+flexGrow={1} would collapse the explicit
+  // `height` inside a bounded-height parent, leaving only borders.
+  const mainAxisSizing = layout === "row" ? { flexGrow: 1, flexBasis: 0 } : {};
 
   return (
     <Box flexDirection={layout} flexShrink={0}>
       <Box
-        flexGrow={1}
-        flexBasis={0}
+        {...mainAxisSizing}
         borderStyle="single"
         borderColor="gray"
         paddingX={1}
@@ -154,8 +156,7 @@ export function TokenBar({
         <Text>{displayA}</Text>
       </Box>
       <Box
-        flexGrow={1}
-        flexBasis={0}
+        {...mainAxisSizing}
         borderStyle="single"
         borderColor="gray"
         paddingX={1}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -2242,6 +2242,29 @@ describe("TokenBar layout prop", () => {
     expect(agentBIdx).toBeGreaterThanOrEqual(0);
     expect(agentAIdx).not.toBe(agentBIdx);
   });
+
+  test("shows agent text in column layout inside a bounded-height parent", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box height={20} flexDirection="column">
+        <TokenBar emitter={emitter} layout="column" contentWidth={76} />
+      </Box>,
+    );
+
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    emitter.emit("agent:usage", {
+      agent: "b",
+      usage: { inputTokens: 2000, outputTokens: 800, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Agent A (author)");
+    expect(frame).toContain("Agent B (reviewer)");
+  });
 });
 
 // ---- cliDisplayName ----------------------------------------------------------


### PR DESCRIPTION
## Summary

In column (vertical) layout, `TokenBar` applied `flexGrow={1}` and `flexBasis={0}` to each agent box unconditionally. When the bar sits inside a bounded-height parent (as it does in `App.tsx`), the main axis is vertical, so `flexBasis={0}` zeros each box's initial height and `flexGrow={1}` stretches the borders, overriding the explicit `height={3}`. The content row collapses and only the borders render.

The fix restricts the flex equal-sizing trick to `layout === "row"`. In column layout each inner box keeps its explicit height and stretches only on the cross axis (width).

A regression test renders `TokenBar` with `layout="column"`, `contentWidth=76`, inside a `<Box height={20} flexDirection="column">` parent and asserts both agents' text strings appear in the frame. The previous column test only checked that A and B landed on different lines, which passes even when both boxes are empty borders.

Closes #256

## Test plan

- [x] `pnpm vitest run` — full suite passes (1747 tests)
- [x] `pnpm biome check` — no issues
- [x] `pnpm tsc --noEmit` — no type errors
- [x] New test: TokenBar in column layout inside bounded-height parent shows both agents' text (`components.test.tsx:2246`)
- [x] Column layout (Ctrl+L): verified programmatically via the new regression test, which reproduces the App.tsx bounded-height parent scenario and asserts both `Agent A (author)` and `Agent B (reviewer)` strings render in the frame
- [x] Row layout: verified programmatically via the existing `renders two boxes side by side in row layout` test (`components.test.tsx:2195`), which continues to pass — row rendering is unchanged