### PR TITLE
Remove legacy squash suggestion parser (#267)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   dynamically per the CommonMark rule
   (`max(longest backtick run in content, 2) + 1`, minimum 3) so commit
   bodies containing their own triple-backtick samples survive unchanged.
-- `parseSquashSuggestionBlock` now accepts either the new fenced format or
-  the legacy `**Title:** …` / `**Body:** …` plain-text format, returning
-  the same `{ title, body }` shape.  This is required because Stage 8
-  short-circuits on `squashSubStep === "applied_in_pr_body"` without
-  re-invoking the agent, so existing PRs in that state still render
-  correctly in the Stage 9 inline preview after upgrade.
 - Stage 8 verdict keywords are now `SQUASHED_MULTI` / `SUGGESTED_SINGLE` /
   `BLOCKED` (previously `COMPLETED` / `BLOCKED`).  When the verdict is
   ambiguous after a clarification retry, the handler runs a deterministic
@@ -67,14 +61,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   (`pipeline.mergeConfirmSquashTip`) when a squash suggestion is live in
   the PR body.
 
-### Deprecated
+### Removed
 
-- The legacy `**Title:** …` / `**Body:** …` plain-text form of the squash
-  suggestion block (written by older versions of Stage 8) is deprecated.
-  `parseSquashSuggestionBlock` continues to accept it for one release cycle
-  so PRs already in the `applied_in_pr_body` state still render in the
-  Stage 9 inline preview after upgrade.  The legacy branch will be removed
-  in the following release — tracked by #267.
+- `parseSquashSuggestionBlock` no longer accepts the legacy
+  `**Title:** …` / `**Body:** …` plain-text form of the squash suggestion
+  block.  The one-release compatibility window that allowed PRs already in
+  the `applied_in_pr_body` state to render in the Stage 9 inline preview
+  after upgrade has expired; only the fenced form is recognized now.  A
+  PR body still carrying the legacy form will silently skip the Stage 9
+  preview — a cosmetic degradation, not a pipeline failure.
 
 ### Fixed
 
@@ -107,7 +102,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   branch silently skipped telemetry.
 - Stage 8 now validates the squash suggestion block strictly before
   accepting `SUGGESTED_SINGLE` / `applied_in_pr_body`.  A bare start
-  marker or a block missing `**Title:**` / the end marker is treated
+  marker or a block missing `**Title**` / the end marker is treated
   as malformed and fails closed (or re-runs planning on resume)
   instead of completing with `squash.messageAppended` and leaving
   Stage 9 unable to render the inline preview.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1315,8 +1315,9 @@ because the three-way distinction is squash-specific.
 - `SUGGESTED_SINGLE` → verify a fully parseable suggestion block is
   present in the PR body before asking the user.  "Parseable" means
   both markers are present **and** `parseSquashSuggestionBlock`
-  succeeds (the block contains a `**Title:**` line).  A bare start
-  marker or a block missing `**Title:**`/the end marker fails
+  succeeds (the block contains a `**Title**` label followed by a
+  parseable fenced code block).  A bare start marker or a block
+  missing `**Title**`/the end marker fails
   closed with `blocked` rather than completing as if the suggestion
   were valid — Stage 9 reads the same block via
   `parseSquashSuggestionBlock` to render the inline preview, so a

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -53,6 +53,25 @@ function makeCiStatus(verdict: CiVerdict, runs: CiRun[] = []): CiStatus {
   return { verdict, runs, findings: [] };
 }
 
+/** Build a fenced squash suggestion block wrapped in marker delimiters. */
+function fencedSuggestionBlock(title: string, body: string): string {
+  return [
+    SQUASH_SUGGESTION_START_MARKER,
+    "**Title**",
+    "",
+    "```text",
+    title,
+    "```",
+    "",
+    "**Body**",
+    "",
+    "```text",
+    body,
+    "```",
+    SQUASH_SUGGESTION_END_MARKER,
+  ].join("\n");
+}
+
 const BASE_CTX: StageContext = {
   owner: "org",
   repo: "repo",
@@ -722,7 +741,7 @@ describe("createSquashStageHandler", () => {
   // -- SUGGESTED_SINGLE: user picks "agent" ----------------------------------
 
   test("SUGGESTED_SINGLE + user picks agent → follow-up + CI poll runs", async () => {
-    const prBodyWithMarker = `Hello\n${SQUASH_SUGGESTION_START_MARKER}\n## Suggested squash commit\n\n**Title:** My title\n\n**Body:**\nLine\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const prBodyWithMarker = `Hello\n${fencedSuggestionBlock("My title", "Line")}`;
     let resumeCall = 0;
     const resumeResults = [
       makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
@@ -770,7 +789,7 @@ describe("createSquashStageHandler", () => {
   // -- SUGGESTED_SINGLE: user picks "github" ---------------------------------
 
   test("SUGGESTED_SINGLE + user picks github → no CI poll, applied_in_pr_body", async () => {
-    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const prBodyWithMarker = fencedSuggestionBlock("T", "B");
     const agent: AgentAdapter = {
       invoke: vi
         .fn()
@@ -836,7 +855,7 @@ describe("createSquashStageHandler", () => {
   // -- PR already merged short-circuit ---------------------------------------
 
   test("SUGGESTED_SINGLE + PR already merged before user prompt → alreadyMerged, no chooseSquashApplyMode call", async () => {
-    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const prBodyWithMarker = fencedSuggestionBlock("T", "B");
     const agent: AgentAdapter = {
       invoke: vi
         .fn()
@@ -877,7 +896,7 @@ describe("createSquashStageHandler", () => {
   });
 
   test("user picks agent, but PR merges between query and follow-up → alreadyMerged, no sendFollowUp call", async () => {
-    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+    const prBodyWithMarker = fencedSuggestionBlock("T", "B");
     const agent: AgentAdapter = {
       invoke: vi
         .fn()
@@ -954,7 +973,7 @@ describe("createSquashStageHandler", () => {
     }
 
     test("count decreased AND marker present → SQUASHED_MULTI (count wins)", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** stale\n\n**Body:**\nstale body\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("stale", "stale body");
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi
@@ -970,7 +989,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("count unchanged AND marker present → SUGGESTED_SINGLE", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** suggested\n\n**Body:**\nsuggested body\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("suggested", "suggested body");
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
@@ -1018,7 +1037,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("awaiting_user_choice with marker present → re-presents user choice", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("T", "B");
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const opts = makeOpts({
         savedSquashSubStep: "awaiting_user_choice",
@@ -1036,7 +1055,7 @@ describe("createSquashStageHandler", () => {
     // available must be blocked, not silently routed to the github
     // completion message (which would misrepresent what happened).
     test("awaiting_user_choice + user picks agent + no session → blocked", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("T", "B");
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
       const onSquashSubStep = vi.fn();
       const getCiStatus = vi.fn();
@@ -1289,7 +1308,7 @@ describe("createSquashStageHandler", () => {
   // drafted the PR-body suggestion — not the older planning session.
   describe("verdict session id persistence", () => {
     test("SUGGESTED_SINGLE persists verdict session (distinct from planning) before awaiting choice", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("T", "B");
       const invoke = vi.fn().mockReturnValue(
         makeStream(
           makeResult({
@@ -1348,7 +1367,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("resume from awaiting_user_choice + user picks agent resumes the verdict session id via getSavedAgentSessionId", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n\n**Body:**\nB\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("T", "B");
       const resume = vi.fn().mockReturnValue(
         makeStream(
           makeResult({
@@ -1432,7 +1451,7 @@ describe("createSquashStageHandler", () => {
     });
 
     test("emits SUGGESTED_SINGLE when marker block is present", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** s\n\n**Body:**\ns body\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const prBody = fencedSuggestionBlock("s", "s body");
       const events = new PipelineEventEmitter();
       const handler = vi.fn();
       events.on("pipeline:verdict", handler);
@@ -1471,14 +1490,14 @@ describe("createSquashStageHandler", () => {
   // Stage 9 reads the block via `parseSquashSuggestionBlock` to render
   // the inline preview, so Stage 8 must reject any block the parser
   // cannot handle (start marker only, missing end marker, missing
-  // `**Title:**`).  Otherwise the SUGGESTED_SINGLE path completes with
+  // `**Title**`).  Otherwise the SUGGESTED_SINGLE path completes with
   // `applied_in_pr_body` and Stage 9 has nothing to show.
   describe("malformed suggestion block", () => {
     function makeMalformedBodies(): Array<{ name: string; body: string }> {
       return [
         {
           name: "start marker only (no end marker)",
-          body: `${SQUASH_SUGGESTION_START_MARKER}\n**Title:** T\n**Body:**\nB`,
+          body: `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\``,
         },
         {
           name: "both markers but no Title line",
@@ -1745,131 +1764,9 @@ describe("parseSquashSuggestionBlock", () => {
     expect(parseSquashSuggestionBlock(body)).toBeUndefined();
   });
 
-  test("returns undefined when fenced-intent block has legacy-looking prose inside an unterminated fence", () => {
-    // Regression: a malformed fenced block whose contents happen to
-    // contain `**Title:**` / `**Body:**` strings must not be rescued
-    // by the legacy-format fallback.  The new-format `**Title**`
-    // label signals fenced intent, so the block must strictly fail
-    // rather than silently parse the prose as a legacy block.
-    const body = [
-      SQUASH_SUGGESTION_START_MARKER,
-      "## Suggested squash commit",
-      "",
-      "**Title**",
-      "",
-      "```text",
-      "Broken suggestion",
-      "",
-      "**Title:** this is just prose inside the broken fence",
-      "",
-      "**Body:**",
-      "still just prose inside the same broken fence",
-      SQUASH_SUGGESTION_END_MARKER,
-    ].join("\n");
-    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
-  });
-
-  // ---- legacy format (deprecated, one release cycle) ------------------------
-
-  test("parses the deprecated legacy `**Title:**` / `**Body:**` format", () => {
-    const body = `noise\n${SQUASH_SUGGESTION_START_MARKER}\n## Suggested squash commit\n\n**Title:** Fix widget rendering\n\n**Body:**\nFirst line.\n\nCloses #42\n${SQUASH_SUGGESTION_END_MARKER}\nmore noise`;
-    expect(parseSquashSuggestionBlock(body)).toEqual({
-      title: "Fix widget rendering",
-      body: "First line.\n\nCloses #42",
-    });
-  });
-
-  test("legacy format parses when body contains a standalone `**Title**` line", () => {
-    // Regression: a valid legacy block whose body happens to include a
-    // standalone `**Title**` line (the new-format label) must still
-    // parse as legacy.  The format selector must key off the actual
-    // top-level fenced shape (label + opening fence), not the mere
-    // presence of `**Title**` anywhere inside the block.
-    const body = [
-      SQUASH_SUGGESTION_START_MARKER,
-      "## Suggested squash commit",
-      "",
-      "**Title:** Fix widget rendering",
-      "",
-      "**Body:**",
-      "Intro paragraph.",
-      "",
-      "**Title**",
-      "",
-      "Closes #42",
-      SQUASH_SUGGESTION_END_MARKER,
-    ].join("\n");
-    expect(parseSquashSuggestionBlock(body)).toEqual({
-      title: "Fix widget rendering",
-      body: "Intro paragraph.\n\n**Title**\n\nCloses #42",
-    });
-  });
-
-  test("legacy format parses when body contains `**Title**` immediately followed by a fenced block", () => {
-    // Regression: a valid legacy block whose body includes a
-    // standalone `**Title**` line directly followed by a fenced code
-    // sample must still parse as legacy.  The format selector must key
-    // off whichever top-level title label appears *first* in the
-    // block; the legacy `**Title:**` at the top wins over any later
-    // `**Title**` + fence shape found inside the legacy body.
-    const body = [
-      SQUASH_SUGGESTION_START_MARKER,
-      "## Suggested squash commit",
-      "",
-      "**Title:** Fix widget rendering",
-      "",
-      "**Body:**",
-      "Intro paragraph.",
-      "",
-      "**Title**",
-      "",
-      "```text",
-      "example",
-      "```",
-      "",
-      "Closes #42",
-      SQUASH_SUGGESTION_END_MARKER,
-    ].join("\n");
-    expect(parseSquashSuggestionBlock(body)).toEqual({
-      title: "Fix widget rendering",
-      body: "Intro paragraph.\n\n**Title**\n\n```text\nexample\n```\n\nCloses #42",
-    });
-  });
-
-  test("legacy format returns undefined when the `**Body:**` label is missing", () => {
-    // Regression: the legacy parser must require both labels on their
-    // own top-level lines.  A block with `**Title:** ...` but no
-    // `**Body:**` label is syntactically malformed and must fail so
-    // the Stage 8 strict gate blocks instead of silently accepting.
-    const body = [
-      SQUASH_SUGGESTION_START_MARKER,
-      "## Suggested squash commit",
-      "",
-      "**Title:** Fix widget rendering",
-      "",
-      "This forgot the body label entirely.",
-      SQUASH_SUGGESTION_END_MARKER,
-    ].join("\n");
-    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
-  });
-
-  test("legacy format returns undefined when labels appear only inside prose", () => {
-    // Regression: stray `**Title:**` / `**Body:**` strings that appear
-    // mid-line inside prose must not be mistaken for real top-level
-    // legacy labels.  Both labels must be line-anchored.
-    const body = [
-      SQUASH_SUGGESTION_START_MARKER,
-      "## Suggested squash commit",
-      "",
-      "This paragraph mentions **Title:** inline and **Body:** inline too.",
-      SQUASH_SUGGESTION_END_MARKER,
-    ].join("\n");
-    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
-  });
-
   // ---- malformed / missing --------------------------------------------------
 
-  test("returns undefined when the block is neither fenced nor legacy", () => {
+  test("returns undefined when the block contains no fenced title", () => {
     const body = [
       SQUASH_SUGGESTION_START_MARKER,
       "## Suggested squash commit",

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -319,21 +319,13 @@ export function buildAgentSquashFollowupPrompt(): string {
  * in `prBody`.  Returns `undefined` when the markers are missing or
  * the block does not contain a parseable title.
  *
- * Accepts two formats:
- *
- * 1. **Fenced** (current, written by the agent) — `**Title**` and
- *    `**Body**` labels each followed by a CommonMark-style fenced code
- *    block.  The fence length is chosen dynamically by the agent so
- *    the block can survive commit bodies that themselves contain
- *    triple-backtick samples; the parser mirrors that rule by
- *    matching any opening fence of three or more backticks and
- *    scanning for a closing line with a run of the same character
- *    that is at least as long.
- * 2. **Legacy** (deprecated) — `**Title:** <title>` / `**Body:**`
- *    plain-text format.  Kept for one release cycle so that PRs
- *    written by older versions still render in the stage 9 inline
- *    preview after upgrade.  Remove once the deprecation window
- *    expires.
+ * The block uses the fenced format: `**Title**` and `**Body**` labels
+ * each followed by a CommonMark-style fenced code block.  The fence
+ * length is chosen dynamically by the agent so the block can survive
+ * commit bodies that themselves contain triple-backtick samples; the
+ * parser mirrors that rule by matching any opening fence of three or
+ * more backticks and scanning for a closing line with a run of the
+ * same character that is at least as long.
  */
 export function parseSquashSuggestionBlock(
   prBody: string | undefined,
@@ -348,45 +340,7 @@ export function parseSquashSuggestionBlock(
     endIdx,
   );
 
-  // Decide format by whichever top-level title label appears *first*
-  // in the block, not merely by whether a fenced-intent shape exists
-  // anywhere.  A legacy body may legitimately contain a standalone
-  // `**Title**` line followed by a fenced code sample as part of its
-  // own prose, so scanning the whole block for a fenced shape would
-  // misroute valid legacy blocks.  The first recognized top-level
-  // label wins: `**Title:** <content>` → legacy, `**Title**` + fence
-  // → fenced.  Once classified as fenced, a malformed fenced block
-  // must fail to `undefined` rather than silently fall through to
-  // legacy parsing (which would otherwise pick up `**Title:**` /
-  // `**Body:**` strings that appeared as prose inside an unterminated
-  // fence).
-  const format = detectFormat(inner);
-  if (format === "fenced") return parseFencedSuggestion(inner);
-  if (format === "legacy") return parseLegacySuggestion(inner);
-  return undefined;
-}
-
-/**
- * Classify the block by the first top-level title label it contains.
- * Returns `"legacy"` if a `**Title:** <content>` line appears before
- * any fenced-intent shape, `"fenced"` if a `**Title**` label line
- * followed (after optional blank lines) by an opening code fence
- * appears first, or `undefined` when neither shape is present.
- */
-function detectFormat(inner: string): "fenced" | "legacy" | undefined {
-  const lines = inner.split("\n");
-  const legacyTitleRe = /^\s*\*\*Title:\*\*\s+\S/;
-  const fencedTitleRe = labelLineRe("Title");
-  const openFenceRe = /^\s*`{3,}[^`]*$/;
-  for (let i = 0; i < lines.length; i++) {
-    if (legacyTitleRe.test(lines[i])) return "legacy";
-    if (fencedTitleRe.test(lines[i])) {
-      let j = i + 1;
-      while (j < lines.length && lines[j].trim() === "") j++;
-      if (j < lines.length && openFenceRe.test(lines[j])) return "fenced";
-    }
-  }
-  return undefined;
+  return parseFencedSuggestion(inner);
 }
 
 /** Label-line regex for the fenced format (`**Title**` / `**Body**`). */
@@ -473,63 +427,15 @@ function readFencedBlock(
 }
 
 /**
- * Parse the deprecated legacy format (`**Title:** <title>` /
- * `**Body:**` plain text).  Maintained for one release cycle after
- * the switch to fenced blocks so PRs written by older agent runs
- * still render correctly in the stage 9 inline preview.
- *
- * Both labels must appear on their own top-level lines in order —
- * `**Title:** <content>` with content on the same line, then a
- * later line that is exactly `**Body:**`.  A whole-block
- * `match()` / `indexOf()` approach would happily pick up stray
- * `**Title:**` / `**Body:**` strings that appeared mid-prose and
- * accept malformed blocks (e.g. missing the body label), weakening
- * the Stage 8 strict gate in `hasValidSuggestionBlock`.
- */
-function parseLegacySuggestion(inner: string): SquashSuggestion | undefined {
-  const lines = inner.split("\n");
-  const titleLineRe = /^\s*\*\*Title:\*\*\s+(.+?)\s*$/;
-  const bodyLabelRe = /^\s*\*\*Body:\*\*\s*$/;
-
-  let titleIdx = -1;
-  let title = "";
-  for (let i = 0; i < lines.length; i++) {
-    const m = lines[i].match(titleLineRe);
-    if (m) {
-      titleIdx = i;
-      title = m[1].trim();
-      break;
-    }
-  }
-  if (titleIdx === -1) return undefined;
-
-  let bodyIdx = -1;
-  for (let i = titleIdx + 1; i < lines.length; i++) {
-    if (bodyLabelRe.test(lines[i])) {
-      bodyIdx = i;
-      break;
-    }
-  }
-  if (bodyIdx === -1) return undefined;
-
-  const body = lines
-    .slice(bodyIdx + 1)
-    .join("\n")
-    .trim();
-
-  return { title, body };
-}
-
-/**
  * True when `prBody` contains a fully parseable squash suggestion
- * block (start + end markers AND a `**Title:**` line that
+ * block (start + end markers AND a `**Title**` label that
  * `parseSquashSuggestionBlock` can extract).
  *
  * Stage 8 must use this strict check rather than a marker-presence
  * check because Stage 9 reads the same block via
  * `parseSquashSuggestionBlock` to render the inline preview.  If
  * Stage 8 accepted a malformed block (e.g. only the start marker, or
- * a block missing `**Title:**`/the end marker), the SUGGESTED_SINGLE
+ * a block missing `**Title**`/the end marker), the SUGGESTED_SINGLE
  * path could complete with `applied_in_pr_body` while leaving Stage 9
  * with nothing to show.
  */
@@ -840,7 +746,7 @@ export function createSquashStageHandler(
       // effect, so detect it first.  Only then check the suggestion
       // block, because an earlier run may have left a stale block in
       // the PR body that would otherwise be misclassified.  The block
-      // must be fully parseable (markers + `**Title:**`) — a malformed
+      // must be fully parseable (markers + `**Title**`) — a malformed
       // block is treated as missing because Stage 9 cannot render a
       // preview from it.
       if (verdict === undefined) {
@@ -880,7 +786,7 @@ export function createSquashStageHandler(
       if (verdict === "SUGGESTED_SINGLE") {
         // Verify the PR body holds a fully parseable suggestion block
         // before asking the user.  A bare start marker or a block
-        // missing `**Title:**`/the end marker would let the stage
+        // missing `**Title**`/the end marker would let the stage
         // complete with `applied_in_pr_body` but leave Stage 9 unable
         // to render the inline preview, so fail closed instead.
         const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);


### PR DESCRIPTION
## Summary

The `**Title:** …` / `**Body:**` plain-text form of the squash suggestion block was kept for one release cycle so that PRs already in the `applied_in_pr_body` state would still render in the Stage 9 inline preview after upgrade. That compatibility window has now expired.

- Delete `parseLegacySuggestion` and its `detectFormat` selector in `src/stage-squash.ts`; `parseSquashSuggestionBlock` now parses the fenced format only.
- Delete the legacy-format tests (parse, body-contains-`**Title**`, missing `**Body:**`, prose-only labels, and unterminated-fence fallback) in `src/stage-squash.test.ts`. Remaining tests use a new `fencedSuggestionBlock` helper.
- Update docstrings in `parseSquashSuggestionBlock` / `hasValidSuggestionBlock` and `docs/pipeline.md` to refer to the fenced `**Title**` label.
- Move the CHANGELOG entry from `### Deprecated` (previous release) to `### Removed` on this one.

A PR body that still carries the legacy form will silently skip the Stage 9 inline preview — a cosmetic degradation, not a pipeline failure. No `RUN_STATE_VERSION` bump and no migration shim, per the issue.

Closes #267

## Test plan

- [x] `pnpm vitest run src/stage-squash.test.ts` — squash suite still passes (legacy cases removed)
- [x] `pnpm vitest run` — full test suite passes
- [x] `pnpm tsc --noEmit` — type check clean
- [x] `pnpm biome check` — lint clean for modified files
- [x] Manual: confirm a freshly produced fenced `applied_in_pr_body` PR still renders the Stage 9 inline preview
- [x] Manual: confirm a hand-crafted legacy-format PR body no longer renders a preview (silent skip, pipeline unaffected)