### PR TITLE
Split label from value in squash merge preview (#264)

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -145,7 +145,7 @@ export const en: Messages = {
   "pipeline.mergeConfirmSquashTip":
     "If this repo allows 'Squash and merge', the suggested commit " +
     "message is in the PR body.",
-  "pipeline.suggestedSquashTitle": (title) => `Suggested title: ${title}`,
+  "pipeline.suggestedSquashTitle": "Suggested title:",
   "pipeline.suggestedSquashBody": "Suggested body:",
   "pipeline.prUrl": (url) => `PR: ${url}`,
   "pipeline.worktreeCleanedUp": "Worktree cleaned up.",

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -179,7 +179,7 @@ export const ko: Messages = {
     "PR이 병합되었습니까? 확인하면 워크트리를 정리합니다.",
   "pipeline.mergeConfirmSquashTip":
     "이 저장소가 'Squash and merge'를 허용한다면, 제안된 커밋 메시지가 PR 본문에 있습니다.",
-  "pipeline.suggestedSquashTitle": (title) => `제안 제목: ${title}`,
+  "pipeline.suggestedSquashTitle": "제안 제목:",
   "pipeline.suggestedSquashBody": "제안 본문:",
   "pipeline.prUrl": (url) => `PR: ${url}`,
   "pipeline.worktreeCleanedUp": "워크트리가 정리되었습니다.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -139,7 +139,7 @@ export interface Messages {
   ) => string;
   "pipeline.mergeConfirm": string;
   "pipeline.mergeConfirmSquashTip": string;
-  "pipeline.suggestedSquashTitle": (title: string) => string;
+  "pipeline.suggestedSquashTitle": string;
   "pipeline.suggestedSquashBody": string;
   "pipeline.prUrl": (url: string) => string;
   "pipeline.worktreeCleanedUp": string;

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1143,6 +1143,15 @@ describe("createDoneStageHandler", () => {
     expect(message).toContain("Fix widget rendering");
     expect(message).toContain("Closes #5");
     expect(message).toContain("https://github.com/org/repo/pull/123");
+    // Title and body sit on their own lines with no inline prefix so that
+    // triple-click selects exactly the value.
+    expect(message).toContain("Suggested title:\nFix widget rendering\n");
+    expect(message).toContain("Suggested body:\nBody line\n\nCloses #5");
+    expect(message).not.toMatch(/Suggested title: Fix widget rendering/);
+    // Blank lines separate each labelled section from surrounding content.
+    expect(message).toContain("\n\nSuggested title:");
+    expect(message).toContain("\n\nSuggested body:");
+    expect(message).toMatch(/Closes #5\n\nPR: https:\/\//);
   });
 
   test("MERGEABLE: omits hint when getSquashMergeHint returns undefined", async () => {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1177,18 +1177,21 @@ export function createDoneStageHandler(
       const hint = options.getSquashMergeHint?.();
       const sections: string[] = [summary];
       if (hint) {
-        const tipLines: string[] = [m["pipeline.mergeConfirmSquashTip"]];
+        const tipSections: string[] = [m["pipeline.mergeConfirmSquashTip"]];
         if (hint.title) {
-          tipLines.push(m["pipeline.suggestedSquashTitle"](hint.title));
+          tipSections.push(
+            `${m["pipeline.suggestedSquashTitle"]}\n${hint.title}`,
+          );
         }
         if (hint.body) {
-          tipLines.push(m["pipeline.suggestedSquashBody"]);
-          tipLines.push(hint.body);
+          tipSections.push(
+            `${m["pipeline.suggestedSquashBody"]}\n${hint.body}`,
+          );
         }
         if (hint.prUrl) {
-          tipLines.push(m["pipeline.prUrl"](hint.prUrl));
+          tipSections.push(m["pipeline.prUrl"](hint.prUrl));
         }
-        sections.push(tipLines.join("\n"));
+        sections.push(tipSections.join("\n\n"));
       }
       sections.push(m["pipeline.mergeConfirm"]);
       const choice = await options.prompt.confirmMerge(sections.join("\n\n"));


### PR DESCRIPTION
## Summary

- Split the suggested squash title and body off their label lines so each value sits on its own line with no prefix, and separate every labelled section with a blank line. Triple-clicking the title now selects exactly the value, and the body has a clean selection boundary.
- Simplify `pipeline.suggestedSquashTitle` from `(title) => string` to a plain label string, mirroring `pipeline.suggestedSquashBody`, in `messages.ts`, `en.ts`, and `ko.ts`.
- Extend the existing stage 9 squash suggestion test to assert the new line structure — values on their own lines, blank lines between sections, and no inline prefix.

Part of #262
Closes #264

## Test plan

- [x] `pnpm vitest run` passes (full suite).
- [x] Stage 9 merge-confirm preview shows `Suggested title:` and the title on separate lines, with a blank line before and after.
- [x] Stage 9 merge-confirm preview shows `Suggested body:` and the body on separate lines, with a blank line before the PR URL.
- [x] Triple-clicking the suggested-title line selects only the title (no `Suggested title: ` prefix).
- [x] Korean locale renders the same structure with the `제안 제목:` / `제안 본문:` labels on their own lines.