### PR TITLE
Wrap squash suggestion title/body in fenced code blocks (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,21 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Stage 8's squash suggestion block in the PR body now emits the title and
+  body inside separate fenced code blocks (info string `text`) instead of
+  bold-labeled plain Markdown (`**Title:** …` / `**Body:** …`).  GitHub
+  renders a one-click copy icon on fenced blocks and does not reinterpret
+  Markdown characters inside, so the user can paste the suggestion verbatim
+  into the "Squash and merge" dialog.  The agent chooses each fence length
+  dynamically per the CommonMark rule
+  (`max(longest backtick run in content, 2) + 1`, minimum 3) so commit
+  bodies containing their own triple-backtick samples survive unchanged.
+- `parseSquashSuggestionBlock` now accepts either the new fenced format or
+  the legacy `**Title:** …` / `**Body:** …` plain-text format, returning
+  the same `{ title, body }` shape.  This is required because Stage 8
+  short-circuits on `squashSubStep === "applied_in_pr_body"` without
+  re-invoking the agent, so existing PRs in that state still render
+  correctly in the Stage 9 inline preview after upgrade.
 - Stage 8 verdict keywords are now `SQUASHED_MULTI` / `SUGGESTED_SINGLE` /
   `BLOCKED` (previously `COMPLETED` / `BLOCKED`).  When the verdict is
   ambiguous after a clarification retry, the handler runs a deterministic
@@ -51,6 +66,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Stage 9 merge-confirm screen now includes a conditional one-line tip
   (`pipeline.mergeConfirmSquashTip`) when a squash suggestion is live in
   the PR body.
+
+### Deprecated
+
+- The legacy `**Title:** …` / `**Body:** …` plain-text form of the squash
+  suggestion block (written by older versions of Stage 8) is deprecated.
+  `parseSquashSuggestionBlock` continues to accept it for one release cycle
+  so PRs already in the `applied_in_pr_body` state still render in the
+  Stage 9 inline preview after upgrade.  The legacy branch will be removed
+  in the following release — tracked by #267.
 
 ### Fixed
 

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -954,7 +954,7 @@ describe("createSquashStageHandler", () => {
     }
 
     test("count decreased AND marker present → SQUASHED_MULTI (count wins)", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** stale\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** stale\n\n**Body:**\nstale body\n${SQUASH_SUGGESTION_END_MARKER}`;
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi
@@ -970,7 +970,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("count unchanged AND marker present → SUGGESTED_SINGLE", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** suggested\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** suggested\n\n**Body:**\nsuggested body\n${SQUASH_SUGGESTION_END_MARKER}`;
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
@@ -1018,7 +1018,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("awaiting_user_choice with marker present → re-presents user choice", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const opts = makeOpts({
         savedSquashSubStep: "awaiting_user_choice",
@@ -1432,7 +1432,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("emits SUGGESTED_SINGLE when marker block is present", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** s\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** s\n\n**Body:**\ns body\n${SQUASH_SUGGESTION_END_MARKER}`;
       const events = new PipelineEventEmitter();
       const handler = vi.fn();
       events.on("pipeline:verdict", handler);
@@ -1591,12 +1591,293 @@ describe("createSquashStageHandler", () => {
 // ---- parseSquashSuggestionBlock --------------------------------------------
 
 describe("parseSquashSuggestionBlock", () => {
-  test("parses title and body from a well-formed block", () => {
+  // ---- fenced format (current) ---------------------------------------------
+
+  test("parses title and body from a well-formed fenced block", () => {
+    const body = [
+      "noise",
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "Fix widget rendering",
+      "```",
+      "",
+      "**Body**",
+      "",
+      "```text",
+      "First line.",
+      "",
+      "Closes #42",
+      "```",
+      SQUASH_SUGGESTION_END_MARKER,
+      "more noise",
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Fix widget rendering",
+      body: "First line.\n\nCloses #42",
+    });
+  });
+
+  test("parses a body that contains a nested triple-backtick fenced block (outer fence length 4)", () => {
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "Fix code sample rendering",
+      "```",
+      "",
+      "**Body**",
+      "",
+      "````text",
+      "Repro:",
+      "",
+      "```js",
+      "foo();",
+      "```",
+      "",
+      "Closes #1",
+      "````",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Fix code sample rendering",
+      body: "Repro:\n\n```js\nfoo();\n```\n\nCloses #1",
+    });
+  });
+
+  test("parses a body containing a run of five backticks (outer fence length 6)", () => {
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "Handle large fences",
+      "```",
+      "",
+      "**Body**",
+      "",
+      "``````text",
+      "Look at this nesting:",
+      "",
+      "`````",
+      "inner",
+      "`````",
+      "``````",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Handle large fences",
+      body: "Look at this nesting:\n\n`````\ninner\n`````",
+    });
+  });
+
+  test("parses a title that contains a single backtick (fence length stays 3)", () => {
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "Rename `foo` to `bar`",
+      "```",
+      "",
+      "**Body**",
+      "",
+      "```text",
+      "See #9",
+      "```",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Rename `foo` to `bar`",
+      body: "See #9",
+    });
+  });
+
+  test("fenced format tolerates extra blank lines around fences", () => {
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "",
+      "**Title**",
+      "",
+      "",
+      "```text",
+      "T",
+      "```",
+      "",
+      "",
+      "**Body**",
+      "",
+      "",
+      "```text",
+      "B",
+      "```",
+      "",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "T",
+      body: "B",
+    });
+  });
+
+  test("returns undefined when the title fenced block is unterminated", () => {
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "**Title**",
+      "",
+      "```text",
+      "no close",
+      "",
+      "**Body**",
+      "",
+      "```text",
+      "B",
+      "```",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
+  });
+
+  test("returns undefined when fenced-intent block has legacy-looking prose inside an unterminated fence", () => {
+    // Regression: a malformed fenced block whose contents happen to
+    // contain `**Title:**` / `**Body:**` strings must not be rescued
+    // by the legacy-format fallback.  The new-format `**Title**`
+    // label signals fenced intent, so the block must strictly fail
+    // rather than silently parse the prose as a legacy block.
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "Broken suggestion",
+      "",
+      "**Title:** this is just prose inside the broken fence",
+      "",
+      "**Body:**",
+      "still just prose inside the same broken fence",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
+  });
+
+  // ---- legacy format (deprecated, one release cycle) ------------------------
+
+  test("parses the deprecated legacy `**Title:**` / `**Body:**` format", () => {
     const body = `noise\n${SQUASH_SUGGESTION_START_MARKER}\n## Suggested squash commit\n\n**Title:** Fix widget rendering\n\n**Body:**\nFirst line.\n\nCloses #42\n${SQUASH_SUGGESTION_END_MARKER}\nmore noise`;
     expect(parseSquashSuggestionBlock(body)).toEqual({
       title: "Fix widget rendering",
       body: "First line.\n\nCloses #42",
     });
+  });
+
+  test("legacy format parses when body contains a standalone `**Title**` line", () => {
+    // Regression: a valid legacy block whose body happens to include a
+    // standalone `**Title**` line (the new-format label) must still
+    // parse as legacy.  The format selector must key off the actual
+    // top-level fenced shape (label + opening fence), not the mere
+    // presence of `**Title**` anywhere inside the block.
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "**Title:** Fix widget rendering",
+      "",
+      "**Body:**",
+      "Intro paragraph.",
+      "",
+      "**Title**",
+      "",
+      "Closes #42",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Fix widget rendering",
+      body: "Intro paragraph.\n\n**Title**\n\nCloses #42",
+    });
+  });
+
+  test("legacy format parses when body contains `**Title**` immediately followed by a fenced block", () => {
+    // Regression: a valid legacy block whose body includes a
+    // standalone `**Title**` line directly followed by a fenced code
+    // sample must still parse as legacy.  The format selector must key
+    // off whichever top-level title label appears *first* in the
+    // block; the legacy `**Title:**` at the top wins over any later
+    // `**Title**` + fence shape found inside the legacy body.
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "**Title:** Fix widget rendering",
+      "",
+      "**Body:**",
+      "Intro paragraph.",
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "example",
+      "```",
+      "",
+      "Closes #42",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toEqual({
+      title: "Fix widget rendering",
+      body: "Intro paragraph.\n\n**Title**\n\n```text\nexample\n```\n\nCloses #42",
+    });
+  });
+
+  test("legacy format returns undefined when the `**Body:**` label is missing", () => {
+    // Regression: the legacy parser must require both labels on their
+    // own top-level lines.  A block with `**Title:** ...` but no
+    // `**Body:**` label is syntactically malformed and must fail so
+    // the Stage 8 strict gate blocks instead of silently accepting.
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "**Title:** Fix widget rendering",
+      "",
+      "This forgot the body label entirely.",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
+  });
+
+  test("legacy format returns undefined when labels appear only inside prose", () => {
+    // Regression: stray `**Title:**` / `**Body:**` strings that appear
+    // mid-line inside prose must not be mistaken for real top-level
+    // legacy labels.  Both labels must be line-anchored.
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "This paragraph mentions **Title:** inline and **Body:** inline too.",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
+  });
+
+  // ---- malformed / missing --------------------------------------------------
+
+  test("returns undefined when the block is neither fenced nor legacy", () => {
+    const body = [
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "Just some prose without labels or fences.",
+      SQUASH_SUGGESTION_END_MARKER,
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
   });
 
   test("returns undefined when markers are missing", () => {

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -180,18 +180,54 @@ export function buildSquashPrompt(
     `   - Update the PR body to include a marker-delimited block`,
     `     containing the suggestion.  The block must be idempotent —`,
     `     replace any existing block between the same markers, do not`,
-    `     stack duplicates.  Use exactly these markers:`,
+    `     stack duplicates.  Inside the block, wrap the title and body`,
+    `     each in their own fenced code block (info string \`text\`) so`,
+    `     GitHub renders a one-click copy icon and does not`,
+    `     re-interpret Markdown characters inside the commit message.`,
+    `     Use exactly these markers and this structure:`,
     ``,
-    `     \`\`\`text`,
+    `     \`\`\`\`text`,
     `     ${SQUASH_SUGGESTION_START_MARKER}`,
     `     ## Suggested squash commit`,
     ``,
-    `     **Title:** <your title>`,
+    `     **Title**`,
     ``,
-    `     **Body:**`,
-    `     <your body — may include \`Closes #N\` / \`Part of #N\`>`,
-    `     ${SQUASH_SUGGESTION_END_MARKER}`,
+    `     \`\`\`text`,
+    `     <your title>`,
     `     \`\`\``,
+    ``,
+    `     **Body**`,
+    ``,
+    `     \`\`\`text`,
+    `     <your body — may include \`Closes #N\` / \`Part of #N\`>`,
+    `     \`\`\``,
+    `     ${SQUASH_SUGGESTION_END_MARKER}`,
+    `     \`\`\`\``,
+    ``,
+    `     **Choose each fence length dynamically.**  Per CommonMark, a`,
+    `     fenced code block closes only on a line containing a run of`,
+    `     the same character that is **as long or longer** than the`,
+    `     opening fence.  Commit bodies may legitimately contain code`,
+    `     samples with their own triple-backtick fences, so a fixed`,
+    `     three-backtick outer fence would close early at the first`,
+    `     \`\`\`\` line inside the content.  Compute:`,
+    ``,
+    `       fence_len = max(longest run of backticks in the content, 2) + 1`,
+    ``,
+    `     (minimum 3).  Calculate the title fence length from the`,
+    `     title string and the body fence length from the body string,`,
+    `     independently.  Use the same character (backtick) for both`,
+    `     the opening and closing line of a given block.`,
+    ``,
+    `     Worked example — if the body contains a line of triple`,
+    `     backticks anywhere (e.g. a README excerpt), open and close`,
+    `     the body with **four** backticks; a run of five backticks in`,
+    `     the content requires six on the fence; and so on.  The title`,
+    `     fence typically stays at three.`,
+    ``,
+    `     Do not add a blank line between the opening fence and the`,
+    `     first line of content, or between the last line of content`,
+    `     and the closing fence.  Do not indent the fences.`,
     ``,
     `     Read the current body with`,
     `     \`gh pr view --json body --jq .body\`, replace any prior`,
@@ -282,6 +318,22 @@ export function buildAgentSquashFollowupPrompt(): string {
  * Extract the title and body from the squash suggestion marker block
  * in `prBody`.  Returns `undefined` when the markers are missing or
  * the block does not contain a parseable title.
+ *
+ * Accepts two formats:
+ *
+ * 1. **Fenced** (current, written by the agent) — `**Title**` and
+ *    `**Body**` labels each followed by a CommonMark-style fenced code
+ *    block.  The fence length is chosen dynamically by the agent so
+ *    the block can survive commit bodies that themselves contain
+ *    triple-backtick samples; the parser mirrors that rule by
+ *    matching any opening fence of three or more backticks and
+ *    scanning for a closing line with a run of the same character
+ *    that is at least as long.
+ * 2. **Legacy** (deprecated) — `**Title:** <title>` / `**Body:**`
+ *    plain-text format.  Kept for one release cycle so that PRs
+ *    written by older versions still render in the stage 9 inline
+ *    preview after upgrade.  Remove once the deprecation window
+ *    expires.
  */
 export function parseSquashSuggestionBlock(
   prBody: string | undefined,
@@ -291,22 +343,179 @@ export function parseSquashSuggestionBlock(
   const endIdx = prBody.indexOf(SQUASH_SUGGESTION_END_MARKER);
   if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return undefined;
 
-  const inner = prBody
-    .slice(startIdx + SQUASH_SUGGESTION_START_MARKER.length, endIdx)
-    .trim();
+  const inner = prBody.slice(
+    startIdx + SQUASH_SUGGESTION_START_MARKER.length,
+    endIdx,
+  );
 
-  // Match `**Title:** <title>` on its own line.
-  const titleMatch = inner.match(/\*\*Title:\*\*\s*(.+?)\s*$/m);
-  if (!titleMatch) return undefined;
-  const title = titleMatch[1].trim();
+  // Decide format by whichever top-level title label appears *first*
+  // in the block, not merely by whether a fenced-intent shape exists
+  // anywhere.  A legacy body may legitimately contain a standalone
+  // `**Title**` line followed by a fenced code sample as part of its
+  // own prose, so scanning the whole block for a fenced shape would
+  // misroute valid legacy blocks.  The first recognized top-level
+  // label wins: `**Title:** <content>` → legacy, `**Title**` + fence
+  // → fenced.  Once classified as fenced, a malformed fenced block
+  // must fail to `undefined` rather than silently fall through to
+  // legacy parsing (which would otherwise pick up `**Title:**` /
+  // `**Body:**` strings that appeared as prose inside an unterminated
+  // fence).
+  const format = detectFormat(inner);
+  if (format === "fenced") return parseFencedSuggestion(inner);
+  if (format === "legacy") return parseLegacySuggestion(inner);
+  return undefined;
+}
 
-  // Body starts after `**Body:**`.
-  const bodyMarker = "**Body:**";
-  const bodyStart = inner.indexOf(bodyMarker);
-  let body = "";
-  if (bodyStart !== -1) {
-    body = inner.slice(bodyStart + bodyMarker.length).trim();
+/**
+ * Classify the block by the first top-level title label it contains.
+ * Returns `"legacy"` if a `**Title:** <content>` line appears before
+ * any fenced-intent shape, `"fenced"` if a `**Title**` label line
+ * followed (after optional blank lines) by an opening code fence
+ * appears first, or `undefined` when neither shape is present.
+ */
+function detectFormat(inner: string): "fenced" | "legacy" | undefined {
+  const lines = inner.split("\n");
+  const legacyTitleRe = /^\s*\*\*Title:\*\*\s+\S/;
+  const fencedTitleRe = labelLineRe("Title");
+  const openFenceRe = /^\s*`{3,}[^`]*$/;
+  for (let i = 0; i < lines.length; i++) {
+    if (legacyTitleRe.test(lines[i])) return "legacy";
+    if (fencedTitleRe.test(lines[i])) {
+      let j = i + 1;
+      while (j < lines.length && lines[j].trim() === "") j++;
+      if (j < lines.length && openFenceRe.test(lines[j])) return "fenced";
+    }
   }
+  return undefined;
+}
+
+/** Label-line regex for the fenced format (`**Title**` / `**Body**`). */
+function labelLineRe(label: "Title" | "Body"): RegExp {
+  return new RegExp(`^\\s*\\*\\*${label}\\*\\*\\s*$`);
+}
+
+/**
+ * Parse the fenced format.  Returns `undefined` when either label is
+ * missing, when the fenced block that should follow the label is
+ * malformed (missing opening fence, unterminated), or when the
+ * blocks appear in the wrong order.
+ */
+function parseFencedSuggestion(inner: string): SquashSuggestion | undefined {
+  const lines = inner.split("\n");
+
+  const titleLabelIdx = findLabelLine(lines, 0, "Title");
+  if (titleLabelIdx === -1) return undefined;
+
+  const titleBlock = readFencedBlock(lines, titleLabelIdx + 1);
+  if (!titleBlock) return undefined;
+
+  const bodyLabelIdx = findLabelLine(lines, titleBlock.endIdx + 1, "Body");
+  if (bodyLabelIdx === -1) return undefined;
+
+  const bodyBlock = readFencedBlock(lines, bodyLabelIdx + 1);
+  if (!bodyBlock) return undefined;
+
+  return {
+    title: titleBlock.content.replace(/^\n+|\n+$/g, "").trim(),
+    body: bodyBlock.content.replace(/^\n+|\n+$/g, ""),
+  };
+}
+
+function findLabelLine(
+  lines: string[],
+  start: number,
+  label: "Title" | "Body",
+): number {
+  const re = labelLineRe(label);
+  for (let i = start; i < lines.length; i++) {
+    if (re.test(lines[i])) return i;
+  }
+  return -1;
+}
+
+/**
+ * Read a CommonMark-style fenced code block starting at or after
+ * `start`.  Skips blank lines before the opening fence, records the
+ * fence length, then scans for the first line that is a closing
+ * fence — a run of backticks of length `>=` the opening, optionally
+ * with surrounding whitespace, and no info string.
+ *
+ * Returns `{ content, endIdx }` where `endIdx` is the line index of
+ * the closing fence.  Returns `undefined` when no opening fence is
+ * found or the block is not terminated.
+ */
+function readFencedBlock(
+  lines: string[],
+  start: number,
+): { content: string; endIdx: number } | undefined {
+  let i = start;
+  while (i < lines.length && lines[i].trim() === "") i++;
+  if (i >= lines.length) return undefined;
+
+  // Opening fence: 3+ backticks, optional info string (no backticks).
+  const openMatch = lines[i].match(/^\s*(`{3,})([^`]*)$/);
+  if (!openMatch) return undefined;
+  const fenceLen = openMatch[1].length;
+
+  const contentStart = i + 1;
+  for (let j = contentStart; j < lines.length; j++) {
+    // Closing fence: run of backticks of length >= opening, nothing
+    // else on the line besides whitespace.
+    const closeMatch = lines[j].match(/^\s*(`{3,})\s*$/);
+    if (closeMatch && closeMatch[1].length >= fenceLen) {
+      return {
+        content: lines.slice(contentStart, j).join("\n"),
+        endIdx: j,
+      };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Parse the deprecated legacy format (`**Title:** <title>` /
+ * `**Body:**` plain text).  Maintained for one release cycle after
+ * the switch to fenced blocks so PRs written by older agent runs
+ * still render correctly in the stage 9 inline preview.
+ *
+ * Both labels must appear on their own top-level lines in order —
+ * `**Title:** <content>` with content on the same line, then a
+ * later line that is exactly `**Body:**`.  A whole-block
+ * `match()` / `indexOf()` approach would happily pick up stray
+ * `**Title:**` / `**Body:**` strings that appeared mid-prose and
+ * accept malformed blocks (e.g. missing the body label), weakening
+ * the Stage 8 strict gate in `hasValidSuggestionBlock`.
+ */
+function parseLegacySuggestion(inner: string): SquashSuggestion | undefined {
+  const lines = inner.split("\n");
+  const titleLineRe = /^\s*\*\*Title:\*\*\s+(.+?)\s*$/;
+  const bodyLabelRe = /^\s*\*\*Body:\*\*\s*$/;
+
+  let titleIdx = -1;
+  let title = "";
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(titleLineRe);
+    if (m) {
+      titleIdx = i;
+      title = m[1].trim();
+      break;
+    }
+  }
+  if (titleIdx === -1) return undefined;
+
+  let bodyIdx = -1;
+  for (let i = titleIdx + 1; i < lines.length; i++) {
+    if (bodyLabelRe.test(lines[i])) {
+      bodyIdx = i;
+      break;
+    }
+  }
+  if (bodyIdx === -1) return undefined;
+
+  const body = lines
+    .slice(bodyIdx + 1)
+    .join("\n")
+    .trim();
 
   return { title, body };
 }


### PR DESCRIPTION
## Summary

- Stage 8's squash suggestion block in the PR body now emits the title and body inside separate fenced code blocks (info string `text`) instead of `**Title:** …` / `**Body:** …` plain Markdown. GitHub renders a one-click copy icon on fenced blocks and does not reinterpret Markdown characters inside them, so the user can paste the suggestion verbatim into the "Squash and merge" dialog.
- The agent is instructed to choose each fence length dynamically per the CommonMark rule (`max(longest backtick run in content, 2) + 1`, minimum 3), with a worked example covering the backtick-in-body case. Title and body fence lengths are computed independently.
- `parseSquashSuggestionBlock` is rewritten to extract the title and body from the fenced blocks using CommonMark-style fence matching (close length `>=` open length, same character). It still accepts the legacy `**Title:** …` / `**Body:** …` plain-text format for one release cycle so that PRs already in the `applied_in_pr_body` state — which stage 8 does not re-invoke the agent for — continue to render in stage 9's inline preview after upgrade.
- The legacy branch is marked deprecated in `CHANGELOG.md`; removal is tracked by #267.

Closes #263

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title:** Render squash suggestion as fenced code blocks

**Body:**
Stage 8 previously emitted the suggested squash title and body in
the PR body as `**Title:** <title>` / `**Body:** <body>` plain
Markdown.  GitHub's "Squash and merge" dialog does not render a
one-click copy icon for that shape, and Markdown characters that
are legal in a commit message (`*`, `` ` ``, `_`, leading `#`,
`>`, backslashes) can be reinterpreted or swallowed when the user
drag-selects the suggestion to paste.

Wrap each field in its own CommonMark fenced code block with the
`text` info string so GitHub renders a one-click copy icon and
preserves the content verbatim.  Fence length is chosen per
`max(longest backtick run in content, 2) + 1` (minimum 3),
independently for title and body, so commit bodies that contain
code samples with their own triple-backtick fences do not close
the outer block early.

Rewrite `parseSquashSuggestionBlock` to match CommonMark fence
semantics (close length `>=` open length, same character).  For
one release cycle it also accepts the legacy bold-labeled format
so PRs already in the `applied_in_pr_body` state — which stage 8
does not re-invoke the agent for — continue to render stage 9's
inline preview after upgrade.  Legacy-branch removal is tracked
by #267.

Closes #263
<!-- agentcoop:squash-suggestion:end -->

## Test plan

- [x] `pnpm vitest run` — full suite green (1827 tests).
- [x] `parseSquashSuggestionBlock` parses a well-formed fenced block.
- [x] Parser handles a body containing a nested triple-backtick block (outer fence length 4).
- [x] Parser handles a body containing a run of five backticks (outer fence length 6).
- [x] Parser handles a title that contains a single backtick (fence length stays 3).
- [x] Parser tolerates extra blank lines around fences.
- [x] Parser still accepts the legacy `**Title:** …` / `**Body:** …` format.
- [x] Parser returns `undefined` for a block that is neither fenced nor legacy.
- [x] Parser returns `undefined` for unterminated fenced blocks.
- [x] `pnpm biome check` clean for changed files.
- [x] `pnpm tsc --noEmit` passes.
- [x] `pnpm build` succeeds.
