### PR TITLE
Show Stage 1 (Bootstrap) retrospectively in TUI (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Stage 1 (Bootstrap) is now surfaced retrospectively in the TUI. At first
+  render, the status bar shows `Stage 1: Bootstrap → Stage N: <name>` briefly
+  (where `N` is 2 on a fresh run or `startFromStage` on resume) before
+  collapsing to the normal single-stage display once the first real
+  `stage:enter` fires. Both agent panes prepend a Stage 1 enter divider, the
+  buffered bootstrap log lines (repository bootstrap, worktree ready, and
+  the conditional uncommitted-preserved / PR-exists-skip messages) as
+  timestamped `[HH:MM:SS] Pipeline: …` rows, and a Stage 1 → Stage N
+  transition divider. Terminal scrollback still receives the bootstrap
+  lines live before the TUI mounts.
 - Status bar now wraps the issue reference on line 1 with an OSC 8 terminal
   hyperlink so supporting terminals (iTerm2, WezTerm, Ghostty, Kitty, modern
   VS Code, Windows Terminal, Alacritty, etc.) render it as a clickable link

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -18,6 +18,7 @@ the [README](../README.md).
   - [Additional feedback injection](#additional-feedback-injection)
   - [Ambiguous response clarification](#ambiguous-response-clarification)
 - [Stage reference](#stage-reference)
+  - [Stage 1: Bootstrap](#stage-1-bootstrap)
   - [Stage 2: Implement](#stage-2-implement)
   - [Stage 3: Self-check loop](#stage-3-self-check-loop)
   - [Stage 4: Create PR](#stage-4-create-pr)
@@ -31,12 +32,15 @@ the [README](../README.md).
 ## Pipeline overview
 
 ```text
-Implement -> Self-check -> Create PR -> CI check
-   (A)       (A, loop)       (A)       (A, loop)
+Bootstrap -> Implement -> Self-check -> Create PR -> CI check
+  (orch)       (A)        (A, loop)       (A)       (A, loop)
 
   -> Test plan -> Review -> Squash -> Done
      (A, loop)  (B<->A, loop) (A)    (user)
 ```
+
+Stage 1 (Bootstrap) is orchestrator-managed and runs before the TUI
+mounts; see [Stage 1: Bootstrap](#stage-1-bootstrap) below.
 
 Agent A is the author (implements the issue). Agent B is the
 reviewer. The orchestrator manages transitions, CI polling, and
@@ -234,6 +238,35 @@ Do not include any other commentary — just the keyword.
 ```
 
 ## Stage reference
+
+### Stage 1: Bootstrap
+
+**Agent:** none (orchestrator-managed)\
+**Purpose:** Prepare the repository, default branch, and worktree so
+later stages can run against a known-good local checkout.
+
+Stage 1 runs synchronously before the ink TUI mounts.  It performs:
+
+- **Repository bootstrap:** If the repository is not cloned under
+  `cloneBaseDir/{owner}/{repo}`, clone it. If already cloned, fetch
+  the latest remote state. If a worktree for the same branch already
+  exists, prompt the user to reuse, clean up, or halt.
+- **Default branch detection:** Query via
+  `gh repo view {owner}/{repo} --json defaultBranchRef` instead of
+  assuming `main`.
+- **Worktree creation:** Create a git worktree from the latest remote
+  default branch at
+  `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`, outside the
+  repository to avoid pollution.
+- **Resume pre-flight:** On resume, if `startFromStage === 4` and a PR
+  already exists, promote the starting stage to 5 (CI check) so the
+  side-effectful `gh pr create` is not replayed.
+
+Because Stage 1 completes before the TUI mounts, it is surfaced
+retrospectively.  The `StatusBar` shows `Stage 1: Bootstrap
+\u2192 Stage N: <name>` briefly on first render, and both agent panes
+prepend a Stage 1 enter divider, the buffered bootstrap log lines, and
+a Stage 1 \u2192 Stage N transition divider before live output begins.
 
 ### Stage 2: Implement
 
@@ -1561,19 +1594,11 @@ Do not include any other commentary — just the keyword.
 ## Orchestrator-managed operations
 
 The following operations are handled directly by the orchestrator,
-not delegated to agents:
+not delegated to agents.  Repository cloning, default-branch
+detection, and worktree creation are the three Stage 1 (Bootstrap)
+operations — see [Stage 1: Bootstrap](#stage-1-bootstrap) above for
+details.
 
-- **Repository bootstrap:** If the repository is not cloned under
-  `cloneBaseDir/{owner}/{repo}`, clone it. If already cloned,
-  fetch the latest remote state. If a worktree for the same branch
-  already exists, prompt the user to reuse, clean up, or halt.
-- **Default branch detection:** Query via
-  `gh repo view {owner}/{repo} --json defaultBranchRef` instead
-  of assuming `main`.
-- **Worktree creation:** Create a git worktree from the latest
-  remote default branch at
-  `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`, outside
-  the repository to avoid pollution.
 - **PR number extraction:** After Agent A creates a PR, extract
   the number via `gh pr list --head {branch} --json number`.
 - **CI status polling:** Check CI status and collect failure

--- a/src/bootstrap-log.test.ts
+++ b/src/bootstrap-log.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { createBootstrapLog } from "./bootstrap-log.js";
+
+describe("createBootstrapLog", () => {
+  const stdoutSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  const stderrSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+  beforeEach(() => {
+    stdoutSpy.mockClear();
+    stderrSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("log() prints to stdout and records a timestamped entry", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-15T09:08:07Z"));
+    const log = createBootstrapLog();
+
+    log.log("Bootstrapping repository...");
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Bootstrapping repository...");
+    expect(log.entries).toHaveLength(1);
+    expect(log.entries[0].message).toBe("Bootstrapping repository...");
+    // Timestamp is HH:MM:SS in local time; assert format shape only.
+    expect(log.entries[0].timestamp).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+  });
+
+  test("warn() prints to stderr and records a timestamped entry", () => {
+    const log = createBootstrapLog();
+
+    log.warn("Uncommitted changes preserved");
+
+    expect(stderrSpy).toHaveBeenCalledWith("Uncommitted changes preserved");
+    expect(log.entries).toHaveLength(1);
+    expect(log.entries[0].message).toBe("Uncommitted changes preserved");
+  });
+
+  test("preserves emission order across log and warn calls", () => {
+    const log = createBootstrapLog();
+
+    log.log("first");
+    log.warn("second");
+    log.log("third");
+
+    expect(log.entries.map((e) => e.message)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+});

--- a/src/bootstrap-log.ts
+++ b/src/bootstrap-log.ts
@@ -1,0 +1,58 @@
+/**
+ * Bootstrap-phase log buffer.
+ *
+ * Bootstrap (Stage 1) runs synchronously before the ink TUI mounts, so the
+ * lines describing it are printed to stdout/stderr directly.  To also
+ * surface those lines inside the TUI panes once mounted, we capture each
+ * emitted message here with a timestamp.  The buffered entries are
+ * replayed into both agent panes on mount by `useAgentLines`.
+ */
+
+export interface BootstrapLogEntry {
+  /** HH:MM:SS timestamp, captured when the line was emitted. */
+  timestamp: string;
+  /** The message text, without a trailing newline. */
+  message: string;
+}
+
+export interface BootstrapLog {
+  /** All buffered entries in emission order. */
+  readonly entries: readonly BootstrapLogEntry[];
+  /** Print `line` to stdout and record it in the buffer. */
+  log(line: string): void;
+  /** Print `line` to stderr and record it in the buffer. */
+  warn(line: string): void;
+}
+
+function hhmmss(): string {
+  const d = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/**
+ * Create a fresh bootstrap log buffer.  Each call to `log` / `warn` both
+ * prints to the terminal (so scrollback still shows the bootstrap lines
+ * live) and appends a timestamped entry to the buffer.
+ */
+export function createBootstrapLog(): BootstrapLog {
+  const entries: BootstrapLogEntry[] = [];
+
+  function record(message: string): void {
+    entries.push({ timestamp: hhmmss(), message });
+  }
+
+  return {
+    get entries(): readonly BootstrapLogEntry[] {
+      return entries;
+    },
+    log(line: string): void {
+      console.log(line);
+      record(line);
+    },
+    warn(line: string): void {
+      console.warn(line);
+      record(line);
+    },
+  };
+}

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -114,6 +114,7 @@ export const en: Messages = {
 
   // ---- stage names -------------------------------------------------------
 
+  "stage.bootstrap": "Bootstrap",
   "stage.implement": "Implement",
   "stage.selfCheck": "Self-check",
   "stage.createPr": "Create PR",
@@ -194,6 +195,8 @@ export const en: Messages = {
   "statusBar.stage": (number, name) => `Stage ${number}: ${name}`,
   "statusBar.stageRound": (number, name, round) =>
     `Stage ${number}: ${name} (round ${round})`,
+  "statusBar.bootstrapTransition": (fromNum, fromName, toNum, toName) =>
+    `Stage ${fromNum}: ${fromName} \u2192 Stage ${toNum}: ${toName}`,
   "statusBar.last": (outcome) => `Last: ${outcome}`,
   "statusBar.base": (sha) => `Base: ${sha}`,
   "statusBar.pr": (prNumber) => `PR: #${prNumber}`,

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -146,6 +146,7 @@ export const ko: Messages = {
 
   // ---- stage names -------------------------------------------------------
 
+  "stage.bootstrap": "\uBD80\uD2B8\uC2A4\uD2B8\uB7A9",
   "stage.implement": "\uAD6C\uD604",
   "stage.selfCheck": "\uC140\uD504 \uCCB4\uD06C",
   "stage.createPr": "PR \uC0DD\uC131",
@@ -229,6 +230,8 @@ export const ko: Messages = {
   "statusBar.stage": (number, name) => `${number}\uB2E8\uACC4: ${name}`,
   "statusBar.stageRound": (number, name, round) =>
     `${number}\uB2E8\uACC4: ${name} (\uB77C\uC6B4\uB4DC ${round})`,
+  "statusBar.bootstrapTransition": (fromNum, fromName, toNum, toName) =>
+    `${fromNum}\uB2E8\uACC4: ${fromName} \u2192 ${toNum}\uB2E8\uACC4: ${toName}`,
   "statusBar.last": (outcome) => `\uC774\uC804: ${outcome}`,
   "statusBar.base": (sha) => `\uAE30\uC900: ${sha}`,
   "statusBar.pr": (prNumber) => `PR: #${prNumber}`,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -112,6 +112,7 @@ export interface Messages {
 
   // ---- stage names -------------------------------------------------------
 
+  "stage.bootstrap": string;
   "stage.implement": string;
   "stage.selfCheck": string;
   "stage.createPr": string;
@@ -184,6 +185,12 @@ export interface Messages {
     number: number,
     name: string,
     round: number,
+  ) => string;
+  "statusBar.bootstrapTransition": (
+    fromNum: number,
+    fromName: string,
+    toNum: number,
+    toName: string,
   ) => string;
   "statusBar.last": (outcome: string) => string;
   "statusBar.base": (sha: string) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { confirm, select } from "@inquirer/prompts";
 
 import type { AgentAdapter, AgentStream } from "./agent.js";
+import { type BootstrapLog, createBootstrapLog } from "./bootstrap-log.js";
 import { pollCiAndFix } from "./ci-poll.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
 import {
@@ -258,6 +259,7 @@ async function runCancellationCleanup(opts: {
 function stageNames(): Record<number, string> {
   const m = t();
   return {
+    1: m["stage.bootstrap"],
     2: m["stage.implement"],
     3: m["stage.selfCheck"],
     4: m["stage.createPr"],
@@ -429,9 +431,14 @@ try {
 
   const m = t();
 
+  // Buffer bootstrap (Stage 1) log lines so they can be replayed into
+  // the ink TUI panes once the TUI mounts.  The buffer also prints each
+  // line to stdout/stderr live so terminal scrollback is unaffected.
+  const bootstrapLog: BootstrapLog = createBootstrapLog();
+
   // Bootstrap the repository and create a worktree.
   console.log();
-  console.log(m["boot.bootstrapping"]);
+  bootstrapLog.log(m["boot.bootstrapping"]);
   bootstrapRepo(owner, repo);
 
   const defaultBranch = detectDefaultBranch(owner, repo);
@@ -444,10 +451,10 @@ try {
     branch: `${username}/issue-${issueNumber}`,
     conflictChoice: startFresh ? "clean" : "reuse",
   });
-  console.log(m["boot.worktreeReady"](wt.path, wt.branch));
+  bootstrapLog.log(m["boot.worktreeReady"](wt.path, wt.branch));
 
   if (wt.hadUncommittedChanges) {
-    console.warn(m["boot.uncommittedPreserved"]);
+    bootstrapLog.warn(m["boot.uncommittedPreserved"]);
   }
 
   // Skip stage 4 (PR creation) on resume when the PR already exists.
@@ -456,7 +463,7 @@ try {
   // completion check finished.
   let startFromStage = rawStartFromStage;
   if (startFromStage === 4 && findPrNumber(owner, repo, wt.branch)) {
-    console.log(m["boot.prExistsSkip"]);
+    bootstrapLog.log(m["boot.prExistsSkip"]);
     startFromStage = 5;
   }
 
@@ -927,6 +934,8 @@ try {
       initialSelfCheckCount: runState.selfCheckCount,
       initialReviewCount: runState.reviewCount,
       initialPrNumber: runState.prNumber,
+      bootstrapLog: [...bootstrapLog.entries],
+      firstExecutingStage: startFromStage ?? 2,
     });
   });
 

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -1,6 +1,7 @@
 import { Box, type DOMElement, measureElement, Text, useInput } from "ink";
 import { useEffect, useRef, useState } from "react";
 import wrapAnsi from "wrap-ansi";
+import type { BootstrapLogEntry } from "../bootstrap-log.js";
 import { t } from "../i18n/index.js";
 import type {
   PipelineEventEmitter,
@@ -125,6 +126,12 @@ interface AgentPaneProps {
   arrowScrollEnabled?: boolean;
   /** Whether to show the separator line between header and content. */
   showSeparator?: boolean;
+  /**
+   * Buffered Stage 1 (Bootstrap) log entries to replay into this pane.
+   * Both A and B panes receive the same buffer so bootstrap state is
+   * visible symmetrically.
+   */
+  bootstrapLog?: readonly BootstrapLogEntry[];
 }
 
 export function AgentPane({
@@ -137,8 +144,11 @@ export function AgentPane({
   isActive = false,
   arrowScrollEnabled = false,
   showSeparator = true,
+  bootstrapLog,
 }: AgentPaneProps) {
-  const { lines, pendingLine } = useAgentLines(emitter, agent);
+  const { lines, pendingLine } = useAgentLines(emitter, agent, {
+    bootstrapLog,
+  });
   const contentRef = useRef<DOMElement>(null);
   const [visibleRows, setVisibleRows] = useState(0);
   const [contentWidth, setContentWidth] = useState(0);
@@ -317,8 +327,26 @@ export function AgentPane({
     (l) => typeof l === "string" || l.kind !== "diagnostic",
   );
 
+  // Suppress the empty-state placeholder while the pane's contents are
+  // exclusively Stage 1 (Bootstrap) rows.  Once any non-bootstrap entry
+  // arrives (e.g. a stage:enter divider for the first real stage), the
+  // normal placeholder logic resumes so Agent B's "idle" hint still
+  // appears at its usual time.
+  const hasOnlyBootstrap =
+    allLines.length > 0 &&
+    allLines.every(
+      (l) =>
+        typeof l !== "string" &&
+        l.kind === "diagnostic" &&
+        l.bootstrap === true,
+    );
+
   let placeholder: string | undefined;
-  if (effectiveOffset === 0 && (!hasOutput || visibleRowEntries.length === 0)) {
+  if (
+    effectiveOffset === 0 &&
+    (!hasOutput || visibleRowEntries.length === 0) &&
+    !hasOnlyBootstrap
+  ) {
     const m = t();
     if (hasOutput && visibleRowEntries.length === 0) {
       placeholder = m["agentPane.tooSmall"];

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -132,6 +132,12 @@ interface AgentPaneProps {
    * visible symmetrically.
    */
   bootstrapLog?: readonly BootstrapLogEntry[];
+  /**
+   * First stage that will actually execute in this run.  Used to
+   * render the closing Stage 1 \u2192 Stage N transition divider as
+   * part of the initial mount when `bootstrapLog` is provided.
+   */
+  firstExecutingStage?: number;
 }
 
 export function AgentPane({
@@ -145,9 +151,11 @@ export function AgentPane({
   arrowScrollEnabled = false,
   showSeparator = true,
   bootstrapLog,
+  firstExecutingStage,
 }: AgentPaneProps) {
   const { lines, pendingLine } = useAgentLines(emitter, agent, {
     bootstrapLog,
+    firstExecutingStage,
   });
   const contentRef = useRef<DOMElement>(null);
   const [visibleRows, setVisibleRows] = useState(0);

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -503,6 +503,7 @@ export function App({
           arrowScrollEnabled={!inputRequest}
           showSeparator={flags.showPaneSeparator}
           bootstrapLog={bootstrapLog}
+          firstExecutingStage={firstExecutingStage}
         />
         <AgentPane
           label={labelB}
@@ -515,6 +516,7 @@ export function App({
           arrowScrollEnabled={!inputRequest}
           showSeparator={flags.showPaneSeparator}
           bootstrapLog={bootstrapLog}
+          firstExecutingStage={firstExecutingStage}
         />
       </Box>
 

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,6 @@
 import { Box, useInput, useStdout } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { BootstrapLogEntry } from "../bootstrap-log.js";
 import type { NotificationSettings } from "../config.js";
 import { t } from "../i18n/index.js";
 import { notifyInputWaiting } from "../notify.js";
@@ -266,6 +267,18 @@ export interface AppProps {
   initialReviewCount?: number;
   /** Persisted PR number from RunState; seeds the StatusBar on resume. */
   initialPrNumber?: number;
+  /**
+   * Bootstrap (Stage 1) log entries captured before the ink TUI
+   * mounted.  Replayed into both agent panes on mount so users see a
+   * complete timeline starting from Stage 1.
+   */
+  bootstrapLog?: readonly BootstrapLogEntry[];
+  /**
+   * First stage that will actually execute in this run.  Used to label
+   * the Stage 1 exit divider and the StatusBar's initial transition
+   * text ("Stage 1: Bootstrap \u2192 Stage N: <name>").
+   */
+  firstExecutingStage?: number;
 }
 
 export function App({
@@ -283,6 +296,8 @@ export function App({
   initialSelfCheckCount,
   initialReviewCount,
   initialPrNumber,
+  bootstrapLog,
+  firstExecutingStage,
 }: AppProps) {
   const { height: terminalHeight, width: terminalWidth } =
     useTerminalDimensions();
@@ -487,6 +502,7 @@ export function App({
           isActive={activeAgent === "a"}
           arrowScrollEnabled={!inputRequest}
           showSeparator={flags.showPaneSeparator}
+          bootstrapLog={bootstrapLog}
         />
         <AgentPane
           label={labelB}
@@ -498,6 +514,7 @@ export function App({
           isActive={activeAgent === "b"}
           arrowScrollEnabled={!inputRequest}
           showSeparator={flags.showPaneSeparator}
+          bootstrapLog={bootstrapLog}
         />
       </Box>
 
@@ -525,6 +542,7 @@ export function App({
         startedAt={startedAt}
         initialSelfCheckCount={initialSelfCheckCount}
         initialReviewCount={initialReviewCount}
+        firstExecutingStage={firstExecutingStage}
       />
       <InputArea request={inputRequest} onSubmit={handleSubmit} />
     </Box>

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -2,6 +2,7 @@ import { Box, Text } from "ink";
 import { useEffect, useRef, useState } from "react";
 import stringWidth from "string-width";
 import { t } from "../i18n/index.js";
+import type { Messages } from "../i18n/messages.js";
 import type {
   PipelineEventEmitter,
   ReviewPostedEvent,
@@ -9,6 +10,39 @@ import type {
   StageExitEvent,
   StageNameOverrideEvent,
 } from "../pipeline-events.js";
+
+/**
+ * Map a 1-based stage number to its translated display name.  Returns
+ * `undefined` for unknown stages so callers can fall back to a bare
+ * "Stage N" label.
+ */
+export function stageDisplayName(
+  stageNumber: number,
+  m: Messages,
+): string | undefined {
+  switch (stageNumber) {
+    case 1:
+      return m["stage.bootstrap"];
+    case 2:
+      return m["stage.implement"];
+    case 3:
+      return m["stage.selfCheck"];
+    case 4:
+      return m["stage.createPr"];
+    case 5:
+      return m["stage.ciCheck"];
+    case 6:
+      return m["stage.testPlan"];
+    case 7:
+      return m["stage.review"];
+    case 8:
+      return m["stage.squash"];
+    case 9:
+      return m["stage.done"];
+    default:
+      return undefined;
+  }
+}
 
 /** Stage number for the self-check stage. */
 const SELF_CHECK_STAGE = 3;
@@ -52,6 +86,13 @@ interface StatusBarProps {
   initialSelfCheckCount?: number;
   /** Persisted review count from RunState (initial value on resume). */
   initialReviewCount?: number;
+  /**
+   * First stage that will actually execute in this run (2 on fresh
+   * runs, `startFromStage` on resume).  Drives the "Stage 1: Bootstrap
+   * \u2192 Stage N: <name>" text shown at mount until the first real
+   * `stage:enter` arrives.
+   */
+  firstExecutingStage?: number;
 }
 
 // ---- Elapsed time helpers ----------------------------------------------------
@@ -217,6 +258,7 @@ export function StatusBar({
   startedAt,
   initialSelfCheckCount,
   initialReviewCount,
+  firstExecutingStage,
 }: StatusBarProps) {
   const [stage, setStage] = useState<StageEnterEvent | null>(null);
   const [lastOutcome, setLastOutcome] = useState<string | null>(null);
@@ -263,11 +305,28 @@ export function StatusBar({
       stage.stageNumber === REVIEW_STAGE);
   const round = stage ? stage.iteration + 1 : 0;
 
-  const stageText = stage
-    ? showRound
+  let stageText: string;
+  if (stage) {
+    stageText = showRound
       ? m["statusBar.stageRound"](stage.stageNumber, stage.stageName, round)
-      : m["statusBar.stage"](stage.stageNumber, stage.stageName)
-    : m["statusBar.initialising"];
+      : m["statusBar.stage"](stage.stageNumber, stage.stageName);
+  } else if (firstExecutingStage !== undefined) {
+    // Bootstrap has completed synchronously before the TUI mounted; show
+    // a retrospective "Stage 1: Bootstrap \u2192 Stage N: <name>" label
+    // until the first real stage:enter arrives.
+    const bootstrapName = m["stage.bootstrap"];
+    const nextName =
+      stageDisplayName(firstExecutingStage, m) ??
+      `Stage ${firstExecutingStage}`;
+    stageText = m["statusBar.bootstrapTransition"](
+      1,
+      bootstrapName,
+      firstExecutingStage,
+      nextName,
+    );
+  } else {
+    stageText = m["statusBar.initialising"];
+  }
 
   const outcomeKey = lastOutcome
     ? (`outcome.${lastOutcome}` as keyof typeof m)

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -3448,7 +3448,7 @@ describe("AgentPane diagnostic rendering", () => {
     expect(frame).toContain("Implement");
   });
 
-  test("prepends Stage 1 enter divider and bootstrap log rows on mount", async () => {
+  test("prepends full Stage 1 retrospective block on mount", async () => {
     const emitter = new PipelineEventEmitter();
     const bootstrapLog = [
       { timestamp: "10:00:00", message: "Bootstrapping repository..." },
@@ -3465,6 +3465,7 @@ describe("AgentPane diagnostic rendering", () => {
           emitter={emitter}
           color="blue"
           bootstrapLog={bootstrapLog}
+          firstExecutingStage={2}
         />
       </Box>,
     );
@@ -3477,11 +3478,16 @@ describe("AgentPane diagnostic rendering", () => {
     expect(frame).toContain(
       "[10:00:01] Pipeline: Worktree ready at /tmp/wt (branch: alice/issue-42)",
     );
+    // Closing Stage 1 \u2192 Stage N divider must already be visible at mount,
+    // before any real stage:enter arrives.
+    expect(frame).toContain(
+      "Stage 1 (Bootstrap) \u2192 Stage 2 (Implement) [outcome: completed]",
+    );
     // No placeholder should appear when Stage 1 rows are the only contents.
     expect(frame).not.toContain("waiting for output");
   });
 
-  test("bootstrap replay pre-arms the Stage 1 transition divider", async () => {
+  test("seeds Stage 1 transition with the resolved first executing stage on resume", async () => {
     const emitter = new PipelineEventEmitter();
     const bootstrapLog = [
       { timestamp: "09:00:00", message: "Bootstrapping repository..." },
@@ -3494,10 +3500,20 @@ describe("AgentPane diagnostic rendering", () => {
           emitter={emitter}
           color="blue"
           bootstrapLog={bootstrapLog}
+          firstExecutingStage={5}
         />
       </Box>,
     );
-    // First real stage:enter should produce a Stage 1 → Stage N transition.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Transition divider is present at mount (before any stage:enter fires).
+    const mountFrame = lastFrame() ?? "";
+    expect(mountFrame).toContain(
+      "Stage 1 (Bootstrap) \u2192 Stage 5 (CI check) [outcome: completed]",
+    );
+
+    // The first real stage:enter for the same stage must be silently
+    // consumed so we don't emit a duplicate "Entering Stage 5" row.
     emitter.emit("stage:enter", {
       stageNumber: 5,
       stageName: "CI check",
@@ -3505,14 +3521,10 @@ describe("AgentPane diagnostic rendering", () => {
     });
     await new Promise((r) => setTimeout(r, 50));
 
-    const frame = lastFrame() ?? "";
-    expect(frame).toContain(
-      "Stage 1 (Bootstrap) \u2192 Stage 5 (CI check) [outcome: completed]",
-    );
-    // The transition divider counts as bootstrap content too, so the full
-    // Stage 1 block stays intact with no placeholder above it until real
-    // pane output begins.
-    expect(frame).not.toContain("waiting for output");
+    const afterFrame = lastFrame() ?? "";
+    expect(afterFrame).not.toContain("Entering Stage 5");
+    // No placeholder above the Stage 1 block.
+    expect(afterFrame).not.toContain("waiting for output");
   });
 
   test("Agent B idle placeholder returns after Stage 1 rows are not the only contents", async () => {
@@ -3528,15 +3540,17 @@ describe("AgentPane diagnostic rendering", () => {
           emitter={emitter}
           color="green"
           bootstrapLog={bootstrapLog}
+          firstExecutingStage={2}
         />
       </Box>,
     );
-    // On mount: only Stage 1 rows, so no placeholder.
+    // On mount: full Stage 1 block (enter + bootstrap lines + transition),
+    // all flagged as bootstrap, so no placeholder.
     await new Promise((r) => setTimeout(r, 50));
     expect(lastFrame() ?? "").not.toContain("idle");
 
-    // First stage:enter completes the Stage 1 retrospective; the resulting
-    // transition divider is still bootstrap content, so no placeholder yet.
+    // The first real stage:enter for the same stage is silently consumed,
+    // so pane contents remain bootstrap-only and no placeholder appears.
     emitter.emit("stage:enter", {
       stageNumber: 2,
       stageName: "Implement",

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -3471,7 +3471,8 @@ describe("AgentPane diagnostic rendering", () => {
     await new Promise((r) => setTimeout(r, 50));
 
     const frame = lastFrame() ?? "";
-    expect(frame).toContain("Entering Stage 1 (Bootstrap)");
+    expect(frame).toContain("Stage 1 (Bootstrap)");
+    expect(frame).not.toContain("Entering Stage 1 (Bootstrap)");
     expect(frame).toContain("[10:00:00] Pipeline: Bootstrapping repository...");
     expect(frame).toContain(
       "[10:00:01] Pipeline: Worktree ready at /tmp/wt (branch: alice/issue-42)",
@@ -3508,9 +3509,10 @@ describe("AgentPane diagnostic rendering", () => {
     expect(frame).toContain(
       "Stage 1 (Bootstrap) \u2192 Stage 5 (CI check) [outcome: completed]",
     );
-    // After the transition arrives, placeholder suppression is lifted —
-    // Agent A with no output now shows the "waiting" placeholder.
-    expect(frame).toContain("waiting for output");
+    // The transition divider counts as bootstrap content too, so the full
+    // Stage 1 block stays intact with no placeholder above it until real
+    // pane output begins.
+    expect(frame).not.toContain("waiting for output");
   });
 
   test("Agent B idle placeholder returns after Stage 1 rows are not the only contents", async () => {
@@ -3533,10 +3535,22 @@ describe("AgentPane diagnostic rendering", () => {
     await new Promise((r) => setTimeout(r, 50));
     expect(lastFrame() ?? "").not.toContain("idle");
 
-    // After stage 2 enters, Agent B should show the idle placeholder.
+    // First stage:enter completes the Stage 1 retrospective; the resulting
+    // transition divider is still bootstrap content, so no placeholder yet.
     emitter.emit("stage:enter", {
       stageNumber: 2,
       stageName: "Implement",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame() ?? "").not.toContain("idle");
+
+    // A subsequent stage transition is non-bootstrap content, so Agent B
+    // should now show the idle placeholder.
+    emitter.emit("stage:exit", { stageNumber: 2, outcome: "completed" });
+    emitter.emit("stage:enter", {
+      stageNumber: 3,
+      stageName: "Self-check",
       iteration: 0,
     });
     await new Promise((r) => setTimeout(r, 50));

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -882,6 +882,68 @@ describe("StatusBar", () => {
     expect(lastFrame()).toContain("aicers/agentcoop#49");
   });
 
+  test("shows Stage 1 → Stage 2 bootstrap transition on fresh-run mount", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          firstExecutingStage={2}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Stage 1: Bootstrap \u2192 Stage 2: Implement");
+    expect(frame).not.toContain("Initialising");
+  });
+
+  test("shows Stage 1 → Stage 5 bootstrap transition on resume-into-CI", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          firstExecutingStage={5}
+        />
+      </Box>,
+    );
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Stage 1: Bootstrap \u2192 Stage 5: CI check");
+  });
+
+  test("bootstrap transition text collapses when first real stage:enter fires", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <Box width={200}>
+        <StatusBar
+          emitter={emitter}
+          owner="aicers"
+          repo="agentcoop"
+          issueNumber={49}
+          firstExecutingStage={2}
+        />
+      </Box>,
+    );
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Stage 2: Implement");
+    expect(frame).not.toContain("Bootstrap \u2192");
+  });
+
   test("updates stage display on stage:enter", async () => {
     const emitter = new PipelineEventEmitter();
     const { lastFrame } = render(
@@ -3330,12 +3392,12 @@ describe("renderDiagnosticRow", () => {
     const row = renderDiagnosticRow({
       kind: "diagnostic",
       timestamp: "00:00:00",
-      message: "Entering Stage 1 (Implement)",
+      message: "Entering Stage 2 (Implement)",
       count: 2,
       global: true,
     });
     expect(row).toBe(
-      "\u2500\u2500 Entering Stage 1 (Implement) x2 \u2500\u2500",
+      "\u2500\u2500 Entering Stage 2 (Implement) x2 \u2500\u2500",
     );
   });
 });
@@ -3384,6 +3446,101 @@ describe("AgentPane diagnostic rendering", () => {
     expect(frame).toContain("waiting for output");
     expect(frame).toContain("\u2500\u2500");
     expect(frame).toContain("Implement");
+  });
+
+  test("prepends Stage 1 enter divider and bootstrap log rows on mount", async () => {
+    const emitter = new PipelineEventEmitter();
+    const bootstrapLog = [
+      { timestamp: "10:00:00", message: "Bootstrapping repository..." },
+      {
+        timestamp: "10:00:01",
+        message: "Worktree ready at /tmp/wt (branch: alice/issue-42)",
+      },
+    ];
+    const { lastFrame } = render(
+      <Box height={20} width={120}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          bootstrapLog={bootstrapLog}
+        />
+      </Box>,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Entering Stage 1 (Bootstrap)");
+    expect(frame).toContain("[10:00:00] Pipeline: Bootstrapping repository...");
+    expect(frame).toContain(
+      "[10:00:01] Pipeline: Worktree ready at /tmp/wt (branch: alice/issue-42)",
+    );
+    // No placeholder should appear when Stage 1 rows are the only contents.
+    expect(frame).not.toContain("waiting for output");
+  });
+
+  test("bootstrap replay pre-arms the Stage 1 transition divider", async () => {
+    const emitter = new PipelineEventEmitter();
+    const bootstrapLog = [
+      { timestamp: "09:00:00", message: "Bootstrapping repository..." },
+    ];
+    const { lastFrame } = render(
+      <Box height={20} width={120}>
+        <AgentPane
+          label="Agent A"
+          agent="a"
+          emitter={emitter}
+          color="blue"
+          bootstrapLog={bootstrapLog}
+        />
+      </Box>,
+    );
+    // First real stage:enter should produce a Stage 1 → Stage N transition.
+    emitter.emit("stage:enter", {
+      stageNumber: 5,
+      stageName: "CI check",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain(
+      "Stage 1 (Bootstrap) \u2192 Stage 5 (CI check) [outcome: completed]",
+    );
+    // After the transition arrives, placeholder suppression is lifted —
+    // Agent A with no output now shows the "waiting" placeholder.
+    expect(frame).toContain("waiting for output");
+  });
+
+  test("Agent B idle placeholder returns after Stage 1 rows are not the only contents", async () => {
+    const emitter = new PipelineEventEmitter();
+    const bootstrapLog = [
+      { timestamp: "09:00:00", message: "Bootstrapping repository..." },
+    ];
+    const { lastFrame } = render(
+      <Box height={20} width={120}>
+        <AgentPane
+          label="Agent B"
+          agent="b"
+          emitter={emitter}
+          color="green"
+          bootstrapLog={bootstrapLog}
+        />
+      </Box>,
+    );
+    // On mount: only Stage 1 rows, so no placeholder.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame() ?? "").not.toContain("idle");
+
+    // After stage 2 enters, Agent B should show the idle placeholder.
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame() ?? "").toContain("idle");
   });
 
   test("diagnostic after partial chunk preserves chronological order", async () => {

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -10,6 +10,7 @@ import type {
   StageEnterEvent,
   StageExitEvent,
 } from "../pipeline-events.js";
+import { stageDisplayName } from "./StatusBar.js";
 
 /** Return a HH:MM:SS timestamp string for the current time. */
 function hhmmss(): string {
@@ -76,11 +77,19 @@ export interface UseAgentLinesOptions {
   /**
    * Buffered Stage 1 (Bootstrap) log entries.  When provided and
    * non-empty, the hook prepends a Stage 1 enter divider, then each
-   * entry as a non-global bootstrap diagnostic, then pre-arms the
-   * transition so the next `stage:enter` produces a
-   * "Stage 1 \u2192 Stage N" divider naturally.
+   * entry as a non-global bootstrap diagnostic.  When
+   * `firstExecutingStage` is also known, it also appends the closing
+   * "Stage 1 (Bootstrap) \u2192 Stage N" transition divider in the
+   * same initial mount so the full retrospective Stage 1 block is
+   * visible before any real stage event arrives.
    */
   bootstrapLog?: readonly BootstrapLogEntry[];
+  /**
+   * First stage that will actually execute in this run.  Used to
+   * render the closing Stage 1 \u2192 Stage N transition divider as
+   * part of the initial seed when `bootstrapLog` is provided.
+   */
+  firstExecutingStage?: number;
 }
 
 export function useAgentLines(
@@ -94,6 +103,7 @@ export function useAgentLines(
       : optionsOrMaxLines;
   const maxLines = options.maxLines ?? 500;
   const bootstrapLog = options.bootstrapLog;
+  const firstExecutingStage = options.firstExecutingStage;
 
   // Seed initial lines with the Stage 1 (Bootstrap) timeline so the
   // user sees a complete stage sequence starting from Stage 1.  This
@@ -102,6 +112,7 @@ export function useAgentLines(
     if (!bootstrapLog || bootstrapLog.length === 0) return [];
     const m = t();
     const bootstrapName = m["stage.bootstrap"];
+    const lastTs = bootstrapLog[bootstrapLog.length - 1].timestamp;
     const seeded: LineEntry[] = [
       {
         kind: "diagnostic",
@@ -117,6 +128,18 @@ export function useAgentLines(
         bootstrap: true,
       })),
     ];
+    if (firstExecutingStage !== undefined) {
+      const nextName =
+        stageDisplayName(firstExecutingStage, m) ??
+        `Stage ${firstExecutingStage}`;
+      seeded.push({
+        kind: "diagnostic",
+        timestamp: lastTs,
+        message: `Stage 1 (${bootstrapName}) \u2192 Stage ${firstExecutingStage} (${nextName}) [outcome: completed]`,
+        global: true,
+        bootstrap: true,
+      });
+    }
     return seeded;
   };
 
@@ -207,57 +230,54 @@ export function useAgentLines(
     maxLinesRef.current = maxLines;
   }, [maxLines]);
 
-  const pushDiagnostic = useRef(
-    (message: string, global?: boolean, bootstrap?: boolean) => {
-      const now = hhmmss();
-      const base: DiagnosticBlock = {
-        kind: "diagnostic",
-        timestamp: now,
-        message,
-        ...(global ? { global: true } : {}),
-        ...(bootstrap ? { bootstrap: true } : {}),
-      };
-      // Flush any pending partial line before inserting the diagnostic
-      // so it appears in the correct chronological position.
-      if (bufferRef.current) {
-        const pending = bufferRef.current;
-        bufferRef.current = "";
-        setPendingLine("");
-        setLines((prev) => {
-          const next: LineEntry[] = [...prev, pending, base];
-          return next.length > maxLinesRef.current
-            ? next.slice(-maxLinesRef.current)
-            : next;
-        });
-      } else {
-        setLines((prev) => {
-          // Deduplicate: if the last entry is a diagnostic with the same
-          // message and global flag, update it in place with an
-          // incremented count and the latest timestamp.
-          const last = prev.length > 0 ? prev[prev.length - 1] : undefined;
-          if (
-            last != null &&
-            typeof last !== "string" &&
-            last.kind === "diagnostic" &&
-            last.message === message &&
-            (last.global ?? false) === (global ?? false)
-          ) {
-            const updated: DiagnosticBlock = {
-              ...last,
-              timestamp: now,
-              count: (last.count ?? 1) + 1,
-            };
-            const next: LineEntry[] = [...prev.slice(0, -1), updated];
-            return next;
-          }
-          const next: LineEntry[] = [...prev, base];
-          return next.length > maxLinesRef.current
-            ? next.slice(-maxLinesRef.current)
-            : next;
-        });
-      }
-    },
-  );
+  const pushDiagnostic = useRef((message: string, global?: boolean) => {
+    const now = hhmmss();
+    const base: DiagnosticBlock = {
+      kind: "diagnostic",
+      timestamp: now,
+      message,
+      ...(global ? { global: true } : {}),
+    };
+    // Flush any pending partial line before inserting the diagnostic
+    // so it appears in the correct chronological position.
+    if (bufferRef.current) {
+      const pending = bufferRef.current;
+      bufferRef.current = "";
+      setPendingLine("");
+      setLines((prev) => {
+        const next: LineEntry[] = [...prev, pending, base];
+        return next.length > maxLinesRef.current
+          ? next.slice(-maxLinesRef.current)
+          : next;
+      });
+    } else {
+      setLines((prev) => {
+        // Deduplicate: if the last entry is a diagnostic with the same
+        // message and global flag, update it in place with an
+        // incremented count and the latest timestamp.
+        const last = prev.length > 0 ? prev[prev.length - 1] : undefined;
+        if (
+          last != null &&
+          typeof last !== "string" &&
+          last.kind === "diagnostic" &&
+          last.message === message &&
+          (last.global ?? false) === (global ?? false)
+        ) {
+          const updated: DiagnosticBlock = {
+            ...last,
+            timestamp: now,
+            count: (last.count ?? 1) + 1,
+          };
+          const next: LineEntry[] = [...prev.slice(0, -1), updated];
+          return next;
+        }
+        const next: LineEntry[] = [...prev, base];
+        return next.length > maxLinesRef.current
+          ? next.slice(-maxLinesRef.current)
+          : next;
+      });
+    }
+  });
 
   // --- Diagnostic event subscriptions ---
 
@@ -277,24 +297,22 @@ export function useAgentLines(
   // Buffer exit events and merge with the following enter to produce a single
   // transition line like "Stage 7 (Review) → Stage 8 (Squash) [outcome: completed]".
   //
-  // When bootstrap (Stage 1) ran before the TUI mounted, pre-arm the
-  // pending exit with a synthetic "Stage 1 exited" so the first real
-  // stage:enter emits a "Stage 1 (Bootstrap) \u2192 Stage N (...)" divider.
+  // When bootstrap (Stage 1) ran before the TUI mounted and
+  // `firstExecutingStage` is known, the Stage 1 \u2192 Stage N
+  // transition divider is already part of the initial seed.  In that
+  // case, silently consume the first real `stage:enter` so we don't
+  // emit a duplicate "Entering Stage N" line for the same event.
   const pendingExitRef = useRef<{
     stageNumber: number;
     stageName: string | undefined;
     outcome: string;
-    /** True if this exit was synthesized from the Stage 1 bootstrap replay. */
-    bootstrap?: boolean;
-  } | null>(
-    bootstrapLog && bootstrapLog.length > 0
-      ? {
-          stageNumber: 1,
-          stageName: t()["stage.bootstrap"],
-          outcome: "completed",
-          bootstrap: true,
-        }
-      : null,
+  } | null>(null);
+  const suppressFirstEnterRef = useRef(
+    !!(
+      bootstrapLog &&
+      bootstrapLog.length > 0 &&
+      firstExecutingStage !== undefined
+    ),
   );
 
   useEffect(() => {
@@ -306,6 +324,10 @@ export function useAgentLines(
       };
     };
     const enterHandler = (ev: StageEnterEvent) => {
+      if (suppressFirstEnterRef.current) {
+        suppressFirstEnterRef.current = false;
+        return;
+      }
       const pending = pendingExitRef.current;
       pendingExitRef.current = null;
       if (pending) {
@@ -315,7 +337,6 @@ export function useAgentLines(
         pushDiagnostic.current(
           `${from} → Stage ${ev.stageNumber} (${ev.stageName}) [outcome: ${pending.outcome}]`,
           true,
-          pending.bootstrap,
         );
       } else {
         pushDiagnostic.current(

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from "react";
+import type { BootstrapLogEntry } from "../bootstrap-log.js";
+import { t } from "../i18n/index.js";
 import type {
   AgentInvokeEvent,
   PipelineCiPollEvent,
@@ -35,6 +37,12 @@ export interface DiagnosticBlock {
   count?: number;
   /** Whether this is a global (cross-pane) diagnostic like stage transitions. */
   global?: boolean;
+  /**
+   * Whether this row was produced from the buffered Stage 1 (Bootstrap)
+   * log replay.  Used to suppress the pane's empty-state placeholder
+   * while the only contents are Stage 1 rows.
+   */
+  bootstrap?: boolean;
 }
 
 /** A line buffer entry: plain text, a prompt block, or a diagnostic line. */
@@ -62,12 +70,57 @@ export const PROMPT_SEPARATOR_CHAR = "\u2504";
  * Also listens for `agent:prompt` events and stores structured
  * `PromptBlock` entries so the pane can render them size-aware.
  */
+export interface UseAgentLinesOptions {
+  /** Maximum number of buffered completed lines and blocks. */
+  maxLines?: number;
+  /**
+   * Buffered Stage 1 (Bootstrap) log entries.  When provided and
+   * non-empty, the hook prepends a Stage 1 enter divider, then each
+   * entry as a non-global bootstrap diagnostic, then pre-arms the
+   * transition so the next `stage:enter` produces a
+   * "Stage 1 \u2192 Stage N" divider naturally.
+   */
+  bootstrapLog?: readonly BootstrapLogEntry[];
+}
+
 export function useAgentLines(
   emitter: PipelineEventEmitter,
   agent: "a" | "b",
-  maxLines = 500,
+  optionsOrMaxLines: UseAgentLinesOptions | number = {},
 ): AgentLinesResult {
-  const [lines, setLines] = useState<LineEntry[]>([]);
+  const options: UseAgentLinesOptions =
+    typeof optionsOrMaxLines === "number"
+      ? { maxLines: optionsOrMaxLines }
+      : optionsOrMaxLines;
+  const maxLines = options.maxLines ?? 500;
+  const bootstrapLog = options.bootstrapLog;
+
+  // Seed initial lines with the Stage 1 (Bootstrap) timeline so the
+  // user sees a complete stage sequence starting from Stage 1.  This
+  // is a one-shot initialisation; later re-renders do not re-seed.
+  const initialLines = (): LineEntry[] => {
+    if (!bootstrapLog || bootstrapLog.length === 0) return [];
+    const m = t();
+    const bootstrapName = m["stage.bootstrap"];
+    const seeded: LineEntry[] = [
+      {
+        kind: "diagnostic",
+        timestamp: bootstrapLog[0].timestamp,
+        message: `Entering Stage 1 (${bootstrapName})`,
+        global: true,
+        bootstrap: true,
+      },
+      ...bootstrapLog.map<DiagnosticBlock>((entry) => ({
+        kind: "diagnostic",
+        timestamp: entry.timestamp,
+        message: entry.message,
+        bootstrap: true,
+      })),
+    ];
+    return seeded;
+  };
+
+  const [lines, setLines] = useState<LineEntry[]>(initialLines);
   const [pendingLine, setPendingLine] = useState("");
   const bufferRef = useRef("");
   const stageNameRef = useRef<string | undefined>(undefined);
@@ -220,11 +273,23 @@ export function useAgentLines(
   // stage:enter / stage:exit → show combined stage transitions in both panes.
   // Buffer exit events and merge with the following enter to produce a single
   // transition line like "Stage 7 (Review) → Stage 8 (Squash) [outcome: completed]".
+  //
+  // When bootstrap (Stage 1) ran before the TUI mounted, pre-arm the
+  // pending exit with a synthetic "Stage 1 exited" so the first real
+  // stage:enter emits a "Stage 1 (Bootstrap) \u2192 Stage N (...)" divider.
   const pendingExitRef = useRef<{
     stageNumber: number;
     stageName: string | undefined;
     outcome: string;
-  } | null>(null);
+  } | null>(
+    bootstrapLog && bootstrapLog.length > 0
+      ? {
+          stageNumber: 1,
+          stageName: t()["stage.bootstrap"],
+          outcome: "completed",
+        }
+      : null,
+  );
 
   useEffect(() => {
     const exitHandler = (ev: StageExitEvent) => {

--- a/src/ui/useEventEmitter.ts
+++ b/src/ui/useEventEmitter.ts
@@ -106,7 +106,7 @@ export function useAgentLines(
       {
         kind: "diagnostic",
         timestamp: bootstrapLog[0].timestamp,
-        message: `Entering Stage 1 (${bootstrapName})`,
+        message: `Stage 1 (${bootstrapName})`,
         global: true,
         bootstrap: true,
       },
@@ -207,54 +207,57 @@ export function useAgentLines(
     maxLinesRef.current = maxLines;
   }, [maxLines]);
 
-  const pushDiagnostic = useRef((message: string, global?: boolean) => {
-    const now = hhmmss();
-    const base: DiagnosticBlock = {
-      kind: "diagnostic",
-      timestamp: now,
-      message,
-      ...(global ? { global: true } : {}),
-    };
-    // Flush any pending partial line before inserting the diagnostic
-    // so it appears in the correct chronological position.
-    if (bufferRef.current) {
-      const pending = bufferRef.current;
-      bufferRef.current = "";
-      setPendingLine("");
-      setLines((prev) => {
-        const next: LineEntry[] = [...prev, pending, base];
-        return next.length > maxLinesRef.current
-          ? next.slice(-maxLinesRef.current)
-          : next;
-      });
-    } else {
-      setLines((prev) => {
-        // Deduplicate: if the last entry is a diagnostic with the same
-        // message and global flag, update it in place with an
-        // incremented count and the latest timestamp.
-        const last = prev.length > 0 ? prev[prev.length - 1] : undefined;
-        if (
-          last != null &&
-          typeof last !== "string" &&
-          last.kind === "diagnostic" &&
-          last.message === message &&
-          (last.global ?? false) === (global ?? false)
-        ) {
-          const updated: DiagnosticBlock = {
-            ...last,
-            timestamp: now,
-            count: (last.count ?? 1) + 1,
-          };
-          const next: LineEntry[] = [...prev.slice(0, -1), updated];
-          return next;
-        }
-        const next: LineEntry[] = [...prev, base];
-        return next.length > maxLinesRef.current
-          ? next.slice(-maxLinesRef.current)
-          : next;
-      });
-    }
-  });
+  const pushDiagnostic = useRef(
+    (message: string, global?: boolean, bootstrap?: boolean) => {
+      const now = hhmmss();
+      const base: DiagnosticBlock = {
+        kind: "diagnostic",
+        timestamp: now,
+        message,
+        ...(global ? { global: true } : {}),
+        ...(bootstrap ? { bootstrap: true } : {}),
+      };
+      // Flush any pending partial line before inserting the diagnostic
+      // so it appears in the correct chronological position.
+      if (bufferRef.current) {
+        const pending = bufferRef.current;
+        bufferRef.current = "";
+        setPendingLine("");
+        setLines((prev) => {
+          const next: LineEntry[] = [...prev, pending, base];
+          return next.length > maxLinesRef.current
+            ? next.slice(-maxLinesRef.current)
+            : next;
+        });
+      } else {
+        setLines((prev) => {
+          // Deduplicate: if the last entry is a diagnostic with the same
+          // message and global flag, update it in place with an
+          // incremented count and the latest timestamp.
+          const last = prev.length > 0 ? prev[prev.length - 1] : undefined;
+          if (
+            last != null &&
+            typeof last !== "string" &&
+            last.kind === "diagnostic" &&
+            last.message === message &&
+            (last.global ?? false) === (global ?? false)
+          ) {
+            const updated: DiagnosticBlock = {
+              ...last,
+              timestamp: now,
+              count: (last.count ?? 1) + 1,
+            };
+            const next: LineEntry[] = [...prev.slice(0, -1), updated];
+            return next;
+          }
+          const next: LineEntry[] = [...prev, base];
+          return next.length > maxLinesRef.current
+            ? next.slice(-maxLinesRef.current)
+            : next;
+        });
+      }
+    },
+  );
 
   // --- Diagnostic event subscriptions ---
 
@@ -281,12 +284,15 @@ export function useAgentLines(
     stageNumber: number;
     stageName: string | undefined;
     outcome: string;
+    /** True if this exit was synthesized from the Stage 1 bootstrap replay. */
+    bootstrap?: boolean;
   } | null>(
     bootstrapLog && bootstrapLog.length > 0
       ? {
           stageNumber: 1,
           stageName: t()["stage.bootstrap"],
           outcome: "completed",
+          bootstrap: true,
         }
       : null,
   );
@@ -309,6 +315,7 @@ export function useAgentLines(
         pushDiagnostic.current(
           `${from} → Stage ${ev.stageNumber} (${ev.stageName}) [outcome: ${pending.outcome}]`,
           true,
+          pending.bootstrap,
         );
       } else {
         pushDiagnostic.current(


### PR DESCRIPTION
## Summary

The pipeline has nine stages internally but only stages 2–9 were surfaced through the TUI, so users never saw "Stage 1" labelled anywhere even though the code and docs consistently describe the pipeline as stage 1 through stage 9. Bootstrap (repository clone/fetch, default-branch detection, worktree creation, and the resume pre-flight that promotes a saved `startFromStage === 4` to `5` when the PR already exists) runs synchronously before the ink App mounts, so there is no pane to stream into while it happens.

This PR surfaces Stage 1 retrospectively:

- A new `createBootstrapLog()` helper in `src/bootstrap-log.ts` buffers each `boot.*` line with a timestamp while still printing it to stdout/stderr live, so terminal scrollback for non-TUI observers is unchanged.
- The buffered log and the resolved first-executing stage number are threaded into `renderApp` and on through `App` to both `AgentPane` instances and the `StatusBar`.
- On first mount, both panes prepend the full Stage 1 retrospective block as the initial seed: a Stage 1 enter divider, each buffered bootstrap line as a timestamped non-global diagnostic, and a `Stage 1 (Bootstrap) → Stage N (<name>) [outcome: completed]` transition divider. The first real `stage:enter` for that same stage is then silently consumed so no duplicate `Entering Stage N` row is emitted.
- The `StatusBar` shows `Stage 1: Bootstrap → Stage N: <name>` until the first real `stage:enter` arrives, where `N` is `2` on a fresh run, `startFromStage` on resume, and `5` when a saved `startFromStage === 4` is promoted because the PR already exists.
- The `AgentPane` empty-state placeholder is suppressed while the pane's only contents are Stage 1 rows (new `bootstrap: true` flag on `DiagnosticBlock`), so Stage 1 rows are genuinely the first thing users see. Agent B's "waiting for review stage" placeholder still appears at its usual time for later stages.
- `docs/pipeline.md` is restructured: the orchestrator-managed bootstrap bullets are promoted into a new `### Stage 1: Bootstrap` subsection under *Stage reference*, and the Table of contents and overview diagram are updated to match.
- `stage.bootstrap` and `statusBar.bootstrapTransition` i18n keys are added to `src/i18n/messages.ts`, `en.ts`, and `ko.ts`, and `stageNames()` in `src/index.ts` is extended with `1: Bootstrap`.
- The stale `"Entering Stage 1 (Implement)"` test literal in `src/ui/components.test.tsx` is fixed — Implement is Stage 2.

Closes #254

## Test plan

- [x] `pnpm biome check src/` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run` passes (including new tests for bootstrap log buffer, full Stage 1 retrospective block seeded at mount, the resolved-next-stage transition divider for fresh-run and resume cases, the StatusBar `bootstrapTransition` text, silent consumption of the first real `stage:enter`, and placeholder suppression while Stage 1 rows are the pane contents)
- [x] `pnpm build` succeeds
- [x] Fresh run: at mount, `StatusBar` shows `Stage 1: Bootstrap → Stage 2: Implement` briefly, then collapses to `Stage 2: Implement` when stage 2 enters
- [x] Resume with `startFromStage = 5`: `StatusBar` shows `Stage 1: Bootstrap → Stage 5: CI check`, then collapses to `Stage 5: CI check`
- [x] Resume where saved `startFromStage === 4` and the PR already exists: the transition divider and StatusBar both reference Stage 5, not 4
- [x] Both A and B agent panes show, as their first visible entries at mount (before any `stage:enter` arrives): the Stage 1 enter divider, the buffered bootstrap log lines in `[HH:MM:SS] Pipeline: …` format, and the Stage 1 → Stage N transition divider — with no placeholder text above them
- [x] Conditional `boot.uncommittedPreserved` and `boot.prExistsSkip` lines appear in the pane log when they are emitted
- [x] Terminal scrollback still shows the bootstrap lines printed live before the TUI mounts
- [x] Agent B's normal "waiting for review stage" placeholder still appears at its usual time for later stages

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title:** Show Stage 1 (Bootstrap) retrospectively in TUI

**Body:**
The pipeline has nine stages internally, but only stages 2–9 were
surfaced through the TUI because Stage 1 (repository clone/fetch,
default-branch detection, worktree creation, and the resume
pre-flight that promotes `startFromStage === 4` to `5` when a PR
already exists) runs synchronously before the ink App mounts.
Users therefore saw the timeline begin mid-pipeline with no
explanation of what had already happened.

Surface Stage 1 retrospectively so the user-visible timeline
matches the documented stage 1–9 numbering:

- Add `createBootstrapLog()` in `src/bootstrap-log.ts` that buffers
  each `boot.*` line with a timestamp while still printing it to
  stdout/stderr live, so terminal scrollback for non-TUI observers
  is unchanged.
- Thread the buffered log and the resolved first-executing stage
  number through `renderApp` → `App` → both `AgentPane` instances
  and the `StatusBar`.
- Seed the full Stage 1 retrospective block (enter divider, each
  buffered log entry as a timestamped non-global diagnostic, and
  an exit divider naming the first real stage) into both panes on
  mount, and silently consume the first real `stage:enter` so no
  duplicate "Entering Stage N" row is emitted.
- Show `Stage 1: Bootstrap → Stage N: <name>` in the `StatusBar`
  until the first real `stage:enter` arrives, where N is 2 on a
  fresh run, `startFromStage` on resume, and 5 when a saved
  `startFromStage === 4` is promoted because the PR exists.
- Suppress the `AgentPane` empty-state placeholder while the pane's
  only contents are Stage 1 rows (new `bootstrap: true` flag on
  `DiagnosticBlock`), preserving Agent B's "waiting for review"
  placeholder for later stages.
- Add `stage.bootstrap` and `statusBar.bootstrapTransition` i18n
  keys across `messages.ts`, `en.ts`, and `ko.ts`, and extend
  `stageNames()` with `1: Bootstrap`.
- Restructure `docs/pipeline.md`: promote the orchestrator-managed
  bootstrap bullets into a new `### Stage 1: Bootstrap` subsection
  under *Stage reference*, and update the Table of contents and
  overview diagram to match.
- Fix the stale `"Entering Stage 1 (Implement)"` test literal in
  `src/ui/components.test.tsx` — Implement is Stage 2.

Closes #254
<!-- agentcoop:squash-suggestion:end -->