### PR TITLE
Fix squash hotkey sentinels leaking to TUI (#272)

### DIFF
--- a/src/done-prompt-options.ts
+++ b/src/done-prompt-options.ts
@@ -1,0 +1,57 @@
+import type { DoneStageOptions, UserPrompt } from "./pipeline.js";
+
+/**
+ * Minimal subset of {@link UserPrompt} that the Done stage
+ * prompt-options factory relies on.  Matches the structural shape of
+ * the `tuiPrompt` reference held in `src/index.ts`, which is itself
+ * populated by a subset of TuiUserPrompt's methods at mount time.
+ */
+export type DoneStageTuiPrompt = Pick<
+  UserPrompt,
+  | "confirmMerge"
+  | "handleConflict"
+  | "handleUnknownMergeable"
+  | "waitForManualResolve"
+>;
+
+/**
+ * Build the `prompt` options object for {@link createDoneStageHandler}
+ * from a late-bound `tuiPrompt` getter.  Each field is an inline
+ * wrapper that reads the current `tuiPrompt` via the getter at
+ * invocation time, delegating to it when present and otherwise
+ * returning a safe default for non-TUI environments.
+ *
+ * The getter indirection is required because `src/index.ts` assembles
+ * `createDoneStageHandler` before the ink <App> mounts and supplies
+ * the prompt via `onPromptReady`.  Passing a live value here would
+ * snapshot `undefined` and permanently route every Stage 9 callback
+ * to the non-TUI fallback, even after the prompt is assigned.
+ *
+ * Regression for #272: the `confirmMerge` wrapper previously dropped
+ * the `hotkeys` argument, leaking `{{hk:...}}` sentinels to the TUI.
+ */
+export function createDonePromptOptions(
+  getTuiPrompt: () => DoneStageTuiPrompt | undefined,
+): DoneStageOptions["prompt"] {
+  return {
+    confirmMerge: async (msg, hotkeys) => {
+      const tuiPrompt = getTuiPrompt();
+      if (tuiPrompt) return tuiPrompt.confirmMerge(msg, hotkeys);
+      return "merged";
+    },
+    handleConflict: async (msg) => {
+      const tuiPrompt = getTuiPrompt();
+      if (tuiPrompt) return tuiPrompt.handleConflict(msg);
+      return "manual";
+    },
+    handleUnknownMergeable: async (msg) => {
+      const tuiPrompt = getTuiPrompt();
+      if (tuiPrompt) return tuiPrompt.handleUnknownMergeable(msg);
+      return "exit";
+    },
+    waitForManualResolve: async (msg) => {
+      const tuiPrompt = getTuiPrompt();
+      if (tuiPrompt) return tuiPrompt.waitForManualResolve(msg);
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import {
   assembleSquashStage,
   loadConfig,
 } from "./config.js";
+import { createDonePromptOptions } from "./done-prompt-options.js";
 import { getGitHubUsername, getIssue } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
 import {
@@ -731,23 +732,7 @@ try {
     events: emitter,
     checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
     queryPrState: async () => queryPrState(owner, repo, wt.branch),
-    prompt: {
-      confirmMerge: async (msg) => {
-        if (tuiPrompt) return tuiPrompt.confirmMerge(msg);
-        return "merged";
-      },
-      handleConflict: async (msg) => {
-        if (tuiPrompt) return tuiPrompt.handleConflict(msg);
-        return "manual";
-      },
-      handleUnknownMergeable: async (msg) => {
-        if (tuiPrompt) return tuiPrompt.handleUnknownMergeable(msg);
-        return "exit";
-      },
-      waitForManualResolve: async (msg) => {
-        if (tuiPrompt) return tuiPrompt.waitForManualResolve(msg);
-      },
-    },
+    prompt: createDonePromptOptions(() => tuiPrompt),
     rebaseOntoMain: createRebaseHandler(agentA, defaultBranch),
     pollCiAndFix: async (ctx) => {
       return pollCiAndFix({

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
+import { createDonePromptOptions } from "./done-prompt-options.js";
 import type {
   PipelineOptions,
   StageContext,
@@ -1277,6 +1278,116 @@ describe("createDoneStageHandler", () => {
     const [message, hotkeys] = confirmMerge.mock.calls[0] as [string, unknown];
     expect(message).not.toContain("{{hk:");
     expect(hotkeys).toBeUndefined();
+  });
+
+  // Regression for #272: exercises the real prompt-options factory from
+  // `src/done-prompt-options.ts` (the same function `src/index.ts` uses)
+  // end-to-end through the Stage 9 MERGEABLE path.  If the `confirmMerge`
+  // wrapper ever drops the `hotkeys` argument again — the original defect
+  // that leaked `{{hk:...}}` sentinel tokens to the TUI — the inner
+  // `tuiPrompt.confirmMerge` spy will receive `undefined` for its second
+  // argument and this test fails.
+  //
+  // The factory is called with a late-bound getter that initially returns
+  // `undefined` and only resolves to the spy-backed prompt after the
+  // factory has been installed into the options object.  This mirrors the
+  // real `src/index.ts` lifecycle where `tuiPrompt` is assigned inside
+  // `onPromptReady` after `createDoneStageHandler` is already wired up,
+  // and guards against a regression where the wrapper snapshots the
+  // prompt value at factory-call time instead of reading it per-call.
+  test("MERGEABLE: done-prompt-options factory forwards hotkeys to tuiPrompt.confirmMerge via late-bound getter", async () => {
+    const tuiConfirmMerge = vi.fn().mockResolvedValue("merged" as const);
+    let tuiPromptRef: UserPrompt | undefined;
+    const opts = makeDoneOpts({
+      prompt: createDonePromptOptions(() => tuiPromptRef),
+      getSquashMergeHint: () => ({
+        title: "Fix widget rendering",
+        body: "Body line\n\nCloses #5",
+        prUrl: "https://github.com/org/repo/pull/123",
+      }),
+      detectClipboardSupport: () => ["pbcopy"],
+      writeToClipboard: vi.fn().mockResolvedValue("ok"),
+    });
+    // Assign the prompt only after the factory has been invoked and the
+    // options object assembled — matches `onPromptReady` in `src/index.ts`.
+    tuiPromptRef = makePrompt({ confirmMerge: tuiConfirmMerge });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    expect(tuiConfirmMerge).toHaveBeenCalledOnce();
+    const [message, hotkeys] = tuiConfirmMerge.mock.calls[0];
+    expect(message).toMatch(/\{\{hk:title-[0-9a-f]+\}\}/);
+    expect(message).toMatch(/\{\{hk:body-[0-9a-f]+\}\}/);
+    // Strong-form: the second argument must be the non-empty hotkeys
+    // array the pipeline built.  Rejects regressions that strip the
+    // value to `undefined` or `[]`.
+    expect(Array.isArray(hotkeys)).toBe(true);
+    expect(hotkeys).toHaveLength(2);
+    expect(hotkeys?.[0].key).toBe("t");
+    expect(hotkeys?.[1].key).toBe("b");
+  });
+
+  // Focused factory-level deep-equality check.  Unlike the Stage 9
+  // integration test above — which only asserts the `.key` shape of the
+  // forwarded array — this test pins the exact `InputHotkey[]` payload
+  // via `toEqual`, guarding `id` and `onPress` as well.  The real
+  // `InputArea` substitution contract depends on `id` (used to look up
+  // sentinels) and `onPress` (invoked on key press); a wrapper that
+  // forwarded objects with correct `.key` but stripped or mangled `id`
+  // or `onPress` would still break the TUI, so the regression test
+  // must guard the full payload.
+  test("done-prompt-options: confirmMerge deep-forwards the full InputHotkey[] payload", async () => {
+    const tuiConfirmMerge = vi.fn().mockResolvedValue("merged" as const);
+    const tuiPromptRef: UserPrompt = makePrompt({
+      confirmMerge: tuiConfirmMerge,
+    });
+    const promptOpts = createDonePromptOptions(() => tuiPromptRef);
+    const onPressTitle = vi.fn().mockResolvedValue("ok" as const);
+    const onPressBody = vi.fn().mockResolvedValue("ok" as const);
+    const hotkeys = [
+      { id: "title-abcd1234", key: "t", onPress: onPressTitle },
+      { id: "body-abcd1234", key: "b", onPress: onPressBody },
+    ];
+    const message =
+      "Suggested title: {{hk:title-abcd1234}}\nSuggested body: {{hk:body-abcd1234}}";
+    const result = await promptOpts.confirmMerge?.(message, hotkeys);
+    expect(result).toBe("merged");
+    expect(tuiConfirmMerge).toHaveBeenCalledOnce();
+    const [forwardedMessage, forwardedHotkeys] = tuiConfirmMerge.mock.calls[0];
+    expect(forwardedMessage).toBe(message);
+    // Deep equality rejects regressions that forward stripped values
+    // (e.g. `[]`, `undefined`, or objects missing `id` / `onPress`).
+    // Reference equality would over-constrain future implementations
+    // that immutably clone or wrap the array.
+    expect(forwardedHotkeys).toEqual(hotkeys);
+  });
+
+  // Guards against snapshotting the getter's initial value: the factory
+  // must read `tuiPrompt` per-call, so flipping the ref from a populated
+  // prompt back to `undefined` must route the next `confirmMerge` call
+  // to the non-TUI fallback and not to the stale spy.
+  test("MERGEABLE: done-prompt-options wrappers re-read the getter on each call", async () => {
+    const tuiConfirmMerge = vi.fn().mockResolvedValue("merged" as const);
+    let tuiPromptRef: UserPrompt | undefined = makePrompt({
+      confirmMerge: tuiConfirmMerge,
+    });
+    const promptOpts = createDonePromptOptions(() => tuiPromptRef);
+    // First call: getter resolves to the live prompt — spy is invoked.
+    const first = await promptOpts.confirmMerge?.("hello", []);
+    expect(first).toBe("merged");
+    expect(tuiConfirmMerge).toHaveBeenCalledOnce();
+    // Flip the ref back to undefined (simulates TUI teardown).  The
+    // wrapper must observe the change and take the fallback branch.
+    tuiPromptRef = undefined;
+    const second = await promptOpts.confirmMerge?.("hello again", []);
+    expect(second).toBe("merged");
+    // Spy must NOT have been called again — fallback was taken.
+    expect(tuiConfirmMerge).toHaveBeenCalledOnce();
   });
 
   test("MERGEABLE: omits hint when getSquashMergeHint returns undefined", async () => {


### PR DESCRIPTION
## Summary

The `confirmMerge` wrapper inside `createDoneStageHandler({ prompt: { ... } })` in `src/index.ts` accepted only the `msg` argument and dropped the `hotkeys` argument the pipeline passes. As a result `tuiPrompt.confirmMerge` was invoked with `hotkeys = undefined`, `InputArea`'s `hotkeyById` map was empty, and every `{{hk:title-...}}` / `{{hk:body-...}}` sentinel token fell through to the "unknown id" branch in `renderMessageLines` and was rendered as literal text next to the `Suggested title:` / `Suggested body:` labels on the Stage 9 merge-confirm prompt.

The fix forwards both `msg` and `hotkeys` through the wrapper.

The prompt-options assembly is extracted into `src/done-prompt-options.ts` (`createDonePromptOptions(getTuiPrompt)`) so a regression test can exercise the real production wiring instead of a hand-copied replica. The factory takes a late-bound getter (`() => tuiPrompt | undefined`) and re-reads it on every wrapper invocation, preserving the `src/index.ts` lifecycle where `tuiPrompt` is `undefined` at factory-call time and only populated later via `onPromptReady`. It keeps the four sibling wrappers inline — the extraction is of the wiring site, not of the wrappers themselves.

Regression coverage consists of three tests in `src/pipeline.test.ts`:
1. A Stage 9 MERGEABLE integration test that drives the real factory through `createDoneStageHandler` end-to-end and confirms hotkeys arrive at `tuiPrompt.confirmMerge`.
2. A focused factory-level test that invokes the assembled `prompt.confirmMerge(message, hotkeys)` with a known `InputHotkey[]` and asserts **deep equality** on the spy's second argument, pinning `id` / `key` / `onPress` — not just `.key` shape.
3. A late-binding test that flips the getter's ref from populated to `undefined` between calls and asserts the wrapper re-reads it each time rather than snapshotting.

Addresses the Round 2 review that correctly pointed out the first extraction snapshotted `tuiPrompt` too early and permanently routed Stage 9 callbacks to the non-TUI fallback, and the Round 3 review that correctly pointed out the initial regression test only checked hotkey shape and would pass for wrappers that forward malformed payloads.

Closes #272

## Test plan

- [x] `pnpm vitest run` — 1862 tests pass
- [x] `pnpm tsc --noEmit` — no type errors
- [x] `pnpm check` (biome ci) — clean
- [x] `pnpm build` — clean
- [x] Stage 9 SUGGESTED_SINGLE squash path renders `[t] copy` / `[b] copy` instead of raw `{{hk:...}}` sentinels — covered by the combination of the three forwarding regression tests (`src/pipeline.test.ts`) plus the existing InputArea sentinel-substitution test (`src/ui/components.test.tsx`). Together they cover the full path from pipeline → late-bound wrapper → tuiPrompt → InputArea render. A live Stage 9 TUI run requires a real GitHub PR plus live Claude/Codex CLIs through the full pipeline and was not exercised end-to-end in this verification.
- [x] Pressing `[t]` / `[b]` invokes the clipboard write — covered by the existing InputArea hotkey `onPress` tests (`src/ui/components.test.tsx`). Live key-press confirmation in the TUI was not exercised.

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title**

```text
Forward hotkeys through confirmMerge wrapper
```

**Body**

```text
The confirmMerge wrapper in the createDoneStageHandler options
object dropped the hotkeys argument passed by askMerge, so the
TUI received hotkeys=undefined and InputArea's hotkeyById map
was empty. Every {{hk:<id>}} sentinel fell through to the
"unknown id" literal-text branch in renderMessageLines, leaking
raw sentinel tokens next to the "Suggested title:" / "Suggested
body:" labels on the Stage 9 merge-confirm prompt.

Forward both arguments in the wrapper. Extract the prompt
options assembly into src/done-prompt-options.ts with a
late-bound getter so a regression test can drive the real
production wiring through createDoneStageHandler. The getter
indirection preserves the index.ts lifecycle where tuiPrompt is
assigned after onPromptReady fires.

Regression coverage in src/pipeline.test.ts: a Stage 9 MERGEABLE
end-to-end test, a factory-level test that deep-equals the
forwarded hotkeys payload, and a late-binding test that flips
the getter between calls.

Closes #272
```
<!-- agentcoop:squash-suggestion:end -->
