### PR TITLE
Make status bar issue/PR references clickable (#253)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Status bar now wraps the issue reference on line 1 with an OSC 8 terminal
+  hyperlink so supporting terminals (iTerm2, WezTerm, Ghostty, Kitty, modern
+  VS Code, Windows Terminal, Alacritty, etc.) render it as a clickable link
+  pointing at the GitHub issue page. Older terminals render the text
+  unchanged.
+- Status bar line 2 now includes a `PR: #{n}` segment (between `Base:` and
+  `Stage:`) once the pull-request number is known, also wrapped with an
+  OSC 8 hyperlink pointing at the PR page.
 - Stage 8 (Squash) now offers a single-commit suggestion path: when the agent
   judges that one commit is appropriate, it writes the suggested title and
   body into a marker-delimited block in the PR body instead of force-pushing.

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -196,6 +196,7 @@ export const en: Messages = {
     `Stage ${number}: ${name} (round ${round})`,
   "statusBar.last": (outcome) => `Last: ${outcome}`,
   "statusBar.base": (sha) => `Base: ${sha}`,
+  "statusBar.pr": (prNumber) => `PR: #${prNumber}`,
   "statusBar.completed": (selfCheckCount, reviewCount) =>
     `Completed: self-check \u00d7${selfCheckCount}, review \u00d7${reviewCount}`,
   "statusBar.layout": (mode) => `Layout: ${mode}`,

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -78,6 +78,7 @@ describe("catalogs are complete", () => {
       "statusBar.stage": [1, "Implement"],
       "statusBar.stageRound": [3, "Self-check", 1],
       "statusBar.last": ["ok"],
+      "statusBar.pr": [42],
       "statusBar.completed": [2, 3],
       "stageError.maxTurns": [" (stage 1)"],
       "stageError.inactivityTimeout": [" (stage 2)"],

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -231,6 +231,7 @@ export const ko: Messages = {
     `${number}\uB2E8\uACC4: ${name} (\uB77C\uC6B4\uB4DC ${round})`,
   "statusBar.last": (outcome) => `\uC774\uC804: ${outcome}`,
   "statusBar.base": (sha) => `\uAE30\uC900: ${sha}`,
+  "statusBar.pr": (prNumber) => `PR: #${prNumber}`,
   "statusBar.completed": (selfCheckCount, reviewCount) =>
     `\uC644\uB8CC: \uC140\uD504 \uCCB4\uD06C \u00d7${selfCheckCount}, \uB9AC\uBDF0 \u00d7${reviewCount}`,
   "statusBar.layout": (mode) => `\uB808\uC774\uC544\uC6C3: ${mode}`,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -187,6 +187,7 @@ export interface Messages {
   ) => string;
   "statusBar.last": (outcome: string) => string;
   "statusBar.base": (sha: string) => string;
+  "statusBar.pr": (prNumber: number) => string;
   "statusBar.completed": (
     selfCheckCount: number,
     reviewCount: number,

--- a/src/index.ts
+++ b/src/index.ts
@@ -868,6 +868,9 @@ try {
       // Update PR number when entering stage 5+ (PR should exist by then).
       if (stageNumber >= 5 && runState.prNumber === undefined) {
         runState.prNumber = findPrNumber(owner, repo, wt.branch);
+        if (runState.prNumber !== undefined) {
+          emitter.emit("pr:resolved", { prNumber: runState.prNumber });
+        }
       }
       // Track review round.
       if (stageNumber === 7) {
@@ -923,6 +926,7 @@ try {
       notifications,
       initialSelfCheckCount: runState.selfCheckCount,
       initialReviewCount: runState.reviewCount,
+      initialPrNumber: runState.prNumber,
     });
   });
 

--- a/src/pipeline-events.ts
+++ b/src/pipeline-events.ts
@@ -25,6 +25,10 @@ export interface ReviewPostedEvent {
   round: number;
 }
 
+export interface PrResolvedEvent {
+  prNumber: number;
+}
+
 export interface AgentInvokeEvent {
   agent: "a" | "b";
   type: "invoke" | "resume";
@@ -114,6 +118,7 @@ interface PipelineEventMap {
   "stage:exit": [StageExitEvent];
   "stage:name-override": [StageNameOverrideEvent];
   "review:posted": [ReviewPostedEvent];
+  "pr:resolved": [PrResolvedEvent];
   "agent:invoke": [AgentInvokeEvent];
   "pipeline:verdict": [PipelineVerdictEvent];
   "pipeline:loop": [PipelineLoopEvent];

--- a/src/ui/App.test.tsx
+++ b/src/ui/App.test.tsx
@@ -78,6 +78,46 @@ describe("App dispatch notifications", () => {
     );
   });
 
+  test("renders PR segment after pr:resolved event", async () => {
+    initI18n("en");
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <App
+        emitter={emitter}
+        pipelineOptions={minimalOptions}
+        onExit={vi.fn()}
+      />,
+    );
+
+    // Before the event, no PR segment is rendered.
+    await vi.waitFor(() => {
+      expect(lastFrame() ?? "").not.toContain("PR: #");
+    });
+
+    emitter.emit("pr:resolved", { prNumber: 523 });
+
+    await vi.waitFor(() => {
+      expect(lastFrame() ?? "").toContain("PR: #523");
+    });
+  });
+
+  test("seeds PR segment from initialPrNumber on resume", async () => {
+    initI18n("en");
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <App
+        emitter={emitter}
+        pipelineOptions={minimalOptions}
+        onExit={vi.fn()}
+        initialPrNumber={42}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(lastFrame() ?? "").toContain("PR: #42");
+    });
+  });
+
   test("does not call notifyInputWaiting when notifications prop is undefined", async () => {
     initI18n("en");
     const emitter = new PipelineEventEmitter();

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -12,6 +12,7 @@ import { runPipeline } from "../pipeline.js";
 import type {
   AgentInvokeEvent,
   PipelineEventEmitter,
+  PrResolvedEvent,
 } from "../pipeline-events.js";
 import { AgentPane, splitIntoRows } from "./AgentPane.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
@@ -263,6 +264,8 @@ export interface AppProps {
   initialSelfCheckCount?: number;
   /** Persisted review count for StatusBar initialisation on resume. */
   initialReviewCount?: number;
+  /** Persisted PR number from RunState; seeds the StatusBar on resume. */
+  initialPrNumber?: number;
 }
 
 export function App({
@@ -279,6 +282,7 @@ export function App({
   startedAt,
   initialSelfCheckCount,
   initialReviewCount,
+  initialPrNumber,
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
     useTerminalDimensions();
@@ -294,6 +298,15 @@ export function App({
     "row",
   );
   const [hasTokenData, setHasTokenData] = useState(false);
+  const [prNumber, setPrNumber] = useState<number | undefined>(initialPrNumber);
+
+  useEffect(() => {
+    const onPrResolved = (ev: PrResolvedEvent) => setPrNumber(ev.prNumber);
+    emitter.on("pr:resolved", onPrResolved);
+    return () => {
+      emitter.off("pr:resolved", onPrResolved);
+    };
+  }, [emitter]);
 
   // AbortController for pipeline cancellation on Ctrl+C.
   const abortController = useMemo(() => new AbortController(), []);
@@ -503,6 +516,7 @@ export function App({
         repo={pipelineOptions.context.repo}
         issueNumber={pipelineOptions.context.issueNumber}
         issueTitle={pipelineOptions.context.issueTitle}
+        prNumber={prNumber}
         baseSha={pipelineOptions.context.baseSha}
         layout={effectiveLayout}
         showKeyHints={flags.showKeyHints}

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -15,6 +15,18 @@ const SELF_CHECK_STAGE = 3;
 /** Stage number for the review stage. */
 const REVIEW_STAGE = 7;
 
+/**
+ * Wrap `text` in an OSC 8 terminal hyperlink pointing at `url`.
+ * Terminals that support OSC 8 render the text as a clickable link;
+ * others render the text unchanged. `string-width` strips ANSI
+ * escapes before measuring, so width calculations are unaffected.
+ */
+export function wrapTerminalHyperlink(url: string, text: string): string {
+  const OSC = "\x1b]8;;";
+  const BEL = "\x07";
+  return `${OSC}${url}${BEL}${text}${OSC}${BEL}`;
+}
+
 interface StatusBarProps {
   emitter: PipelineEventEmitter;
   owner: string;
@@ -22,6 +34,8 @@ interface StatusBarProps {
   issueNumber: number;
   /** Title of the GitHub issue, shown after the issue reference. */
   issueTitle?: string;
+  /** PR number associated with the run, once known. */
+  prNumber?: number;
   /** Full SHA of the base commit; displayed abbreviated in the bar. */
   baseSha?: string;
   /** Current pane layout direction. */
@@ -194,6 +208,7 @@ export function StatusBar({
   repo,
   issueNumber,
   issueTitle,
+  prNumber,
   baseSha,
   layout,
   showKeyHints = true,
@@ -302,10 +317,12 @@ export function StatusBar({
     }
   }
 
-  const issueLine =
+  const issueLineTruncated =
     issueBudget !== undefined
       ? truncateWithEllipsis(issueLineText, issueBudget)
       : issueLineText;
+  const issueUrl = `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
+  const issueLine = wrapTerminalHyperlink(issueUrl, issueLineTruncated);
 
   // Line 2: Pipeline status segments with drop priorities.
   // Priority 0 = required (never dropped); higher = dropped sooner.
@@ -313,6 +330,13 @@ export function StatusBar({
   const pipelineSegments: InfoSegment[] = [];
   if (baseText) {
     pipelineSegments.push({ text: baseText, dropPriority: 1 });
+  }
+  if (prNumber !== undefined) {
+    const prUrl = `https://github.com/${owner}/${repo}/pull/${prNumber}`;
+    pipelineSegments.push({
+      text: wrapTerminalHyperlink(prUrl, m["statusBar.pr"](prNumber)),
+      dropPriority: 1,
+    });
   }
   pipelineSegments.push({ text: stageText, bold: true, dropPriority: 0 });
   if (outcomeText) {

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1270,6 +1270,86 @@ describe("StatusBar", () => {
     expect(lastFrame()).toContain("Stage 9: Done");
     expect(lastFrame()).not.toContain("Stage 9: Rebase");
   });
+
+  test("wraps issue reference with OSC 8 hyperlink", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={49}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain(
+      "\x1b]8;;https://github.com/aicers/agentcoop/issues/49\x07",
+    );
+    expect(frame).toContain("aicers/agentcoop#49");
+  });
+
+  test("shows PR segment with OSC 8 hyperlink when prNumber is set", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          prNumber={523}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("PR: #523");
+    expect(frame).toContain(
+      "\x1b]8;;https://github.com/aicers/agentcoop/pull/523\x07",
+    );
+  });
+
+  test("omits PR segment when prNumber is undefined", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("PR: #");
+    expect(frame).not.toContain("/pull/");
+  });
+
+  test("escape sequences are zero-width for issue-line truncation", () => {
+    const emitter = new PipelineEventEmitter();
+    // Compare the truncation behavior with and without the hyperlink
+    // wrapping active. The rendered width budget must be identical.
+    const issueTitle = "Bug fix";
+    const { lastFrame } = render(
+      <StatusBar
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={42}
+        issueTitle={issueTitle}
+        contentWidth={22}
+      />,
+    );
+
+    const frame = lastFrame() ?? "";
+    // Truncation still fits: ellipsis must be present and the issue
+    // reference must still appear.
+    expect(frame).toContain("aicers/agentcoop#42:");
+    expect(frame).toContain("\u2026");
+  });
 });
 
 // ---- InputArea ---------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Wrap the status bar's issue reference on line 1 with an OSC 8 terminal hyperlink so supporting terminals (iTerm2, WezTerm, Ghostty, Kitty, modern VS Code, Windows Terminal, Alacritty, etc.) render it as a clickable link to the GitHub issue page. Older terminals render the text unchanged.
- Add a `PR: #{n}` segment on line 2 (between `Base:` and `Stage:`, drop priority `1`) once the pull-request number is known, also wrapped with an OSC 8 hyperlink pointing at the PR page.
- Propagate the PR number from the orchestrator to the UI via a new `pr:resolved` pipeline event, and seed it on resume from the persisted `RunState.prNumber` via a new `initialPrNumber` prop on `App`.
- Add a `wrapTerminalHyperlink(url, text)` helper to keep the OSC 8 escape sequence in one place.
- Add `statusBar.pr` i18n key (en/ko).
- `CHANGELOG.md`: add `## [Unreleased]` / `### Added` notes.

Closes #253

## Test plan

- [x] `pnpm biome check` passes.
- [x] `pnpm tsc --noEmit` passes.
- [x] `pnpm vitest run` passes (includes new coverage in `src/ui/components.test.tsx` and `src/ui/App.test.tsx`).
- [x] `pnpm build` succeeds.
- [x] Line 1 output contains the OSC 8 escape sequence wrapping `https://github.com/{owner}/{repo}/issues/{issueNumber}`.
- [x] `PR: #{n}` segment appears when `prNumber` is set and wraps `https://github.com/{owner}/{repo}/pull/{prNumber}`.
- [x] `PR: #{n}` segment is absent when `prNumber` is undefined.
- [x] Truncation still fits inside the width budget (escape sequences are zero-width for display).
- [x] `pr:resolved` event updates `StatusBar` and `initialPrNumber` seeds it on resume.
- [x] Manual smoke test in an OSC 8-capable terminal: Cmd/Ctrl-click on the issue reference and `PR: #{n}` both open the correct GitHub URLs.
- [x] Smoke test in an older terminal without OSC 8 support: text renders as plain text without visible artifacts.
