### PR TITLE
Post squash suggestion as PR comment and ask apply policy at startup (#274)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Stage 8 (Squash) now posts the single-commit suggestion as a PR
+  comment instead of editing the PR body. The agent looks up any
+  prior squash-suggestion comment by its start marker and PATCHes it
+  in place so the timeline stays near the "Squash and merge" dropdown
+  rather than accumulating duplicates.
+- Startup now asks once per run whether a SUGGESTED_SINGLE squash
+  verdict should be applied automatically by the agent or interrupt
+  the pipeline with the per-run chooser. Asked on both the fresh
+  start and resume branches; not persisted to config or RunState.
+  Default is "let the agent handle it".
 - Stage 1 (Bootstrap) is now surfaced retrospectively in the TUI. At first
   render, the status bar shows `Stage 1: Bootstrap → Stage N: <name>` briefly
   (where `N` is 2 on a fresh run or `startFromStage` on resume) before
@@ -27,15 +37,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `Stage:`) once the pull-request number is known, also wrapped with an
   OSC 8 hyperlink pointing at the PR page.
 - Stage 8 (Squash) now offers a single-commit suggestion path: when the agent
-  judges that one commit is appropriate, it writes the suggested title and
-  body into a marker-delimited block in the PR body instead of force-pushing.
-  The user can then either let the agent perform the squash (which reruns CI)
+  judges that one commit is appropriate, it posts the suggested title and
+  body inside a marker-delimited PR comment instead of force-pushing. The
+  user can then either let the agent perform the squash (which reruns CI)
   or apply the suggestion via GitHub's "Squash and merge" at merge time
   (which avoids the extra CI cycle).
 - Stage 9 (Done) merge-confirm screen now prints the suggested squash title,
   body, and PR URL inline when the squash stage finished via the
-  PR-body suggestion path, so the user can copy-paste without opening the
-  browser.
+  squash-suggestion comment path, so the user can copy-paste without opening
+  the browser.
 - Stage 9 (Done) merge-confirm screen now renders `[t] copy` / `[b] copy`
   hotkey hints next to the suggested squash title and body when the terminal
   can write to the system clipboard.  Pressing `t` copies the title and `b`
@@ -53,27 +63,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Stage 8's squash suggestion block in the PR body now emits the title and
-  body inside separate fenced code blocks (info string `text`) instead of
-  bold-labeled plain Markdown (`**Title:** …` / `**Body:** …`).  GitHub
-  renders a one-click copy icon on fenced blocks and does not reinterpret
-  Markdown characters inside, so the user can paste the suggestion verbatim
-  into the "Squash and merge" dialog.  The agent chooses each fence length
+- Stage 8's squash suggestion comment now emits the title and body inside
+  separate fenced code blocks (info string `text`) instead of bold-labeled
+  plain Markdown (`**Title:** …` / `**Body:** …`).  GitHub renders a
+  one-click copy icon on fenced blocks and does not reinterpret Markdown
+  characters inside, so the user can paste the suggestion verbatim into the
+  "Squash and merge" dialog.  The agent chooses each fence length
   dynamically per the CommonMark rule
   (`max(longest backtick run in content, 2) + 1`, minimum 3) so commit
   bodies containing their own triple-backtick samples survive unchanged.
 - Stage 8 verdict keywords are now `SQUASHED_MULTI` / `SUGGESTED_SINGLE` /
   `BLOCKED` (previously `COMPLETED` / `BLOCKED`).  When the verdict is
   ambiguous after a clarification retry, the handler runs a deterministic
-  fallback chain — commit-count decrease, then PR-body marker presence,
-  then BLOCKED.
+  fallback chain — commit-count decrease, then suggestion-comment marker
+  presence, then BLOCKED.
 - `RunState` now persists a `squashSubStep` field tracking progress through
   the squash stage's substates so resume can re-enter at the correct point.
   `RUN_STATE_VERSION` bumped from 2 to 3 (the new field defaults to
   `undefined` for older state files; no destructive migration).
 - Stage 9 merge-confirm screen now includes a conditional one-line tip
-  (`pipeline.mergeConfirmSquashTip`) when a squash suggestion is live in
-  the PR body.
+  (`pipeline.mergeConfirmSquashTip`) when a squash suggestion comment is
+  live on the PR.
 
 ### Fixed
 
@@ -104,9 +114,9 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   derived verdict.  Previously the event was only emitted when the
   agent response parsed into a concrete keyword, so the fallback
   branch silently skipped telemetry.
-- Stage 8 now validates the squash suggestion block strictly before
-  accepting `SUGGESTED_SINGLE` / `applied_in_pr_body`.  A bare start
-  marker or a block missing the `**Title**` label / the end marker
+- Stage 8 now validates the squash suggestion comment strictly before
+  accepting `SUGGESTED_SINGLE` / `applied_via_github`.  A bare start
+  marker or a comment missing the `**Title**` label / the end marker
   is treated as malformed and fails closed (or re-runs planning on
   resume) instead of completing with `squash.messageAppended` and
   leaving Stage 9 unable to render the inline preview.
@@ -117,7 +127,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   earlier.  Without this, a resume where the user picks "agent
   squashes now" could re-send the follow-up on the older planning
   session rather than the exact conversation that drafted the
-  PR-body suggestion.
+  squash-suggestion comment.
 
 ## [0.1.0] - 2026-04-18
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -142,15 +142,16 @@ The standard PR sync instructions appear in stages 5 through 8:
 
 The squash stage extends this contract with a marker-delimited
 **squash suggestion block**.  When a single commit is the right
-shape for the branch, the agent writes the proposed title and body
-into the PR description between the markers
-`<!-- agentcoop:squash-suggestion:start -->` and
+shape for the branch, the agent posts the proposed title and body
+as a PR comment whose body contains the marker block
+`<!-- agentcoop:squash-suggestion:start -->` …
 `<!-- agentcoop:squash-suggestion:end -->` instead of force-pushing.
-The block is idempotent — re-runs replace any prior block between
-the same markers rather than stacking duplicates.  The Stage 9
-merge-confirm screen reads this block back so the user can apply
-the message via GitHub's "Squash and merge" without opening the
-browser.
+The comment is updated idempotently — re-runs PATCH any prior
+squash-suggestion comment rather than appending a new one so the
+timeline stays close to the "Squash and merge" dropdown.  The
+Stage 9 merge-confirm screen reads this block back so the user can
+apply the message via GitHub's "Squash and merge" without opening
+the browser.
 
 ### Issue-implementation reconciliation
 
@@ -1258,8 +1259,8 @@ avoiding re-execution of already-completed work within a round.
 
 **Agent:** A\
 **Purpose:** Decide whether the branch is best presented as a
-single squash commit (in which case the agent writes the suggested
-message into the PR body and lets GitHub's "Squash and merge"
+single squash commit (in which case the agent posts the suggested
+message as a PR comment and lets GitHub's "Squash and merge"
 apply it at merge time) or several meaningful commits (rewrite
 history and force-push).  Skipped automatically if the branch has
 only one commit.
@@ -1276,11 +1277,15 @@ The work prompt asks the agent to:
 2. Decide whether the work belongs in **one** commit or **several**.
 3. Branch on that decision:
    - **Single commit appropriate:** do not rewrite history.  Draft
-     the squash title and body, then write them into the PR body
-     between the markers
-     `<!-- agentcoop:squash-suggestion:start -->` and
-     `<!-- agentcoop:squash-suggestion:end -->` (replacing any prior
-     block between the same markers).  Do not force-push.
+     the squash title and body, then post them as a PR comment whose
+     body contains the marker block
+     `<!-- agentcoop:squash-suggestion:start -->` …
+     `<!-- agentcoop:squash-suggestion:end -->`.  Post idempotently:
+     if a prior comment with the same start marker exists, edit it
+     via `gh api --method PATCH
+     /repos/{owner}/{repo}/issues/comments/{id}` so the timeline
+     does not accumulate duplicates.  The PR body is left untouched.
+     Do not force-push.
    - **Multiple commits appropriate:** consolidate the branch
      commits — using `git reset --soft {baseSha}` + `git commit` or
      interactive rebase — write clear messages, and force-push
@@ -1295,8 +1300,8 @@ of the following keywords:
 - SQUASHED_MULTI — if you rewrote history into multiple meaningful
   commits and force-pushed
 - SUGGESTED_SINGLE — if a single commit is appropriate and you
-  wrote the suggested title/body into the PR body marker block
-  (no force-push)
+  posted the suggested title/body as a PR comment containing the
+  marker block (no force-push)
 - BLOCKED — if you could not complete either path and need user
   intervention
 
@@ -1313,23 +1318,25 @@ because the three-way distinction is squash-specific.
   behaviour, up to 3 internal fix attempts) and finish with
   `squash.completed` when CI passes.
 - `SUGGESTED_SINGLE` → verify a fully parseable suggestion block is
-  present in the PR body before asking the user.  "Parseable" means
-  both markers are present **and** `parseSquashSuggestionBlock`
-  succeeds (the block contains a `**Title**` label followed by a
-  well-formed fenced block).  A bare start marker or a block missing
-  the `**Title**` label / the end marker fails closed with `blocked`
-  rather than completing as if the suggestion were valid — Stage 9
-  reads the same block via
+  present in the squash-suggestion PR comment before asking the
+  user.  "Parseable" means both markers are present **and**
+  `parseSquashSuggestionBlock` succeeds (the block contains a
+  `**Title**` label followed by a well-formed fenced block).  A
+  bare start marker or a block missing the `**Title**` label / the
+  end marker fails closed with `blocked` rather than completing as
+  if the suggestion were valid — Stage 9 reads the same block via
   `parseSquashSuggestionBlock` to render the inline preview, so a
   malformed block would leave the merge-confirm screen blank.  Once
