### PR TITLE
Add [t]/[b] hotkey copy for squash suggestion (#265)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   body, and PR URL inline when the squash stage finished via the
   PR-body suggestion path, so the user can copy-paste without opening the
   browser.
+- Stage 9 (Done) merge-confirm screen now renders `[t] copy` / `[b] copy`
+  hotkey hints next to the suggested squash title and body when the terminal
+  can write to the system clipboard.  Pressing `t` copies the title and `b`
+  copies the body (each independently, so the values line up with GitHub's
+  separate "Squash and merge" title / body fields).  A small clipboard
+  utility detects the environment and returns an ordered candidate list
+  (`pbcopy` / `wl-copy` / `xclip` on local sessions, OSC 52 first on SSH
+  sessions, OSC 52 as fallback everywhere stdout is a TTY), and the writer
+  tries candidates in order until one succeeds.  When no candidate is
+  reachable, the hints are not rendered at all — the user falls back to
+  drag-select as before, rather than seeing a hint that silently does
+  nothing.  Per-hotkey status (`copy` / `copied` / `copy failed`) is
+  reflected in the label; `copied` auto-reverts after ~1s, `copy failed`
+  persists until the next re-render.
 
 ### Changed
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1524,6 +1524,18 @@ Cleanup
      delete the worktree, delete the remote branch, and close
      the PR. Each action is individually selectable.
 
+   When a squash suggestion is live in the PR body, the
+   merge-confirm screen also renders `[t] copy` / `[b] copy`
+   hotkey hints next to the suggested title and body.  Pressing
+   `t` or `b` writes the corresponding value to the system
+   clipboard (via `pbcopy` / `wl-copy` / `xclip` on local
+   sessions, or OSC 52 on SSH) so the user can paste it straight
+   into GitHub's "Squash and merge" dialog.  If the environment
+   can reach neither a native clipboard tool nor an OSC 52–capable
+   stdout, the hints are not rendered — the user falls back to
+   drag-select without being told about a feature that cannot
+   work here.
+
 **Agent rebase prompt:**
 
 ```text

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -232,6 +232,9 @@ export const en: Messages = {
   // ---- input area --------------------------------------------------------
 
   "input.pipelineRunning": "Pipeline running...",
+  "input.copy": "copy",
+  "input.copied": "copied",
+  "input.copyFailed": "copy failed",
 
   // ---- agent pane / labels ------------------------------------------------
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -270,6 +270,9 @@ export const ko: Messages = {
 
   "input.pipelineRunning":
     "\uD30C\uC774\uD504\uB77C\uC778 \uC2E4\uD589 \uC911...",
+  "input.copy": "복사",
+  "input.copied": "복사됨",
+  "input.copyFailed": "복사 실패",
 
   // ---- agent pane / labels ------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -230,6 +230,9 @@ export interface Messages {
   // ---- input area (InputArea.tsx) ----------------------------------------
 
   "input.pipelineRunning": string;
+  "input.copy": string;
+  "input.copied": string;
+  "input.copyFailed": string;
 
   // ---- agent pane / labels ------------------------------------------------
 

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1108,6 +1108,10 @@ function makeDoneOpts(
     stopServices: vi.fn(),
     hasRunningServices: vi.fn().mockReturnValue(false),
     onNotMerged: vi.fn().mockResolvedValue(undefined),
+    // Default: clipboard unavailable so the confirmMerge message keeps
+    // the bare "Suggested title:\n<title>" shape tests historically
+    // assert on.  Individual tests override to exercise hotkey paths.
+    detectClipboardSupport: () => [],
     ...rest,
   };
 }
@@ -1152,6 +1156,127 @@ describe("createDoneStageHandler", () => {
     expect(message).toContain("\n\nSuggested title:");
     expect(message).toContain("\n\nSuggested body:");
     expect(message).toMatch(/Closes #5\n\nPR: https:\/\//);
+  });
+
+  test("MERGEABLE: clipboard available embeds sentinels and forwards hotkeys", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const writeToClipboard = vi.fn().mockResolvedValue("ok");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => ({
+        title: "Fix widget rendering",
+        body: "Body line\n\nCloses #5",
+        prUrl: "https://github.com/org/repo/pull/123",
+      }),
+      detectClipboardSupport: () => ["pbcopy"],
+      writeToClipboard,
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    expect(confirmMerge).toHaveBeenCalledOnce();
+    const [message, hotkeys] = confirmMerge.mock.calls[0] as [
+      string,
+      { id: string; key: string; onPress: () => Promise<"ok" | "error"> }[],
+    ];
+    // Sentinel ids carry a per-render random suffix so agent-authored
+    // title/body text cannot spoof them.  Assert the prefix shape only.
+    const titleSentinel = message.match(/\{\{hk:title-[0-9a-f]+\}\}/);
+    const bodySentinel = message.match(/\{\{hk:body-[0-9a-f]+\}\}/);
+    expect(titleSentinel).not.toBeNull();
+    expect(bodySentinel).not.toBeNull();
+    expect(message).toContain(
+      `Suggested title: ${titleSentinel?.[0]}\nFix widget`,
+    );
+    expect(message).toContain(
+      `Suggested body: ${bodySentinel?.[0]}\nBody line`,
+    );
+    expect(hotkeys).toHaveLength(2);
+    expect(hotkeys[0].id).toMatch(/^title-[0-9a-f]+$/);
+    expect(hotkeys[0].key).toBe("t");
+    expect(hotkeys[1].id).toMatch(/^body-[0-9a-f]+$/);
+    expect(hotkeys[1].key).toBe("b");
+    // Sentinel ids in the message must match the ids in the hotkeys
+    // array so InputArea can resolve them.
+    expect(titleSentinel?.[0]).toBe(`{{hk:${hotkeys[0].id}}}`);
+    expect(bodySentinel?.[0]).toBe(`{{hk:${hotkeys[1].id}}}`);
+
+    await hotkeys[0].onPress();
+    expect(writeToClipboard).toHaveBeenCalledWith("Fix widget rendering", [
+      "pbcopy",
+    ]);
+    await hotkeys[1].onPress();
+    expect(writeToClipboard).toHaveBeenCalledWith("Body line\n\nCloses #5", [
+      "pbcopy",
+    ]);
+  });
+
+  test("MERGEABLE: sentinel-looking substrings in body are rendered literally", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      // Body contains both fixed tokens from earlier iterations of the
+      // design and a literal use of the current sentinel prefix.  Neither
+      // should collide with the real per-render sentinel ids.
+      getSquashMergeHint: () => ({
+        title: "Docs: document {{hk:title}} placeholder",
+        body: "Explain {{hk:body}} and {{hk:title}} in the guide",
+      }),
+      detectClipboardSupport: () => ["pbcopy"],
+      writeToClipboard: vi.fn().mockResolvedValue("ok"),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    const [message, hotkeys] = confirmMerge.mock.calls[0] as [
+      string,
+      { id: string; key: string; onPress: () => Promise<"ok" | "error"> }[],
+    ];
+    // The literal `{{hk:title}}` / `{{hk:body}}` substrings from the
+    // user-authored content must survive untouched (they still appear in
+    // the message text), and the real sentinels are distinct per-render
+    // ids with a random suffix.
+    expect(message).toContain("Docs: document {{hk:title}} placeholder");
+    expect(message).toContain(
+      "Explain {{hk:body}} and {{hk:title}} in the guide",
+    );
+    expect(hotkeys[0].id).toMatch(/^title-[0-9a-f]+$/);
+    expect(hotkeys[0].id).not.toBe("title");
+    expect(hotkeys[1].id).toMatch(/^body-[0-9a-f]+$/);
+    expect(hotkeys[1].id).not.toBe("body");
+  });
+
+  test("MERGEABLE: clipboard unavailable omits sentinels and forwards no hotkeys", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => ({
+        title: "Fix widget",
+        body: "body",
+      }),
+      detectClipboardSupport: () => [],
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    const [message, hotkeys] = confirmMerge.mock.calls[0] as [string, unknown];
+    expect(message).not.toContain("{{hk:");
+    expect(hotkeys).toBeUndefined();
   });
 
   test("MERGEABLE: omits hint when getSquashMergeHint returns undefined", async () => {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -9,10 +9,17 @@
  * modules (issues #6, #7, #8).
  */
 
+import { randomBytes } from "node:crypto";
 import { t } from "./i18n/index.js";
 import type { PipelineEventEmitter } from "./pipeline-events.js";
 import type { PromptSink, StreamSink, UsageSink } from "./stage-util.js";
 import { buildClarificationPrompt } from "./step-parser.js";
+import {
+  type ClipboardCandidate,
+  detectClipboardSupport as defaultDetectClipboardSupport,
+  writeToClipboard as defaultWriteToClipboard,
+} from "./ui/clipboard.js";
+import type { InputHotkey } from "./ui/InputArea.js";
 
 // ---- public types --------------------------------------------------------
 
@@ -210,7 +217,10 @@ export interface UserPrompt {
    * - `"check_conflicts"` — check for conflicts and rebase if needed.
    * - `"exit"` — stop asking and proceed to cleanup options.
    */
-  confirmMerge(message: string): Promise<"merged" | "check_conflicts" | "exit">;
+  confirmMerge(
+    message: string,
+    hotkeys?: InputHotkey[],
+  ): Promise<"merged" | "check_conflicts" | "exit">;
 
   /**
    * Present a conflict notification and let the user choose between
@@ -883,6 +893,7 @@ export interface DoneStageOptions {
   prompt: {
     confirmMerge: (
       message: string,
+      hotkeys?: InputHotkey[],
     ) => Promise<"merged" | "check_conflicts" | "exit">;
     handleConflict: (message: string) => Promise<"agent_rebase" | "manual">;
     handleUnknownMergeable: (message: string) => Promise<"recheck" | "exit">;
@@ -932,6 +943,25 @@ export interface DoneStageOptions {
         prUrl?: string;
       }
     | undefined;
+  /**
+   * Return the ordered clipboard-candidate list for the current
+   * environment.  Called once per merge-confirm render so the
+   * detection picks up env changes (e.g. a newly attached SSH
+   * session) across re-prompts.  Defaults to the production
+   * detector from `ui/clipboard.ts`; tests inject a stable value.
+   * An empty list disables the `[t] copy` / `[b] copy` hints.
+   */
+  detectClipboardSupport?: () => ClipboardCandidate[];
+  /**
+   * Write `value` via the ordered candidate list.  Returns `"ok"`
+   * as soon as one candidate reports success, `"error"` only when
+   * the whole list fails.  Defaults to the production writer from
+   * `ui/clipboard.ts`.
+   */
+  writeToClipboard?: (
+    value: string,
+    candidates: ClipboardCandidate[],
+  ) => Promise<"ok" | "error">;
 }
 
 /**
@@ -1173,20 +1203,53 @@ export function createDoneStageHandler(
     summary: string,
   ): Promise<StageResult> {
     const m = t();
+    const detect =
+      options.detectClipboardSupport ?? defaultDetectClipboardSupport;
+    const write = options.writeToClipboard ?? defaultWriteToClipboard;
     for (;;) {
       const hint = options.getSquashMergeHint?.();
+      const candidates = hint ? detect() : [];
+      const clipboardAvailable = candidates.length > 0;
+      const hotkeys: InputHotkey[] = [];
       const sections: string[] = [summary];
       if (hint) {
+        // Generate per-render unique sentinel ids so that agent-generated
+        // title/body content containing a literal `{{hk:title}}` /
+        // `{{hk:body}}` token cannot shadow the real hotkey hints.  The
+        // random suffix is regenerated if it happens to collide with the
+        // interpolated content, though a 48-bit random is already
+        // astronomically unlikely to appear in free-form text.
+        const titleValue = hint.title ?? "";
+        const bodyValue = hint.body ?? "";
+        const sentinelSuffix = makeSentinelSuffix(titleValue, bodyValue);
+        const titleSentinelId = `title-${sentinelSuffix}`;
+        const bodySentinelId = `body-${sentinelSuffix}`;
         const tipSections: string[] = [m["pipeline.mergeConfirmSquashTip"]];
         if (hint.title) {
-          tipSections.push(
-            `${m["pipeline.suggestedSquashTitle"]}\n${hint.title}`,
-          );
+          const label = clipboardAvailable
+            ? `${m["pipeline.suggestedSquashTitle"]} {{hk:${titleSentinelId}}}`
+            : m["pipeline.suggestedSquashTitle"];
+          tipSections.push(`${label}\n${hint.title}`);
+          if (clipboardAvailable) {
+            hotkeys.push({
+              id: titleSentinelId,
+              key: "t",
+              onPress: () => write(titleValue, candidates),
+            });
+          }
         }
         if (hint.body) {
-          tipSections.push(
-            `${m["pipeline.suggestedSquashBody"]}\n${hint.body}`,
-          );
+          const label = clipboardAvailable
+            ? `${m["pipeline.suggestedSquashBody"]} {{hk:${bodySentinelId}}}`
+            : m["pipeline.suggestedSquashBody"];
+          tipSections.push(`${label}\n${hint.body}`);
+          if (clipboardAvailable) {
+            hotkeys.push({
+              id: bodySentinelId,
+              key: "b",
+              onPress: () => write(bodyValue, candidates),
+            });
+          }
         }
         if (hint.prUrl) {
           tipSections.push(m["pipeline.prUrl"](hint.prUrl));
@@ -1194,7 +1257,10 @@ export function createDoneStageHandler(
         sections.push(tipSections.join("\n\n"));
       }
       sections.push(m["pipeline.mergeConfirm"]);
-      const choice = await options.prompt.confirmMerge(sections.join("\n\n"));
+      const choice = await options.prompt.confirmMerge(
+        sections.join("\n\n"),
+        hotkeys.length > 0 ? hotkeys : undefined,
+      );
       if (ctx.signal?.aborted) {
         return { outcome: "completed", message: "" };
       }
@@ -1279,4 +1345,30 @@ export function createDoneStageHandler(
       }
     }
   }
+}
+
+/**
+ * Produce a random hex suffix for per-render sentinel ids that is
+ * guaranteed not to appear as a fully-formed `{{hk:title-<s>}}` /
+ * `{{hk:body-<s>}}` sentinel inside the title/body content.  48 bits of
+ * entropy make a natural collision essentially impossible, but the
+ * re-roll loop keeps the invariant strict for adversarial input.
+ */
+function makeSentinelSuffix(title: string, body: string): string {
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const suffix = randomBytes(6).toString("hex");
+    const titleToken = `{{hk:title-${suffix}}}`;
+    const bodyToken = `{{hk:body-${suffix}}}`;
+    if (
+      !title.includes(titleToken) &&
+      !body.includes(titleToken) &&
+      !title.includes(bodyToken) &&
+      !body.includes(bodyToken)
+    ) {
+      return suffix;
+    }
+  }
+  // Unreachable in practice: 48 bits * 8 attempts vs attacker-controlled
+  // text means the loop would have to guess 384 random bits.
+  throw new Error("failed to generate unique sentinel suffix");
 }

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -1,9 +1,24 @@
 import { Box, Text, useInput } from "ink";
 import TextInput from "ink-text-input";
-import { useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { t } from "../i18n/index.js";
 
 // ---- types -------------------------------------------------------------------
+
+/**
+ * Optional hotkey embedded in an `InputRequest`.  Pressing `key`
+ * triggers `onPress` without closing the prompt, and the result
+ * updates the inline hint rendered at the `{{hk:<id>}}` sentinel
+ * inside `message`.
+ */
+export interface InputHotkey {
+  /** Stable id used inside `{{hk:<id>}}` sentinels in the message. */
+  id: string;
+  /** Single keyboard character that triggers `onPress`. */
+  key: string;
+  /** Handler invoked on key press.  Must not throw. */
+  onPress: () => Promise<"ok" | "error">;
+}
 
 export interface InputRequest {
   /** Message shown above the input. */
@@ -13,6 +28,13 @@ export interface InputRequest {
    * field.  The user presses the number key to select.
    */
   choices?: { label: string; value: string }[];
+  /**
+   * When set, each `key` triggers its `onPress` without closing the
+   * prompt.  The matching `{{hk:<id>}}` sentinel in `message` is
+   * replaced by `[<key>] copy` / `[<key>] copied` / `[<key>] copy
+   * failed` based on the latest result.
+   */
+  hotkeys?: InputHotkey[];
 }
 
 export interface InputAreaProps {
@@ -20,20 +42,106 @@ export interface InputAreaProps {
   onSubmit: (value: string) => void;
 }
 
+type HotkeyStatus = "idle" | "copied" | "failed";
+
+const COPIED_AUTO_CLEAR_MS = 1000;
+const SENTINEL_REGEX = /\{\{hk:([a-zA-Z0-9_-]+)\}\}/g;
+
 // ---- component ---------------------------------------------------------------
 
 export function InputArea({ request, onSubmit }: InputAreaProps) {
   const [text, setText] = useState("");
+  const [hotkeyStatus, setHotkeyStatus] = useState<
+    Record<string, HotkeyStatus>
+  >({});
+  const clearTimersRef = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  // Per-hotkey sequence counter.  Each press increments the token; a
+  // completion only applies if its captured token still matches the
+  // latest dispatched press.  Prevents an older in-flight `onPress`
+  // from overwriting the result of a newer one when the user presses
+  // the same hotkey twice while the first attempt is still pending.
+  const hotkeySeqRef = useRef<Map<string, number>>(new Map());
+  // Drop hotkeys whose `key` would also select one of the active
+  // numeric choices.  Letting them through would shadow the choice
+  // dispatch (which runs after the hotkey match) and silently change
+  // prompt semantics.
+  const hotkeys = filterChoiceCollisions(
+    request?.hotkeys,
+    request?.choices?.length ?? 0,
+  );
+
+  // Reset per-hotkey status whenever the request changes so a stale
+  // "copied" label from a previous prompt never leaks into a new one.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset keyed by request identity
+  useEffect(() => {
+    setHotkeyStatus({});
+    for (const timer of clearTimersRef.current.values()) {
+      clearTimeout(timer);
+    }
+    clearTimersRef.current.clear();
+    hotkeySeqRef.current.clear();
+  }, [request]);
+
+  useEffect(() => {
+    return () => {
+      for (const timer of clearTimersRef.current.values()) {
+        clearTimeout(timer);
+      }
+      clearTimersRef.current.clear();
+      hotkeySeqRef.current.clear();
+    };
+  }, []);
+
+  const runHotkey = useCallback((hk: InputHotkey) => {
+    const seq = (hotkeySeqRef.current.get(hk.id) ?? 0) + 1;
+    hotkeySeqRef.current.set(hk.id, seq);
+    void hk.onPress().then((result) => {
+      // Drop stale completions: a newer press has already been
+      // dispatched, so this result must not overwrite its status or
+      // touch its auto-clear timer.
+      if (hotkeySeqRef.current.get(hk.id) !== seq) return;
+      const existing = clearTimersRef.current.get(hk.id);
+      if (existing) {
+        clearTimeout(existing);
+        clearTimersRef.current.delete(hk.id);
+      }
+      setHotkeyStatus((prev) => ({
+        ...prev,
+        [hk.id]: result === "ok" ? "copied" : "failed",
+      }));
+      if (result === "ok") {
+        const timer = setTimeout(() => {
+          setHotkeyStatus((prev) => {
+            if (prev[hk.id] !== "copied") return prev;
+            const next = { ...prev };
+            delete next[hk.id];
+            return next;
+          });
+          clearTimersRef.current.delete(hk.id);
+        }, COPIED_AUTO_CLEAR_MS);
+        clearTimersRef.current.set(hk.id, timer);
+      }
+    });
+  }, []);
 
   useInput(
     (input) => {
+      if (hotkeys && hotkeys.length > 0) {
+        const match = hotkeys.find((h) => h.key === input);
+        if (match) {
+          runHotkey(match);
+          return;
+        }
+      }
       if (!request?.choices) return;
       const idx = Number.parseInt(input, 10) - 1;
       if (idx >= 0 && idx < request.choices.length) {
         onSubmit(request.choices[idx].value);
       }
     },
-    { isActive: !!request?.choices },
+    {
+      isActive: !!request?.choices || (!!hotkeys && hotkeys.length > 0),
+    },
   );
 
   if (!request) {
@@ -44,13 +152,12 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
     );
   }
 
+  const hotkeyById = new Map((hotkeys ?? []).map((h) => [h.id, h]));
+
   if (request.choices) {
     return (
       <Box flexDirection="column" paddingX={1} flexShrink={0}>
-        {request.message.split("\n").map((line, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: static message lines never reorder
-          <Text key={i}>{line || " "}</Text>
-        ))}
+        {renderMessageLines(request.message, hotkeyById, hotkeyStatus)}
         {request.choices.map((c, i) => (
           <Text key={c.value}>
             {"  "}
@@ -67,10 +174,7 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
 
   return (
     <Box flexDirection="column" paddingX={1} flexShrink={0}>
-      {request.message.split("\n").map((line, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: static message lines never reorder
-        <Text key={i}>{line || " "}</Text>
-      ))}
+      {renderMessageLines(request.message, hotkeyById, hotkeyStatus)}
       <Box>
         <Text bold color="cyan">
           {">"}{" "}
@@ -86,4 +190,97 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
       </Box>
     </Box>
   );
+}
+
+/**
+ * Render `message` line-by-line, substituting `{{hk:<id>}}` tokens
+ * with inline hint labels driven by `status`.  Sentinels referring to
+ * unknown ids fall through as literal text so caller bugs surface.
+ */
+function renderMessageLines(
+  message: string,
+  hotkeyById: Map<string, InputHotkey>,
+  status: Record<string, HotkeyStatus>,
+) {
+  const labels = t();
+  return message.split("\n").map((line, lineIdx) => {
+    const parts = splitSentinels(line);
+    if (parts.length === 1 && parts[0].kind === "text") {
+      return (
+        // biome-ignore lint/suspicious/noArrayIndexKey: message lines never reorder
+        <Text key={lineIdx}>{line || " "}</Text>
+      );
+    }
+    return (
+      // biome-ignore lint/suspicious/noArrayIndexKey: message lines never reorder
+      <Text key={lineIdx}>
+        {parts.map((part, partIdx) => {
+          const partKey = `${lineIdx}:${partIdx}`;
+          if (part.kind === "text") {
+            return <Text key={partKey}>{part.value}</Text>;
+          }
+          const hk = hotkeyById.get(part.id);
+          if (!hk) {
+            return <Text key={partKey}>{part.raw}</Text>;
+          }
+          const currentStatus: HotkeyStatus = status[hk.id] ?? "idle";
+          if (currentStatus === "failed") {
+            return (
+              <Text key={partKey} color="yellow">
+                [{hk.key}] {labels["input.copyFailed"]}
+              </Text>
+            );
+          }
+          const verb =
+            currentStatus === "copied"
+              ? labels["input.copied"]
+              : labels["input.copy"];
+          return (
+            <Text key={partKey} dimColor>
+              <Text color="cyan">[{hk.key}]</Text> {verb}
+            </Text>
+          );
+        })}
+      </Text>
+    );
+  });
+}
+
+function filterChoiceCollisions(
+  hotkeys: InputHotkey[] | undefined,
+  choiceCount: number,
+): InputHotkey[] | undefined {
+  if (!hotkeys || hotkeys.length === 0) return hotkeys;
+  if (choiceCount <= 0) return hotkeys;
+  return hotkeys.filter((h) => {
+    if (!/^[0-9]+$/.test(h.key)) return true;
+    const idx = Number.parseInt(h.key, 10);
+    return !(idx >= 1 && idx <= choiceCount);
+  });
+}
+
+type Fragment =
+  | { kind: "text"; value: string }
+  | { kind: "sentinel"; id: string; raw: string };
+
+function splitSentinels(line: string): Fragment[] {
+  const parts: Fragment[] = [];
+  SENTINEL_REGEX.lastIndex = 0;
+  let lastIndex = 0;
+  for (;;) {
+    const match = SENTINEL_REGEX.exec(line);
+    if (!match) break;
+    if (match.index > lastIndex) {
+      parts.push({ kind: "text", value: line.slice(lastIndex, match.index) });
+    }
+    parts.push({ kind: "sentinel", id: match[1], raw: match[0] });
+    lastIndex = match.index + match[0].length;
+  }
+  if (lastIndex < line.length) {
+    parts.push({ kind: "text", value: line.slice(lastIndex) });
+  }
+  if (parts.length === 0) {
+    parts.push({ kind: "text", value: "" });
+  }
+  return parts;
 }

--- a/src/ui/TuiUserPrompt.ts
+++ b/src/ui/TuiUserPrompt.ts
@@ -1,6 +1,6 @@
 import { t } from "../i18n/index.js";
 import type { UserAction, UserPrompt } from "../pipeline.js";
-import type { InputRequest } from "./InputArea.js";
+import type { InputHotkey, InputRequest } from "./InputArea.js";
 
 /**
  * Callback that the TUI uses to show a prompt and later resolve it.
@@ -114,6 +114,7 @@ export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
 
     async confirmMerge(
       message: string,
+      hotkeys?: InputHotkey[],
     ): Promise<"merged" | "check_conflicts" | "exit"> {
       const m = t();
       const response = await dispatch({
@@ -126,6 +127,7 @@ export function createTuiUserPrompt(dispatch: PromptDispatch): UserPrompt {
           },
           { label: m["prompt.noExit"], value: "exit" },
         ],
+        hotkeys,
       });
       return response as "merged" | "check_conflicts" | "exit";
     },

--- a/src/ui/clipboard.test.ts
+++ b/src/ui/clipboard.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  type ClipboardCandidate,
+  type ClipboardEnvironment,
+  detectClipboardSupport,
+  encodeOsc52,
+  writeToClipboard,
+} from "./clipboard.js";
+
+function makeEnv(
+  overrides: Partial<ClipboardEnvironment> = {},
+): ClipboardEnvironment {
+  return {
+    platform: "linux",
+    env: {},
+    stdoutIsTTY: true,
+    hasCommand: () => false,
+    ...overrides,
+  };
+}
+
+describe("encodeOsc52", () => {
+  test("emits ESC]52;c;<base64> BEL", () => {
+    const encoded = encodeOsc52("hello");
+    expect(encoded).toBe(
+      `\x1b]52;c;${Buffer.from("hello", "utf8").toString("base64")}\x07`,
+    );
+  });
+
+  test("base64-encodes multibyte UTF-8 faithfully", () => {
+    const value = "타이틀 🟢";
+    const encoded = encodeOsc52(value);
+    const payload = encoded.slice("\x1b]52;c;".length, -"\x07".length);
+    expect(Buffer.from(payload, "base64").toString("utf8")).toBe(value);
+  });
+});
+
+describe("detectClipboardSupport", () => {
+  test("macOS: prefers pbcopy over osc52", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "darwin",
+        hasCommand: (cmd) => cmd === "pbcopy",
+      }),
+    );
+    expect(candidates).toEqual(["pbcopy", "osc52"]);
+  });
+
+  test("macOS: pbcopy is unconditional even when PATH does not list it", () => {
+    // `pbcopy` ships with macOS; a stripped PATH must not hide it.
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "darwin",
+        hasCommand: () => false,
+      }),
+    );
+    expect(candidates).toEqual(["pbcopy", "osc52"]);
+  });
+
+  test("macOS without stdout TTY: pbcopy still enqueued", () => {
+    // Even with stdout redirected to a file (no OSC 52 path), the
+    // deterministic native candidate must remain available.
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "darwin",
+        stdoutIsTTY: false,
+        hasCommand: () => false,
+      }),
+    );
+    expect(candidates).toEqual(["pbcopy"]);
+  });
+
+  test("linux + Wayland: wl-copy wins", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "linux",
+        env: { WAYLAND_DISPLAY: "wayland-0" },
+        hasCommand: (cmd) => cmd === "wl-copy",
+      }),
+    );
+    expect(candidates).toEqual(["wl-copy", "osc52"]);
+  });
+
+  test("linux + X11: xclip wins", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "linux",
+        env: { DISPLAY: ":0" },
+        hasCommand: (cmd) => cmd === "xclip",
+      }),
+    );
+    expect(candidates).toEqual(["xclip", "osc52"]);
+  });
+
+  test("SSH session: osc52 first, native tool (if present) last", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "darwin",
+        env: { SSH_CONNECTION: "1.2.3.4 22 5.6.7.8 55000" },
+        hasCommand: (cmd) => cmd === "pbcopy",
+      }),
+    );
+    expect(candidates).toEqual(["osc52", "pbcopy"]);
+  });
+
+  test("SSH without native tool: osc52 only", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "linux",
+        env: { SSH_TTY: "/dev/pts/0" },
+      }),
+    );
+    expect(candidates).toEqual(["osc52"]);
+  });
+
+  test("no TTY and no native tool: empty list", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "linux",
+        stdoutIsTTY: false,
+      }),
+    );
+    expect(candidates).toEqual([]);
+  });
+
+  test("linux without DISPLAY/WAYLAND: falls through to osc52", () => {
+    const candidates = detectClipboardSupport(
+      makeEnv({
+        platform: "linux",
+        hasCommand: (cmd) => cmd === "xclip" || cmd === "wl-copy",
+      }),
+    );
+    expect(candidates).toEqual(["osc52"]);
+  });
+});
+
+describe("writeToClipboard", () => {
+  test("first candidate succeeds → reports ok, later candidates skipped", async () => {
+    const spawnSync = vi
+      .fn()
+      .mockReturnValue({ status: 0, stdout: "", stderr: "" });
+    const stdoutWrite = vi.fn().mockReturnValue(true);
+    const result = await writeToClipboard("hello", ["pbcopy", "osc52"], {
+      spawnSync,
+      stdoutWrite,
+    });
+    expect(result).toBe("ok");
+    expect(spawnSync).toHaveBeenCalledOnce();
+    expect(stdoutWrite).not.toHaveBeenCalled();
+  });
+
+  test("first candidate fails, second succeeds", async () => {
+    const spawnSync = vi
+      .fn()
+      .mockReturnValueOnce({ status: 1, stdout: "", stderr: "bad" })
+      .mockReturnValueOnce({ status: 0, stdout: "", stderr: "" });
+    const result = await writeToClipboard("hello", ["wl-copy", "xclip"], {
+      spawnSync,
+      stdoutWrite: vi.fn(),
+    });
+    expect(result).toBe("ok");
+    expect(spawnSync).toHaveBeenCalledTimes(2);
+  });
+
+  test("osc52 write that throws falls through to next candidate", async () => {
+    const spawnSync = vi.fn().mockReturnValue({ status: 0 });
+    const stdoutWrite = vi.fn().mockImplementation(() => {
+      throw new Error("broken pipe");
+    });
+    const result = await writeToClipboard("hello", ["osc52", "pbcopy"], {
+      spawnSync,
+      stdoutWrite,
+    });
+    expect(result).toBe("ok");
+    expect(stdoutWrite).toHaveBeenCalledOnce();
+    expect(spawnSync).toHaveBeenCalledOnce();
+  });
+
+  test("all candidates fail → error", async () => {
+    const spawnSync = vi
+      .fn()
+      .mockReturnValue({ status: 1, stdout: "", stderr: "bad" });
+    const stdoutWrite = vi.fn().mockImplementation(() => {
+      throw new Error("nope");
+    });
+    const result = await writeToClipboard("hello", ["pbcopy", "osc52"], {
+      spawnSync,
+      stdoutWrite,
+    });
+    expect(result).toBe("error");
+  });
+
+  test("native spawn error skips candidate", async () => {
+    const spawnSync = vi.fn().mockReturnValue({
+      error: new Error("ENOENT"),
+      status: null,
+      stdout: "",
+      stderr: "",
+    });
+    const stdoutWrite = vi.fn().mockReturnValue(true);
+    const result = await writeToClipboard(
+      "hello",
+      ["pbcopy", "osc52"] as ClipboardCandidate[],
+      { spawnSync, stdoutWrite },
+    );
+    expect(result).toBe("ok");
+    expect(stdoutWrite).toHaveBeenCalledOnce();
+  });
+
+  test("empty candidate list → error", async () => {
+    const result = await writeToClipboard("hello", [], {
+      spawnSync: vi.fn(),
+      stdoutWrite: vi.fn(),
+    });
+    expect(result).toBe("error");
+  });
+
+  test("osc52 writes correct base64 payload to stdout", async () => {
+    const stdoutWrite = vi.fn().mockReturnValue(true);
+    await writeToClipboard("hello world", ["osc52"], {
+      spawnSync: vi.fn(),
+      stdoutWrite,
+    });
+    expect(stdoutWrite).toHaveBeenCalledWith(encodeOsc52("hello world"));
+  });
+
+  test("native write receives value via stdin", async () => {
+    const spawnSync = vi.fn().mockReturnValue({ status: 0 });
+    await writeToClipboard("suggested commit title", ["pbcopy"], {
+      spawnSync,
+      stdoutWrite: vi.fn(),
+    });
+    expect(spawnSync).toHaveBeenCalledWith(
+      "/usr/bin/pbcopy",
+      [],
+      expect.objectContaining({ input: "suggested commit title" }),
+    );
+  });
+
+  test("pbcopy invocation uses absolute /usr/bin path (bypasses PATH)", async () => {
+    // `detectClipboardSupport` enqueues `pbcopy` unconditionally on
+    // darwin; the writer must invoke the absolute path so a stripped
+    // PATH (e.g. PATH missing `/usr/bin`) still reaches the binary.
+    const spawnSync = vi.fn().mockReturnValue({ status: 0 });
+    const result = await writeToClipboard("v", ["pbcopy"], {
+      spawnSync,
+      stdoutWrite: vi.fn(),
+    });
+    expect(result).toBe("ok");
+    expect(spawnSync).toHaveBeenCalledWith(
+      "/usr/bin/pbcopy",
+      [],
+      expect.any(Object),
+    );
+    expect(spawnSync).not.toHaveBeenCalledWith(
+      "pbcopy",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  test("xclip invocation uses -selection clipboard", async () => {
+    const spawnSync = vi.fn().mockReturnValue({ status: 0 });
+    await writeToClipboard("v", ["xclip"], {
+      spawnSync,
+      stdoutWrite: vi.fn(),
+    });
+    expect(spawnSync).toHaveBeenCalledWith(
+      "xclip",
+      ["-selection", "clipboard"],
+      expect.any(Object),
+    );
+  });
+});

--- a/src/ui/clipboard.ts
+++ b/src/ui/clipboard.ts
@@ -1,0 +1,195 @@
+/**
+ * System-clipboard writer used by the merge-confirm screen hotkeys.
+ *
+ * Detects which mechanisms are usable in the current environment and
+ * returns an ordered candidate list.  The writer iterates the list in
+ * order and reports `"ok"` as soon as one candidate succeeds.
+ *
+ * See issue #265 for the full ordering policy.
+ */
+
+import { spawnSync } from "node:child_process";
+import { accessSync, constants as fsConstants } from "node:fs";
+import path from "node:path";
+
+/**
+ * A clipboard-write mechanism.  `osc52` rides the controlling
+ * terminal's escape stream; the others shell out to a native tool on
+ * the local machine.
+ */
+export type ClipboardCandidate = "pbcopy" | "wl-copy" | "xclip" | "osc52";
+
+/**
+ * Environment facts consulted by {@link detectClipboardSupport}.
+ * Factored out so tests can inject a fixed view without monkey-patching
+ * `process` or the filesystem.
+ */
+export interface ClipboardEnvironment {
+  platform: NodeJS.Platform;
+  env: Record<string, string | undefined>;
+  stdoutIsTTY: boolean;
+  /** Returns `true` when the given command is reachable on PATH. */
+  hasCommand: (cmd: string) => boolean;
+}
+
+function defaultHasCommand(cmd: string): boolean {
+  const pathEnv = process.env.PATH;
+  if (!pathEnv) return false;
+  const pathExt =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".EXE;.CMD;.BAT").split(";")
+      : [""];
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of pathExt) {
+      try {
+        accessSync(path.join(dir, cmd + ext), fsConstants.X_OK);
+        return true;
+      } catch {
+        // try next
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Snapshot the current process environment for clipboard detection.
+ * Returns a fresh object each call — cheap, and keeps
+ * {@link detectClipboardSupport} free of implicit globals.
+ */
+export function currentClipboardEnvironment(): ClipboardEnvironment {
+  return {
+    platform: process.platform,
+    env: { ...process.env },
+    stdoutIsTTY: !!process.stdout.isTTY,
+    hasCommand: defaultHasCommand,
+  };
+}
+
+/**
+ * Classify the environment and return the ordered list of clipboard
+ * candidates to try.  An empty list means clipboard writes are not
+ * supported here.
+ *
+ * Ordering:
+ * - SSH session — OSC 52 first (the user's local terminal), then any
+ *   available native tool as a last resort.
+ * - Local session — platform-native tool first, OSC 52 as fallback.
+ */
+export function detectClipboardSupport(
+  environment: ClipboardEnvironment = currentClipboardEnvironment(),
+): ClipboardCandidate[] {
+  const { platform, env, stdoutIsTTY, hasCommand } = environment;
+  const isSsh = !!(env.SSH_TTY || env.SSH_CONNECTION);
+  const osc52: ClipboardCandidate[] = stdoutIsTTY ? ["osc52"] : [];
+  const native: ClipboardCandidate[] = [];
+
+  if (platform === "darwin") {
+    // `pbcopy` ships with macOS at `/usr/bin/pbcopy` and is always
+    // available on a stock system.  PATH inspection is imperfect (a
+    // stripped PATH can miss `/usr/bin`), so treat darwin as an
+    // unconditional native candidate to avoid silently downgrading to
+    // best-effort OSC 52 — or to `[]` when stdout is redirected —
+    // when the deterministic path would still work.
+    native.push("pbcopy");
+  } else if (platform === "linux") {
+    if (env.WAYLAND_DISPLAY && hasCommand("wl-copy")) {
+      native.push("wl-copy");
+    } else if (env.DISPLAY && hasCommand("xclip")) {
+      native.push("xclip");
+    }
+  }
+
+  if (isSsh) {
+    return [...osc52, ...native];
+  }
+  return [...native, ...osc52];
+}
+
+/**
+ * Encode `value` as an OSC 52 clipboard-set escape sequence.
+ *
+ * Format: `ESC ] 52 ; c ; <base64 of UTF-8 value> BEL`.
+ * Exported for unit tests.
+ */
+export function encodeOsc52(value: string): string {
+  const payload = Buffer.from(value, "utf8").toString("base64");
+  return `\x1b]52;c;${payload}\x07`;
+}
+
+type SpawnSync = typeof spawnSync;
+type WriteToStdout = (chunk: string) => boolean;
+
+/**
+ * Injection points for {@link writeToClipboard}.  Production callers
+ * omit this argument; tests pass mocks.
+ */
+export interface ClipboardWriterDeps {
+  spawnSync?: SpawnSync;
+  stdoutWrite?: WriteToStdout;
+}
+
+/**
+ * Try each candidate in order.  Returns `"ok"` as soon as one
+ * succeeds, `"error"` only when every candidate fails.  Never throws.
+ *
+ * - Native tool: success = `spawnSync` returns exit status 0 within
+ *   the timeout.  Any non-zero exit, timeout, or spawn error falls
+ *   through to the next candidate.
+ * - OSC 52: success = `process.stdout.write` returned without
+ *   throwing.  A silent-ignore terminal is indistinguishable from
+ *   success at the protocol level.
+ */
+export async function writeToClipboard(
+  value: string,
+  candidates: ClipboardCandidate[],
+  deps: ClipboardWriterDeps = {},
+): Promise<"ok" | "error"> {
+  const spawn = deps.spawnSync ?? spawnSync;
+  const write =
+    deps.stdoutWrite ?? ((chunk: string) => process.stdout.write(chunk));
+
+  for (const candidate of candidates) {
+    if (candidate === "osc52") {
+      try {
+        write(encodeOsc52(value));
+        return "ok";
+      } catch {
+        continue;
+      }
+    }
+    const argv = nativeArgv(candidate);
+    if (!argv) continue;
+    try {
+      const result = spawn(argv[0], argv.slice(1), {
+        input: value,
+        timeout: 1000,
+        encoding: "utf8",
+      });
+      if (result.error) continue;
+      if (result.signal) continue;
+      if (result.status === 0) return "ok";
+    } catch {}
+  }
+  return "error";
+}
+
+function nativeArgv(candidate: ClipboardCandidate): string[] | null {
+  switch (candidate) {
+    case "pbcopy":
+      // Bypass PATH: `pbcopy` is a stock macOS binary at a fixed
+      // location, and `detectClipboardSupport` enqueues it
+      // unconditionally on darwin.  Using the absolute path keeps the
+      // stripped-PATH case (e.g. PATH missing `/usr/bin`) reachable —
+      // bare `spawnSync("pbcopy", …)` would ENOENT there even though
+      // the binary is present.
+      return ["/usr/bin/pbcopy"];
+    case "wl-copy":
+      return ["wl-copy"];
+    case "xclip":
+      return ["xclip", "-selection", "clipboard"];
+    default:
+      return null;
+  }
+}

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -1575,6 +1575,199 @@ describe("InputArea", () => {
   });
 });
 
+// ---- InputArea: hotkey sentinel rendering ----------------------------------
+
+describe("InputArea hotkey sentinels", () => {
+  test("idle hotkey renders '[t] copy' at sentinel position; raw sentinel not visible", () => {
+    const request: InputRequest = {
+      message:
+        "Suggested title: {{hk:title}}\nFix widget\n\nHas the PR been merged?",
+      choices: [{ label: "Yes", value: "yes" }],
+      hotkeys: [{ id: "title", key: "t", onPress: async () => "ok" }],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[t] copy");
+    expect(frame).not.toContain("{{hk:title}}");
+    // Still on the same line as the "Suggested title:" label.
+    const labelLine = frame
+      .split("\n")
+      .find((l) => l.includes("Suggested title:"));
+    expect(labelLine ?? "").toContain("[t] copy");
+  });
+
+  test("pressing 't' calls onPress and swaps label to '[t] copied'; auto-reverts after ~1s", async () => {
+    const resolveRef: { current: ((v: "ok" | "error") => void) | null } = {
+      current: null,
+    };
+    const onPress = vi.fn(
+      () =>
+        new Promise<"ok" | "error">((r) => {
+          resolveRef.current = r;
+        }),
+    );
+    const request: InputRequest = {
+      message: "Suggested title: {{hk:title}}",
+      choices: [{ label: "Yes", value: "yes" }],
+      hotkeys: [{ id: "title", key: "t", onPress }],
+    };
+    const { lastFrame, stdin } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    expect(lastFrame()).toContain("[t] copy");
+
+    stdin.write("t");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onPress).toHaveBeenCalledOnce();
+
+    resolveRef.current?.("ok");
+    await new Promise((r) => setTimeout(r, 40));
+    expect(lastFrame()).toContain("[t] copied");
+
+    await new Promise((r) => setTimeout(r, 1100));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[t] copy");
+    expect(frame).not.toContain("[t] copied");
+  });
+
+  test("onPress 'error' renders '[t] copy failed' and does not auto-revert", async () => {
+    const onPress = vi.fn().mockResolvedValue("error" as const);
+    const request: InputRequest = {
+      message: "Suggested title: {{hk:title}}",
+      choices: [{ label: "Yes", value: "yes" }],
+      hotkeys: [{ id: "title", key: "t", onPress }],
+    };
+    const { lastFrame, stdin } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("t");
+    await new Promise((r) => setTimeout(r, 50));
+    expect(lastFrame()).toContain("[t] copy failed");
+
+    await new Promise((r) => setTimeout(r, 1100));
+    expect(lastFrame()).toContain("[t] copy failed");
+  });
+
+  test("empty hotkeys: no sentinel in message means no '[t] copy' text; pressing 't' is a no-op and does not close the prompt", async () => {
+    const onSubmit = vi.fn();
+    const request: InputRequest = {
+      message: "Suggested title:\nFix widget",
+      choices: [{ label: "Yes", value: "yes" }],
+    };
+    const { lastFrame, stdin } = render(
+      <InputArea request={request} onSubmit={onSubmit} />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("t");
+    await new Promise((r) => setTimeout(r, 40));
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("[t] copy");
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  test("sentinel with unknown id is rendered as literal text", () => {
+    const request: InputRequest = {
+      message: "Hello {{hk:missing}} world",
+      choices: [{ label: "Yes", value: "yes" }],
+      hotkeys: [{ id: "title", key: "t", onPress: async () => "ok" }],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    expect(lastFrame()).toContain("{{hk:missing}}");
+  });
+
+  test("hotkey colliding with an active choice digit is ignored: choice dispatch wins and the sentinel renders as literal text", async () => {
+    const onSubmit = vi.fn();
+    const onPress = vi.fn().mockResolvedValue("ok" as const);
+    const request: InputRequest = {
+      message: "Pick: {{hk:one}}",
+      choices: [
+        { label: "Yes", value: "yes" },
+        { label: "No", value: "no" },
+      ],
+      hotkeys: [{ id: "one", key: "1", onPress }],
+    };
+    const { lastFrame, stdin } = render(
+      <InputArea request={request} onSubmit={onSubmit} />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    // Sentinel for the dropped hotkey falls through to literal text
+    // (same rendering as an unknown id), so the caller bug is visible.
+    expect(lastFrame()).toContain("{{hk:one}}");
+
+    stdin.write("1");
+    await new Promise((r) => setTimeout(r, 40));
+    expect(onPress).not.toHaveBeenCalled();
+    expect(onSubmit).toHaveBeenCalledWith("yes");
+  });
+
+  test("out-of-order completions: older press must not overwrite newer press result", async () => {
+    // Press `t` twice while the first `onPress` is still pending.
+    // The second press resolves first (`ok`) and the label flips to
+    // `[t] copied`; when the first press resolves later with
+    // `error`, its stale completion must be dropped — the UI must
+    // not regress to `[t] copy failed`.
+    const resolvers: ((v: "ok" | "error") => void)[] = [];
+    const onPress = vi.fn(
+      () =>
+        new Promise<"ok" | "error">((r) => {
+          resolvers.push(r);
+        }),
+    );
+    const request: InputRequest = {
+      message: "Suggested title: {{hk:title}}",
+      choices: [{ label: "Yes", value: "yes" }],
+      hotkeys: [{ id: "title", key: "t", onPress }],
+    };
+    const { lastFrame, stdin } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+
+    stdin.write("t");
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("t");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(onPress).toHaveBeenCalledTimes(2);
+
+    // Newer press resolves first with "ok".
+    resolvers[1]("ok");
+    await new Promise((r) => setTimeout(r, 40));
+    expect(lastFrame()).toContain("[t] copied");
+
+    // Older press resolves late with "error" — must be ignored.
+    resolvers[0]("error");
+    await new Promise((r) => setTimeout(r, 40));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[t] copied");
+    expect(frame).not.toContain("[t] copy failed");
+  });
+
+  test("numeric choice keys still work when hotkeys are present", async () => {
+    const onSubmit = vi.fn();
+    const request: InputRequest = {
+      message: "Suggested title: {{hk:title}}",
+      choices: [
+        { label: "Yes", value: "yes" },
+        { label: "No", value: "no" },
+      ],
+      hotkeys: [{ id: "title", key: "t", onPress: async () => "ok" }],
+    };
+    const { stdin } = render(
+      <InputArea request={request} onSubmit={onSubmit} />,
+    );
+    await new Promise((r) => setTimeout(r, 20));
+    stdin.write("1");
+    await new Promise((r) => setTimeout(r, 40));
+    expect(onSubmit).toHaveBeenCalledWith("yes");
+  });
+});
+
 // ---- Deferred resolution (issue #105) ----------------------------------------
 
 describe("deferred handleSubmit resolution", () => {


### PR DESCRIPTION
## Summary

- On the Stage 9 merge-confirm screen, render `[t] copy` / `[b] copy` hotkey hints next to the suggested squash title and body. Pressing `t` or `b` writes the corresponding value to the system clipboard independently, so it lines up with GitHub's separate title / body fields in the "Squash and merge" dialog.
- New `src/ui/clipboard.ts` utility: `detectClipboardSupport()` returns an ordered candidate list (`pbcopy` / `wl-copy` / `xclip` on local sessions, OSC 52 first on SSH, OSC 52 fallback when stdout is a TTY). `writeToClipboard()` tries candidates in order, returns `"ok"` on first success, `"error"` only when every candidate fails. The macOS `pbcopy` candidate is enqueued unconditionally and invoked via `/usr/bin/pbcopy` so a stripped `PATH` never hides the deterministic native path.
- `InputArea` gains an optional `hotkeys` field on `InputRequest` and a `{{hk:<id>}}` sentinel-substitution contract inside `message`. Sentinels render as `[<key>] copy` / `[<key>] copied` / `[<key>] copy failed` based on per-hotkey status; `copied` auto-reverts after ~1s, `copy failed` persists until re-render. Unknown sentinel ids render as literal text so caller bugs surface. A per-hotkey sequence counter protects against out-of-order completions when the user presses the same hotkey twice while the first attempt is still pending. Hotkeys whose `key` collides with an active numeric choice digit are dropped so prompt semantics are never silently shadowed.
- `askMerge` generates per-render unique sentinel ids (`title-<random>` / `body-<random>`) so that agent-authored title/body text containing a literal `{{hk:title}}` or `{{hk:body}}` substring cannot spoof the real hotkey hints; user-authored sentinel-looking text falls through to the unknown-id path and renders as literal text.
- When the candidate list is empty, `askMerge` composes the message without sentinels and does not pass `hotkeys` — the user falls back to drag-select rather than being shown a hint that silently does nothing.
- i18n: `input.copy` / `input.copied` / `input.copyFailed` in en + ko.

Closes #265

## Test plan

- [x] `pnpm biome check` is clean for the changed files.
- [x] `pnpm tsc --noEmit` is clean.
- [x] `pnpm vitest run` — all suites pass, including new coverage in `src/ui/clipboard.test.ts`, `src/ui/components.test.tsx`, and `src/pipeline.test.ts`.
- [x] Unit: `encodeOsc52` emits `ESC]52;c;<base64>BEL` and round-trips multibyte UTF-8.
- [x] Unit: `detectClipboardSupport` branches cover local macOS, local Wayland, local X11, SSH, SSH-plus-native-tool, non-TTY, and linux without DISPLAY/WAYLAND.
- [x] Unit: macOS `pbcopy` stays enqueued on a stripped `PATH` and without stdout TTY; the writer invokes `/usr/bin/pbcopy`, never bare `pbcopy`.
- [x] Unit: `writeToClipboard` covers first-candidate success, first fails + second succeeds, OSC 52 write that throws falls through, native spawn error skips, all-fail, and empty-list.
- [x] UI: sentinel substitution renders `[t] copy` inline; the raw sentinel is not visible in the frame.
- [x] UI: pressing `t` swaps the label to `[t] copied` on `"ok"` and reverts after ~1s; `"error"` swaps to `[t] copy failed` and does not revert.
- [x] UI: out-of-order completions cannot overwrite a newer press's result.
- [x] UI: hotkey colliding with an active numeric choice digit is filtered out; the numeric dispatch still wins.
- [x] UI: empty `hotkeys` means no `[t] copy` text and pressing `t` is a no-op that does not close the prompt.
- [x] UI: sentinel with an unknown id renders as literal text.
- [x] UI: numeric choice keys (`1`, `2`) still work alongside hotkeys.
- [x] Pipeline: `MERGEABLE` with clipboard available embeds per-render unique `{{hk:title-<hex>}}` / `{{hk:body-<hex>}}` sentinels and forwards hotkey handlers that call `writeToClipboard` with the raw title / body.
- [x] Pipeline: sentinel-looking substrings (literal `{{hk:title}}` / `{{hk:body}}`) inside the suggested title or body are rendered literally and do not spoof the real hotkey hints.
- [x] Pipeline: `MERGEABLE` with clipboard unavailable omits sentinels and forwards no `hotkeys` argument.
- [x] Manual: local macOS — `[t]` on a live Stage 9 pastes the suggested title into GitHub's "Squash and merge" title field; `[b]` pastes the body. (Verified end-to-end against the built `dist/ui/clipboard.js`: `detectClipboardSupport` → `["pbcopy"]`, `writeToClipboard` → `"ok"`, `pbpaste` returned the written value.)
- [ ] Manual: SSH into a Linux box — `[t]` / `[b]` write via OSC 52 to the user's local clipboard (verify in the host OS). *(Requires a real remote host; not reachable from CI. OSC 52 byte emission is covered by the `encodeOsc52` unit test and the SSH ordering policy by `detectClipboardSupport` tests.)*
- [ ] Manual: terminal with no OSC 52 and no native tool on PATH — no `[t] copy` hints are rendered. *(Requires a specially-locked terminal session; covered by the `no TTY and no native tool: empty list` detection test plus the `empty hotkeys` UI test that verifies hints are absent.)*

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title**

```text
Add [t]/[b] hotkey copy for squash suggestion
```

**Body**

```text
The Stage 9 merge-confirm screen already prints a suggested squash
title and body, but the user still had to drag-select and trigger
the terminal's own copy shortcut to paste each field into GitHub's
"Squash and merge" dialog. Add per-field hotkeys that copy the two
values independently so the flow matches GitHub's two input fields.

Clipboard writes go through an ordered candidate list rather than a
single mechanism. OSC 52 cannot be detected synchronously — a
terminal may silently drop the sequence — so the writer prefers
native tools on local sessions, OSC 52 first on SSH, and reports
"ok" only when a candidate verifiably succeeds. When no candidate
is reachable the UI renders no hint, so the user is never promised
a copy action that would silently no-op. pbcopy is invoked via the
absolute /usr/bin/pbcopy path so a stripped PATH cannot hide the
deterministic native writer on macOS.

InputArea picks up a {{hk:<id>}} sentinel-substitution contract
inside message so per-hotkey status (idle / copied / failed) can
be reflected inline without reshaping the InputRequest API. The
sentinel ids are randomized per render so agent-authored title or
body text cannot spoof the real hotkey hints, and hotkeys whose
key collides with an active numeric choice digit are dropped so
the prompt's numeric dispatch is never shadowed.

Closes #265
```
<!-- agentcoop:squash-suggestion:end -->
