### PR TITLE
Detect already-merged PR in stages 8 and 9 (#260)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -159,6 +159,7 @@ export const en: Messages = {
     "Agent could not resolve conflicts. Please resolve manually.",
   "pipeline.rebaseAlreadyAttempted":
     "Agent rebase was already attempted. Please resolve conflicts manually.",
+  "pipeline.prAlreadyMerged": "PR was already merged. Cleaning up worktree.",
 
   // ---- TUI user prompts --------------------------------------------------
 
@@ -273,6 +274,7 @@ export const en: Messages = {
     "Cannot perform the squash: the agent session required to continue " +
     "the conversation was lost. Re-run stage 8 or apply the suggestion " +
     "via GitHub's 'Squash and merge' at merge time.",
+  "squash.alreadyMerged": "PR was already merged; skipping squash.",
   "review.approved": (round) => `Review approved at round ${round}.`,
   "review.unresolvedItems": (base, summary) =>
     `${base}\n\nUnresolved items:\n${summary}`,

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -192,6 +192,8 @@ export const ko: Messages = {
     "에이전트가 충돌을 해결하지 못했습니다. 수동으로 해결해 주세요.",
   "pipeline.rebaseAlreadyAttempted":
     "에이전트 리베이스가 이미 시도되었습니다. 수동으로 충돌을 해결해 주세요.",
+  "pipeline.prAlreadyMerged":
+    "PR이 이미 병합되었습니다. 워크트리를 정리합니다.",
 
   // ---- TUI user prompts --------------------------------------------------
 
@@ -312,6 +314,7 @@ export const ko: Messages = {
     "스쿼시를 수행할 수 없습니다: 대화를 이어갈 에이전트 세션이 유실되었습니다. " +
     "스테이지 8을 다시 실행하거나, 병합 시 GitHub의 'Squash and merge'로 " +
     "제안을 적용하세요.",
+  "squash.alreadyMerged": "PR이 이미 병합되었습니다. 스쿼시를 건너뜁니다.",
   "review.approved": (round) => `${round}라운드에서 리뷰가 승인되었습니다.`,
   "review.unresolvedItems": (base, summary) =>
     `${base}\n\n미해결 항목:\n${summary}`,

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -149,6 +149,7 @@ export interface Messages {
   "pipeline.noConflicts": string;
   "pipeline.rebaseFailed": string;
   "pipeline.rebaseAlreadyAttempted": string;
+  "pipeline.prAlreadyMerged": string;
 
   // ---- TUI user prompts (TuiUserPrompt.ts) -------------------------------
 
@@ -258,6 +259,7 @@ export interface Messages {
   "squash.singleChoiceAgent": string;
   "squash.singleChoiceGithub": string;
   "squash.agentChoiceMissingSession": string;
+  "squash.alreadyMerged": string;
   "review.approved": (round: number) => string;
   "review.unresolvedItems": (base: string, summary: string) => string;
   "review.fixesApplied": (round: number) => string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ import type {
 } from "./pipeline.js";
 import { createDoneStageHandler } from "./pipeline.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
-import { checkMergeable, findPrNumber, getPrBody } from "./pr.js";
+import { checkMergeable, findPrNumber, getPrBody, queryPrState } from "./pr.js";
 import {
   fetchPrComments,
   type PrComment,
@@ -730,6 +730,7 @@ try {
   const doneStage = createDoneStageHandler({
     events: emitter,
     checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
+    queryPrState: async () => queryPrState(owner, repo, wt.branch),
     prompt: {
       confirmMerge: async (msg) => {
         if (tuiPrompt) return tuiPrompt.confirmMerge(msg);

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1957,6 +1957,103 @@ describe("createDoneStageHandler", () => {
     expect(opts.onNotMerged).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
   });
+
+  // ---- PR already merged short-circuit -----------------------------------
+
+  test("PR already merged at mergeableLoop entry → silent cleanup, no checkMergeable or prompts", async () => {
+    const queryPrState = vi.fn().mockResolvedValue("MERGED");
+    const opts = makeDoneOpts({ queryPrState });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(queryPrState).toHaveBeenCalledOnce();
+    expect(opts.checkMergeable).not.toHaveBeenCalled();
+    expect(opts.prompt.confirmMerge).not.toHaveBeenCalled();
+    expect(opts.onNotMerged).not.toHaveBeenCalled();
+    expect(opts.stopServices).toHaveBeenCalledOnce();
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("already merged");
+  });
+
+  test("PR merges during conflict resolution (afterResolution) → silent cleanup, no second checkMergeable", async () => {
+    // First guard (mergeableLoop): OPEN → proceed to checkMergeable (CONFLICTING).
+    // Handle conflict via manual resolve.  Second guard (afterResolution):
+    // MERGED → short-circuit before the post-resolution checkMergeable.
+    const queryPrState = vi
+      .fn()
+      .mockResolvedValueOnce("OPEN")
+      .mockResolvedValueOnce("MERGED");
+    const checkMergeable = vi.fn().mockResolvedValueOnce("CONFLICTING");
+    const waitForManualResolve = vi.fn().mockResolvedValue(undefined);
+    const opts = makeDoneOpts({
+      queryPrState,
+      checkMergeable,
+      prompt: {
+        handleConflict: vi.fn().mockResolvedValue("manual"),
+        waitForManualResolve,
+      },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(queryPrState).toHaveBeenCalledTimes(2);
+    // checkMergeable called exactly once: the initial CONFLICTING check.
+    // The post-resolution re-check must be skipped by the guard.
+    expect(checkMergeable).toHaveBeenCalledOnce();
+    expect(opts.prompt.confirmMerge).not.toHaveBeenCalled();
+    expect(opts.onNotMerged).not.toHaveBeenCalled();
+    expect(opts.stopServices).toHaveBeenCalledOnce();
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("already merged");
+  });
+
+  test("askMerge check_conflicts: PR merged on GitHub → silent cleanup, no inner checkMergeable", async () => {
+    // First guard in mergeableLoop returns OPEN; initial checkMergeable is
+    // MERGEABLE; user clicks "check_conflicts".  Inside the inner loop,
+    // the guard returns MERGED and short-circuits before checkMergeable
+    // runs a second time.
+    const queryPrState = vi
+      .fn()
+      .mockResolvedValueOnce("OPEN")
+      .mockResolvedValueOnce("MERGED");
+    const checkMergeable = vi.fn().mockResolvedValueOnce("MERGEABLE");
+    const confirmMerge = vi.fn().mockResolvedValue("check_conflicts");
+    const opts = makeDoneOpts({
+      queryPrState,
+      checkMergeable,
+      prompt: { confirmMerge },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    const result = await stage.handler(ctx);
+    expect(queryPrState).toHaveBeenCalledTimes(2);
+    // checkMergeable runs only for the outer mergeableLoop; the inner
+    // check_conflicts loop must not re-query after the guard fires.
+    expect(checkMergeable).toHaveBeenCalledOnce();
+    expect(confirmMerge).toHaveBeenCalledOnce();
+    expect(opts.onNotMerged).not.toHaveBeenCalled();
+    expect(opts.stopServices).toHaveBeenCalledOnce();
+    expect(opts.cleanup).toHaveBeenCalledOnce();
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("already merged");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -852,6 +852,9 @@ async function runStage(
 /** Result of the `checkMergeable` callback. */
 export type MergeableState = "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
 
+/** Result of the `queryPrState` callback. */
+export type PrLifecycleState = "OPEN" | "CLOSED" | "MERGED";
+
 /** Result of the `rebaseOntoMain` callback. */
 export interface RebaseResult {
   /** Whether the rebase succeeded and was force-pushed. */
@@ -869,6 +872,13 @@ export interface DoneStageOptions {
    * Returns the resolved mergeable state (with retries for UNKNOWN).
    */
   checkMergeable: (ctx: StageContext) => Promise<MergeableState>;
+  /**
+   * Query the PR's lifecycle state (OPEN / CLOSED / MERGED).  Used to
+   * short-circuit Stage 9 into the silent cleanup path when the user
+   * merged the PR on GitHub while the pipeline was running.  Fails
+   * open: real implementations return "OPEN" on error.
+   */
+  queryPrState?: (ctx: StageContext) => Promise<PrLifecycleState>;
   /** Prompt the user for conflict/unknown/merge choices. */
   prompt: {
     confirmMerge: (
@@ -925,6 +935,36 @@ export interface DoneStageOptions {
 }
 
 /**
+ * Short-circuit the Done stage when the PR has already been merged
+ * on GitHub.  Runs the same silent cleanup the success path uses
+ * (`stopServices` + `cleanup`) and returns a completed
+ * {@link StageResult}; returns `undefined` when the caller should
+ * proceed with the existing flow.
+ *
+ * Centralising the check here keeps the invariant at the API
+ * boundary so the three Done-stage `checkMergeable` sites cannot
+ * drift out of sync.
+ */
+async function ensurePrStillOpen(
+  ctx: StageContext,
+  options: DoneStageOptions,
+  summary: string,
+): Promise<StageResult | undefined> {
+  if (!options.queryPrState) return undefined;
+  const state = await options.queryPrState(ctx);
+  if (ctx.signal?.aborted) {
+    return { outcome: "completed", message: "" };
+  }
+  if (state !== "MERGED") return undefined;
+  options.stopServices();
+  options.cleanup();
+  return {
+    outcome: "completed",
+    message: `${summary} ${t()["pipeline.prAlreadyMerged"]}`,
+  };
+}
+
+/**
  * Built-in stage-9 handler.  Checks for merge conflicts, offers
  * agent rebase or manual resolution, then asks about merge.
  *
@@ -959,6 +999,10 @@ export function createDoneStageHandler(
       const mergeableLoop = async (): Promise<
         { done: true; result: StageResult } | { done: false }
       > => {
+        const alreadyMerged = await ensurePrStillOpen(ctx, options, summary);
+        if (alreadyMerged) {
+          return { done: true, result: alreadyMerged };
+        }
         const state = await options.checkMergeable(ctx);
         if (ctx.signal?.aborted) {
           return { done: true, result: { outcome: "completed", message: "" } };
@@ -1069,6 +1113,8 @@ export function createDoneStageHandler(
         ctx: StageContext,
         summary: string,
       ): Promise<StageResult | undefined> {
+        const alreadyMerged = await ensurePrStillOpen(ctx, options, summary);
+        if (alreadyMerged) return alreadyMerged;
         // Re-check mergeable after resolution.
         const state = await options.checkMergeable(ctx);
         if (ctx.signal?.aborted) {
@@ -1167,6 +1213,8 @@ export function createDoneStageHandler(
       // "check_conflicts" — inner loop lets UNKNOWN → "recheck" retry
       // checkMergeable without going through confirmMerge again.
       for (;;) {
+        const alreadyMerged = await ensurePrStillOpen(ctx, options, summary);
+        if (alreadyMerged) return alreadyMerged;
         const state = await options.checkMergeable(ctx);
         if (ctx.signal?.aborted) {
           return { outcome: "completed", message: "" };

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -5,8 +5,13 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
-const { checkMergeable, findPrNumber, getPrBody, queryMergeableState } =
-  await import("./pr.js");
+const {
+  checkMergeable,
+  findPrNumber,
+  getPrBody,
+  queryMergeableState,
+  queryPrState,
+} = await import("./pr.js");
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -165,6 +170,61 @@ describe("queryMergeableState", () => {
         "feature-branch",
         "--json",
         "mergeable",
+      ],
+      { encoding: "utf-8" },
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// queryPrState
+// ---------------------------------------------------------------------------
+describe("queryPrState", () => {
+  test("returns MERGED when gh reports merged", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ state: "MERGED" }));
+    expect(queryPrState("org", "repo", "branch")).toBe("MERGED");
+  });
+
+  test("returns CLOSED when gh reports closed", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ state: "CLOSED" }));
+    expect(queryPrState("org", "repo", "branch")).toBe("CLOSED");
+  });
+
+  test("returns OPEN when gh reports open", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ state: "OPEN" }));
+    expect(queryPrState("org", "repo", "branch")).toBe("OPEN");
+  });
+
+  test("fails open (OPEN) on unexpected state value", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ state: "WEIRD" }));
+    expect(queryPrState("org", "repo", "branch")).toBe("OPEN");
+  });
+
+  test("fails open (OPEN) when gh command throws", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("gh: not authenticated");
+    });
+    expect(queryPrState("org", "repo", "branch")).toBe("OPEN");
+  });
+
+  test("fails open (OPEN) on malformed JSON output", () => {
+    mockExecFileSync.mockReturnValue("not json");
+    expect(queryPrState("org", "repo", "branch")).toBe("OPEN");
+  });
+
+  test("calls gh with correct arguments", () => {
+    mockExecFileSync.mockReturnValue(JSON.stringify({ state: "OPEN" }));
+    queryPrState("aicers", "agentcoop", "feature-branch");
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "gh",
+      [
+        "pr",
+        "view",
+        "--repo",
+        "aicers/agentcoop",
+        "feature-branch",
+        "--json",
+        "state",
       ],
       { encoding: "utf-8" },
     );

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -147,6 +147,44 @@ export function queryMergeableState(
   }
 }
 
+// ---- PR lifecycle state ------------------------------------------------------
+
+/**
+ * Possible values for the `state` field returned by the GitHub GraphQL
+ * API via `gh pr view --json state`.
+ */
+export type PrLifecycleState = "OPEN" | "CLOSED" | "MERGED";
+
+/**
+ * Query the lifecycle state for the PR associated with `branch`.
+ *
+ * Shells out to `gh pr view --json state`.  Fails open: on `gh`
+ * failure or malformed output returns `"OPEN"` so callers continue
+ * with the existing flow rather than taking a destructive
+ * short-circuit on unreliable data.
+ */
+export function queryPrState(
+  owner: string,
+  repo: string,
+  branch: string,
+): PrLifecycleState {
+  try {
+    const output = execFileSync(
+      "gh",
+      ["pr", "view", "--repo", `${owner}/${repo}`, branch, "--json", "state"],
+      { encoding: "utf-8" },
+    );
+    const parsed = JSON.parse(output) as { state: string };
+    const state = parsed.state;
+    if (state === "OPEN" || state === "CLOSED" || state === "MERGED") {
+      return state;
+    }
+    return "OPEN";
+  } catch {
+    return "OPEN";
+  }
+}
+
 /**
  * Check whether the PR for `branch` is mergeable, retrying with
  * exponential backoff when GitHub returns `UNKNOWN` (merge check

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -96,6 +96,7 @@ function makeOpts(
     emptyRunsGracePeriodMs: 0,
     countBranchCommits: vi.fn().mockReturnValue(2),
     getPrBody: vi.fn().mockReturnValue(""),
+    queryPrState: vi.fn().mockReturnValue("OPEN"),
     chooseSquashApplyMode: vi.fn().mockResolvedValue("agent"),
     ...overrides,
   };
@@ -832,6 +833,99 @@ describe("createSquashStageHandler", () => {
     expect(result.outcome).toBe("blocked");
   });
 
+  // -- PR already merged short-circuit ---------------------------------------
+
+  test("SUGGESTED_SINGLE + PR already merged before user prompt → alreadyMerged, no chooseSquashApplyMode call", async () => {
+    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+        ),
+    };
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const queryPrState = vi.fn().mockReturnValue("MERGED");
+    const onSquashSubStep = vi.fn();
+    const getCiStatus = vi.fn();
+    const opts = makeOpts({
+      agent,
+      chooseSquashApplyMode,
+      getPrBody,
+      queryPrState,
+      onSquashSubStep,
+      getCiStatus,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("already merged");
+    expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+    expect(getCiStatus).not.toHaveBeenCalled();
+    expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
+    // Sub-step must be cleared so a resume does not re-enter the dead choice.
+    expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
+  });
+
+  test("user picks agent, but PR merges between query and follow-up → alreadyMerged, no sendFollowUp call", async () => {
+    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+        ),
+    };
+    // First guardIfPrMerged call (before askUserAndApply) returns OPEN so
+    // the user prompt runs; the second guard call (inside askUserAndApply
+    // before the "agent" branch) returns MERGED.
+    const queryPrState = vi
+      .fn()
+      .mockReturnValueOnce("OPEN")
+      .mockReturnValueOnce("MERGED");
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const onSquashSubStep = vi.fn();
+    const getCiStatus = vi.fn();
+    const opts = makeOpts({
+      agent,
+      chooseSquashApplyMode,
+      getPrBody,
+      queryPrState,
+      onSquashSubStep,
+      getCiStatus,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("already merged");
+    expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+    // Only the verdict resume happened — no follow-up squash resume.
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect(getCiStatus).not.toHaveBeenCalled();
+    const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+    // Never transitioned to "squashing".
+    expect(states).not.toContain("squashing");
+    expect(states[states.length - 1]).toBe(undefined);
+  });
+
   // -- Post-clarification fallback ordering ----------------------------------
 
   describe("post-clarification fallback ordering", () => {
@@ -1057,6 +1151,65 @@ describe("createSquashStageHandler", () => {
       await stage.handler(BASE_CTX);
       // Last-resort fallback: planning prompt is sent via invoke.
       expect(opts.agent.invoke).toHaveBeenCalled();
+    });
+
+    // Regression for issue #260 reviewer round 1: resuming from
+    // "squashing" must re-check PR lifecycle, otherwise a PR merged
+    // between the interruption and the resume sends a wasted
+    // follow-up or burns a CI poll cycle on a closed branch.
+    test("squashing with PR already merged on resume → alreadyMerged, no follow-up, no CI poll", async () => {
+      const resume = vi.fn();
+      const invoke = vi.fn();
+      const agent: AgentAdapter = { invoke, resume };
+      const queryPrState = vi.fn().mockReturnValue("MERGED");
+      const onSquashSubStep = vi.fn();
+      const getCiStatus = vi.fn();
+      const opts = makeOpts({
+        agent,
+        savedSquashSubStep: "squashing",
+        countBranchCommits: vi.fn().mockReturnValue(3),
+        queryPrState,
+        onSquashSubStep,
+        getCiStatus,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler({
+        ...BASE_CTX,
+        savedAgentASessionId: "sess-squash",
+      });
+
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("already merged");
+      expect(invoke).not.toHaveBeenCalled();
+      expect(resume).not.toHaveBeenCalled();
+      expect(getCiStatus).not.toHaveBeenCalled();
+      expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
+      // Sub-step cleared so a later resume does not re-enter the dead state.
+      expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
+    });
+
+    // Companion to the test above: the PR-merged guard fires even
+    // when the branch has already collapsed to one commit (the
+    // "jump straight to CI poll" path), so the wasted CI poll on a
+    // closed branch is also avoided.
+    test("squashing with collapsed branch but PR already merged → alreadyMerged, no CI poll", async () => {
+      const queryPrState = vi.fn().mockReturnValue("MERGED");
+      const getCiStatus = vi.fn();
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        savedSquashSubStep: "squashing",
+        countBranchCommits: vi.fn().mockReturnValue(1),
+        queryPrState,
+        getCiStatus,
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("already merged");
+      expect(getCiStatus).not.toHaveBeenCalled();
+      expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
     });
   });
 

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -32,7 +32,11 @@ import { type CiPollResult, pollCiAndFix } from "./ci-poll.js";
 import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
-import { getPrBody as defaultGetPrBody } from "./pr.js";
+import {
+  getPrBody as defaultGetPrBody,
+  queryPrState as defaultQueryPrState,
+  type PrLifecycleState,
+} from "./pr.js";
 import type { SquashSubStep } from "./run-state.js";
 import {
   invokeOrResume,
@@ -87,6 +91,17 @@ export interface SquashStageOptions {
     repo: string,
     branch: string,
   ) => string | undefined;
+  /**
+   * Query the PR's lifecycle state (OPEN / CLOSED / MERGED).  Used by
+   * {@link guardIfPrMerged} to short-circuit Stage 8 when the user
+   * merged the PR on GitHub while the pipeline was waiting on the
+   * SUGGESTED_SINGLE choice.  Defaults to `pr.queryPrState`.
+   */
+  queryPrState?: (
+    owner: string,
+    repo: string,
+    branch: string,
+  ) => PrLifecycleState;
   /**
    * Ask the user how to apply a single-commit squash suggestion.
    * Required for the SUGGESTED_SINGLE path; if absent the stage
@@ -406,6 +421,30 @@ async function resolveVerdict(
   };
 }
 
+/**
+ * Short-circuit Stage 8 when the PR has already been merged on
+ * GitHub.  Returns a completed {@link StageResult} (and clears the
+ * squash sub-step so a resume does not re-enter the dead choice),
+ * or `undefined` when the caller should proceed.
+ *
+ * Unlike Stage 9, Stage 8 does not own the worktree lifecycle, so
+ * cleanup stays in the Done stage — this guard only aborts the
+ * squash decision / follow-up and lets Stage 9 handle cleanup.
+ */
+function guardIfPrMerged(
+  ctx: StageContext,
+  opts: SquashStageOptions,
+): StageResult | undefined {
+  const query = opts.queryPrState ?? defaultQueryPrState;
+  const state = query(ctx.owner, ctx.repo, ctx.branch);
+  if (state !== "MERGED") return undefined;
+  opts.onSquashSubStep?.(undefined);
+  return {
+    outcome: "completed",
+    message: t()["squash.alreadyMerged"],
+  };
+}
+
 export function createSquashStageHandler(
   opts: SquashStageOptions,
 ): StageDefinition {
@@ -459,6 +498,13 @@ export function createSquashStageHandler(
         // potentially trigger another force-push / CI cycle — the
         // exact waste this feature is meant to avoid.
         //
+        // Re-check the PR lifecycle before deciding between
+        // "resume follow-up" and "go poll CI": if the user merged
+        // the PR on GitHub between the interruption and the resume,
+        // both paths would waste work on a closed branch.
+        const merged = guardIfPrMerged(ctx, opts);
+        if (merged) return merged;
+
         // Detect a completed squash deterministically (commit count
         // collapsed to 1) and jump to CI polling.  Otherwise, reuse
         // the saved session to re-send just the follow-up squash
@@ -503,6 +549,8 @@ export function createSquashStageHandler(
       if (saved === "awaiting_user_choice") {
         const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
         if (hasValidSuggestionBlock(prBody)) {
+          const merged = guardIfPrMerged(ctx, opts);
+          if (merged) return merged;
           return askUserAndApply(ctx, opts, undefined);
         }
         // Suggestion block missing or malformed — fall back to a
@@ -634,6 +682,8 @@ export function createSquashStageHandler(
             message: `${squashResult.responseText}\n\n---\n\n${verdictResponseText}`,
           };
         }
+        const merged = guardIfPrMerged(ctx, opts);
+        if (merged) return merged;
         return askUserAndApply(ctx, opts, verdictSessionId);
       }
 
@@ -667,6 +717,14 @@ async function askUserAndApply(
       message: t()["squash.messageAppended"],
     };
   }
+
+  // User picked "agent" — guard the narrow race where the PR was
+  // merged on GitHub after the first query but before the user
+  // clicked "Agent squashes now".  The destructive follow-up
+  // (force-push on a closed branch) would waste CI cycles and
+  // potentially resurrect a deleted branch.
+  const merged = guardIfPrMerged(ctx, opts);
+  if (merged) return merged;
 
   // User picked "agent" — send the follow-up squash prompt and run CI.
   opts.onSquashSubStep?.("squashing");


### PR DESCRIPTION
## Summary

Adds a PR-lifecycle pre-check so stages 8 and 9 short-circuit into the silent cleanup path when the user merges the PR on GitHub while the pipeline is running, instead of burning the `UNKNOWN`-mergeable retry budget or force-pushing an agent squash to a closed branch.

- New `queryPrState` in `src/pr.ts` reads the PR's `state` field via `gh pr view --json state`. Fails open (returns `"OPEN"`) on `gh` failure or malformed JSON, mirroring the `queryMergeableState` convention.
- New `DoneStageOptions.queryPrState` and `SquashStageOptions.queryPrState` injection points, defaulted to the real implementation. Tests inject a mock per case — no module-level spying needed.
- `src/pipeline.ts`: new `ensurePrStillOpen` helper centralises the MERGED check + silent `stopServices()` + `cleanup()` for the Done stage. Wired in at all three `checkMergeable` sites (initial `mergeableLoop`, `afterResolution`, and the `askMerge` `check_conflicts` inner loop) so a future refactor cannot drop the guard at one site.
- `src/stage-squash.ts`: new local `guardIfPrMerged` helper aborts the squash and clears `squashSubStep` so a resume does not re-enter the dead choice. Called at three sites: before `askUserAndApply`, immediately before the destructive `"agent"` branch inside it, and at the top of the `saved === "squashing"` resume branch (covers the persisted-resume race where the user merges the PR between an interrupted `squashing` step and the resume that would otherwise re-send the follow-up or jump into CI poll on a closed branch). Stage 8 does not own the worktree lifecycle, so cleanup remains in the Done stage.
- New i18n keys `pipeline.prAlreadyMerged` and `squash.alreadyMerged` (en + ko).

Closes #260

## Test plan

- [x] `queryPrState` parses `MERGED` / `CLOSED` / `OPEN` from `gh pr view --json state` output
- [x] `queryPrState` returns `"OPEN"` on `gh` execution failure
- [x] `queryPrState` returns `"OPEN"` on malformed JSON output
- [x] Stage 8 SUGGESTED_SINGLE: PR merged before user prompt → `squash.alreadyMerged`, no `chooseSquashApplyMode` call, `squashSubStep` cleared
- [x] Stage 8 user picks `"agent"`: PR merged before follow-up → squash aborted, `squash.alreadyMerged`, no follow-up `sendFollowUp`/resume, `squashSubStep` cleared
- [x] Stage 8 resume from `squashing` (count > 1): PR already merged → `squash.alreadyMerged`, no follow-up resume, no CI poll, `squashSubStep` cleared
- [x] Stage 8 resume from `squashing` (count = 1, would normally jump to CI poll): PR already merged → `squash.alreadyMerged`, no CI poll
- [x] Stage 9 initial `mergeableLoop`: `queryPrState` returns `MERGED` → silent `stopServices()` + `cleanup()`, no `confirmMerge`, no `checkMergeable` retry cycle, no `onNotMerged`
- [x] Stage 9 `afterResolution`: PR merges during conflict resolution → silent cleanup, post-resolution `checkMergeable` skipped
- [x] Stage 9 `askMerge` → `check_conflicts`: user clicks "check conflicts", PR merged on GitHub, next iteration → silent cleanup, no inner `checkMergeable`
- [x] `pnpm biome check` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm vitest run` — full suite (1820 tests) passes

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title:** Detect already-merged PR in stages 8 and 9

**Body:**
When a user merges the PR on GitHub while the pipeline is running,
neither Stage 8 nor Stage 9 noticed: Stage 9's `checkMergeable` loop
burned its full backoff budget on `mergeable=UNKNOWN`, and Stage 8's
"Agent squashes now" path force-pushed history onto a closed branch
before polling CI for a head SHA with no open PR.

Add a PR-lifecycle pre-check that short-circuits both stages into the
silent cleanup path. `queryPrState` in `src/pr.ts` reads the PR `state`
field via `gh pr view --json state` and fails open (returns `"OPEN"`)
on `gh` or JSON failure, mirroring `queryMergeableState`.

Stage 9 wraps every `checkMergeable` call in `ensurePrStillOpen`, which
runs `stopServices()` + `cleanup()` on `MERGED` — the same silent path
already used on `confirmMerge === "merged"`. Centralising the guard at
the helper boundary keeps future refactors from dropping it at one of
the three call sites (initial `mergeableLoop`, `afterResolution`, and
the `askMerge` `check_conflicts` inner loop).

Stage 8 cannot reuse `ensurePrStillOpen` because the Done stage owns
the worktree lifecycle. A local `guardIfPrMerged` helper aborts the
squash and clears `squashSubStep` so a resume does not re-enter the
dead choice. It fires before `askUserAndApply`, immediately before the
destructive `"agent"` branch inside it, and at the top of the
`saved === "squashing"` resume branch — the last covers the
persisted-resume race where the user merges the PR between an
interrupted squashing step and the resume that would otherwise re-send
the follow-up or jump into CI poll on a closed branch.

Both call-site owners receive `queryPrState` as an injected callback,
matching the existing pattern for `checkMergeable`, `getPrBody`, and
friends, so tests inject mocks per case rather than spying at the
module level.

Closes #260
<!-- agentcoop:squash-suggestion:end -->