-  validated, ask the user via `chooseSquashApplyMode`:
+  validated, ask the user via `chooseSquashApplyMode` (skipped when
+  the startup `squashApplyPolicy` is `"auto"`, in which case the
+  handler proceeds as if the user picked `"agent"`):
   - **"Agent squashes now"** → send a follow-up prompt on the
     same session telling the agent to perform the squash using
     the message it already drafted, then run the post-squash CI
     poll loop.
   - **"Apply via GitHub"** → finish the stage with
     `squash.messageAppended` and persist
-    `squashSubStep === "applied_in_pr_body"` so Stage 9 surfaces
+    `squashSubStep === "applied_via_github"` so Stage 9 surfaces
     the suggestion in the merge-confirm screen.  No CI rerun.
 - `BLOCKED` → existing blocked flow.
 
@@ -1341,8 +1348,8 @@ fails, the handler runs a **deterministic fallback chain**:
    snapshot taken at stage entry, treat as `SQUASHED_MULTI` (the
    force-push has already happened — that hard-to-undo side
    effect must be detected first).
-2. Else, fetch the PR body and check for a fully parseable
-   suggestion block (markers present **and**
+2. Else, fetch the squash-suggestion PR comment and check for a
+   fully parseable suggestion block (markers present **and**
    `parseSquashSuggestionBlock` returns a value).  If present,
    treat as `SUGGESTED_SINGLE`; a malformed block (e.g. only the
    start marker) is treated as missing.
@@ -1350,7 +1357,7 @@ fails, the handler runs a **deterministic fallback chain**:
 
 The order matters: checking the commit count first prevents a
 completed squash from being misclassified as a SINGLE suggestion
-when an earlier run left a stale marker block in the PR body.
+when an earlier run left a stale marker comment on the PR.
 
 The derived verdict is emitted as a `pipeline:verdict` event just
 like a parsed-keyword verdict, so telemetry consumers see every
@@ -1364,19 +1371,20 @@ planning → verdict
         ├── (SQUASHED_MULTI)   → ci_poll → done
         ├── (SUGGESTED_SINGLE) → awaiting_user_choice
         │       ├── (agent)  → squashing → ci_poll → done
-        │       └── (github) → applied_in_pr_body (stage done)
+        │       └── (github) → applied_via_github (stage done)
         └── (BLOCKED)         → user chooses
 ```
 
 `RunState.squashSubStep` persists the current substate so resume
 re-enters at the correct point:
 
-- `applied_in_pr_body` → stage already done; advance to Stage 9.
+- `applied_via_github` → stage already done; advance to Stage 9.
 - `awaiting_user_choice` → re-verify a parseable suggestion block is
-  still in the PR body (same strict check as the verdict path); if
-  present, re-present the user choice without re-invoking the agent.
-  If absent or malformed, fall back to `planning` rather than
-  re-presenting a choice the user could not act on.  If
+  still in the squash-suggestion PR comment (same strict check as
+  the verdict path); if present, re-present the user choice without
+  re-invoking the agent.  If absent or malformed, fall back to
+  `planning` rather than re-presenting a choice the user could not
+  act on.  If
   the user then picks "agent squashes now" but no agent session is
   available (neither the saved run state nor the current verdict
   produced a session ID), the stage fails closed with `blocked`
@@ -1415,8 +1423,8 @@ a follow-up turn, so the verdict session is not guaranteed to
 equal the planning session.  Persisting it ensures that a resume
 from `awaiting_user_choice` — where the user picks "agent
 squashes now" — re-sends the follow-up on the exact conversation
-that drafted the PR-body suggestion, rather than the earlier
-planning session.
+that drafted the squash-suggestion comment, rather than the
+earlier planning session.
 
 **Outcome handling:** `requiresArtifact: true` — if `BLOCKED`,
 only **Instruct** and **Halt** are offered.
@@ -1525,7 +1533,7 @@ Cleanup
      delete the worktree, delete the remote branch, and close
      the PR. Each action is individually selectable.
 
-   When a squash suggestion is live in the PR body, the
+   When a squash suggestion is live in a PR comment, the
    merge-confirm screen also renders `[t] copy` / `[b] copy`
    hotkey hints next to the suggested title and body.  Pressing
    `t` or `b` writes the corresponding value to the system

--- a/src/fetch-pr-comments.test.ts
+++ b/src/fetch-pr-comments.test.ts
@@ -5,7 +5,9 @@ vi.mock("node:child_process", () => ({
   execFileSync: vi.fn(),
 }));
 
-const { fetchPrComments } = await import("./pr-comments.js");
+const { fetchPrComments, findLatestCommentWithMarker } = await import(
+  "./pr-comments.js"
+);
 
 const mockExecFileSync = vi.mocked(execFileSync);
 
@@ -53,5 +55,43 @@ describe("fetchPrComments", () => {
 
     const result = fetchPrComments("org", "repo", 1);
     expect(result).toEqual([]);
+  });
+});
+
+describe("findLatestCommentWithMarker", () => {
+  const MARKER = "<!-- agentcoop:squash-suggestion:start -->";
+
+  test("returns undefined when no comment matches", () => {
+    const page = [
+      { body: "Random comment", user: { login: "a" } },
+      { body: "Another comment", user: { login: "b" } },
+    ];
+    mockExecFileSync.mockReturnValue(JSON.stringify([page]));
+    expect(
+      findLatestCommentWithMarker("org", "repo", 1, MARKER),
+    ).toBeUndefined();
+  });
+
+  test("returns the body of the latest matching comment", () => {
+    // Older matching comment followed by a newer matching comment —
+    // the newer one wins.
+    const page = [
+      { body: `older ${MARKER} v1`, user: { login: "a" } },
+      { body: "noise", user: { login: "b" } },
+      { body: `newer ${MARKER} v2`, user: { login: "a" } },
+    ];
+    mockExecFileSync.mockReturnValue(JSON.stringify([page]));
+    expect(findLatestCommentWithMarker("org", "repo", 1, MARKER)).toBe(
+      `newer ${MARKER} v2`,
+    );
+  });
+
+  test("returns undefined when the gh call throws", () => {
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error("boom");
+    });
+    expect(
+      findLatestCommentWithMarker("org", "repo", 1, MARKER),
+    ).toBeUndefined();
   });
 });

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -48,6 +48,9 @@ export const en: Messages = {
   "startup.issueLabels": (labels) => `  Labels: ${labels}`,
   "startup.proceedWithIssue": "Proceed with this issue?",
   "startup.issueNotConfirmed": "Issue not confirmed. Aborting.",
+  "startup.squashApplyPolicyPrompt":
+    "When a single-commit squash is suggested, apply it automatically " +
+    "via the agent? (No = ask each time)",
 
   // ---- custom model entry --------------------------------------------------
 
@@ -144,7 +147,7 @@ export const en: Messages = {
     "Has the PR been merged? Confirm to clean up the worktree.",
   "pipeline.mergeConfirmSquashTip":
     "If this repo allows 'Squash and merge', the suggested commit " +
-    "message is in the PR body.",
+    "message is in a PR comment.",
   "pipeline.suggestedSquashTitle": "Suggested title:",
   "pipeline.suggestedSquashBody": "Suggested body:",
   "pipeline.prUrl": (url) => `PR: ${url}`,
@@ -264,7 +267,7 @@ export const en: Messages = {
   "squash.completed": "Commits squashed and CI passed.",
   "squash.singleCommitSkip": "Single commit — skipping squash.",
   "squash.messageAppended":
-    "Suggested squash commit message written to PR body. " +
+    "Suggested squash commit message posted as a PR comment. " +
     "Apply it via GitHub's 'Squash and merge' at merge time.",
   "squash.singleChoicePrompt":
     "A single squash commit looks appropriate. " +

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -64,6 +64,9 @@ export const ko: Messages = {
     "\uC774 \uC774\uC288\uB85C \uC9C4\uD589\uD558\uC2DC\uACA0\uC2B5\uB2C8\uAE4C?",
   "startup.issueNotConfirmed":
     "\uC774\uC288\uAC00 \uD655\uC778\uB418\uC9C0 \uC54A\uC558\uC2B5\uB2C8\uB2E4. \uC911\uB2E8\uD569\uB2C8\uB2E4.",
+  "startup.squashApplyPolicyPrompt":
+    "단일 커밋 스쿼시가 제안될 때, 에이전트가 자동으로 적용할까요? " +
+    "(아니오 = 매번 묻기)",
 
   // ---- custom model entry --------------------------------------------------
 
@@ -178,7 +181,7 @@ export const ko: Messages = {
   "pipeline.mergeConfirm":
     "PR이 병합되었습니까? 확인하면 워크트리를 정리합니다.",
   "pipeline.mergeConfirmSquashTip":
-    "이 저장소가 'Squash and merge'를 허용한다면, 제안된 커밋 메시지가 PR 본문에 있습니다.",
+    "이 저장소가 'Squash and merge'를 허용한다면, 제안된 커밋 메시지가 PR 코멘트에 있습니다.",
   "pipeline.suggestedSquashTitle": "제안 제목:",
   "pipeline.suggestedSquashBody": "제안 본문:",
   "pipeline.prUrl": (url) => `PR: ${url}`,
@@ -306,7 +309,7 @@ export const ko: Messages = {
   "squash.completed": "커밋이 스쿼시되고 CI를 통과했습니다.",
   "squash.singleCommitSkip": "커밋이 하나뿐이므로 스쿼시를 건너뜁니다.",
   "squash.messageAppended":
-    "제안된 스쿼시 커밋 메시지가 PR 본문에 기록되었습니다. " +
+    "제안된 스쿼시 커밋 메시지가 PR 코멘트로 게시되었습니다. " +
     "병합 시 GitHub의 'Squash and merge'로 적용하세요.",
   "squash.singleChoicePrompt":
     "단일 스쿼시 커밋이 적합해 보입니다. 제안 메시지를 어떻게 적용할까요?",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -51,6 +51,7 @@ export interface Messages {
   "startup.issueLabels": (labels: string) => string;
   "startup.proceedWithIssue": string;
   "startup.issueNotConfirmed": string;
+  "startup.squashApplyPolicyPrompt": string;
 
   // ---- custom model entry (startup.ts) -------------------------------------
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -262,6 +262,55 @@ describe("module exports", () => {
 });
 
 // ---------------------------------------------------------------------------
+// squash-apply policy join point (issue #274)
+// ---------------------------------------------------------------------------
+//
+// The squash-apply policy must be asked once per run on BOTH the
+// fresh-startup and resume branches (issue #274 §2).  The orchestration
+// in `src/index.ts` is top-level script code that cannot easily be
+// invoked from a unit test, so guard the invariant structurally: the
+// `promptSquashApplyPolicy` helper must be called exactly once and
+// must sit AFTER both the resume branch's params construction and the
+// fresh branch's `params ??= ...` block.  Without this guard a future
+// refactor could silently drop the prompt on one branch and only the
+// stage-level tests in `stage-squash.test.ts` would fail to catch it.
+describe("squash-apply policy join point", () => {
+  const indexSource = readFileSync(resolve(root, "src/index.ts"), "utf-8");
+
+  test("imports promptSquashApplyPolicy from startup", () => {
+    expect(indexSource).toMatch(
+      /import\s*\{[^}]*\bpromptSquashApplyPolicy\b[^}]*\}\s*from\s*"\.\/startup\.js"/s,
+    );
+  });
+
+  test("invokes promptSquashApplyPolicy exactly once", () => {
+    const matches = indexSource.match(/promptSquashApplyPolicy\s*\(/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  test("invocation sits after both the resume branch and the fresh `params ??=` block", () => {
+    // Resume branch sets `resuming: true`; fresh branch is the
+    // `params ??= await (async () => {` IIFE that wraps `runStartup`.
+    const resumeIdx = indexSource.indexOf("resuming: true,");
+    const freshBranchIdx = indexSource.indexOf("params ??= await");
+    const policyCallIdx = indexSource.indexOf("promptSquashApplyPolicy(");
+
+    expect(resumeIdx).toBeGreaterThan(-1);
+    expect(freshBranchIdx).toBeGreaterThan(-1);
+    expect(policyCallIdx).toBeGreaterThan(-1);
+    // Both branches must precede the join-point call.
+    expect(policyCallIdx).toBeGreaterThan(resumeIdx);
+    expect(policyCallIdx).toBeGreaterThan(freshBranchIdx);
+  });
+
+  test("the call assigns to params.squashApplyPolicy", () => {
+    expect(indexSource).toMatch(
+      /params\.squashApplyPolicy\s*=\s*await\s+promptSquashApplyPolicy\s*\(\s*\)/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CLI E2E smoke test
 // ---------------------------------------------------------------------------
 describe("CLI E2E", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,9 +41,10 @@ import type {
 } from "./pipeline.js";
 import { createDoneStageHandler } from "./pipeline.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
-import { checkMergeable, findPrNumber, getPrBody, queryPrState } from "./pr.js";
+import { checkMergeable, findPrNumber, queryPrState } from "./pr.js";
 import {
   fetchPrComments,
+  findLatestCommentWithMarker,
   type PrComment,
   parsePrReviewState,
   reconcileWithPr,
@@ -65,10 +66,16 @@ import { createSelfCheckStageHandler } from "./stage-selfcheck.js";
 import {
   createSquashStageHandler,
   parseSquashSuggestionBlock,
+  SQUASH_SUGGESTION_START_MARKER,
 } from "./stage-squash.js";
 import { createTestPlanStageHandler } from "./stage-testplan.js";
 import type { AgentConfig } from "./startup.js";
-import { modelDisplayName, runStartup, selectTarget } from "./startup.js";
+import {
+  modelDisplayName,
+  promptSquashApplyPolicy,
+  runStartup,
+  selectTarget,
+} from "./startup.js";
 import { renderApp } from "./ui/render-app.js";
 import {
   bootstrapRepo,
@@ -93,6 +100,14 @@ interface RunParams {
   resuming: boolean;
   /** True when user chose "Start fresh" — worktree should be cleaned. */
   startFresh: boolean;
+  /**
+   * Per-run policy controlling how a SUGGESTED_SINGLE squash verdict
+   * is applied.  `"auto"` proceeds silently with the agent path;
+   * `"ask"` presents the mid-pipeline chooser.  Collected fresh on
+   * every run (fresh startup AND resume) so the right default can
+   * change from run to run.
+   */
+  squashApplyPolicy: "auto" | "ask";
 }
 
 // ---- helpers -------------------------------------------------------------
@@ -371,6 +386,8 @@ try {
         startFromStage: savedState.currentStage,
         resuming: true,
         startFresh: false,
+        // Provisional — overwritten below at the shared join point.
+        squashApplyPolicy: "auto",
       };
     } else {
       // Start fresh: warn about uncommitted changes.
@@ -414,8 +431,17 @@ try {
       startFromStage: undefined,
       resuming: false,
       startFresh: userChoseFresh,
+      // Provisional — overwritten below at the shared join point.
+      squashApplyPolicy: "auto",
     };
   })();
+
+  // Ask the squash-apply policy once per run, at the shared join
+  // point so both the fresh-start and resume branches go through
+  // the same prompt.  Routed through `promptSquashApplyPolicy` so
+  // the call site is a single named target — see the helper for the
+  // semantics of "not persisted" and the default-true rationale.
+  params.squashApplyPolicy = await promptSquashApplyPolicy();
 
   const {
     agentAConfig,
@@ -428,6 +454,7 @@ try {
     startFromStage: rawStartFromStage,
     resuming,
     startFresh,
+    squashApplyPolicy,
   } = params;
 
   const m = t();
@@ -582,6 +609,7 @@ try {
         agent: agentA,
         ...issueCtx,
         defaultBranch,
+        squashApplyPolicy,
         chooseSquashApplyMode: async (msg) => {
           if (tuiPrompt) return tuiPrompt.chooseSquashApplyMode(msg);
           return "agent";
@@ -750,10 +778,18 @@ try {
     },
     hasRunningServices: () => hasDockerComposeRunning(wt.path),
     getSquashMergeHint: () => {
-      if (runState.squashSubStep !== "applied_in_pr_body") return undefined;
-      const body = getPrBody(owner, repo, wt.branch);
-      const suggestion = parseSquashSuggestionBlock(body);
+      if (runState.squashSubStep !== "applied_via_github") return undefined;
       const prNum = runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
+      const commentBody =
+        prNum !== undefined
+          ? findLatestCommentWithMarker(
+              owner,
+              repo,
+              prNum,
+              SQUASH_SUGGESTION_START_MARKER,
+            )
+          : undefined;
+      const suggestion = parseSquashSuggestionBlock(commentBody);
       const prUrl =
         prNum !== undefined
           ? `https://github.com/${owner}/${repo}/pull/${prNum}`

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -248,7 +248,7 @@ export interface UserPrompt {
 
   /**
    * Ask the user how to apply a single-commit squash suggestion that
-   * the agent has written to the PR body.  Returns `"agent"` to ask
+   * the agent has posted as a PR comment.  Returns `"agent"` to ask
    * the agent to perform the squash now (force-push, runs CI again),
    * or `"github"` to leave it for GitHub's "Squash and merge" at
    * merge time (no CI rerun).
@@ -935,9 +935,9 @@ export interface DoneStageOptions {
    */
   getSquashMergeHint?: () =>
     | {
-        /** Suggested squash commit title parsed from the PR body. */
+        /** Suggested squash commit title parsed from the PR comment. */
         title?: string;
-        /** Suggested squash commit body parsed from the PR body. */
+        /** Suggested squash commit body parsed from the PR comment. */
         body?: string;
         /** Hyperlink-friendly PR URL. */
         prUrl?: string;

--- a/src/pr-comments.test.ts
+++ b/src/pr-comments.test.ts
@@ -32,6 +32,7 @@ function makeRunState(overrides: Partial<RunState> = {}): RunState {
     selfCheckCount: 0,
     reviewCount: 0,
     reviewSubStep: undefined,
+    squashSubStep: undefined,
     lastVerdict: undefined,
     executionMode: "auto",
     agentA: {

--- a/src/pr-comments.ts
+++ b/src/pr-comments.ts
@@ -110,6 +110,37 @@ export function postPrComment(
   );
 }
 
+// ---- marker-lookup helper ------------------------------------------------
+
+/**
+ * Find the most recent PR comment whose body contains `marker`.
+ *
+ * Returns the body of the latest matching comment (the last one in
+ * chronological order returned by `gh`), or `undefined` when no
+ * comment matches, the PR cannot be resolved, or the API call fails.
+ *
+ * Callers that need the suggestion text parsed should wrap the
+ * returned body with a parser (e.g. `parseSquashSuggestionBlock`).
+ */
+export function findLatestCommentWithMarker(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  marker: string,
+): string | undefined {
+  let comments: PrComment[];
+  try {
+    comments = fetchPrComments(owner, repo, prNumber);
+  } catch {
+    return undefined;
+  }
+  let latest: string | undefined;
+  for (const c of comments) {
+    if (c.body.includes(marker)) latest = c.body;
+  }
+  return latest;
+}
+
 // ---- parsing -------------------------------------------------------------
 
 /**

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -289,11 +289,28 @@ describe("squashSubStep persistence", () => {
   test("round-trips squashSubStep", () => {
     const state = makeRunState({
       currentStage: 8,
-      squashSubStep: "applied_in_pr_body",
+      squashSubStep: "applied_via_github",
     });
     saveRunState(state);
     const loaded = loadRunState("org", "repo", 42);
-    expect(loaded?.squashSubStep).toBe("applied_in_pr_body");
+    expect(loaded?.squashSubStep).toBe("applied_via_github");
+  });
+
+  test("migrates v3 'applied_in_pr_body' to 'applied_via_github'", () => {
+    const { squashSubStep: _, ...rest } = makeRunState({ currentStage: 8 });
+    const raw = {
+      ...rest,
+      version: 3,
+      squashSubStep: "applied_in_pr_body",
+    };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.squashSubStep).toBe("applied_via_github");
+    expect(loaded?.version).toBe(RUN_STATE_VERSION);
   });
 
   test("defaults to undefined for old state files without squashSubStep", () => {

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -44,7 +44,7 @@ export type SquashSubStep =
   | "awaiting_user_choice"
   | "squashing"
   | "ci_poll"
-  | "applied_in_pr_body";
+  | "applied_via_github";
 
 export interface AgentState {
   cli: string;
@@ -63,8 +63,11 @@ export interface AgentState {
  *  1 — original order (stages 7=squash, 8=review)
  *  2 — swapped stages 7↔8 (7=review, 8=squash)
  *  3 — added `squashSubStep` for stage 8 single-commit suggestion flow
+ *  4 — renamed `squashSubStep === "applied_in_pr_body"` to
+ *      `"applied_via_github"` now that the suggestion is posted as a
+ *      PR comment rather than the PR body.
  */
-export const RUN_STATE_VERSION = 3;
+export const RUN_STATE_VERSION = 4;
 
 export interface RunState {
   version: number;
@@ -192,6 +195,11 @@ function isValidRunState(
  *  v2 → v3:                added `squashSubStep`.  No remap required
  *                          (`loadRunState` already backfills
  *                          `undefined`), just bump the version tag.
+ *  v3 → v4:                renamed `squashSubStep === "applied_in_pr_body"`
+ *                          to `"applied_via_github"` when the squash
+ *                          suggestion moved from the PR body to a PR
+ *                          comment.  Remap in place so in-flight runs
+ *                          resume into the same short-circuit branch.
  */
 function migrateRunState(state: RunState): RunState {
   if (state.version >= RUN_STATE_VERSION) return state;
@@ -206,6 +214,15 @@ function migrateRunState(state: RunState): RunState {
       migrated.currentStage = 8;
     } else if (migrated.currentStage === 8) {
       migrated.currentStage = 7;
+    }
+  }
+
+  // v3 → v4: rename the legacy squashSubStep literal.
+  if (migrated.version < 4) {
+    if (
+      (migrated.squashSubStep as string | undefined) === "applied_in_pr_body"
+    ) {
+      migrated.squashSubStep = "applied_via_github";
     }
   }
 

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -95,7 +95,8 @@ function makeOpts(
     pollTimeoutMs: 1000,
     emptyRunsGracePeriodMs: 0,
     countBranchCommits: vi.fn().mockReturnValue(2),
-    getPrBody: vi.fn().mockReturnValue(""),
+    findSuggestionCommentBody: vi.fn().mockReturnValue(undefined),
+    findPrNumber: vi.fn().mockReturnValue(42),
     queryPrState: vi.fn().mockReturnValue("OPEN"),
     chooseSquashApplyMode: vi.fn().mockResolvedValue("agent"),
     ...overrides,
@@ -744,12 +745,12 @@ describe("createSquashStageHandler", () => {
       resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
     };
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
-    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
     const onSquashSubStep = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      getPrBody,
+      findSuggestionCommentBody,
       onSquashSubStep,
     });
     const stage = createSquashStageHandler(opts);
@@ -769,7 +770,7 @@ describe("createSquashStageHandler", () => {
 
   // -- SUGGESTED_SINGLE: user picks "github" ---------------------------------
 
-  test("SUGGESTED_SINGLE + user picks github → no CI poll, applied_in_pr_body", async () => {
+  test("SUGGESTED_SINGLE + user picks github → no CI poll, applied_via_github", async () => {
     const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
     const agent: AgentAdapter = {
       invoke: vi
@@ -786,13 +787,13 @@ describe("createSquashStageHandler", () => {
         ),
     };
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
-    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
     const onSquashSubStep = vi.fn();
     const getCiStatus = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      getPrBody,
+      findSuggestionCommentBody,
       onSquashSubStep,
       getCiStatus,
     });
@@ -803,7 +804,7 @@ describe("createSquashStageHandler", () => {
     expect(result.message).toContain("Squash and merge");
     expect(getCiStatus).not.toHaveBeenCalled();
     const states = onSquashSubStep.mock.calls.map((c) => c[0]);
-    expect(states[states.length - 1]).toBe("applied_in_pr_body");
+    expect(states[states.length - 1]).toBe("applied_via_github");
   });
 
   // -- SUGGESTED_SINGLE missing marker → BLOCKED -----------------------------
@@ -825,7 +826,9 @@ describe("createSquashStageHandler", () => {
     };
     const opts = makeOpts({
       agent,
-      getPrBody: vi.fn().mockReturnValue("body without any marker"),
+      findSuggestionCommentBody: vi
+        .fn()
+        .mockReturnValue("body without any marker"),
     });
     const stage = createSquashStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
@@ -852,14 +855,14 @@ describe("createSquashStageHandler", () => {
         ),
     };
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
-    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
     const queryPrState = vi.fn().mockReturnValue("MERGED");
     const onSquashSubStep = vi.fn();
     const getCiStatus = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      getPrBody,
+      findSuggestionCommentBody,
       queryPrState,
       onSquashSubStep,
       getCiStatus,
@@ -873,6 +876,55 @@ describe("createSquashStageHandler", () => {
     expect(getCiStatus).not.toHaveBeenCalled();
     expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
     // Sub-step must be cleared so a resume does not re-enter the dead choice.
+    expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
+  });
+
+  // Regression for issue #274 reviewer round 1: on the immediate
+  // SUGGESTED_SINGLE branch, the PR-merged guard must also run
+  // BEFORE the suggestion-comment lookup.  `findPrNumber` uses
+  // `gh pr list` (open PRs only), so a concurrent merge would make
+  // the comment lookup return `undefined` and the stage would flip
+  // to `BLOCKED` instead of short-circuiting to `alreadyMerged`.
+  test("SUGGESTED_SINGLE + concurrent merge hides the PR from findPrNumber → alreadyMerged, not blocked", async () => {
+    const agent: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(
+            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+          ),
+        ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+        ),
+    };
+    // `findPrNumber` returns `undefined` once the PR is merged
+    // because `gh pr list` filters to open PRs by default.
+    const findPrNumber = vi.fn().mockReturnValue(undefined);
+    const findSuggestionCommentBody = vi.fn();
+    const chooseSquashApplyMode = vi.fn();
+    const queryPrState = vi.fn().mockReturnValue("MERGED");
+    const onSquashSubStep = vi.fn();
+    const opts = makeOpts({
+      agent,
+      findPrNumber,
+      findSuggestionCommentBody,
+      chooseSquashApplyMode,
+      queryPrState,
+      onSquashSubStep,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("already merged");
+    // Guard runs before the comment lookup.
+    expect(findPrNumber).not.toHaveBeenCalled();
+    expect(findSuggestionCommentBody).not.toHaveBeenCalled();
+    expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+    expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
     expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
   });
 
@@ -900,13 +952,13 @@ describe("createSquashStageHandler", () => {
       .mockReturnValueOnce("OPEN")
       .mockReturnValueOnce("MERGED");
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
-    const getPrBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
     const onSquashSubStep = vi.fn();
     const getCiStatus = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      getPrBody,
+      findSuggestionCommentBody,
       queryPrState,
       onSquashSubStep,
       getCiStatus,
@@ -961,7 +1013,7 @@ describe("createSquashStageHandler", () => {
           .fn()
           .mockReturnValueOnce(3)
           .mockReturnValueOnce(1),
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
       });
       const stage = createSquashStageHandler(opts);
       const result = await stage.handler(BASE_CTX);
@@ -975,7 +1027,7 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi.fn().mockReturnValue(2),
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode,
       });
       const stage = createSquashStageHandler(opts);
@@ -988,19 +1040,55 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi.fn().mockReturnValue(2),
-        getPrBody: vi.fn().mockReturnValue(""),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(undefined),
+        findPrNumber: vi.fn().mockReturnValue(42),
       });
       const stage = createSquashStageHandler(opts);
       const result = await stage.handler(BASE_CTX);
       expect(result.outcome).toBe("blocked");
+    });
+
+    // Regression for issue #274 reviewer round 2: when the agent
+    // never returns a parseable verdict and the deterministic
+    // fallback runs, the PR-merged guard must run BEFORE the
+    // suggestion-comment lookup.  `findPrNumber` uses `gh pr list`
+    // (open PRs only), so a concurrent merge between the
+    // clarification turn and this fallback would make the lookup
+    // return `undefined` and the verdict would flip to BLOCKED
+    // instead of taking the existing merged short-circuit.
+    test("ambiguous verdict + PR merged before fallback → alreadyMerged, not BLOCKED", async () => {
+      const queryPrState = vi.fn().mockReturnValue("MERGED");
+      const findPrNumber = vi.fn().mockReturnValue(undefined);
+      const findSuggestionCommentBody = vi.fn();
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        agent: makeAmbiguousAgent(),
+        // Commit count unchanged → would otherwise fall into the
+        // comment-lookup branch.
+        countBranchCommits: vi.fn().mockReturnValue(2),
+        queryPrState,
+        findPrNumber,
+        findSuggestionCommentBody,
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("already merged");
+      // The lifecycle guard runs before the comment lookup.
+      expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
+      expect(findPrNumber).not.toHaveBeenCalled();
+      expect(findSuggestionCommentBody).not.toHaveBeenCalled();
+      expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
     });
   });
 
   // -- resume on each substate -----------------------------------------------
 
   describe("resume on saved substate", () => {
-    test("applied_in_pr_body → returns completed without invoking agent", async () => {
-      const opts = makeOpts({ savedSquashSubStep: "applied_in_pr_body" });
+    test("applied_via_github → returns completed without invoking agent", async () => {
+      const opts = makeOpts({ savedSquashSubStep: "applied_via_github" });
       const stage = createSquashStageHandler(opts);
       const result = await stage.handler(BASE_CTX);
       expect(result.outcome).toBe("completed");
@@ -1022,7 +1110,7 @@ describe("createSquashStageHandler", () => {
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const opts = makeOpts({
         savedSquashSubStep: "awaiting_user_choice",
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode,
       });
       const stage = createSquashStageHandler(opts);
@@ -1042,7 +1130,7 @@ describe("createSquashStageHandler", () => {
       const getCiStatus = vi.fn();
       const opts = makeOpts({
         savedSquashSubStep: "awaiting_user_choice",
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode,
         onSquashSubStep,
         getCiStatus,
@@ -1058,18 +1146,56 @@ describe("createSquashStageHandler", () => {
       expect(opts.agent.resume).not.toHaveBeenCalled();
       expect(getCiStatus).not.toHaveBeenCalled();
       const states = onSquashSubStep.mock.calls.map((c) => c[0]);
-      expect(states).not.toContain("applied_in_pr_body");
+      expect(states).not.toContain("applied_via_github");
       expect(states).not.toContain("ci_poll");
     });
 
     test("awaiting_user_choice with marker missing → falls back to fresh planning run", async () => {
       const opts = makeOpts({
         savedSquashSubStep: "awaiting_user_choice",
-        getPrBody: vi.fn().mockReturnValue(""),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(undefined),
+        findPrNumber: vi.fn().mockReturnValue(42),
       });
       const stage = createSquashStageHandler(opts);
       await stage.handler(BASE_CTX);
       expect(opts.agent.invoke).toHaveBeenCalled();
+    });
+
+    // Regression for issue #274 reviewer round 1: resuming from
+    // `awaiting_user_choice` must check the PR lifecycle BEFORE
+    // reading the suggestion comment.  `findPrNumber` uses
+    // `gh pr list` (open PRs only), so a PR merged between the
+    // interruption and the resume would make the comment lookup
+    // return `undefined` and fall through to a fresh planning run
+    // — completely bypassing the `squash.alreadyMerged` short-circuit.
+    test("awaiting_user_choice with PR already merged → alreadyMerged, no fresh planning, no user choice", async () => {
+      const queryPrState = vi.fn().mockReturnValue("MERGED");
+      const chooseSquashApplyMode = vi.fn();
+      const findPrNumber = vi.fn().mockReturnValue(undefined);
+      const findSuggestionCommentBody = vi.fn();
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        savedSquashSubStep: "awaiting_user_choice",
+        queryPrState,
+        chooseSquashApplyMode,
+        findPrNumber,
+        findSuggestionCommentBody,
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("already merged");
+      expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
+      // The lifecycle guard must run BEFORE the comment lookup, so
+      // neither `findPrNumber` nor `findSuggestionCommentBody`
+      // should be consulted once the PR is known to be merged.
+      expect(findPrNumber).not.toHaveBeenCalled();
+      expect(findSuggestionCommentBody).not.toHaveBeenCalled();
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
     });
 
     // Regression for issue #252 review feedback: resuming from
@@ -1286,7 +1412,7 @@ describe("createSquashStageHandler", () => {
   // Stage 8 must persist the latest verdict session id via
   // `ctx.onSessionId` BEFORE entering `awaiting_user_choice`, so that a
   // resume + user "agent" choice continues the exact conversation that
-  // drafted the PR-body suggestion — not the older planning session.
+  // drafted the squash-suggestion comment — not the older planning session.
   describe("verdict session id persistence", () => {
     test("SUGGESTED_SINGLE persists verdict session (distinct from planning) before awaiting choice", async () => {
       const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
@@ -1324,7 +1450,7 @@ describe("createSquashStageHandler", () => {
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
       const opts = makeOpts({
         agent,
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode,
       });
       const stage = createSquashStageHandler(opts);
@@ -1363,7 +1489,7 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent,
         savedSquashSubStep: "awaiting_user_choice",
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode,
         // The persisted session id is the VERDICT session, not the
         // planning session — proving the Round 5 fix wires the
@@ -1384,9 +1510,10 @@ describe("createSquashStageHandler", () => {
 
   // -- pipeline:verdict telemetry on fallback chain (issue #252 review round 3)
   // The deterministic fallback chain derives the verdict from commit
-  // count and PR body when both agent responses are ambiguous.  That
-  // derived keyword must still be surfaced as a pipeline:verdict event
-  // so telemetry consumers see every verdict, not just the parsed ones.
+  // count and the squash-suggestion PR comment when both agent
+  // responses are ambiguous.  That derived keyword must still be
+  // surfaced as a pipeline:verdict event so telemetry consumers see
+  // every verdict, not just the parsed ones.
   describe("pipeline:verdict emission from deterministic fallback", () => {
     function makeAmbiguousAgent(): AgentAdapter {
       let resumeCall = 0;
@@ -1422,7 +1549,8 @@ describe("createSquashStageHandler", () => {
           .fn()
           .mockReturnValueOnce(3)
           .mockReturnValueOnce(1),
-        getPrBody: vi.fn().mockReturnValue(""),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(undefined),
+        findPrNumber: vi.fn().mockReturnValue(42),
       });
       const stage = createSquashStageHandler(opts);
       await stage.handler({ ...BASE_CTX, events });
@@ -1439,7 +1567,7 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi.fn().mockReturnValue(2),
-        getPrBody: vi.fn().mockReturnValue(prBody),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode: vi.fn().mockResolvedValue("github"),
       });
       const stage = createSquashStageHandler(opts);
@@ -1456,7 +1584,8 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi.fn().mockReturnValue(2),
-        getPrBody: vi.fn().mockReturnValue(""),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(undefined),
+        findPrNumber: vi.fn().mockReturnValue(42),
       });
       const stage = createSquashStageHandler(opts);
       await stage.handler({ ...BASE_CTX, events });
@@ -1472,7 +1601,7 @@ describe("createSquashStageHandler", () => {
   // the inline preview, so Stage 8 must reject any block the parser
   // cannot handle (start marker only, missing end marker, missing
   // `**Title**` label).  Otherwise the SUGGESTED_SINGLE path completes
-  // with `applied_in_pr_body` and Stage 9 has nothing to show.
+  // with `applied_via_github` and Stage 9 has nothing to show.
   describe("malformed suggestion block", () => {
     function makeMalformedBodies(): Array<{ name: string; body: string }> {
       return [
@@ -1511,7 +1640,7 @@ describe("createSquashStageHandler", () => {
       const onSquashSubStep = vi.fn();
       const opts = makeOpts({
         agent,
-        getPrBody: vi.fn().mockReturnValue(body),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(body),
         chooseSquashApplyMode,
         onSquashSubStep,
       });
@@ -1521,7 +1650,7 @@ describe("createSquashStageHandler", () => {
       expect(result.outcome).toBe("blocked");
       expect(chooseSquashApplyMode).not.toHaveBeenCalled();
       const states = onSquashSubStep.mock.calls.map((c) => c[0]);
-      expect(states).not.toContain("applied_in_pr_body");
+      expect(states).not.toContain("applied_via_github");
       expect(states).not.toContain("awaiting_user_choice");
     });
 
@@ -1557,7 +1686,7 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent,
         countBranchCommits: vi.fn().mockReturnValue(2),
-        getPrBody: vi.fn().mockReturnValue(body),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(body),
       });
       const stage = createSquashStageHandler(opts);
       const result = await stage.handler({ ...BASE_CTX, events });
@@ -1576,7 +1705,7 @@ describe("createSquashStageHandler", () => {
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const opts = makeOpts({
         savedSquashSubStep: "awaiting_user_choice",
-        getPrBody: vi.fn().mockReturnValue(body),
+        findSuggestionCommentBody: vi.fn().mockReturnValue(body),
         chooseSquashApplyMode,
       });
       const stage = createSquashStageHandler(opts);
@@ -1584,6 +1713,129 @@ describe("createSquashStageHandler", () => {
 
       expect(chooseSquashApplyMode).not.toHaveBeenCalled();
       expect(opts.agent.invoke).toHaveBeenCalled();
+    });
+  });
+
+  // -- squashApplyPolicy: auto vs ask --------------------------------------
+
+  describe("squashApplyPolicy", () => {
+    function makePrCommentBody(): string {
+      return `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+    }
+
+    test("policy=auto skips chooseSquashApplyMode and proceeds as agent", async () => {
+      const prBody = makePrCommentBody();
+      const resumeResults = [
+        makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      ];
+      let resumeCall = 0;
+      const agent: AgentAdapter = {
+        invoke: vi
+          .fn()
+          .mockReturnValue(
+            makeStream(
+              makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+            ),
+          ),
+        resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+      };
+      const chooseSquashApplyMode = vi.fn();
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        agent,
+        chooseSquashApplyMode,
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
+        onSquashSubStep,
+        squashApplyPolicy: "auto",
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(result.message).toContain("CI passed");
+      // Policy prompt never fired.
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      // Followed the "agent" branch: verdict resume + follow-up resume.
+      expect(agent.resume).toHaveBeenCalledTimes(2);
+      expect(opts.getCiStatus).toHaveBeenCalled();
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states).toContain("squashing");
+      expect(states).toContain("ci_poll");
+      expect(states).not.toContain("applied_via_github");
+    });
+
+    test("policy=ask still calls chooseSquashApplyMode and honors the user choice", async () => {
+      const prBody = makePrCommentBody();
+      const agent: AgentAdapter = {
+        invoke: vi
+          .fn()
+          .mockReturnValue(
+            makeStream(
+              makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
+            ),
+          ),
+        resume: vi
+          .fn()
+          .mockReturnValue(
+            makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+          ),
+      };
+      const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+      const onSquashSubStep = vi.fn();
+      const getCiStatus = vi.fn();
+      const opts = makeOpts({
+        agent,
+        chooseSquashApplyMode,
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
+        onSquashSubStep,
+        getCiStatus,
+        squashApplyPolicy: "ask",
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+      expect(getCiStatus).not.toHaveBeenCalled();
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states[states.length - 1]).toBe("applied_via_github");
+    });
+
+    test("policy=auto applies on resume from awaiting_user_choice as well", async () => {
+      const prBody = makePrCommentBody();
+      const resume = vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      );
+      const agent: AgentAdapter = { invoke: vi.fn(), resume };
+      const chooseSquashApplyMode = vi.fn();
+      const opts = makeOpts({
+        agent,
+        savedSquashSubStep: "awaiting_user_choice",
+        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
+        chooseSquashApplyMode,
+        getSavedAgentSessionId: () => "sess-verdict",
+        squashApplyPolicy: "auto",
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("completed");
+      // Auto policy on resume still skips the prompt.
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      // Agent follow-up was sent via the saved verdict session.
+      expect(resume).toHaveBeenCalledTimes(1);
+      expect(resume.mock.calls[0][0]).toBe("sess-verdict");
     });
   });
 });
@@ -1776,7 +2028,7 @@ describe("parseSquashSuggestionBlock", () => {
 
   // The deprecated `**Title:** …` / `**Body:** …` plain-text format was
   // supported for one release cycle for backward compatibility with PRs
-  // already in `applied_in_pr_body` state.  Parsing it is now a hard
+  // already in `applied_via_github` state.  Parsing it is now a hard
   // rejection — this test pins the new contract directly so the legacy
   // branch cannot silently reappear.
   test("returns undefined for a legacy `**Title:** … / **Body:** …` block", () => {

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -2,8 +2,8 @@
  * Stage 8 — Squash commits.
  *
  * Three-way verdict: the agent decides whether the branch is best
- * consolidated into one commit (write the suggested message into the
- * PR body and let GitHub's "Squash and merge" apply it at merge
+ * consolidated into one commit (post the suggested message as a PR
+ * comment and let GitHub's "Squash and merge" apply it at merge
  * time, avoiding an extra CI cycle) or several meaningful commits
  * (rewrite history and force-push as before).
  *
@@ -33,10 +33,11 @@ import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
-  getPrBody as defaultGetPrBody,
+  findPrNumber as defaultFindPrNumber,
   queryPrState as defaultQueryPrState,
   type PrLifecycleState,
 } from "./pr.js";
+import { findLatestCommentWithMarker as defaultFindLatestCommentWithMarker } from "./pr-comments.js";
 import type { SquashSubStep } from "./run-state.js";
 import {
   invokeOrResume,
@@ -52,7 +53,11 @@ import { countBranchCommits as defaultCountBranchCommits } from "./worktree.js";
 
 // ---- public types ------------------------------------------------------------
 
-/** Marker block delimiters used in the PR body for the SUGGESTED_SINGLE path. */
+/**
+ * Marker block delimiters used inside the squash-suggestion PR
+ * comment.  The start marker also doubles as the lookup key for
+ * finding the previous comment to update idempotently.
+ */
 export const SQUASH_SUGGESTION_START_MARKER =
   "<!-- agentcoop:squash-suggestion:start -->";
 export const SQUASH_SUGGESTION_END_MARKER =
@@ -85,12 +90,27 @@ export interface SquashStageOptions {
   delay?: (ms: number) => Promise<void>;
   /** Injected for testability. Defaults to `worktree.countBranchCommits`. */
   countBranchCommits?: (cwd: string, baseBranch: string) => number;
-  /** Injected for testability. Defaults to `pr.getPrBody`. */
-  getPrBody?: (
+  /**
+   * Look up the squash-suggestion PR comment body containing `marker`.
+   * Injected for testability.  Defaults to
+   * `pr-comments.findLatestCommentWithMarker`, which shells out to
+   * `gh api` to list PR comments.
+   */
+  findSuggestionCommentBody?: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+    marker: string,
+  ) => string | undefined;
+  /**
+   * Resolve the PR number for the current branch.  Injected for
+   * testability.  Defaults to `pr.findPrNumber`.
+   */
+  findPrNumber?: (
     owner: string,
     repo: string,
     branch: string,
-  ) => string | undefined;
+  ) => number | undefined;
   /**
    * Query the PR's lifecycle state (OPEN / CLOSED / MERGED).  Used by
    * {@link guardIfPrMerged} to short-circuit Stage 8 when the user
@@ -108,6 +128,16 @@ export interface SquashStageOptions {
    * conservatively defaults to "agent".
    */
   chooseSquashApplyMode?: (message: string) => Promise<"agent" | "github">;
+  /**
+   * Per-run policy for how a SUGGESTED_SINGLE verdict should be
+   * applied.  When `"auto"` the handler skips
+   * {@link chooseSquashApplyMode} and proceeds as if the user picked
+   * `"agent"`; when `"ask"` the user is prompted every time.
+   * Collected by the startup flow (see `src/startup.ts`) and
+   * threaded in via the pipeline boot code.  Defaults to `"ask"` so
+   * missing wiring falls back to today's behaviour.
+   */
+  squashApplyPolicy?: "auto" | "ask";
   /**
    * Persist the current squash sub-step so resume can re-enter at
    * the correct point.  Optional — when omitted, sub-step transitions
@@ -177,14 +207,9 @@ export function buildSquashPrompt(
     `     PR is squash-merged.  The title must not include issue or PR`,
     `     numbers; reference the issue in the body using \`Closes #N\``,
     `     or \`Part of #N\`.`,
-    `   - Update the PR body to include a marker-delimited block`,
-    `     containing the suggestion.  The block must be idempotent —`,
-    `     replace any existing block between the same markers, do not`,
-    `     stack duplicates.  Inside the block, wrap the title and body`,
-    `     each in their own fenced code block (info string \`text\`) so`,
-    `     GitHub renders a one-click copy icon and does not`,
-    `     re-interpret Markdown characters inside the commit message.`,
-    `     Use exactly these markers and this structure:`,
+    `   - Post the suggestion as a **PR comment** (not in the PR body).`,
+    `     The comment body must contain a marker-delimited block with`,
+    `     this exact structure:`,
     ``,
     `     \`\`\`\`text`,
     `     ${SQUASH_SUGGESTION_START_MARKER}`,
@@ -229,10 +254,31 @@ export function buildSquashPrompt(
     `     first line of content, or between the last line of content`,
     `     and the closing fence.  Do not indent the fences.`,
     ``,
-    `     Read the current body with`,
-    `     \`gh pr view --json body --jq .body\`, replace any prior`,
-    `     suggestion block, and write the result back via`,
-    `     \`gh pr edit --body "..."\`.`,
+    `     **Update idempotently.**  This prompt may run more than once`,
+    `     on the same PR.  Before posting, list existing PR comments`,
+    `     and look for a previous squash-suggestion comment — one`,
+    `     whose body contains \`${SQUASH_SUGGESTION_START_MARKER}\`.`,
+    `     If found, edit that comment via`,
+    `     \`gh api --method PATCH /repos/{owner}/{repo}/issues/comments/{id} --field body="..."\``,
+    `     so its body becomes the new suggestion.  If no prior comment`,
+    `     exists, create a fresh one with`,
+    `     \`gh pr comment <pr> --repo <owner>/<repo> --body "..."\`.`,
+    `     Locate any prior comment with:`,
+    ``,
+    `     \`\`\`text`,
+    `     gh api repos/{owner}/{repo}/issues/{pr}/comments --paginate --slurp \\`,
+    `       --jq '[.[] | .[] | select(.body | contains("${SQUASH_SUGGESTION_START_MARKER}"))] | last'`,
+    `     \`\`\``,
+    ``,
+    `     \`--paginate --slurp\` is required: \`--paginate\` alone applies`,
+    `     the \`--jq\` filter page-by-page, so on a long PR timeline`,
+    `     \`| last\` would return the last match within each page rather`,
+    `     than the latest match overall.  \`--slurp\` wraps all pages in`,
+    `     an outer array (\`[[page1...], [page2...]]\`); the \`.[] | .[]\``,
+    `     prefix flattens that before filtering.`,
+    ``,
+    `     Do not write the suggestion into the PR body.  Leave the`,
+    `     PR body untouched.`,
     ``,
     `   **If multiple commits are appropriate:**`,
     ...(ctx.baseSha
@@ -285,8 +331,8 @@ export function buildSquashCompletionCheckPrompt(): string {
     `- SQUASHED_MULTI — if you rewrote history into multiple meaningful`,
     `  commits and force-pushed`,
     `- SUGGESTED_SINGLE — if a single commit is appropriate and you`,
-    `  wrote the suggested title/body into the PR body marker block`,
-    `  (no force-push)`,
+    `  posted the suggested title/body as a PR comment containing`,
+    `  the marker block (no force-push)`,
     `- BLOCKED — if you could not complete either path and need user`,
     `  intervention`,
     ``,
@@ -297,27 +343,28 @@ export function buildSquashCompletionCheckPrompt(): string {
 /**
  * Follow-up prompt sent on the same session when the user picks
  * "agent squashes now" after a SUGGESTED_SINGLE verdict.  The agent
- * already drafted the message in the PR body, so this just asks it
+ * already drafted the message in a PR comment, so this just asks it
  * to perform the squash with the same message.
  */
 export function buildAgentSquashFollowupPrompt(): string {
   return [
     `The user chose to have you perform the squash now using the title`,
-    `and body you wrote into the PR body marker block.`,
+    `and body you posted in the squash-suggestion PR comment.`,
     ``,
     `Squash the branch into a single commit using that exact title and`,
     `body, then force-push (\`git push --force-with-lease\`).  You may`,
-    `leave the marker block in the PR body — it does not interfere with`,
-    `merging.`,
+    `leave the squash-suggestion comment on the PR — it does not`,
+    `interfere with merging.`,
   ].join("\n");
 }
 
 // ---- marker block parsing ----------------------------------------------------
 
 /**
- * Extract the title and body from the squash suggestion marker block
- * in `prBody`.  Returns `undefined` when the markers are missing or
- * the block does not contain a parseable title.
+ * Extract the title and body from the squash-suggestion marker block
+ * in `source` (a PR comment body).  Returns `undefined` when the
+ * markers are missing or the block does not contain a parseable
+ * title.
  *
  * The block uses `**Title**` and `**Body**` labels each followed by a
  * CommonMark-style fenced code block.  The fence length is chosen
@@ -328,14 +375,14 @@ export function buildAgentSquashFollowupPrompt(): string {
  * character that is at least as long.
  */
 export function parseSquashSuggestionBlock(
-  prBody: string | undefined,
+  source: string | undefined,
 ): SquashSuggestion | undefined {
-  if (!prBody) return undefined;
-  const startIdx = prBody.indexOf(SQUASH_SUGGESTION_START_MARKER);
-  const endIdx = prBody.indexOf(SQUASH_SUGGESTION_END_MARKER);
+  if (!source) return undefined;
+  const startIdx = source.indexOf(SQUASH_SUGGESTION_START_MARKER);
+  const endIdx = source.indexOf(SQUASH_SUGGESTION_END_MARKER);
   if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return undefined;
 
-  const inner = prBody.slice(
+  const inner = source.slice(
     startIdx + SQUASH_SUGGESTION_START_MARKER.length,
     endIdx,
   );
@@ -427,21 +474,21 @@ function readFencedBlock(
 }
 
 /**
- * True when `prBody` contains a fully parseable squash suggestion
- * block (start + end markers AND a `**Title**` label followed by a
- * well-formed fenced block that `parseSquashSuggestionBlock` can
- * extract).
+ * True when `source` (a PR comment body) contains a fully parseable
+ * squash suggestion block (start + end markers AND a `**Title**`
+ * label followed by a well-formed fenced block that
+ * `parseSquashSuggestionBlock` can extract).
  *
  * Stage 8 must use this strict check rather than a marker-presence
  * check because Stage 9 reads the same block via
  * `parseSquashSuggestionBlock` to render the inline preview.  If
  * Stage 8 accepted a malformed block (e.g. only the start marker, or
  * a block missing the `**Title**` label / the end marker), the
- * SUGGESTED_SINGLE path could complete with `applied_in_pr_body`
+ * SUGGESTED_SINGLE path could complete with `applied_via_github`
  * while leaving Stage 9 with nothing to show.
  */
-function hasValidSuggestionBlock(prBody: string | undefined): boolean {
-  return parseSquashSuggestionBlock(prBody) !== undefined;
+function hasValidSuggestionBlock(source: string | undefined): boolean {
+  return parseSquashSuggestionBlock(source) !== undefined;
 }
 
 // ---- handler -----------------------------------------------------------------
@@ -571,7 +618,25 @@ export function createSquashStageHandler(
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
       const countCommits = opts.countBranchCommits ?? defaultCountBranchCommits;
-      const getPrBody = opts.getPrBody ?? defaultGetPrBody;
+      const findSuggestionCommentBody =
+        opts.findSuggestionCommentBody ?? defaultFindLatestCommentWithMarker;
+      const findPrNumber = opts.findPrNumber ?? defaultFindPrNumber;
+
+      /**
+       * Resolve and fetch the squash-suggestion comment body for the
+       * current branch's PR.  Returns `undefined` when the PR cannot
+       * be resolved or when no matching comment exists.
+       */
+      const readSuggestionCommentBody = (): string | undefined => {
+        const prNumber = findPrNumber(ctx.owner, ctx.repo, ctx.branch);
+        if (prNumber === undefined) return undefined;
+        return findSuggestionCommentBody(
+          ctx.owner,
+          ctx.repo,
+          prNumber,
+          SQUASH_SUGGESTION_START_MARKER,
+        );
+      };
 
       // Read the persisted agent-A session id (live) with a fallback
       // to the one-shot pipeline value, so in-process retries can
@@ -594,7 +659,7 @@ export function createSquashStageHandler(
           ? opts.savedSquashSubStep()
           : opts.savedSquashSubStep;
 
-      if (saved === "applied_in_pr_body") {
+      if (saved === "applied_via_github") {
         // Stage already finished via the SUGGESTED_SINGLE / github path.
         return {
           outcome: "completed",
@@ -663,13 +728,19 @@ export function createSquashStageHandler(
       }
 
       if (saved === "awaiting_user_choice") {
-        const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
-        if (hasValidSuggestionBlock(prBody)) {
-          const merged = guardIfPrMerged(ctx, opts);
-          if (merged) return merged;
+        // Check the PR lifecycle BEFORE reading the suggestion
+        // comment: `findPrNumber` uses `gh pr list` which only
+        // returns open PRs, so once the user merges on GitHub the
+        // comment lookup fails and we would otherwise fall through
+        // to a fresh planning run instead of short-circuiting to
+        // `squash.alreadyMerged`.
+        const merged = guardIfPrMerged(ctx, opts);
+        if (merged) return merged;
+        const commentBody = readSuggestionCommentBody();
+        if (hasValidSuggestionBlock(commentBody)) {
           return askUserAndApply(ctx, opts, undefined);
         }
-        // Suggestion block missing or malformed — fall back to a
+        // Suggestion comment missing or malformed — fall back to a
         // fresh planning run rather than re-presenting a choice that
         // the user could not act on.
       }
@@ -737,7 +808,7 @@ export function createSquashStageHandler(
       // `squashResult.sessionId`.  Without this, a resume from
       // `awaiting_user_choice` that routes the user's "agent" choice
       // back to the older planning session would not continue the
-      // exact conversation that drafted the PR-body suggestion.
+      // exact conversation that drafted the squash-suggestion comment.
       if (verdictSessionId) {
         ctx.onSessionId?.("a", verdictSessionId);
       }
@@ -745,8 +816,8 @@ export function createSquashStageHandler(
       // ---- post-clarification deterministic fallback chain -----------------
       // Order matters: a completed force-push is the hard-to-undo side
       // effect, so detect it first.  Only then check the suggestion
-      // block, because an earlier run may have left a stale block in
-      // the PR body that would otherwise be misclassified.  The block
+      // comment, because an earlier run may have left a stale comment
+      // on the PR that would otherwise be misclassified.  The block
       // must be fully parseable (markers + `**Title**` label) — a malformed
       // block is treated as missing because Stage 9 cannot render a
       // preview from it.
@@ -755,8 +826,16 @@ export function createSquashStageHandler(
         if (postCount < initialCount) {
           verdict = "SQUASHED_MULTI";
         } else {
-          const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
-          if (hasValidSuggestionBlock(prBody)) {
+          // Check the PR lifecycle BEFORE the comment lookup:
+          // `findPrNumber` uses `gh pr list` (open PRs only), so a
+          // concurrent merge between the clarification turn and this
+          // fallback would make the lookup return `undefined` and flip
+          // the verdict to `BLOCKED` instead of taking the existing
+          // merged short-circuit.
+          const merged = guardIfPrMerged(ctx, opts);
+          if (merged) return merged;
+          const commentBody = readSuggestionCommentBody();
+          if (hasValidSuggestionBlock(commentBody)) {
             verdict = "SUGGESTED_SINGLE";
           } else {
             verdict = "BLOCKED";
@@ -785,21 +864,28 @@ export function createSquashStageHandler(
       }
 
       if (verdict === "SUGGESTED_SINGLE") {
-        // Verify the PR body holds a fully parseable suggestion block
-        // before asking the user.  A bare start marker or a block
-        // missing the `**Title**` label / the end marker would let the stage
-        // complete with `applied_in_pr_body` but leave Stage 9 unable
-        // to render the inline preview, so fail closed instead.
-        const prBody = getPrBody(ctx.owner, ctx.repo, ctx.branch);
-        if (!hasValidSuggestionBlock(prBody)) {
+        // Check the PR lifecycle BEFORE reading the suggestion
+        // comment: a concurrent merge on GitHub would make the
+        // `findPrNumber` lookup (which uses `gh pr list`, open PRs
+        // only) return `undefined`, and the verdict would flip to
+        // `BLOCKED` instead of taking the existing merged
+        // short-circuit.
+        const merged = guardIfPrMerged(ctx, opts);
+        if (merged) return merged;
+        // Verify the PR comment holds a fully parseable suggestion
+        // block before asking the user.  A bare start marker or a
+        // block missing the `**Title**` label / the end marker would
+        // let the stage complete with `applied_via_github` but leave
+        // Stage 9 unable to render the inline preview, so fail closed
+        // instead.
+        const commentBody = readSuggestionCommentBody();
+        if (!hasValidSuggestionBlock(commentBody)) {
           opts.onSquashSubStep?.(undefined);
           return {
             outcome: "blocked",
             message: `${squashResult.responseText}\n\n---\n\n${verdictResponseText}`,
           };
         }
-        const merged = guardIfPrMerged(ctx, opts);
-        if (merged) return merged;
         return askUserAndApply(ctx, opts, verdictSessionId);
       }
 
@@ -822,12 +908,19 @@ async function askUserAndApply(
 ): Promise<StageResult> {
   opts.onSquashSubStep?.("awaiting_user_choice");
 
-  const choice = opts.chooseSquashApplyMode
-    ? await opts.chooseSquashApplyMode(t()["squash.singleChoicePrompt"])
-    : "agent";
+  // The startup policy decides whether to interrupt the pipeline
+  // with a per-run prompt or proceed silently with "agent".  Default
+  // policy is "ask" so missing wiring keeps today's behaviour.
+  const policy = opts.squashApplyPolicy ?? "ask";
+  const choice: "agent" | "github" =
+    policy === "auto"
+      ? "agent"
+      : opts.chooseSquashApplyMode
+        ? await opts.chooseSquashApplyMode(t()["squash.singleChoicePrompt"])
+        : "agent";
 
   if (choice === "github") {
-    opts.onSquashSubStep?.("applied_in_pr_body");
+    opts.onSquashSubStep?.("applied_via_github");
     return {
       outcome: "completed",
       message: t()["squash.messageAppended"],

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -50,9 +50,8 @@ vi.mock("./models.js", () => ({
   setCustomModels: (...args: unknown[]) => mockSetCustomModels(...args),
 }));
 
-const { runStartup, selectTarget, modelDisplayName } = await import(
-  "./startup.js"
-);
+const { runStartup, selectTarget, modelDisplayName, promptSquashApplyPolicy } =
+  await import("./startup.js");
 
 // ---------------------------------------------------------------------------
 // Model mock setup
@@ -2802,5 +2801,31 @@ describe("runStartup — manage custom models", () => {
       (c: { value: string }) => c.value,
     );
     expect(values).not.toContain("__manage_custom__");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// promptSquashApplyPolicy
+// ---------------------------------------------------------------------------
+//
+// Lives in `startup.ts` and is invoked by `src/index.ts` at the
+// shared join point so the question fires once per run regardless of
+// whether `RunParams` came from `runStartup()` (fresh) or from saved
+// state (resume).  The structural test in `index.test.ts` enforces
+// that the join-point call site exists; these tests cover the
+// prompt's own behaviour.
+describe("promptSquashApplyPolicy", () => {
+  test("default Enter (true) → 'auto'", async () => {
+    mockConfirm.mockResolvedValueOnce(true);
+    const policy = await promptSquashApplyPolicy();
+    expect(policy).toBe("auto");
+    // Default is Yes so a bare Enter picks the low-friction path.
+    expect(mockConfirm.mock.calls[0][0]).toHaveProperty("default", true);
+  });
+
+  test("explicit no → 'ask'", async () => {
+    mockConfirm.mockResolvedValueOnce(false);
+    const policy = await promptSquashApplyPolicy();
+    expect(policy).toBe("ask");
   });
 });

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -126,6 +126,26 @@ function agentConfigEqual(a: AgentConfig | undefined, b: AgentConfig): boolean {
 }
 
 /**
+ * Ask the squash-apply policy once per run.  Lives in this module
+ * (rather than inline at the join point in `src/index.ts`) so that
+ * the prompt can be unit-tested independently and so the call is a
+ * single named target — a future refactor cannot silently drop the
+ * question on either the fresh-startup or the resume path.
+ *
+ * Not persisted to config or `RunState`: the right answer depends on
+ * the state of the current branch / PR.  Default is "let the agent
+ * handle it" so a bare Enter keypress picks the low-friction path.
+ */
+export async function promptSquashApplyPolicy(): Promise<"auto" | "ask"> {
+  const m = t();
+  const autoApply = await confirm({
+    message: m["startup.squashApplyPolicyPrompt"],
+    default: true,
+  });
+  return autoApply ? "auto" : "ask";
+}
+
+/**
  * First phase of startup: select owner, repo, and issue number.
  * Returns early so the caller can check for a resumable run state
  * before collecting the remaining options.


### PR DESCRIPTION
## Summary

Two changes to the single-commit squash flow, landed together because they share i18n, state-shape, and test fixtures.

**1. Move the squash suggestion from the PR body into a PR comment.** The suggestion now lives next to the "Squash and merge" dropdown at the bottom of the page rather than a full scroll above it. The agent looks up its own prior squash-suggestion comment by the start marker and PATCHes it in place on every iteration so the timeline stays close to the merge box instead of accumulating duplicates. A new `findLatestCommentWithMarker` helper in `src/pr-comments.ts` is the single source of truth for the lookup, used by both Stage 8's validation path and Stage 9's merge-confirm hint renderer.

**2. Ask the squash-apply policy once per run at startup.** Instead of interrupting the pipeline with an `agent`/`github` chooser every time a SUGGESTED_SINGLE verdict lands, the startup flow now asks once whether to apply it automatically via the agent or ask each time. Default is "let the agent handle it" — a bare Enter picks the low-friction path. The prompt is owned by a small `promptSquashApplyPolicy()` helper in `src/startup.ts`, called once at the shared join point in `src/index.ts` after both the fresh-start and resume branches produce `RunParams`, so both paths go through the same question with no duplication. Not persisted to config or `RunState`: the right answer depends on the state of the current branch / PR, so it is collected fresh every run.

**Other changes bundled in:**
- Sub-step literal renamed `applied_in_pr_body` → `applied_via_github`. `RunState` bumped to v4 with an in-place migration so in-flight runs resume into the same short-circuit branch.
- All three agent-visible prompts (main squash, completion-check, agent-squash follow-up) updated together to describe the comment location consistently — mismatched wording would fall back to the old PR-body location.
- The agent-facing example for locating a prior comment uses `--paginate --slurp` (with a `.[] | .[]` flatten) so the `| last` filter sees the latest match across all pages, matching the production helper in `src/pr-comments.ts`.
- The PR-merged guard now runs before the suggestion-comment lookup in all three Stage 8 paths (immediate `SUGGESTED_SINGLE`, `awaiting_user_choice` resume, and the deterministic fallback after an ambiguous verdict). `findPrNumber` uses open-only `gh pr list`, so without the guard a concurrent merge would either flip the verdict to `BLOCKED` or fall through to a fresh planning run instead of taking the existing `squash.alreadyMerged` short-circuit.
- i18n strings under both `squash.*` and `pipeline.*` updated in `en.ts` and `ko.ts`.
- Doc comments in `src/pipeline.ts` and `src/stage-squash.ts` plus the Stage 8 / Stage 9 sections of `docs/pipeline.md` refreshed to match.
- `stage-squash.test.ts` now fixtures the comment body via `findSuggestionCommentBody` and `findPrNumber` injections in place of the old `getPrBody`.
- A structural test in `src/index.test.ts` guards the join-point invariant: `promptSquashApplyPolicy` is imported from `startup.js`, called exactly once, and the call sits after both the resume branch's params construction and the fresh branch's `params ??=` block.

Closes #274

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes on all changed files
- [x] `pnpm vitest run` passes (1878 tests including new `squashApplyPolicy`, `findLatestCommentWithMarker`, `promptSquashApplyPolicy`, and join-point structural cases)
- [x] Fresh run: startup prompt appears after issue selection, accepts Enter (auto), reaches Stage 8, verifies no mid-pipeline chooser fires on SUGGESTED_SINGLE
- [x] Fresh run with "ask" policy: mid-pipeline chooser still fires as before
- [x] Resume run: startup prompt also fires on the resume branch (not only fresh start)
- [x] Squash suggestion is posted as a PR comment (not the PR body) and re-running the stage edits the same comment instead of creating a second one
- [x] Stage 9 merge-confirm screen reads the suggestion from the PR comment; `[t]` and `[b]` hotkeys copy title / body
- [x] Load a v3 `RunState` with `squashSubStep === "applied_in_pr_body"` and confirm it migrates to `"applied_via_github"` on load

<!-- agentcoop:squash-suggestion:start -->
## Suggested squash commit

**Title**

```text
Post squash suggestion as PR comment, ask apply policy
```

**Body**

```text
Move the single-commit squash suggestion from the PR body to a PR
comment so it sits next to the "Squash and merge" dropdown instead
of a full scroll above it. The agent looks up its own prior comment
by start marker and PATCHes it in place each iteration, so the
timeline stays close to the merge box without accumulating
duplicates.

Ask the squash-apply policy once per run at startup instead of
interrupting the pipeline with an agent/github chooser every time a
SUGGESTED_SINGLE verdict lands. Default is "let the agent handle
it"; a bare Enter picks the low-friction path. Not persisted — the
right answer depends on the state of the current branch / PR, so it
is collected fresh every run, including on the resume path.

Rename the sub-step literal `applied_in_pr_body` to
`applied_via_github` and bump RunState to v4 with an in-place
migration so in-flight runs resume into the same short-circuit
branch.

Closes #274
```
<!-- agentcoop:squash-suggestion:end -->
