### PR TITLE
Track, display, and check CLI versions (#276)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,73 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Agent pane headers now include the CLI name and installed CLI
+  version next to the model label (e.g.
+  `Agent A (author) — Claude Opus 4.6 v1.2.3`). The CLI name
+  disambiguates panes when model names are shared or user-configured.
+  The version is detected once at pipeline start so it does not flicker
+  mid-run, and is threaded through `renderApp` so no adapter changes are
+  required.
+- Startup now compares the installed `claude` / `codex` CLI against the
+  channel-appropriate "latest" version and prompts the user to update
+  when a newer release is available. The check runs after the CLIs
+  actually used this run are known (fresh and resume branches joined,
+  `params` finalized) so it never prompts for a CLI that is not in use.
+  Claude's latest is fetched from the npm registry. Codex's latest is
+  resolved by matching the installed binary's realpath against known
+  layouts (npm global prefix anchored on
+  `lib/node_modules/@openai/codex/` so a project-local install at
+  `<repo>/node_modules/@openai/codex/...` — reachable via
+  `node_modules/.bin/codex` — is treated as inconclusive rather than
+  pointed at the npm registry, Homebrew formula `Cellar/codex/`,
+  Homebrew cask `Caskroom/codex/`, or a standalone install rooted at
+  `~/.codex/` — specifically `~/.codex/bin/`,
+  `~/.codex/versions/<ver>/`, or the current
+  `~/.codex/packages/standalone/releases/` layout). Homebrew matches
+  are anchored on the `codex` package segment and root-anchored on the
+  Homebrew prefixes (`/opt/homebrew/`, `/usr/local/`,
+  `/home/linuxbrew/.linuxbrew/`),
+  so a custom wrapper formula/cask (e.g. `Cellar/my-codex-wrapper/...`,
+  `Caskroom/custom-codex/...`) and a copied tree under a non-Homebrew
+  root (e.g. `/tmp/opt/homebrew/Cellar/codex/...`,
+  `/Users/me/sandbox/usr/local/Caskroom/codex/...`) are not
+  misclassified as the official `codex` package. Only the known
+  subpaths under the running user's home directory are accepted as a
+  standalone install; any other
+  layout — including an unrecognized subpath inside `~/.codex/` (e.g.
+  `~/.codex/tools/codex`) or a raw `Applications/` path that did not
+  resolve through `realpath` into a Caskroom directory — is treated as
+  inconclusive and the check is skipped for that CLI rather than
+  guessed. When an update is
+  chosen, AgentCoop pauses for the user to run their package manager
+  and re-runs `--version` on return; if the
+  version is unchanged it offers retry / skip (proceed with the current
+  version) / abort. The check can be disabled with
+  `skipVersionCheck: true` in `~/.agentcoop/config.json` and is
+  throttled to once per 24h via `lastVersionCheckAt`. The throttle
+  timestamp only advances after at least one CLI reached a real
+  installed-vs-latest comparison, so a run where every channel was
+  inconclusive or the registry fetch failed still re-checks on the
+  next start rather than being silently throttled for 24h. Network
+  failures are logged but never fatal. The persistence writes
+  `lastKnownVersions` / `lastVersionCheckAt` as a narrow patch into
+  the raw JSON rather than round-tripping through the normalized
+  `Config` shape, so unknown top-level keys in
+  `~/.agentcoop/config.json` (user-added fields, fields from a newer
+  AgentCoop version, etc.) are preserved across the update. The patch
+  also merges `lastKnownVersions` against the existing nested object
+  rather than replacing it, so unknown nested CLI entries (e.g. a
+  forward-compatible `gemini` field added by a newer AgentCoop
+  version) survive a claude/codex-only check.
+- Per-run CLI versions are now recorded into `RunState`
+  (`agentA.cliVersion` / `agentB.cliVersion`) and into the run-log
+  header under a `version` line for each agent, so postmortem
+  reproduction can identify the exact CLI build that produced a run.
+  The values survive across resume and are refreshed at resume time so
+  a CLI upgrade between runs is captured, not silently discarded. A
+  failed re-probe on resume (e.g. `--version` crashed or its output
+  could not be parsed) intentionally keeps the previously recorded
+  version rather than blanking it, preserving the postmortem record.
 - Stage 8 (Squash) now posts the single-commit suggestion as a PR
   comment instead of editing the PR body. The agent looks up any
   prior squash-suggestion comment by its start marker and PATCHes it

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ minimal human involvement.
 ## Terminal UI
 
 ```text
-┌─ Agent A (author) — Claude Opus 4.6 ● [*] ─┬─ Agent B (reviewer) — GPT-5.4 ─┐
+┌─ Agent A (author) — Claude Opus 4.6 v1.2.3 ● [*] ─┬─ Agent B (reviewer) — Codex GPT-5.4 v0.46.0 ─┐
 │                                            │                                │
 │  (streamed output)                         │  (streamed output)             │
 │                                            │                                │
@@ -43,7 +43,9 @@ minimal human involvement.
 ```
 
 - **Agent panes** — Streamed output from each agent in real time.
-  The active agent is marked with `●`, the focused pane (for
+  The pane header shows the agent role, the CLI name (Claude / Codex),
+  the model name, and the installed CLI version (detected at pipeline
+  start). The active agent is marked with `●`, the focused pane (for
   scrolling) with `[*]`.
 - **TokenBar** — Per-agent token usage (input/output, with cached
   token counts when available).
@@ -243,6 +245,50 @@ to reuse it, clean up and recreate, or halt.
 - Any external services the agents use (e.g., Figma Desktop MCP)
   must be running and authenticated
 
+### CLI update check
+
+At startup (after the agents for this run are known) AgentCoop runs
+`claude --version` / `codex --version` and compares the installed
+version against the latest release from the channel-appropriate
+source. Claude always uses the npm registry
+(`@anthropic-ai/claude-code`). Codex's channel is resolved from the
+installed binary's realpath: npm global prefix, Homebrew formula
+(`Cellar/codex/`), Homebrew cask (`Caskroom/codex/`), or a standalone
+install rooted at `~/.codex/` — specifically `~/.codex/bin/`,
+`~/.codex/versions/<ver>/`, or the current
+`~/.codex/packages/standalone/releases/` layout. Homebrew matches are
+anchored on the `codex` package segment and root-anchored on the
+Homebrew prefixes (`/opt/homebrew/`, `/usr/local/`,
+`/home/linuxbrew/.linuxbrew/`), so
+a custom wrapper formula or cask (e.g. `Cellar/my-codex-wrapper/…`,
+`Caskroom/custom-codex/…`) and a copied tree under a non-Homebrew
+root (e.g. `/tmp/opt/homebrew/Cellar/codex/…`,
+`/Users/me/sandbox/usr/local/Caskroom/codex/…`) are not misclassified
+as the official `codex` package. Only the known
+subpaths under the running user's home directory are accepted as a
+standalone install; an unrecognized subpath inside `~/.codex/` (e.g.
+`~/.codex/tools/codex`) or any `.codex` directory outside `$HOME`
+(e.g. `/tmp/.codex/…`) is treated as inconclusive and the check is
+skipped rather than guessed.
+Likewise, a raw `Applications/` path that did not resolve through
+`realpath` into a Caskroom directory is treated as inconclusive rather
+than guessed as a cask, so a hand-placed `~/Applications/Codex.app/…`
+or `/tmp/Applications/codex` never produces a bogus update prompt.
+
+If the installed version is older, AgentCoop prompts to update and
+pauses until you press Enter so you can run your package manager in
+another tab. On return it re-runs `--version` and either proceeds, or
+— if the version is unchanged — offers retry / skip / abort.
+
+Skip the check in CI or offline environments by setting
+`skipVersionCheck: true` in `~/.agentcoop/config.json`. The check is
+also throttled to once per 24h via the `lastVersionCheckAt`
+timestamp. That timestamp only advances after at least one CLI
+reached a real installed-vs-latest comparison — a run where every
+channel was inconclusive, or where the registry fetch failed, will
+re-check on the next start rather than being silently throttled
+for 24h. Network failures are logged but never fatal.
+
 ## Installation & quick start
 
 ```bash
@@ -283,6 +329,10 @@ Settings are stored in `~/.agentcoop/config.json`:
 | `notifications.desktop` | Desktop notification | `false` |
 | `customModels.claude` | Extra Claude model entries | _(none)_ |
 | `customModels.codex` | Extra Codex/GPT model entries | _(none)_ |
+| `lastKnownVersions.claude` | Most recent `claude --version` output | _(first run)_ |
+| `lastKnownVersions.codex` | Most recent `codex --version` output | _(first run)_ |
+| `skipVersionCheck` | Skip the startup update check | `false` |
+| `lastVersionCheckAt` | Epoch ms of the last check (throttle) | _(first run)_ |
 
 Agent presets (CLI, model, context window, effort level) are also
 saved per agent slot.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -14,7 +14,8 @@ vi.mock("node:os", () => ({
   homedir: () => tmpHome,
 }));
 
-const { configPath, loadConfig, saveConfig } = await import("./config.js");
+const { configPath, loadConfig, patchVersionCheckState, saveConfig } =
+  await import("./config.js");
 
 describe("configPath", () => {
   test("returns path under ~/.agentcoop/", () => {
@@ -135,6 +136,41 @@ describe("loadConfig", () => {
     writeFileSync(configPath(), JSON.stringify({ owners: "not-an-array" }));
     const config = loadConfig();
     expect(config.owners).toEqual([]);
+  });
+
+  test("reads version-check fields when present", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: ["aicers"],
+        lastKnownVersions: { claude: "1.2.3", codex: "0.46.0" },
+        skipVersionCheck: true,
+        lastVersionCheckAt: 1_700_000_000_000,
+      }),
+    );
+    const config = loadConfig();
+    expect(config.lastKnownVersions).toEqual({
+      claude: "1.2.3",
+      codex: "0.46.0",
+    });
+    expect(config.skipVersionCheck).toBe(true);
+    expect(config.lastVersionCheckAt).toBe(1_700_000_000_000);
+  });
+
+  test("ignores malformed version-check fields", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: ["aicers"],
+        lastKnownVersions: "not-an-object",
+        skipVersionCheck: "yes",
+        lastVersionCheckAt: "not-a-number",
+      }),
+    );
+    const config = loadConfig();
+    expect(config.lastKnownVersions).toBeUndefined();
+    expect(config.skipVersionCheck).toBeUndefined();
+    expect(config.lastVersionCheckAt).toBeUndefined();
   });
 
   test("filters out non-string elements from owners array", () => {
@@ -762,5 +798,105 @@ describe("saveConfig", () => {
     saveConfig(original);
     const loaded = loadConfig();
     expect(loaded).toEqual(original);
+  });
+});
+
+describe("patchVersionCheckState", () => {
+  beforeEach(() => {
+    mkdirSync(join(tmpHome, ".agentcoop"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("preserves unknown top-level keys when patching fields", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: ["aicers"],
+        cloneBaseDir: "~/code",
+        language: "en",
+        futureUnknownField: { nested: "value" },
+        anotherUnknown: 42,
+      }),
+    );
+    patchVersionCheckState({
+      lastKnownVersions: { claude: "1.3.0" },
+      lastVersionCheckAt: 1_700_000_000_000,
+    });
+    const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
+    expect(raw.futureUnknownField).toEqual({ nested: "value" });
+    expect(raw.anotherUnknown).toBe(42);
+    expect(raw.lastKnownVersions).toEqual({ claude: "1.3.0" });
+    expect(raw.lastVersionCheckAt).toBe(1_700_000_000_000);
+    // Existing recognized fields are left untouched as well.
+    expect(raw.owners).toEqual(["aicers"]);
+    expect(raw.cloneBaseDir).toBe("~/code");
+    expect(raw.language).toBe("en");
+  });
+
+  test("writes only the supplied fields (merges rather than replaces)", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        lastKnownVersions: { claude: "1.0.0", codex: "0.1.0" },
+        lastVersionCheckAt: 100,
+      }),
+    );
+    // Only updating `lastKnownVersions` — timestamp should stay.
+    patchVersionCheckState({
+      lastKnownVersions: { claude: "1.1.0", codex: "0.1.0" },
+    });
+    const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
+    expect(raw.lastKnownVersions).toEqual({ claude: "1.1.0", codex: "0.1.0" });
+    expect(raw.lastVersionCheckAt).toBe(100);
+  });
+
+  test("creates the file when it does not exist", () => {
+    rmSync(configPath(), { force: true });
+    patchVersionCheckState({
+      lastKnownVersions: { claude: "1.3.0" },
+    });
+    const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
+    expect(raw.lastKnownVersions).toEqual({ claude: "1.3.0" });
+  });
+
+  test("written file ends with newline", () => {
+    patchVersionCheckState({
+      lastKnownVersions: { claude: "1.3.0" },
+    });
+    expect(readFileSync(configPath(), "utf-8").endsWith("\n")).toBe(true);
+  });
+
+  test("preserves unknown nested CLI entries inside lastKnownVersions", () => {
+    // `loadLastKnownVersions` filters the runtime view down to
+    // `{ claude?, codex? }`, so an `updates.lastKnownVersions` built
+    // from that view does not know about other CLI entries.  The
+    // patcher must merge against the existing nested object — not
+    // replace it — so a forward-compatible field (e.g. `gemini` from
+    // a newer AgentCoop version) or a hand-added entry survives a
+    // claude/codex-only check.
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        lastKnownVersions: {
+          claude: "1.0.0",
+          codex: "0.46.0",
+          gemini: "0.5.0",
+        },
+      }),
+    );
+    patchVersionCheckState({
+      lastKnownVersions: { claude: "1.3.0", codex: "0.46.0" },
+    });
+    const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
+    expect(raw.lastKnownVersions).toEqual({
+      claude: "1.3.0",
+      codex: "0.46.0",
+      gemini: "0.5.0",
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,6 +50,22 @@ export interface Config {
     claude?: Array<{ name: string; value: string }>;
     codex?: Array<{ name: string; value: string }>;
   };
+  /**
+   * Most recently observed CLI versions, updated after the startup
+   * version check.  Used as the "previous" side of the comparison on
+   * the next run so the user can spot regressions across runs.
+   */
+  lastKnownVersions?: {
+    claude?: string;
+    codex?: string;
+  };
+  /** When `true`, the startup version check is skipped entirely. */
+  skipVersionCheck?: boolean;
+  /**
+   * Epoch milliseconds of the last successful version check.  Used to
+   * throttle network calls to roughly once per 24h.
+   */
+  lastVersionCheckAt?: number;
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -100,6 +116,22 @@ function loadModelEntries(
         typeof (e as Record<string, unknown>).value === "string",
     )
     .map((e) => ({ name: e.name, value: e.value }));
+}
+
+function loadLastKnownVersions(
+  raw: unknown,
+): Config["lastKnownVersions"] | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+  const r = raw as Record<string, unknown>;
+  const result: NonNullable<Config["lastKnownVersions"]> = {};
+  if (typeof r.claude === "string") result.claude = r.claude;
+  if (typeof r.codex === "string") result.codex = r.codex;
+  if (result.claude === undefined && result.codex === undefined) {
+    return undefined;
+  }
+  return result;
 }
 
 function loadCustomModels(raw: unknown): Config["customModels"] | undefined {
@@ -199,6 +231,16 @@ export function loadConfig(): Config {
         ? raw.executionMode
         : undefined,
     customModels: loadCustomModels(raw.customModels),
+    lastKnownVersions: loadLastKnownVersions(raw.lastKnownVersions),
+    skipVersionCheck:
+      typeof raw.skipVersionCheck === "boolean"
+        ? raw.skipVersionCheck
+        : undefined,
+    lastVersionCheckAt:
+      typeof raw.lastVersionCheckAt === "number" &&
+      Number.isFinite(raw.lastVersionCheckAt)
+        ? raw.lastVersionCheckAt
+        : undefined,
   };
 }
 
@@ -261,4 +303,58 @@ export function saveConfig(config: Config): void {
   const path = configPath();
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+/**
+ * Patch only the version-check state fields in `~/.agentcoop/config.json`
+ * without round-tripping through the normalized `Config` shape.
+ *
+ * `loadConfig` / `saveConfig` drop top-level keys that the schema does
+ * not recognize, so using `saveConfig` to persist these fields would
+ * silently delete any unknown entries a user or future version may have
+ * added.  This helper reads the raw JSON, merges the supplied fields,
+ * and writes the file back, preserving unknown keys.
+ */
+export function patchVersionCheckState(updates: {
+  lastKnownVersions?: NonNullable<Config["lastKnownVersions"]>;
+  lastVersionCheckAt?: number;
+}): void {
+  const path = configPath();
+  let raw: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8"));
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        raw = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Unreadable or invalid JSON — fall through and write a fresh file.
+    }
+  }
+  if (updates.lastKnownVersions !== undefined) {
+    // Merge against the existing nested object instead of replacing
+    // it wholesale.  `loadLastKnownVersions` filters the runtime view
+    // down to `{ claude?, codex? }`, so an `updates.lastKnownVersions`
+    // built from that view does not know about other CLI entries
+    // (e.g. a `gemini` field a future AgentCoop version may write, or
+    // a hand-added user entry).  Replacing would silently drop those
+    // — the same class of failure that motivated this helper for
+    // unknown top-level keys.
+    const existing =
+      typeof raw.lastKnownVersions === "object" &&
+      raw.lastKnownVersions !== null &&
+      !Array.isArray(raw.lastKnownVersions)
+        ? (raw.lastKnownVersions as Record<string, unknown>)
+        : {};
+    raw.lastKnownVersions = { ...existing, ...updates.lastKnownVersions };
+  }
+  if (updates.lastVersionCheckAt !== undefined) {
+    raw.lastVersionCheckAt = updates.lastVersionCheckAt;
+  }
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(raw, null, 2)}\n`);
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -348,6 +348,30 @@ export const en: Messages = {
   "worktree.alreadyExists": (path) =>
     `Worktree already exists at ${path}. ` +
     "Provide a conflictChoice (reuse | clean | halt).",
+
+  // ---- version check -----------------------------------------------------
+
+  "versionCheck.checking": "Checking CLI versions...",
+  "versionCheck.inconclusive": (cli, reason) =>
+    `  ${cli}: update check skipped (${reason})`,
+  "versionCheck.fetchFailed": (cli, reason) =>
+    `  ${cli}: could not fetch latest version (${reason})`,
+  "versionCheck.upToDate": (cli, version) =>
+    `  ${cli} v${version} is up to date.`,
+  "versionCheck.updatePrompt": (cli, from, to) =>
+    `A newer version of ${cli} is available (v${from} → v${to}). Update now?`,
+  "versionCheck.updateWaiting": (cli) =>
+    `Please update ${cli}, then press Enter to continue.`,
+  "versionCheck.versionUnchanged": (version) => `Version is still v${version}.`,
+  "versionCheck.retrySkipAbortPrompt": "How would you like to proceed?",
+  "versionCheck.proceedingWith": (cli, version) =>
+    `  ${cli} updated to v${version}. Continuing.`,
+  "versionCheck.abortedByUser": "Update check aborted by user.",
+  "versionCheck.versionUnknown": (cli) =>
+    `  Could not determine ${cli} version — skipping update check.`,
+  "versionCheck.retry": "Retry",
+  "versionCheck.skip": "Skip (use current version)",
+  "versionCheck.abort": "Abort",
   "worktree.haltConflict":
     "User chose to halt \u2014 worktree conflict unresolved.",
 };

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -390,6 +390,31 @@ export const ko: Messages = {
 
   "notification.title": "agentcoop",
 
+  // ---- version check -----------------------------------------------------
+
+  "versionCheck.checking": "CLI 버전 확인 중...",
+  "versionCheck.inconclusive": (cli, reason) =>
+    `  ${cli}: 업데이트 검사 건너뜀 (${reason})`,
+  "versionCheck.fetchFailed": (cli, reason) =>
+    `  ${cli}: 최신 버전을 가져올 수 없습니다 (${reason})`,
+  "versionCheck.upToDate": (cli, version) =>
+    `  ${cli} v${version} 최신 버전입니다.`,
+  "versionCheck.updatePrompt": (cli, from, to) =>
+    `${cli}의 새 버전이 있습니다 (v${from} → v${to}). 지금 업데이트하시겠습니까?`,
+  "versionCheck.updateWaiting": (cli) =>
+    `${cli}를 업데이트한 후 Enter 키를 눌러 계속 진행하세요.`,
+  "versionCheck.versionUnchanged": (version) =>
+    `버전이 여전히 v${version}입니다.`,
+  "versionCheck.retrySkipAbortPrompt": "어떻게 진행하시겠습니까?",
+  "versionCheck.proceedingWith": (cli, version) =>
+    `  ${cli}가 v${version}로 업데이트되었습니다. 계속 진행합니다.`,
+  "versionCheck.abortedByUser": "사용자에 의해 업데이트 검사가 중단되었습니다.",
+  "versionCheck.versionUnknown": (cli) =>
+    `  ${cli} 버전을 확인할 수 없어 업데이트 검사를 건너뜁니다.`,
+  "versionCheck.retry": "재시도",
+  "versionCheck.skip": "건너뛰기 (현재 버전 사용)",
+  "versionCheck.abort": "중단",
+
   // ---- worktree errors ---------------------------------------------------
 
   "worktree.alreadyExists": (path) =>

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -315,4 +315,25 @@ export interface Messages {
 
   "worktree.alreadyExists": (path: string) => string;
   "worktree.haltConflict": string;
+
+  // ---- version check -----------------------------------------------------
+
+  "versionCheck.checking": string;
+  "versionCheck.inconclusive": (cli: string, reason: string) => string;
+  "versionCheck.fetchFailed": (cli: string, reason: string) => string;
+  "versionCheck.upToDate": (cli: string, version: string) => string;
+  "versionCheck.updatePrompt": (
+    cli: string,
+    from: string,
+    to: string,
+  ) => string;
+  "versionCheck.updateWaiting": (cli: string) => string;
+  "versionCheck.versionUnchanged": (version: string) => string;
+  "versionCheck.retrySkipAbortPrompt": string;
+  "versionCheck.proceedingWith": (cli: string, version: string) => string;
+  "versionCheck.abortedByUser": string;
+  "versionCheck.versionUnknown": (cli: string) => string;
+  "versionCheck.retry": string;
+  "versionCheck.skip": string;
+  "versionCheck.abort": string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { confirm, select } from "@inquirer/prompts";
+import { confirm, input, select } from "@inquirer/prompts";
 
 import type { AgentAdapter, AgentStream } from "./agent.js";
 import { type BootstrapLog, createBootstrapLog } from "./bootstrap-log.js";
@@ -24,6 +24,7 @@ import {
   assembleReviewStage,
   assembleSquashStage,
   loadConfig,
+  patchVersionCheckState,
 } from "./config.js";
 import { createDonePromptOptions } from "./done-prompt-options.js";
 import { getGitHubUsername, getIssue } from "./github.js";
@@ -77,6 +78,12 @@ import {
   selectTarget,
 } from "./startup.js";
 import { renderApp } from "./ui/render-app.js";
+import {
+  type CliName,
+  refreshAgentCliVersion,
+  runStartupVersionCheck,
+  VersionCheckAbortError,
+} from "./version-check.js";
 import {
   bootstrapRepo,
   createWorktree,
@@ -443,6 +450,64 @@ try {
   // semantics of "not persisted" and the default-true rationale.
   params.squashApplyPolicy = await promptSquashApplyPolicy();
 
+  // Check CLI versions against the appropriate distribution channel
+  // and prompt the user to update when a newer version is available.
+  // Runs after the CLIs actually used this run are known (fresh /
+  // resume branches joined, `params` finalized) so we do not prompt
+  // for a CLI that is not used this run.
+  const versionCheckConfig = loadConfig();
+  const uniqueClis: CliName[] = [];
+  for (const c of [params.agentAConfig.cli, params.agentBConfig.cli]) {
+    if (!uniqueClis.includes(c)) uniqueClis.push(c);
+  }
+  let cliVersionMap = new Map<CliName, string | undefined>();
+  try {
+    const versionMessages = t();
+    cliVersionMap = await runStartupVersionCheck({
+      clis: uniqueClis,
+      config: versionCheckConfig,
+      persistVersionCheckState: patchVersionCheckState,
+      prompts: {
+        confirmUpdate: async (message) => confirm({ message, default: true }),
+        waitForEnter: async (message) => {
+          await input({ message, default: "" });
+        },
+        chooseRetrySkipAbort: async (message) =>
+          select({
+            message,
+            choices: [
+              { name: versionMessages["versionCheck.retry"], value: "retry" },
+              { name: versionMessages["versionCheck.skip"], value: "skip" },
+              { name: versionMessages["versionCheck.abort"], value: "abort" },
+            ],
+          }),
+        log: (msg) => console.log(msg),
+        warn: (msg) => console.warn(msg),
+      },
+      translations: {
+        checking: versionMessages["versionCheck.checking"],
+        inconclusive: versionMessages["versionCheck.inconclusive"],
+        fetchFailed: versionMessages["versionCheck.fetchFailed"],
+        upToDate: versionMessages["versionCheck.upToDate"],
+        updatePrompt: versionMessages["versionCheck.updatePrompt"],
+        updateWaiting: versionMessages["versionCheck.updateWaiting"],
+        versionUnchanged: versionMessages["versionCheck.versionUnchanged"],
+        retrySkipAbortPrompt:
+          versionMessages["versionCheck.retrySkipAbortPrompt"],
+        proceedingWith: versionMessages["versionCheck.proceedingWith"],
+        abortedByUser: versionMessages["versionCheck.abortedByUser"],
+        versionUnknown: versionMessages["versionCheck.versionUnknown"],
+      },
+    });
+  } catch (err) {
+    if (err instanceof VersionCheckAbortError) {
+      process.exit(1);
+    }
+    throw err;
+  }
+  const agentAVersion = cliVersionMap.get(params.agentAConfig.cli);
+  const agentBVersion = cliVersionMap.get(params.agentBConfig.cli);
+
   const {
     agentAConfig,
     agentBConfig,
@@ -690,6 +755,7 @@ try {
       contextWindow: agentAConfig.contextWindow,
       effortLevel: agentAConfig.effortLevel,
       sessionId: undefined,
+      cliVersion: agentAVersion,
     },
     agentB: {
       cli: agentBConfig.cli,
@@ -697,10 +763,20 @@ try {
       contextWindow: agentBConfig.contextWindow,
       effortLevel: agentBConfig.effortLevel,
       sessionId: undefined,
+      cliVersion: agentBVersion,
     },
     issueSyncStatus: "skipped",
     issueChanges: [],
   };
+
+  // Refresh the per-run CLI version on resume so the saved state
+  // reflects the CLI build this run is actually driving (a CLI
+  // upgrade between runs must not be silently discarded).  The helper
+  // intentionally leaves the saved value alone when the probe
+  // returned `undefined`, so a failed re-probe does not erase the
+  // postmortem record from the previous successful run.
+  refreshAgentCliVersion(runState.agentA, agentAVersion);
+  refreshAgentCliVersion(runState.agentB, agentBVersion);
 
   // Save initial state.
   saveRunState(runState);
@@ -741,12 +817,19 @@ try {
       model: agentAConfig.model,
       contextWindow: agentAConfig.contextWindow,
       effortLevel: agentAConfig.effortLevel,
+      // Read through `runState` so a failed re-probe on resume keeps
+      // the previously recorded version in the run-log header instead
+      // of blanking it — preserving the postmortem record matches the
+      // behavior already implemented for `RunState` via
+      // `refreshAgentCliVersion`.
+      cliVersion: runState.agentA.cliVersion,
     },
     agentB: {
       cli: agentBConfig.cli,
       model: agentBConfig.model,
       contextWindow: agentBConfig.contextWindow,
       effortLevel: agentBConfig.effortLevel,
+      cliVersion: runState.agentB.cliVersion,
     },
     selfCheckAutoIterations: pipelineSettings.selfCheckAutoIterations,
     reviewAutoRounds: pipelineSettings.reviewAutoRounds,
@@ -952,6 +1035,8 @@ try {
       modelNameB: modelDisplayName(agentBConfig),
       cliTypeA: agentAConfig.cli,
       cliTypeB: agentBConfig.cli,
+      cliVersionA: agentAVersion,
+      cliVersionB: agentBVersion,
       notifications,
       initialSelfCheckCount: runState.selfCheckCount,
       initialReviewCount: runState.reviewCount,

--- a/src/run-log.test.ts
+++ b/src/run-log.test.ts
@@ -115,6 +115,43 @@ describe("createRunLog", () => {
     expect(content).toContain("auto");
   });
 
+  test("records cliVersion in header when provided", async () => {
+    // The run-log header is a postmortem surface — when version
+    // detection succeeded for this run we want the CLI build to land
+    // on disk next to the agent/model lines.
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(
+      emitter,
+      meta({
+        agentA: {
+          cli: "claude",
+          model: "opus",
+          contextWindow: "200k",
+          effortLevel: "high",
+          cliVersion: "1.2.3",
+        },
+        agentB: { cli: "codex", model: "sonnet", cliVersion: "0.46.0" },
+      }),
+    );
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).toContain("version  : 1.2.3");
+    expect(content).toContain("version  : 0.46.0");
+  });
+
+  test("omits version line when cliVersion is undefined", async () => {
+    // On a fresh run where `--version` failed we have no value to
+    // record — the header must omit the line rather than print a
+    // stray `version  : undefined`.
+    const emitter = new PipelineEventEmitter();
+    const log = createRunLog(emitter, meta());
+    await log.close();
+
+    const content = readLog(log.path);
+    expect(content).not.toContain("version  :");
+  });
+
   test("logs agent:chunk events", async () => {
     const emitter = new PipelineEventEmitter();
     const log = createRunLog(emitter, meta());

--- a/src/run-log.ts
+++ b/src/run-log.ts
@@ -23,6 +23,8 @@ export interface RunLogAgentMeta {
   model: string;
   contextWindow?: string;
   effortLevel?: string;
+  /** CLI version string captured at pipeline start (e.g. "1.2.3"). */
+  cliVersion?: string;
 }
 
 export interface RunLogMetadata {
@@ -174,10 +176,12 @@ export function createRunLog(
   if (meta.agentA.contextWindow)
     write(`  context  : ${meta.agentA.contextWindow}`);
   if (meta.agentA.effortLevel) write(`  effort   : ${meta.agentA.effortLevel}`);
+  if (meta.agentA.cliVersion) write(`  version  : ${meta.agentA.cliVersion}`);
   write(`Agent B    : ${meta.agentB.cli} / ${meta.agentB.model}`);
   if (meta.agentB.contextWindow)
     write(`  context  : ${meta.agentB.contextWindow}`);
   if (meta.agentB.effortLevel) write(`  effort   : ${meta.agentB.effortLevel}`);
+  if (meta.agentB.cliVersion) write(`  version  : ${meta.agentB.cliVersion}`);
   write(
     `Auto-budget: self-check=${meta.selfCheckAutoIterations}, review=${meta.reviewAutoRounds}, ci-check=${meta.ciCheckAutoIterations}`,
   );

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -52,6 +52,13 @@ export interface AgentState {
   contextWindow: string | undefined;
   effortLevel: string | undefined;
   sessionId: string | undefined;
+  /**
+   * Version of the CLI that was executed for this run (e.g. "1.2.3").
+   * Captured at pipeline start so it survives into the saved run state
+   * for post-mortem reproduction.  Optional for backward compatibility
+   * with state files written before version tracking existed.
+   */
+  cliVersion?: string;
 }
 
 /**
@@ -138,7 +145,8 @@ function isValidAgentState(v: unknown): v is AgentState {
     typeof r.model === "string" &&
     isOptionalString(r.contextWindow) &&
     isOptionalString(r.effortLevel) &&
-    isOptionalString(r.sessionId)
+    isOptionalString(r.sessionId) &&
+    isOptionalString(r.cliVersion)
   );
 }
 
@@ -268,12 +276,14 @@ export function loadRunState(
       contextWindow: raw.agentA.contextWindow ?? undefined,
       effortLevel: raw.agentA.effortLevel ?? undefined,
       sessionId: raw.agentA.sessionId ?? undefined,
+      cliVersion: raw.agentA.cliVersion ?? undefined,
     },
     agentB: {
       ...raw.agentB,
       contextWindow: raw.agentB.contextWindow ?? undefined,
       effortLevel: raw.agentB.effortLevel ?? undefined,
       sessionId: raw.agentB.sessionId ?? undefined,
+      cliVersion: raw.agentB.cliVersion ?? undefined,
     },
   };
 

--- a/src/ui/AgentPane.tsx
+++ b/src/ui/AgentPane.tsx
@@ -103,6 +103,52 @@ export function renderDiagnosticRow(block: DiagnosticBlock): string {
   return `[${block.timestamp}] Pipeline: ${block.message}${suffix}`;
 }
 
+/**
+ * Compose the pane-header text from label, CLI name, model name, and
+ * CLI version.
+ *
+ * Shape (CLI name included when provided, so panes are unambiguous
+ * even when model names are shared or user-configured):
+ *   - Nothing extra:            "Agent A (author)"
+ *   - Model only:               "Agent A (author) — Opus 4.6"
+ *   - CLI + model:              "Agent A (author) — Claude Opus 4.6"
+ *   - CLI + model + version:    "Agent A (author) — Claude Opus 4.6 v1.2.3"
+ *   - CLI + version (no model): "Agent A (author) — Claude v1.2.3"
+ *   - Version only:             "Agent A (author) — v1.2.3"
+ *
+ * The version is rendered with a leading `v` so "1.2.3" and "v1.2.3"
+ * display uniformly.  Leading `v`s already present in the input are
+ * stripped to avoid "vv1.2.3".
+ *
+ * When `modelName` already begins with `cliName` (e.g. models.json's
+ * "Claude Opus 4.7" paired with cliName "Claude"), the CLI prefix is
+ * dropped to avoid rendering the CLI name twice.
+ */
+export function formatPaneHeader(
+  label: string,
+  modelName?: string,
+  cliVersion?: string,
+  cliName?: string,
+): string {
+  const versionSuffix = cliVersion ? ` v${cliVersion.replace(/^v/, "")}` : "";
+  if (!modelName && !cliVersion && !cliName) return label;
+  const effectiveCliName =
+    cliName && modelName && modelStartsWithCli(modelName, cliName)
+      ? undefined
+      : cliName;
+  const modelPart = [effectiveCliName, modelName].filter(Boolean).join(" ");
+  if (!modelPart) return `${label} —${versionSuffix}`;
+  return `${label} — ${modelPart}${versionSuffix}`;
+}
+
+function modelStartsWithCli(modelName: string, cliName: string): boolean {
+  const lowerModel = modelName.toLowerCase();
+  const lowerCli = cliName.toLowerCase();
+  if (!lowerModel.startsWith(lowerCli)) return false;
+  const next = lowerModel.charAt(lowerCli.length);
+  return next === "" || next === " ";
+}
+
 /** A single terminal row tagged with display metadata. */
 interface RowEntry {
   text: string;
@@ -115,6 +161,18 @@ interface RowEntry {
 interface AgentPaneProps {
   label: string;
   modelName?: string;
+  /**
+   * Installed CLI version detected at pipeline start (e.g. "1.2.3").
+   * Rendered in the pane header next to `modelName` so the user can
+   * see which CLI build is driving this pane without leaving the TUI.
+   */
+  cliVersion?: string;
+  /**
+   * CLI display name (e.g. "Claude" or "Codex").  Rendered in the pane
+   * header ahead of `modelName` so users can see which CLI is driving
+   * this pane even when model names are shared or ambiguous.
+   */
+  cliName?: string;
   agent: "a" | "b";
   emitter: PipelineEventEmitter;
   color: string;
@@ -143,6 +201,8 @@ interface AgentPaneProps {
 export function AgentPane({
   label,
   modelName,
+  cliVersion,
+  cliName,
   agent,
   emitter,
   color,
@@ -389,7 +449,7 @@ export function AgentPane({
     >
       <Box flexShrink={0}>
         <Text bold color={borderCol}>
-          {modelName ? `${label} \u2014 ${modelName}` : label}
+          {formatPaneHeader(label, modelName, cliVersion, cliName)}
           {isActive ? " \u25CF" : ""}
           {isFocused ? " [*]" : ""}
         </Text>

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -15,10 +15,10 @@ import type {
   PipelineEventEmitter,
   PrResolvedEvent,
 } from "../pipeline-events.js";
-import { AgentPane, splitIntoRows } from "./AgentPane.js";
+import { AgentPane, formatPaneHeader, splitIntoRows } from "./AgentPane.js";
 import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
-import { TokenBar } from "./TokenBar.js";
+import { cliDisplayName, TokenBar } from "./TokenBar.js";
 import { createTuiUserPrompt } from "./TuiUserPrompt.js";
 
 // ---- Terminal helpers --------------------------------------------------------
@@ -252,6 +252,10 @@ export interface AppProps {
   cliTypeA?: string;
   /** CLI identifier for Agent B (e.g. "claude" or "codex"). */
   cliTypeB?: string;
+  /** Installed CLI version for Agent A, detected at pipeline start. */
+  cliVersionA?: string;
+  /** Installed CLI version for Agent B, detected at pipeline start. */
+  cliVersionB?: string;
   /** Notification settings (bell / desktop). */
   notifications?: NotificationSettings;
   /**
@@ -290,6 +294,8 @@ export function App({
   modelNameB,
   cliTypeA,
   cliTypeB,
+  cliVersionA,
+  cliVersionB,
   notifications,
   onCancel,
   startedAt,
@@ -347,12 +353,23 @@ export function App({
   const inputHeight = inputAreaHeight(inputRequest);
   const labelA = messages["agent.labelARole"];
   const labelB = messages["agent.labelBRole"];
+  const cliNameA = cliTypeA ? cliDisplayName(cliTypeA) : undefined;
+  const cliNameB = cliTypeB ? cliDisplayName(cliTypeB) : undefined;
   const paneHeaderTexts = useMemo(
     () => [
-      `${modelNameA ? `${labelA} \u2014 ${modelNameA}` : labelA} \u25CF [*]`,
-      `${modelNameB ? `${labelB} \u2014 ${modelNameB}` : labelB} \u25CF [*]`,
+      `${formatPaneHeader(labelA, modelNameA, cliVersionA, cliNameA)} \u25CF [*]`,
+      `${formatPaneHeader(labelB, modelNameB, cliVersionB, cliNameB)} \u25CF [*]`,
     ],
-    [labelA, labelB, modelNameA, modelNameB],
+    [
+      labelA,
+      labelB,
+      modelNameA,
+      modelNameB,
+      cliVersionA,
+      cliVersionB,
+      cliNameA,
+      cliNameB,
+    ],
   );
   const flags = useMemo<VisibilityFlags>(() => {
     if (terminalHeight === undefined) {
@@ -495,6 +512,8 @@ export function App({
         <AgentPane
           label={labelA}
           modelName={modelNameA}
+          cliVersion={cliVersionA}
+          cliName={cliNameA}
           agent="a"
           emitter={emitter}
           color="blue"
@@ -508,6 +527,8 @@ export function App({
         <AgentPane
           label={labelB}
           modelName={modelNameB}
+          cliVersion={cliVersionB}
+          cliName={cliNameB}
           agent="b"
           emitter={emitter}
           color="green"

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -16,6 +16,7 @@ import {
 } from "../pipeline-events.js";
 import {
   AgentPane,
+  formatPaneHeader,
   renderDiagnosticRow,
   renderPromptRows,
   splitIntoRows,
@@ -36,6 +37,82 @@ import {
 
 afterEach(() => {
   cleanup();
+});
+
+// ---- formatPaneHeader --------------------------------------------------------
+
+describe("formatPaneHeader", () => {
+  test("label only when no model / version", () => {
+    expect(formatPaneHeader("Agent A (author)")).toBe("Agent A (author)");
+  });
+
+  test("appends model name", () => {
+    expect(formatPaneHeader("Agent A (author)", "Claude Opus 4.6")).toBe(
+      "Agent A (author) — Claude Opus 4.6",
+    );
+  });
+
+  test("appends model and version", () => {
+    expect(
+      formatPaneHeader("Agent A (author)", "Claude Opus 4.6", "1.2.3"),
+    ).toBe("Agent A (author) — Claude Opus 4.6 v1.2.3");
+  });
+
+  test("strips a leading v from the input version", () => {
+    expect(formatPaneHeader("Agent A", "Opus", "v1.2.3")).toBe(
+      "Agent A — Opus v1.2.3",
+    );
+  });
+
+  test("version without model still appears after dash", () => {
+    expect(formatPaneHeader("Agent A", undefined, "1.2.3")).toBe(
+      "Agent A — v1.2.3",
+    );
+  });
+
+  test("prefixes the model name with the CLI name when provided", () => {
+    // The CLI name (e.g. "Claude", "Codex") disambiguates panes when
+    // model names are ambiguous or user-configured.  Issue #276 asked
+    // for the CLI name beside the version in the header.
+    expect(
+      formatPaneHeader("Agent B (reviewer)", "GPT-5.4", "0.46.0", "Codex"),
+    ).toBe("Agent B (reviewer) — Codex GPT-5.4 v0.46.0");
+  });
+
+  test("does not duplicate CLI name when model already starts with it", () => {
+    // models.json entries like "Claude Opus 4.7" already embed the CLI
+    // name, so prepending cliName="Claude" would render "Claude Claude
+    // Opus 4.7".  formatPaneHeader must collapse that duplication.
+    expect(
+      formatPaneHeader(
+        "Agent A (author)",
+        "Claude Opus 4.7",
+        "1.2.3",
+        "Claude",
+      ),
+    ).toBe("Agent A (author) — Claude Opus 4.7 v1.2.3");
+    // Case-insensitive match still collapses.
+    expect(
+      formatPaneHeader("Agent A", "claude opus 4.7", undefined, "Claude"),
+    ).toBe("Agent A — claude opus 4.7");
+    // Prefix must end at a word boundary — a model literally named
+    // "Claudette" should still get the "Claude" prefix prepended.
+    expect(
+      formatPaneHeader("Agent A", "Claudette Turbo", undefined, "Claude"),
+    ).toBe("Agent A — Claude Claudette Turbo");
+  });
+
+  test("falls back to CLI name + version when model is absent", () => {
+    expect(
+      formatPaneHeader("Agent A (author)", undefined, "1.2.3", "Claude"),
+    ).toBe("Agent A (author) — Claude v1.2.3");
+  });
+
+  test("renders CLI name alone when model and version are absent", () => {
+    expect(formatPaneHeader("Agent A", undefined, undefined, "Claude")).toBe(
+      "Agent A — Claude",
+    );
+  });
 });
 
 // ---- AgentPane ---------------------------------------------------------------
@@ -95,6 +172,26 @@ describe("AgentPane", () => {
 
     const frame = lastFrame();
     expect(frame).toContain("Agent A (author) \u2014 opus");
+  });
+
+  test("renders CLI name alongside model and version in header", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <AgentPane
+        label="Agent B (reviewer)"
+        modelName="GPT-5.4"
+        cliVersion="0.46.0"
+        cliName="Codex"
+        agent="b"
+        emitter={emitter}
+        color="green"
+      />,
+    );
+
+    const frame = lastFrame();
+    // The CLI name is what answers "which CLI build is driving this
+    // pane?" when model names are shared or ambiguous.
+    expect(frame).toContain("Agent B (reviewer) — Codex GPT-5.4 v0.46.0");
   });
 
   test("renders streamed lines after agent:chunk events", async () => {

--- a/src/version-check.test.ts
+++ b/src/version-check.test.ts
@@ -1,0 +1,1009 @@
+import { homedir } from "node:os";
+import { describe, expect, test, vi } from "vitest";
+import type { Config } from "./config.js";
+import {
+  checkCliVersion,
+  compareVersions,
+  detectCodexSource,
+  detectInstallSource,
+  parseVersion,
+  refreshAgentCliVersion,
+  resolveLatestVersion,
+  runStartupVersionCheck,
+  shouldRunVersionCheck,
+  VersionCheckAbortError,
+  type VersionCheckDeps,
+  type VersionCheckPrompts,
+  type VersionCheckTranslations,
+} from "./version-check.js";
+
+// ---- parseVersion --------------------------------------------------------
+
+describe("parseVersion", () => {
+  test("extracts x.y.z from plain output", () => {
+    expect(parseVersion("1.2.3")).toBe("1.2.3");
+  });
+
+  test("extracts from 'codex-cli 0.46.0' style", () => {
+    expect(parseVersion("codex-cli 0.46.0\n")).toBe("0.46.0");
+  });
+
+  test("extracts from '1.2.3 (Claude Code)' style", () => {
+    expect(parseVersion("1.2.3 (Claude Code)")).toBe("1.2.3");
+  });
+
+  test("keeps pre-release suffix", () => {
+    expect(parseVersion("1.2.3-beta.1")).toBe("1.2.3-beta.1");
+  });
+
+  test("strips leading v by *not* capturing it", () => {
+    expect(parseVersion("v1.2.3")).toBe("1.2.3");
+  });
+
+  test("returns undefined for un-versioned strings", () => {
+    expect(parseVersion("nothing useful here")).toBeUndefined();
+  });
+});
+
+// ---- compareVersions -----------------------------------------------------
+
+describe("compareVersions", () => {
+  test("returns -1 when a < b", () => {
+    expect(compareVersions("1.2.3", "1.2.4")).toBe(-1);
+    expect(compareVersions("1.2.3", "1.3.0")).toBe(-1);
+    expect(compareVersions("1.9.9", "2.0.0")).toBe(-1);
+  });
+
+  test("returns 0 when equal", () => {
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    expect(compareVersions("v1.2.3", "1.2.3")).toBe(0);
+  });
+
+  test("returns 1 when a > b", () => {
+    expect(compareVersions("2.0.0", "1.9.9")).toBe(1);
+  });
+
+  test("treats missing segment as 0", () => {
+    expect(compareVersions("1.2", "1.2.0")).toBe(0);
+    expect(compareVersions("1.2.0", "1.2")).toBe(0);
+  });
+
+  test("release > pre-release of the same base", () => {
+    expect(compareVersions("1.2.3", "1.2.3-beta")).toBe(1);
+    expect(compareVersions("1.2.3-beta", "1.2.3")).toBe(-1);
+  });
+});
+
+// ---- detectCodexSource ---------------------------------------------------
+
+describe("detectCodexSource", () => {
+  test("npm global prefix", () => {
+    expect(
+      detectCodexSource(
+        "/opt/homebrew/lib/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "npm", registryPackage: "@openai/codex" });
+    expect(
+      detectCodexSource(
+        "/Users/user/.nvm/versions/node/v24.0.0/lib/node_modules/@openai/codex/bin/codex",
+      ),
+    ).toEqual({ kind: "npm", registryPackage: "@openai/codex" });
+  });
+
+  test("pnpm global layout resolves to npm", () => {
+    // `pnpm add -g @openai/codex` installs under `pnpm/global/<store>/
+    // node_modules/@openai/codex/...` — no `lib/` segment — so the
+    // `lib/node_modules/` marker alone misses it.  The `/pnpm/global/`
+    // segment is unique to the global install (project-local pnpm uses
+    // `<repo>/node_modules/.pnpm/...` with no `global`), so this is
+    // safe against the project-local false positive.
+    //
+    // Exercise the cross-platform global roots that `pnpm root -g`
+    // returns in practice:
+    //   macOS:   ~/Library/pnpm/global/<N>/node_modules
+    //   Linux:   ~/.local/share/pnpm/global/<N>/node_modules
+    //   Windows: %LOCALAPPDATA%/pnpm/global/<N>/node_modules
+    //   $PNPM_HOME: $PNPM_HOME/global/<N>/node_modules
+    expect(
+      detectCodexSource(
+        "/Users/sehkone/Library/pnpm/global/5/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "npm", registryPackage: "@openai/codex" });
+    expect(
+      detectCodexSource(
+        "/home/alice/.local/share/pnpm/global/5/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "npm", registryPackage: "@openai/codex" });
+    expect(
+      detectCodexSource(
+        "/Users/me/.pnpm-home/pnpm/global/5/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "npm", registryPackage: "@openai/codex" });
+    // realpath resolution through the `.pnpm` virtual store still
+    // keeps the path under `pnpm/global/<N>/node_modules/...`.
+    expect(
+      detectCodexSource(
+        "/Users/sehkone/Library/pnpm/global/5/node_modules/.pnpm/@openai+codex@0.46.0/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "npm", registryPackage: "@openai/codex" });
+  });
+
+  test("project-local pnpm is inconclusive, not guessed as pnpm global", () => {
+    // A project using pnpm has `<repo>/node_modules/.pnpm/@openai+codex@<ver>/
+    // node_modules/@openai/codex/...` — no `pnpm/global/` segment —
+    // so the new pnpm-global marker must not match it.  Otherwise we
+    // would reopen the very project-local false positive the
+    // `lib/node_modules/` anchor was added to close.
+    expect(
+      detectCodexSource(
+        "/Users/me/proj/node_modules/.pnpm/@openai+codex@0.46.0/node_modules/@openai/codex/bin/codex.js",
+      ).kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/worktree/node_modules/.pnpm/@openai+codex@0.46.0/node_modules/@openai/codex/bin/codex.js",
+      ).kind,
+    ).toBe("inconclusive");
+  });
+
+  test("project-local node_modules is inconclusive, not guessed as npm", () => {
+    // A repo-local install lives at `<repo>/node_modules/@openai/codex/...`
+    // — no `lib/` segment in front of `node_modules`.  `realpath(command -v
+    // codex)` can resolve to that path via `node_modules/.bin/codex`, so
+    // the marker `node_modules/@openai/codex/` alone is not enough — only
+    // a global npm prefix (which always uses `lib/node_modules/...`)
+    // should route to the npm registry.  Routing a project-local
+    // dependency to the global update prompt would tell the user to
+    // `npm install -g` a package they intentionally pinned per-project.
+    expect(
+      detectCodexSource("/worktree/node_modules/@openai/codex/bin/codex.js")
+        .kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/Users/me/proj/node_modules/@openai/codex/bin/codex.js",
+      ).kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource("/tmp/sandbox/node_modules/@openai/codex/bin/codex.js")
+        .kind,
+    ).toBe("inconclusive");
+  });
+
+  test("Homebrew formula path", () => {
+    expect(
+      detectCodexSource("/opt/homebrew/Cellar/codex/0.46.0/bin/codex"),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+    expect(
+      detectCodexSource("/usr/local/Cellar/codex/0.46.0/bin/codex"),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+    // Homebrew's supported default Linux prefix is
+    // `/home/linuxbrew/.linuxbrew`, so a standard Linuxbrew install
+    // must be recognized — otherwise a normal Linux install would fall
+    // through to `inconclusive` and never get the update check.
+    expect(
+      detectCodexSource(
+        "/home/linuxbrew/.linuxbrew/Cellar/codex/0.46.0/bin/codex",
+      ),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+  });
+
+  test("Homebrew formula bundling node_modules resolves to formula, not npm", () => {
+    // Some `codex` formulae bundle the JS distribution internally
+    // under `libexec/lib/node_modules/@openai/codex/...`.  Even though
+    // the resolved path contains the npm marker
+    // (`node_modules/@openai/codex/`), it is still inside
+    // `Cellar/codex/`, so the channel is the Homebrew formula —
+    // formula and npm update independently and routing this to npm
+    // would produce the wrong update prompt.
+    expect(
+      detectCodexSource(
+        "/opt/homebrew/Cellar/codex/0.46.0/libexec/lib/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+    expect(
+      detectCodexSource(
+        "/usr/local/Cellar/codex/0.46.0/libexec/lib/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+    expect(
+      detectCodexSource(
+        "/home/linuxbrew/.linuxbrew/Cellar/codex/0.46.0/libexec/lib/node_modules/@openai/codex/bin/codex.js",
+      ),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+  });
+
+  test("Homebrew cask path", () => {
+    expect(
+      detectCodexSource("/opt/homebrew/Caskroom/codex/0.122.0/codex"),
+    ).toEqual({ kind: "homebrew-cask", cask: "codex" });
+    expect(
+      detectCodexSource("/usr/local/Caskroom/codex/0.122.0/codex"),
+    ).toEqual({ kind: "homebrew-cask", cask: "codex" });
+    expect(
+      detectCodexSource(
+        "/home/linuxbrew/.linuxbrew/Caskroom/codex/0.122.0/codex",
+      ),
+    ).toEqual({ kind: "homebrew-cask", cask: "codex" });
+  });
+
+  test("custom Homebrew formula (not codex) is inconclusive, not guessed", () => {
+    // Brew stores each formula's files at
+    // `<prefix>/Cellar/<formula-name>/<version>/...`.  A custom
+    // wrapper formula like `my-codex-wrapper` must not be classified
+    // as the official `codex` formula — a wrong update prompt is
+    // worse than no prompt.
+    expect(
+      detectCodexSource("/opt/homebrew/Cellar/my-codex-wrapper/1.0/bin/codex")
+        .kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource("/usr/local/Cellar/codex-extras/0.1.0/bin/codex").kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/home/linuxbrew/.linuxbrew/Cellar/not-codex/1.0/bin/codex",
+      ).kind,
+    ).toBe("inconclusive");
+  });
+
+  test("custom Homebrew cask (not codex) is inconclusive, not guessed", () => {
+    // Casks live at `<prefix>/Caskroom/<cask-name>/<version>/...`.
+    // A custom cask like `custom-codex` must not be classified as the
+    // official `codex` cask.
+    expect(
+      detectCodexSource("/opt/homebrew/Caskroom/custom-codex/1.0/codex").kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource("/usr/local/Caskroom/codex-preview/0.1/codex").kind,
+    ).toBe("inconclusive");
+  });
+
+  test("prefixed Homebrew lookalikes are inconclusive, not guessed", () => {
+    // A hand-placed binary under a copied tree like
+    // `/tmp/opt/homebrew/Cellar/codex/...` or
+    // `/Users/me/sandbox/usr/local/Caskroom/codex/...` is not actually
+    // installed under the Homebrew prefix.  Detection must be
+    // root-anchored on the prefix so these do not get an official
+    // formula/cask update prompt — a wrong prompt is worse than no
+    // prompt.
+    expect(
+      detectCodexSource("/tmp/opt/homebrew/Cellar/codex/0.46.0/bin/codex").kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/Users/me/sandbox/usr/local/Cellar/codex/0.46.0/bin/codex",
+      ).kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/var/tmp/home/linuxbrew/.linuxbrew/Cellar/codex/0.46.0/bin/codex",
+      ).kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource("/tmp/opt/homebrew/Caskroom/codex/0.122.0/codex").kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/Users/me/sandbox/usr/local/Caskroom/codex/0.122.0/codex",
+      ).kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        "/var/tmp/home/linuxbrew/.linuxbrew/Caskroom/codex/0.122.0/codex",
+      ).kind,
+    ).toBe("inconclusive");
+  });
+
+  test("any /Applications/ path is inconclusive, not guessed as cask", () => {
+    // A real cask install of the CLI resolves through `realpath` into
+    // a Caskroom directory, so if we still see a raw `Applications`
+    // path at detection time the binary is *not* a cask symlink.
+    // Classifying it as cask would be a guess — exactly the "wrong
+    // prompt is worse than no prompt" failure the issue warns
+    // against.  All of these shapes — system-wide, home-rooted, and
+    // rogue — fall through to `inconclusive`.
+    expect(
+      detectCodexSource("/Applications/Codex.app/Contents/MacOS/codex").kind,
+    ).toBe("inconclusive");
+    expect(
+      detectCodexSource(
+        `${homedir()}/Applications/Codex.app/Contents/MacOS/codex`,
+      ).kind,
+    ).toBe("inconclusive");
+    expect(detectCodexSource("/tmp/Applications/codex").kind).toBe(
+      "inconclusive",
+    );
+    expect(
+      detectCodexSource("/opt/shared/Applications/codex/bin/codex").kind,
+    ).toBe("inconclusive");
+  });
+
+  test("standalone ~/.codex/bin layout", () => {
+    expect(detectCodexSource(`${homedir()}/.codex/bin/codex`)).toEqual({
+      kind: "github-releases",
+      repo: "openai/codex",
+    });
+  });
+
+  test("standalone ~/.codex/versions/<ver> layout", () => {
+    expect(
+      detectCodexSource(`${homedir()}/.codex/versions/0.46.0/codex`),
+    ).toEqual({ kind: "github-releases", repo: "openai/codex" });
+  });
+
+  test("standalone ~/.codex/packages/standalone/releases layout", () => {
+    expect(
+      detectCodexSource(
+        `${homedir()}/.codex/packages/standalone/releases/0.122.0-aarch64-apple-darwin/codex`,
+      ),
+    ).toEqual({ kind: "github-releases", repo: "openai/codex" });
+  });
+
+  test("unknown layout is inconclusive", () => {
+    const result = detectCodexSource("/usr/local/bin/my-codex");
+    expect(result.kind).toBe("inconclusive");
+  });
+
+  test("a rogue /.codex/ path outside $HOME is inconclusive, not guessed", () => {
+    // A hand-placed binary that happens to sit under any directory
+    // named `.codex` must not be classified as an official standalone
+    // install — the update prompt would be wrong.  Only the current
+    // user's home directory is accepted.
+    expect(detectCodexSource("/tmp/.codex/codex").kind).toBe("inconclusive");
+    expect(detectCodexSource("/var/tmp/fake/.codex/bin/codex").kind).toBe(
+      "inconclusive",
+    );
+    expect(
+      detectCodexSource("/opt/shared/.codex/versions/0.46.0/codex").kind,
+    ).toBe("inconclusive");
+  });
+
+  test("unknown subpath inside ~/.codex/ is inconclusive, not guessed", () => {
+    // Home-rooted `.codex` is necessary but not sufficient — a binary
+    // at a hand-placed subpath like `~/.codex/tools/codex` or
+    // `~/.codex/tmp/codex` is not one of the known standalone
+    // layouts, so it must fall through to `inconclusive` rather than
+    // get a bogus GitHub-releases update prompt.
+    expect(detectCodexSource(`${homedir()}/.codex/tools/codex`).kind).toBe(
+      "inconclusive",
+    );
+    expect(detectCodexSource(`${homedir()}/.codex/tmp/codex`).kind).toBe(
+      "inconclusive",
+    );
+    expect(detectCodexSource(`${homedir()}/.codex/codex`).kind).toBe(
+      "inconclusive",
+    );
+    expect(
+      detectCodexSource(`${homedir()}/.codex/packages/custom/codex`).kind,
+    ).toBe("inconclusive");
+  });
+});
+
+describe("detectInstallSource", () => {
+  test("claude always resolves to npm", () => {
+    expect(detectInstallSource("claude", "/random/path")).toEqual({
+      kind: "npm",
+      registryPackage: "@anthropic-ai/claude-code",
+    });
+  });
+
+  test("codex delegates to detectCodexSource", () => {
+    expect(
+      detectInstallSource(
+        "codex",
+        "/opt/homebrew/Cellar/codex/0.46.0/bin/codex",
+      ),
+    ).toEqual({ kind: "homebrew-formula", formula: "codex" });
+  });
+});
+
+// ---- resolveLatestVersion ------------------------------------------------
+
+function makeDeps(overrides: Partial<VersionCheckDeps> = {}): VersionCheckDeps {
+  return {
+    runVersion: vi.fn(),
+    resolveBinary: vi.fn(),
+    fetchJson: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("resolveLatestVersion", () => {
+  test("npm fetches /latest and reads version", async () => {
+    const deps = makeDeps({
+      fetchJson: vi.fn(async (url: string) => {
+        expect(url).toBe(
+          "https://registry.npmjs.org/@anthropic-ai/claude-code/latest",
+        );
+        return { version: "1.3.0" };
+      }),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "npm", registryPackage: "@anthropic-ai/claude-code" },
+      deps,
+    );
+    expect(v).toBe("1.3.0");
+  });
+
+  test("homebrew formula reads versions.stable", async () => {
+    const deps = makeDeps({
+      fetchJson: vi.fn(async (url: string) => {
+        expect(url).toBe("https://formulae.brew.sh/api/formula/codex.json");
+        return { versions: { stable: "0.46.0" } };
+      }),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "homebrew-formula", formula: "codex" },
+      deps,
+    );
+    expect(v).toBe("0.46.0");
+  });
+
+  test("homebrew cask reads version", async () => {
+    const deps = makeDeps({
+      fetchJson: vi.fn(async () => ({ version: "0.122.0" })),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "homebrew-cask", cask: "codex" },
+      deps,
+    );
+    expect(v).toBe("0.122.0");
+  });
+
+  test("github-releases strips leading v from tag_name", async () => {
+    const deps = makeDeps({
+      fetchJson: vi.fn(async () => ({ tag_name: "v0.122.0" })),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "github-releases", repo: "openai/codex" },
+      deps,
+    );
+    expect(v).toBe("0.122.0");
+  });
+
+  test("github-releases extracts semver from prefixed tag_name", async () => {
+    // openai/codex currently publishes `tag_name: rust-v0.122.0` with
+    // `name: 0.122.0` — a bare `^v` strip leaves `rust-v0.122.0` and
+    // makes compareVersions treat any real install as ahead of latest.
+    const deps = makeDeps({
+      fetchJson: vi.fn(async () => ({
+        tag_name: "rust-v0.122.0",
+        name: "0.122.0",
+      })),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "github-releases", repo: "openai/codex" },
+      deps,
+    );
+    expect(v).toBe("0.122.0");
+  });
+
+  test("github-releases falls back to tag_name when name is missing", async () => {
+    const deps = makeDeps({
+      fetchJson: vi.fn(async () => ({ tag_name: "rust-v0.122.0" })),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "github-releases", repo: "openai/codex" },
+      deps,
+    );
+    expect(v).toBe("0.122.0");
+  });
+
+  test("github-releases returns undefined when neither field is semver", async () => {
+    const deps = makeDeps({
+      fetchJson: vi.fn(async () => ({ tag_name: "nightly", name: "" })),
+    });
+    const v = await resolveLatestVersion(
+      { kind: "github-releases", repo: "openai/codex" },
+      deps,
+    );
+    expect(v).toBeUndefined();
+  });
+
+  test("inconclusive returns undefined", async () => {
+    const deps = makeDeps();
+    const v = await resolveLatestVersion(
+      { kind: "inconclusive", reason: "test" },
+      deps,
+    );
+    expect(v).toBeUndefined();
+  });
+});
+
+// ---- checkCliVersion -----------------------------------------------------
+
+describe("checkCliVersion", () => {
+  test("reports installed + latest for claude", async () => {
+    const deps = makeDeps({
+      runVersion: () => "1.2.3 (Claude Code)\n",
+      resolveBinary: () => "/usr/local/bin/claude",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    const r = await checkCliVersion("claude", deps);
+    expect(r.installed).toBe("1.2.3");
+    expect(r.latest).toBe("1.3.0");
+    expect(r.source?.kind).toBe("npm");
+  });
+
+  test("surfaces inconclusive codex layout as skippedReason", async () => {
+    const deps = makeDeps({
+      runVersion: () => "0.46.0\n",
+      resolveBinary: () => "/opt/custom/codex",
+      fetchJson: vi.fn(),
+    });
+    const r = await checkCliVersion("codex", deps);
+    expect(r.installed).toBe("0.46.0");
+    expect(r.source?.kind).toBe("inconclusive");
+    expect(r.skippedReason).toBeDefined();
+    expect(deps.fetchJson).not.toHaveBeenCalled();
+  });
+
+  test("network failure is surfaced as skippedReason", async () => {
+    const deps = makeDeps({
+      runVersion: () => "0.46.0\n",
+      resolveBinary: () => "/opt/homebrew/Cellar/codex/0.46.0/bin/codex",
+      fetchJson: async () => {
+        throw new Error("ECONNREFUSED");
+      },
+    });
+    const r = await checkCliVersion("codex", deps);
+    expect(r.installed).toBe("0.46.0");
+    expect(r.skippedReason).toContain("ECONNREFUSED");
+  });
+
+  test("skips when --version fails", async () => {
+    const deps = makeDeps({
+      runVersion: () => undefined,
+    });
+    const r = await checkCliVersion("claude", deps);
+    expect(r.installed).toBeUndefined();
+    expect(r.skippedReason).toContain("--version");
+  });
+
+  test("skips when version cannot be parsed", async () => {
+    const deps = makeDeps({
+      runVersion: () => "totally not a version\n",
+    });
+    const r = await checkCliVersion("claude", deps);
+    expect(r.installed).toBeUndefined();
+    expect(r.skippedReason).toContain("parse");
+  });
+});
+
+// ---- shouldRunVersionCheck ----------------------------------------------
+
+describe("shouldRunVersionCheck", () => {
+  const base: Config = {
+    owners: [],
+    cloneBaseDir: "~/projects",
+    language: "en",
+    pipelineSettings: {
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
+      inactivityTimeoutMinutes: 20,
+      autoResumeAttempts: 3,
+    },
+    notifications: { bell: true, desktop: false },
+  };
+
+  test("runs when never run before", () => {
+    expect(shouldRunVersionCheck(base, Date.now())).toBe(true);
+  });
+
+  test("skipped when skipVersionCheck=true", () => {
+    expect(
+      shouldRunVersionCheck({ ...base, skipVersionCheck: true }, Date.now()),
+    ).toBe(false);
+  });
+
+  test("skipped within throttle window", () => {
+    const now = 1_000_000_000_000;
+    expect(
+      shouldRunVersionCheck({ ...base, lastVersionCheckAt: now - 60_000 }, now),
+    ).toBe(false);
+  });
+
+  test("runs after throttle window", () => {
+    const now = 1_000_000_000_000;
+    const dayAgo = now - 25 * 60 * 60 * 1000;
+    expect(
+      shouldRunVersionCheck({ ...base, lastVersionCheckAt: dayAgo }, now),
+    ).toBe(true);
+  });
+});
+
+// ---- runStartupVersionCheck ---------------------------------------------
+
+function makeTranslations(): VersionCheckTranslations {
+  return {
+    checking: "Checking...",
+    inconclusive: (c, r) => `${c} inconclusive: ${r}`,
+    fetchFailed: (c, r) => `${c} fetch failed: ${r}`,
+    upToDate: (c, v) => `${c} v${v} up to date`,
+    updatePrompt: (c, f, t) => `${c} ${f} -> ${t}?`,
+    updateWaiting: (c) => `update ${c}`,
+    versionUnchanged: (v) => `still v${v}`,
+    retrySkipAbortPrompt: "proceed?",
+    proceedingWith: (c, v) => `${c} now v${v}`,
+    abortedByUser: "aborted",
+    versionUnknown: (c) => `${c} unknown`,
+  };
+}
+
+function makeConfig(): Config {
+  return {
+    owners: [],
+    cloneBaseDir: "~/projects",
+    language: "en",
+    pipelineSettings: {
+      selfCheckAutoIterations: 5,
+      reviewAutoRounds: 5,
+      ciCheckAutoIterations: 3,
+      ciCheckTimeoutMinutes: 10,
+      inactivityTimeoutMinutes: 20,
+      autoResumeAttempts: 3,
+    },
+    notifications: { bell: true, desktop: false },
+  };
+}
+
+function makePrompts(
+  overrides: Partial<VersionCheckPrompts> = {},
+): VersionCheckPrompts {
+  return {
+    confirmUpdate: vi.fn(async () => false),
+    waitForEnter: vi.fn(async () => {}),
+    chooseRetrySkipAbort: vi.fn(async () => "skip"),
+    log: vi.fn(),
+    warn: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("runStartupVersionCheck", () => {
+  test("does not prompt when up to date", async () => {
+    const config = makeConfig();
+    const persistVersionCheckState = vi.fn();
+    const deps = makeDeps({
+      runVersion: () => "1.3.0\n",
+      resolveBinary: () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    const prompts = makePrompts();
+    const versions = await runStartupVersionCheck({
+      clis: ["claude"],
+      config,
+      persistVersionCheckState,
+      prompts,
+      translations: makeTranslations(),
+      deps,
+    });
+    expect(versions.get("claude")).toBe("1.3.0");
+    expect(prompts.confirmUpdate).not.toHaveBeenCalled();
+    expect(persistVersionCheckState).toHaveBeenCalled();
+    // The persistence callback receives only the patchable fields, not
+    // a whole Config object.  That's what keeps unknown top-level keys
+    // in ~/.agentcoop/config.json from being silently dropped.
+    const payload = persistVersionCheckState.mock.calls[0]?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(payload).toBeDefined();
+    expect(Object.keys(payload ?? {}).sort()).toEqual([
+      "lastKnownVersions",
+      "lastVersionCheckAt",
+    ]);
+    expect(
+      (payload as { lastKnownVersions: { claude: string } }).lastKnownVersions
+        .claude,
+    ).toBe("1.3.0");
+    expect(config.lastKnownVersions?.claude).toBe("1.3.0");
+    expect(config.lastVersionCheckAt).toBeDefined();
+  });
+
+  test("deduplicates CLIs when agentA and agentB share one", async () => {
+    const runVersion = vi.fn(() => "1.3.0\n");
+    const deps = makeDeps({
+      runVersion,
+      resolveBinary: () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    await runStartupVersionCheck({
+      clis: ["claude", "claude"],
+      config: makeConfig(),
+      persistVersionCheckState: vi.fn(),
+      prompts: makePrompts(),
+      translations: makeTranslations(),
+      deps,
+    });
+    expect(runVersion).toHaveBeenCalledTimes(1);
+  });
+
+  test("prompts and re-checks after successful update", async () => {
+    const runVersionMock = vi
+      .fn()
+      .mockReturnValueOnce("1.2.3\n")
+      .mockReturnValueOnce("1.3.0\n");
+    const deps = makeDeps({
+      runVersion: runVersionMock,
+      resolveBinary: () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    const prompts = makePrompts({
+      confirmUpdate: vi.fn(async () => true),
+    });
+    const versions = await runStartupVersionCheck({
+      clis: ["claude"],
+      config: makeConfig(),
+      persistVersionCheckState: vi.fn(),
+      prompts,
+      translations: makeTranslations(),
+      deps,
+    });
+    expect(prompts.confirmUpdate).toHaveBeenCalledTimes(1);
+    expect(prompts.waitForEnter).toHaveBeenCalledTimes(1);
+    expect(versions.get("claude")).toBe("1.3.0");
+  });
+
+  test("retry / skip / abort flow on unchanged version", async () => {
+    const runVersionMock = vi.fn(() => "1.2.3\n");
+    const deps = makeDeps({
+      runVersion: runVersionMock,
+      resolveBinary: () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    const prompts = makePrompts({
+      confirmUpdate: vi.fn(async () => true),
+      chooseRetrySkipAbort: vi
+        .fn()
+        .mockResolvedValueOnce("retry")
+        .mockResolvedValueOnce("skip"),
+    });
+    const versions = await runStartupVersionCheck({
+      clis: ["claude"],
+      config: makeConfig(),
+      persistVersionCheckState: vi.fn(),
+      prompts,
+      translations: makeTranslations(),
+      deps,
+    });
+    expect(prompts.chooseRetrySkipAbort).toHaveBeenCalledTimes(2);
+    // Second --version call after "retry", third after "skip".
+    expect(runVersionMock).toHaveBeenCalledTimes(3);
+    expect(versions.get("claude")).toBe("1.2.3");
+  });
+
+  test("abort throws VersionCheckAbortError", async () => {
+    const deps = makeDeps({
+      runVersion: () => "1.2.3\n",
+      resolveBinary: () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    const prompts = makePrompts({
+      confirmUpdate: vi.fn(async () => true),
+      chooseRetrySkipAbort: vi.fn(async () => "abort"),
+    });
+    await expect(
+      runStartupVersionCheck({
+        clis: ["claude"],
+        config: makeConfig(),
+        persistVersionCheckState: vi.fn(),
+        prompts,
+        translations: makeTranslations(),
+        deps,
+      }),
+    ).rejects.toBeInstanceOf(VersionCheckAbortError);
+  });
+
+  test("inconclusive codex channel is logged and skipped (no prompt)", async () => {
+    const deps = makeDeps({
+      runVersion: () => "0.46.0\n",
+      resolveBinary: () => "/opt/custom/codex",
+      fetchJson: vi.fn(),
+    });
+    const prompts = makePrompts();
+    const versions = await runStartupVersionCheck({
+      clis: ["codex"],
+      config: makeConfig(),
+      persistVersionCheckState: vi.fn(),
+      prompts,
+      translations: makeTranslations(),
+      deps,
+    });
+    expect(versions.get("codex")).toBe("0.46.0");
+    expect(prompts.confirmUpdate).not.toHaveBeenCalled();
+    expect(deps.fetchJson).not.toHaveBeenCalled();
+  });
+
+  test("inconclusive-only run does NOT advance lastVersionCheckAt", async () => {
+    // Regression for the 24h throttle semantics: if no CLI reaches a
+    // real installed-vs-latest comparison, the throttle timestamp must
+    // not move forward — otherwise a transient outage or a custom
+    // layout would suppress all re-checks for 24h without ever having
+    // made a successful comparison.
+    const now = 1_000_000_000_000;
+    const config = makeConfig();
+    const persistVersionCheckState = vi.fn();
+    const deps = makeDeps({
+      runVersion: () => "0.46.0\n",
+      resolveBinary: () => "/opt/custom/codex",
+      fetchJson: vi.fn(),
+    });
+    await runStartupVersionCheck({
+      clis: ["codex"],
+      config,
+      persistVersionCheckState,
+      prompts: makePrompts(),
+      translations: makeTranslations(),
+      deps,
+      now: () => now,
+    });
+    expect(config.lastVersionCheckAt).toBeUndefined();
+    // lastKnownVersions still updates because the installed probe
+    // succeeded — only the throttle timestamp is gated.
+    expect(config.lastKnownVersions?.codex).toBe("0.46.0");
+  });
+
+  test("network fetch failure does NOT advance lastVersionCheckAt", async () => {
+    const now = 1_000_000_000_000;
+    const config = makeConfig();
+    const deps = makeDeps({
+      runVersion: () => "1.2.3\n",
+      resolveBinary: () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+      fetchJson: async () => {
+        throw new Error("network down");
+      },
+    });
+    await runStartupVersionCheck({
+      clis: ["claude"],
+      config,
+      persistVersionCheckState: vi.fn(),
+      prompts: makePrompts(),
+      translations: makeTranslations(),
+      deps,
+      now: () => now,
+    });
+    // Fetch failed before installed-vs-latest comparison completed,
+    // so the throttle timestamp must not advance.
+    expect(config.lastVersionCheckAt).toBeUndefined();
+  });
+
+  test("mixed run advances timestamp when at least one CLI reached comparison", async () => {
+    // Claude succeeds, Codex is inconclusive — at least one CLI made
+    // a definitive comparison, so the throttle timestamp should
+    // advance.  This is the "mixed success" case.
+    const now = 1_000_000_000_000;
+    const config = makeConfig();
+    const deps = makeDeps({
+      runVersion: () => "1.3.0\n",
+      resolveBinary: (cli) =>
+        cli === "claude"
+          ? "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude"
+          : "/opt/custom/codex",
+      fetchJson: async () => ({ version: "1.3.0" }),
+    });
+    await runStartupVersionCheck({
+      clis: ["claude", "codex"],
+      config,
+      persistVersionCheckState: vi.fn(),
+      prompts: makePrompts(),
+      translations: makeTranslations(),
+      deps,
+      now: () => now,
+    });
+    expect(config.lastVersionCheckAt).toBe(now);
+  });
+
+  test("skipVersionCheck=true still records installed version", async () => {
+    const config = makeConfig();
+    config.skipVersionCheck = true;
+    const persistVersionCheckState = vi.fn();
+    const fetchJson = vi.fn(async () => ({ version: "1.3.0" }));
+    const resolveBinary = vi.fn(
+      () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+    );
+    const deps = makeDeps({
+      runVersion: () => "1.2.3\n",
+      resolveBinary,
+      fetchJson,
+    });
+    const prompts = makePrompts();
+    const versions = await runStartupVersionCheck({
+      clis: ["claude"],
+      config,
+      persistVersionCheckState,
+      prompts,
+      translations: makeTranslations(),
+      deps,
+    });
+    expect(versions.get("claude")).toBe("1.2.3");
+    expect(prompts.confirmUpdate).not.toHaveBeenCalled();
+    // lastVersionCheckAt is NOT set when throttled/skipped.
+    expect(config.lastVersionCheckAt).toBeUndefined();
+    expect(config.lastKnownVersions?.claude).toBe("1.2.3");
+    // No network call and no install-source resolution on a skipped run.
+    expect(fetchJson).not.toHaveBeenCalled();
+    expect(resolveBinary).not.toHaveBeenCalled();
+  });
+
+  test("throttled run (within 24h) does not hit the network", async () => {
+    const now = 1_000_000_000_000;
+    const config = makeConfig();
+    config.lastVersionCheckAt = now - 60_000;
+    const persistVersionCheckState = vi.fn();
+    const fetchJson = vi.fn(async () => ({ version: "1.3.0" }));
+    const resolveBinary = vi.fn(
+      () =>
+        "/opt/homebrew/lib/node_modules/@anthropic-ai/claude-code/bin/claude",
+    );
+    const deps = makeDeps({
+      runVersion: () => "1.2.3\n",
+      resolveBinary,
+      fetchJson,
+    });
+    const prompts = makePrompts();
+    const versions = await runStartupVersionCheck({
+      clis: ["claude"],
+      config,
+      persistVersionCheckState,
+      prompts,
+      translations: makeTranslations(),
+      deps,
+      now: () => now,
+    });
+    expect(versions.get("claude")).toBe("1.2.3");
+    expect(prompts.confirmUpdate).not.toHaveBeenCalled();
+    expect(fetchJson).not.toHaveBeenCalled();
+    expect(resolveBinary).not.toHaveBeenCalled();
+    // Throttled timestamp is not refreshed.
+    expect(config.lastVersionCheckAt).toBe(now - 60_000);
+  });
+});
+
+// ---- refreshAgentCliVersion ---------------------------------------------
+
+describe("refreshAgentCliVersion", () => {
+  test("overwrites the saved version when a new one is detected", () => {
+    // A successful re-probe on resume should capture a CLI upgrade
+    // between runs — otherwise the postmortem record would still
+    // point at the old build.
+    const agent = { cliVersion: "1.2.3" };
+    refreshAgentCliVersion(agent, "1.3.0");
+    expect(agent.cliVersion).toBe("1.3.0");
+  });
+
+  test("keeps the saved version when the re-probe returns undefined", () => {
+    // Regression: a failed re-probe (e.g. `--version` crashed, output
+    // unparseable, binary temporarily unavailable) used to blank the
+    // previously recorded version on resume, erasing the per-run
+    // postmortem record that issue #276 asked to preserve.
+    const agent = { cliVersion: "1.2.3" };
+    refreshAgentCliVersion(agent, undefined);
+    expect(agent.cliVersion).toBe("1.2.3");
+  });
+
+  test("leaves an undefined saved version undefined when probe fails", () => {
+    // Nothing previously recorded and nothing detected now — stay
+    // undefined rather than materializing a bogus value.
+    const agent: { cliVersion?: string } = {};
+    refreshAgentCliVersion(agent, undefined);
+    expect(agent.cliVersion).toBeUndefined();
+  });
+
+  test("populates cliVersion on first successful probe", () => {
+    // Saved state predates version tracking (cliVersion optional) —
+    // the first successful probe should fill it in.
+    const agent: { cliVersion?: string } = {};
+    refreshAgentCliVersion(agent, "0.46.0");
+    expect(agent.cliVersion).toBe("0.46.0");
+  });
+});

--- a/src/version-check.ts
+++ b/src/version-check.ts
@@ -1,0 +1,813 @@
+/**
+ * CLI version tracking and startup update check.
+ *
+ * Runs `claude --version` / `codex --version` before the pipeline
+ * starts, resolves the installed binary's distribution channel, and
+ * fetches the channel-appropriate "latest" version.  When the installed
+ * version is older, the user is prompted to update.
+ *
+ * Structured so each CLI plugs in its own channel-detection and
+ * latest-version resolver — adding a third CLI should not require
+ * touching the orchestration code.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { sep } from "node:path";
+
+import type { Config } from "./config.js";
+
+// ---- public types --------------------------------------------------------
+
+export type CliName = "claude" | "codex";
+
+/**
+ * Where a CLI was installed from.  Drives which "latest version" URL
+ * we fetch.  Claude only has one meaningful channel (npm), so it
+ * always uses {@link npm}; Codex has multiple independent channels
+ * (see issue #276 rationale).
+ */
+export type InstallSource =
+  | { kind: "npm"; registryPackage: string }
+  | { kind: "homebrew-formula"; formula: string }
+  | { kind: "homebrew-cask"; cask: string }
+  | { kind: "github-releases"; repo: string }
+  | { kind: "inconclusive"; reason: string };
+
+export interface VersionCheckDeps {
+  /** Run `cli --version` and return the raw stdout, or undefined. */
+  runVersion: (cli: CliName) => string | undefined;
+  /** Resolve the installed binary path following symlinks, or undefined. */
+  resolveBinary: (cli: CliName) => string | undefined;
+  /** Fetch a JSON document.  Throws on network / HTTP / parse errors. */
+  fetchJson: (url: string) => Promise<unknown>;
+}
+
+export interface CliVersionCheckResult {
+  cli: CliName;
+  /** Raw `--version` stdout, useful for logging. */
+  rawOutput?: string;
+  /** Parsed installed version string (e.g. "1.2.3"), or undefined. */
+  installed?: string;
+  /** Latest version from the appropriate channel, when resolvable. */
+  latest?: string;
+  /** Resolved install source, or an inconclusive marker. */
+  source?: InstallSource;
+  /** When set, the check could not reach a definitive verdict. */
+  skippedReason?: string;
+}
+
+// ---- version string parsing ----------------------------------------------
+
+/**
+ * Extract the first semver-looking version from a `--version` output.
+ *
+ * Accepts shapes like:
+ *   "1.2.3"
+ *   "v1.2.3"
+ *   "codex-cli 0.46.0"
+ *   "1.2.3 (Claude Code)"
+ *   "1.2.3-beta.1"
+ */
+export function parseVersion(output: string): string | undefined {
+  // Allow a leading `v` (e.g. "v1.2.3") or any non-digit delimiter;
+  // `\b` alone would not split `v` from the digits because both are
+  // word characters.
+  const m = output.match(
+    /(?:^|[^0-9])v?(\d+\.\d+\.\d+(?:\.\d+)?(?:[-+][0-9A-Za-z.-]+)?)/,
+  );
+  return m ? m[1] : undefined;
+}
+
+/**
+ * Compare two version strings as dotted integer tuples, ignoring a
+ * leading `v` and treating a missing segment as `0`.  Non-numeric
+ * segments (e.g. `-beta.1`) fall back to lexicographic comparison at
+ * the first mismatch.
+ *
+ * Returns -1 if `a < b`, 0 if equal, 1 if `a > b`.
+ */
+export function compareVersions(a: string, b: string): -1 | 0 | 1 {
+  const strip = (v: string) => v.replace(/^v/, "");
+  const aParts = strip(a).split(/[.-]/);
+  const bParts = strip(b).split(/[.-]/);
+  const len = Math.max(aParts.length, bParts.length);
+  for (let i = 0; i < len; i++) {
+    const ap = aParts[i] ?? "0";
+    const bp = bParts[i] ?? "0";
+    const an = Number(ap);
+    const bn = Number(bp);
+    const aIsNum = !Number.isNaN(an) && /^\d+$/.test(ap);
+    const bIsNum = !Number.isNaN(bn) && /^\d+$/.test(bp);
+    if (aIsNum && bIsNum) {
+      if (an < bn) return -1;
+      if (an > bn) return 1;
+    } else if (aIsNum && !bIsNum) {
+      // numeric > pre-release tag ("1.2.3" > "1.2.3-beta")
+      return 1;
+    } else if (!aIsNum && bIsNum) {
+      return -1;
+    } else {
+      if (ap < bp) return -1;
+      if (ap > bp) return 1;
+    }
+  }
+  return 0;
+}
+
+// ---- install-source detection --------------------------------------------
+
+/**
+ * Match a realpath-resolved binary location against known install
+ * layouts and return the corresponding distribution channel.  An
+ * unrecognized layout returns `inconclusive` — we do not guess, because
+ * a wrong prompt is worse than no prompt.
+ */
+export function detectCodexSource(binPath: string): InstallSource {
+  // Homebrew formula layouts.  Brew stores each formula's files under
+  // `<prefix>/Cellar/<formula-name>/<version>/...`, so the package
+  // name is the path segment directly after `Cellar/`.  A custom
+  // wrapper formula like `my-codex-wrapper` would land in
+  // `.../Cellar/my-codex-wrapper/...` and must not be classified as
+  // the official `codex` formula — a wrong prompt is worse than no
+  // prompt.  Anchor the match on the `codex` segment explicitly, and
+  // root-anchor on the Homebrew prefixes so a copied tree like
+  // `/tmp/opt/homebrew/Cellar/codex/...` or
+  // `/Users/me/sandbox/usr/local/Cellar/codex/...` does not pass as
+  // an actual Homebrew install.  The three supported prefixes are
+  // Homebrew's documented defaults: Apple Silicon macOS
+  // (`/opt/homebrew`), Intel macOS (`/usr/local`), and Linuxbrew
+  // (`/home/linuxbrew/.linuxbrew`).
+  //
+  // The Homebrew formula check runs before the npm-prefix check
+  // because some `codex` formulae bundle their JS via an internal
+  // `libexec/lib/node_modules/@openai/codex/...` tree.  A realpath
+  // resolved into that tree is still under `Cellar/codex/`, so it
+  // must resolve to the formula channel — npm and the formula update
+  // independently and pointing a formula install at the npm registry
+  // can produce a wrong update prompt, which is exactly what this
+  // feature is meant to avoid.
+  if (
+    binPath.startsWith(
+      `${sep}opt${sep}homebrew${sep}Cellar${sep}codex${sep}`,
+    ) ||
+    binPath.startsWith(`${sep}usr${sep}local${sep}Cellar${sep}codex${sep}`) ||
+    binPath.startsWith(
+      `${sep}home${sep}linuxbrew${sep}.linuxbrew${sep}Cellar${sep}codex${sep}`,
+    )
+  ) {
+    return { kind: "homebrew-formula", formula: "codex" };
+  }
+  // Homebrew cask layouts.  A real cask install of the CLI binary
+  // resolves through `realpath` into a Caskroom directory under the
+  // Homebrew prefix, so Caskroom is the only reliable marker.  An
+  // earlier version of this check also matched any path containing
+  // `/Applications/` on the reasoning that casks stage GUI apps
+  // there, but after `realpath` resolution a cask-managed
+  // `~/Applications/` entry always points back into Caskroom — if we
+  // still see the raw `~/Applications/` path it means the binary is
+  // *not* a cask symlink and classifying it as cask would be a
+  // guess.  A hand-placed `/tmp/Applications/codex` or a plain
+  // `~/Applications/Codex.app/Contents/MacOS/codex` would otherwise
+  // get a bogus cask update prompt, which is exactly the "guess a
+  // channel" failure the issue warns against.  Drop the
+  // `Applications` check entirely — unrecognized Applications-style
+  // layouts fall through to `inconclusive`.
+  //
+  // Casks are stored at `<prefix>/Caskroom/<cask-name>/<version>/...`,
+  // so the cask name is the path segment directly after `Caskroom/`.
+  // Anchor on the `codex` segment so a custom cask like
+  // `custom-codex` does not get an official Codex update prompt, and
+  // root-anchor on the Homebrew prefixes so a copied tree like
+  // `/Users/me/sandbox/usr/local/Caskroom/codex/...` does not pass as
+  // an actual Homebrew install.
+  if (
+    binPath.startsWith(
+      `${sep}opt${sep}homebrew${sep}Caskroom${sep}codex${sep}`,
+    ) ||
+    binPath.startsWith(`${sep}usr${sep}local${sep}Caskroom${sep}codex${sep}`) ||
+    binPath.startsWith(
+      `${sep}home${sep}linuxbrew${sep}.linuxbrew${sep}Caskroom${sep}codex${sep}`,
+    )
+  ) {
+    return { kind: "homebrew-cask", cask: "codex" };
+  }
+  // npm global prefix — anchor on `lib/node_modules/@openai/codex/`
+  // because a project-local install lives at
+  // `<repo>/node_modules/@openai/codex/...` (no `lib/` segment) and
+  // `realpath(command -v codex)` can hit it via `node_modules/.bin`.
+  // Routing a project-local install to the npm registry would produce
+  // an unwanted update prompt for a dependency the user didn't pick
+  // globally — exactly the "wrong prompt is worse than no prompt"
+  // failure the issue warns against.  Most npm-style global layouts we
+  // care about (system npm, nvm, asdf, Volta, custom `--prefix`)
+  // place packages under `<prefix>/lib/node_modules/...`, so this
+  // marker covers them.  pnpm's global layout is different and is
+  // handled by the separate check below.  This runs after the
+  // Homebrew checks because a `codex` formula that bundles its JS
+  // internally places the resolved binary under
+  // `Cellar/codex/.../libexec/lib/node_modules/@openai/codex/...` — a
+  // path that contains the global-npm marker but is really a formula
+  // install.
+  if (
+    binPath.includes(
+      `${sep}lib${sep}node_modules${sep}@openai${sep}codex${sep}`,
+    )
+  ) {
+    return { kind: "npm", registryPackage: "@openai/codex" };
+  }
+  // pnpm global layout: `<pnpm-home>/pnpm/global/<store>/node_modules/
+  // @openai/codex/...`, or after realpath resolution through pnpm's
+  // `.pnpm` virtual store, `<pnpm-home>/pnpm/global/<store>/node_modules/
+  // .pnpm/@openai+codex@<ver>/node_modules/@openai/codex/...`.  pnpm
+  // global does not use a `lib/node_modules/` segment, so it is missed
+  // by the npm-prefix check above (`pnpm root -g` returns e.g.
+  // `~/Library/pnpm/global/5/node_modules` on macOS,
+  // `~/.local/share/pnpm/global/<N>/node_modules` on Linux,
+  // `%LOCALAPPDATA%/pnpm/global/<N>/node_modules` on Windows, or
+  // `$PNPM_HOME/global/<N>/node_modules` when set).
+  //
+  // The `/pnpm/global/` segment is the distinguishing marker — project-
+  // local pnpm uses `<repo>/node_modules/.pnpm/...` with no `global`
+  // segment, so anchoring on `/pnpm/global/` keeps the project-local
+  // false positive closed while still routing a real `pnpm add -g
+  // @openai/codex` to the npm registry.
+  if (
+    binPath.includes(`${sep}pnpm${sep}global${sep}`) &&
+    binPath.includes(`${sep}node_modules${sep}@openai${sep}codex${sep}`)
+  ) {
+    return { kind: "npm", registryPackage: "@openai/codex" };
+  }
+  // Standalone GitHub-release layouts.  The installer has shipped
+  // several shapes over time, and only these specific subpaths under
+  // `~/.codex/` count as a recognized standalone install:
+  //   ~/.codex/bin/codex               (symlink farm)
+  //   ~/.codex/versions/<ver>/codex    (older per-version layout)
+  //   ~/.codex/packages/standalone/releases/<ver>-<triple>/codex
+  //                                     (current standalone layout)
+  //
+  // Any other path inside `~/.codex/` (e.g. `~/.codex/tools/codex`,
+  // `~/.codex/tmp/codex`) is a hand-placed / custom binary and must
+  // fall through to `inconclusive` — matching the whole directory
+  // would hand out a bogus update prompt, which is the "guess a
+  // channel" failure the issue warns against.  The home-anchoring
+  // also rejects rogue `.codex` directories outside `$HOME`.
+  const homeCodex = `${homedir()}${sep}.codex${sep}`;
+  if (
+    binPath.startsWith(`${homeCodex}bin${sep}`) ||
+    binPath.startsWith(`${homeCodex}versions${sep}`) ||
+    binPath.startsWith(
+      `${homeCodex}packages${sep}standalone${sep}releases${sep}`,
+    )
+  ) {
+    return { kind: "github-releases", repo: "openai/codex" };
+  }
+  return {
+    kind: "inconclusive",
+    reason: `Unrecognized install layout: ${binPath}`,
+  };
+}
+
+function detectClaudeSource(_binPath: string): InstallSource {
+  // Claude is effectively distributed via npm only, so the registry
+  // is the source of truth even when the binary is shimmed through a
+  // version manager.  The _binPath parameter is kept for symmetry with
+  // detectCodexSource and so a future channel can be wired in without
+  // changing the caller signature.
+  return { kind: "npm", registryPackage: "@anthropic-ai/claude-code" };
+}
+
+/** Dispatch install-source detection by CLI name. */
+export function detectInstallSource(
+  cli: CliName,
+  binPath: string,
+): InstallSource {
+  return cli === "claude"
+    ? detectClaudeSource(binPath)
+    : detectCodexSource(binPath);
+}
+
+// ---- latest-version resolvers --------------------------------------------
+
+async function fetchNpmLatest(
+  pkg: string,
+  deps: VersionCheckDeps,
+): Promise<string | undefined> {
+  const data = await deps.fetchJson(`https://registry.npmjs.org/${pkg}/latest`);
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as { version?: unknown }).version === "string"
+  ) {
+    return (data as { version: string }).version;
+  }
+  return undefined;
+}
+
+async function fetchHomebrewFormulaLatest(
+  formula: string,
+  deps: VersionCheckDeps,
+): Promise<string | undefined> {
+  const data = await deps.fetchJson(
+    `https://formulae.brew.sh/api/formula/${formula}.json`,
+  );
+  if (typeof data === "object" && data !== null) {
+    const versions = (data as { versions?: { stable?: unknown } }).versions;
+    if (versions && typeof versions.stable === "string") {
+      return versions.stable;
+    }
+  }
+  return undefined;
+}
+
+async function fetchHomebrewCaskLatest(
+  cask: string,
+  deps: VersionCheckDeps,
+): Promise<string | undefined> {
+  const data = await deps.fetchJson(
+    `https://formulae.brew.sh/api/cask/${cask}.json`,
+  );
+  if (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as { version?: unknown }).version === "string"
+  ) {
+    return (data as { version: string }).version;
+  }
+  return undefined;
+}
+
+async function fetchGitHubReleasesLatest(
+  repo: string,
+  deps: VersionCheckDeps,
+): Promise<string | undefined> {
+  const data = await deps.fetchJson(
+    `https://api.github.com/repos/${repo}/releases/latest`,
+  );
+  if (typeof data !== "object" || data === null) return undefined;
+  // GitHub release tag shapes vary (`v1.2.3`, `rust-v0.122.0`, `1.2.3`),
+  // so extract the first semver-looking substring rather than blindly
+  // stripping a leading `v`.  Prefer `name` when present — upstream
+  // often sets it to the bare semver even when `tag_name` carries a
+  // prefix like `rust-v` — and fall back to `tag_name` otherwise.
+  const obj = data as { name?: unknown; tag_name?: unknown };
+  const candidates = [obj.name, obj.tag_name];
+  for (const c of candidates) {
+    if (typeof c !== "string") continue;
+    const v = parseVersion(c);
+    if (v) return v;
+  }
+  return undefined;
+}
+
+/** Resolve the latest version string for a given install source. */
+export async function resolveLatestVersion(
+  source: InstallSource,
+  deps: VersionCheckDeps,
+): Promise<string | undefined> {
+  switch (source.kind) {
+    case "npm":
+      return fetchNpmLatest(source.registryPackage, deps);
+    case "homebrew-formula":
+      return fetchHomebrewFormulaLatest(source.formula, deps);
+    case "homebrew-cask":
+      return fetchHomebrewCaskLatest(source.cask, deps);
+    case "github-releases":
+      return fetchGitHubReleasesLatest(source.repo, deps);
+    case "inconclusive":
+      return undefined;
+  }
+}
+
+// ---- default deps (real process + real fetch) ----------------------------
+
+function defaultRunVersion(cli: CliName): string | undefined {
+  try {
+    const out = execFileSync(cli, ["--version"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 10_000,
+    });
+    return out;
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultResolveBinary(cli: CliName): string | undefined {
+  try {
+    // `command -v` is POSIX-portable and works in both sh and bash.
+    // We run it inside /bin/sh -c so the user's $PATH is honored.
+    const raw = execFileSync("/bin/sh", ["-c", `command -v ${cli}`], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 5_000,
+    }).trim();
+    if (!raw) return undefined;
+    // Expand a leading `~/` to the real home before realpath.
+    const resolved = raw.startsWith(`~${sep}`)
+      ? raw.replace(/^~/, homedir())
+      : raw;
+    if (!existsSync(resolved)) return undefined;
+    return realpathSync(resolved);
+  } catch {
+    return undefined;
+  }
+}
+
+async function defaultFetchJson(url: string): Promise<unknown> {
+  const res = await fetch(url, {
+    headers: { Accept: "application/json" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status} fetching ${url}`);
+  }
+  return res.json();
+}
+
+export function defaultVersionCheckDeps(): VersionCheckDeps {
+  return {
+    runVersion: defaultRunVersion,
+    resolveBinary: defaultResolveBinary,
+    fetchJson: defaultFetchJson,
+  };
+}
+
+// ---- per-CLI check -------------------------------------------------------
+
+/**
+ * Probe just the installed version (`--version` + parse).  No install-source
+ * detection and no network calls — used on throttled / skipped runs where we
+ * still want to display the version in the pane header but must not hit the
+ * registry / Homebrew / GitHub.
+ */
+export function probeInstalledVersion(
+  cli: CliName,
+  deps: VersionCheckDeps = defaultVersionCheckDeps(),
+): CliVersionCheckResult {
+  const rawOutput = deps.runVersion(cli);
+  if (!rawOutput) {
+    return {
+      cli,
+      skippedReason: `could not run \`${cli} --version\``,
+    };
+  }
+  const installed = parseVersion(rawOutput);
+  if (!installed) {
+    return {
+      cli,
+      rawOutput,
+      skippedReason: `could not parse version from \`${cli} --version\``,
+    };
+  }
+  return { cli, rawOutput, installed };
+}
+
+/**
+ * Run the full install-source → installed-version → latest-version flow
+ * for a single CLI.  Network failures and inconclusive install layouts
+ * surface as `skippedReason` rather than throwing, so the caller can
+ * continue the pipeline (the check is a convenience, not a gate).
+ */
+export async function checkCliVersion(
+  cli: CliName,
+  deps: VersionCheckDeps = defaultVersionCheckDeps(),
+): Promise<CliVersionCheckResult> {
+  const rawOutput = deps.runVersion(cli);
+  if (!rawOutput) {
+    return {
+      cli,
+      skippedReason: `could not run \`${cli} --version\``,
+    };
+  }
+  const installed = parseVersion(rawOutput);
+  if (!installed) {
+    return {
+      cli,
+      rawOutput,
+      skippedReason: `could not parse version from \`${cli} --version\``,
+    };
+  }
+
+  const binPath = deps.resolveBinary(cli);
+  if (!binPath) {
+    return {
+      cli,
+      rawOutput,
+      installed,
+      skippedReason: `could not resolve \`${cli}\` binary path`,
+    };
+  }
+
+  const source = detectInstallSource(cli, binPath);
+  if (source.kind === "inconclusive") {
+    return {
+      cli,
+      rawOutput,
+      installed,
+      source,
+      skippedReason: source.reason,
+    };
+  }
+
+  let latest: string | undefined;
+  try {
+    latest = await resolveLatestVersion(source, deps);
+  } catch (err) {
+    return {
+      cli,
+      rawOutput,
+      installed,
+      source,
+      skippedReason: `could not fetch latest version: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    };
+  }
+
+  if (!latest) {
+    return {
+      cli,
+      rawOutput,
+      installed,
+      source,
+      skippedReason: "latest version missing from channel response",
+    };
+  }
+
+  return { cli, rawOutput, installed, source, latest };
+}
+
+// ---- prompt orchestration ------------------------------------------------
+
+export type RetryChoice = "retry" | "skip" | "abort";
+
+export interface VersionCheckPrompts {
+  /** "An update is available — update now?" (yes/no). */
+  confirmUpdate: (message: string) => Promise<boolean>;
+  /** "Please update, then press Enter to continue." */
+  waitForEnter: (message: string) => Promise<void>;
+  /** Retry / skip / abort selection after an unchanged version. */
+  chooseRetrySkipAbort: (message: string) => Promise<RetryChoice>;
+  /** Informational message (same semantics as console.log). */
+  log: (message: string) => void;
+  /** Warning — non-fatal, user-facing. */
+  warn: (message: string) => void;
+}
+
+export interface VersionCheckTranslations {
+  /** "Checking CLI versions..." */
+  checking: string;
+  /** "No update check — {cli} install channel is inconclusive: {reason}" */
+  inconclusive: (cli: string, reason: string) => string;
+  /** "Could not check {cli} latest version: {reason}" */
+  fetchFailed: (cli: string, reason: string) => string;
+  /** "{cli} is up to date (v{version})" */
+  upToDate: (cli: string, version: string) => string;
+  /** "A newer version of {cli} is available (v{from} → v{to}). Update now?" */
+  updatePrompt: (cli: string, from: string, to: string) => string;
+  /** "Please update {cli}, then press Enter to continue." */
+  updateWaiting: (cli: string) => string;
+  /** "Version is still v{version}." */
+  versionUnchanged: (version: string) => string;
+  /** "How would you like to proceed?" */
+  retrySkipAbortPrompt: string;
+  /** "Continuing with {cli} v{version}." */
+  proceedingWith: (cli: string, version: string) => string;
+  /** "Update check aborted by user." */
+  abortedByUser: string;
+  /** "Could not determine {cli} version; skipping update check." */
+  versionUnknown: (cli: string) => string;
+}
+
+export interface StartupVersionCheckOptions {
+  /** CLIs in use for this run.  Deduplicated internally. */
+  clis: readonly CliName[];
+  config: Config;
+  /**
+   * Persist the version-check state fields (`lastKnownVersions` and/or
+   * `lastVersionCheckAt`) to disk.  Implemented as a narrow patch
+   * rather than a whole-`Config` save so unknown top-level keys in
+   * `~/.agentcoop/config.json` survive the update — mirroring the
+   * "don't rewrite unless dirty" guard in `runStartup()`.
+   */
+  persistVersionCheckState: (updates: {
+    lastKnownVersions?: NonNullable<Config["lastKnownVersions"]>;
+    lastVersionCheckAt?: number;
+  }) => void;
+  prompts: VersionCheckPrompts;
+  translations: VersionCheckTranslations;
+  /** Defaults to real process/network deps. */
+  deps?: VersionCheckDeps;
+  /** Defaults to Date.now(). */
+  now?: () => number;
+}
+
+/**
+ * Decide whether the throttle allows a check.  Treats a missing or
+ * malformed timestamp as "check".
+ */
+export function shouldRunVersionCheck(
+  config: Config,
+  now: number,
+  throttleMs = 24 * 60 * 60 * 1000,
+): boolean {
+  if (config.skipVersionCheck === true) return false;
+  const last = config.lastVersionCheckAt;
+  if (typeof last !== "number" || !Number.isFinite(last)) return true;
+  return now - last >= throttleMs;
+}
+
+/**
+ * Top-level startup check.  Runs after the CLIs actually used this run
+ * are known (fresh/resume branches joined and `params` finalized).
+ *
+ * Returns a map of installed versions keyed by CLI name.  A value of
+ * `undefined` means the version could not be determined (`--version`
+ * failed or the output could not be parsed) — callers should still be
+ * able to proceed.
+ *
+ * Non-fatal: every failure path returns control to the caller rather
+ * than throwing.  The only way to abort is the explicit retry-skip-abort
+ * flow after an update failure.
+ */
+export async function runStartupVersionCheck(
+  opts: StartupVersionCheckOptions,
+): Promise<Map<CliName, string | undefined>> {
+  const deps = opts.deps ?? defaultVersionCheckDeps();
+  const now = opts.now ?? (() => Date.now());
+  const tr = opts.translations;
+  const prompts = opts.prompts;
+
+  const unique: CliName[] = [];
+  for (const cli of opts.clis) {
+    if (!unique.includes(cli)) unique.push(cli);
+  }
+
+  const versions = new Map<CliName, string | undefined>();
+  // Tracks whether at least one CLI reached a definitive
+  // installed-vs-latest comparison this run.  `lastVersionCheckAt`
+  // only advances when this is true — otherwise a transient registry
+  // outage or a fully inconclusive run would suppress re-checks for
+  // the next 24h without ever comparing against a real "latest".
+  let didDefinitiveCheck = false;
+
+  const throttled = !shouldRunVersionCheck(opts.config, now());
+
+  if (!throttled) {
+    prompts.log(tr.checking);
+  }
+
+  for (const cli of unique) {
+    // Throttled/skipped runs still probe the installed version so the
+    // pane header can display it, but MUST NOT hit the registry /
+    // Homebrew / GitHub.  `checkCliVersion` does network I/O; use the
+    // lightweight probe instead.
+    if (throttled) {
+      const probe = probeInstalledVersion(cli, deps);
+      versions.set(cli, probe.installed);
+      continue;
+    }
+
+    const result = await checkCliVersion(cli, deps);
+    versions.set(cli, result.installed);
+
+    if (!result.installed) {
+      prompts.warn(tr.versionUnknown(cli));
+      continue;
+    }
+
+    if (result.skippedReason) {
+      // Inconclusive layout or network failure: log and continue.
+      if (result.source?.kind === "inconclusive") {
+        prompts.log(tr.inconclusive(cli, result.skippedReason));
+      } else {
+        prompts.log(tr.fetchFailed(cli, result.skippedReason));
+      }
+      continue;
+    }
+
+    if (!result.latest) continue;
+
+    // Reached installed-vs-latest comparison — this counts as a
+    // successful check for throttle bookkeeping.
+    didDefinitiveCheck = true;
+
+    const cmp = compareVersions(result.installed, result.latest);
+    if (cmp >= 0) {
+      prompts.log(tr.upToDate(cli, result.installed));
+      continue;
+    }
+
+    // Interactive update flow.
+    const wantsUpdate = await prompts.confirmUpdate(
+      tr.updatePrompt(cli, result.installed, result.latest),
+    );
+    if (!wantsUpdate) continue;
+
+    let currentInstalled = result.installed;
+    for (;;) {
+      await prompts.waitForEnter(tr.updateWaiting(cli));
+
+      const rawAfter = deps.runVersion(cli);
+      const parsedAfter = rawAfter ? parseVersion(rawAfter) : undefined;
+
+      if (parsedAfter && compareVersions(parsedAfter, result.latest) >= 0) {
+        versions.set(cli, parsedAfter);
+        currentInstalled = parsedAfter;
+        prompts.log(tr.proceedingWith(cli, parsedAfter));
+        break;
+      }
+
+      // Version is unchanged (or regressed, or unreadable).
+      prompts.warn(tr.versionUnchanged(parsedAfter ?? currentInstalled));
+      const choice = await prompts.chooseRetrySkipAbort(
+        tr.retrySkipAbortPrompt,
+      );
+      if (choice === "retry") continue;
+      if (choice === "skip") {
+        versions.set(cli, parsedAfter ?? currentInstalled);
+        break;
+      }
+      // "abort" — throw a sentinel so the caller can exit.
+      prompts.warn(tr.abortedByUser);
+      throw new VersionCheckAbortError();
+    }
+  }
+
+  // Persist only the version-check state fields (best-effort — never
+  // crash on a write error).  The callback patches the raw JSON so
+  // unknown top-level keys are preserved; going through `saveConfig`
+  // here would silently drop them.
+  const updates: Partial<NonNullable<Config["lastKnownVersions"]>> = {};
+  for (const cli of unique) {
+    const v = versions.get(cli);
+    if (typeof v === "string") updates[cli] = v;
+  }
+  const prev = opts.config.lastKnownVersions ?? {};
+  const merged = { ...prev, ...updates };
+  const changed = Object.keys(updates).some(
+    (k) =>
+      (prev as Record<string, string | undefined>)[k] !== merged[k as CliName],
+  );
+  if (changed) {
+    opts.config.lastKnownVersions = merged;
+  }
+  // Only advance the throttle timestamp if at least one CLI reached a
+  // real installed-vs-latest comparison.  A run where every CLI was
+  // inconclusive or network-failed should re-check on the next start.
+  const advanceTimestamp = !throttled && didDefinitiveCheck;
+  if (advanceTimestamp) {
+    opts.config.lastVersionCheckAt = now();
+  }
+  if (changed || advanceTimestamp) {
+    const patch: {
+      lastKnownVersions?: NonNullable<Config["lastKnownVersions"]>;
+      lastVersionCheckAt?: number;
+    } = {};
+    if (changed) patch.lastKnownVersions = merged;
+    if (advanceTimestamp)
+      patch.lastVersionCheckAt = opts.config.lastVersionCheckAt;
+    try {
+      opts.persistVersionCheckState(patch);
+    } catch {
+      // Config write failures are non-fatal — the next run will retry.
+    }
+  }
+
+  return versions;
+}
+
+/**
+ * Refresh the `cliVersion` field on a mutable per-agent state object.
+ *
+ * On resume, `runStartupVersionCheck` may return `undefined` for a CLI
+ * when `--version` failed or its output could not be parsed.  Blanking
+ * the saved value in that case would discard the per-run version
+ * record that issue #276 asked to preserve for postmortem.  This
+ * helper overwrites only when a non-empty new value is available, so
+ * a successful upgrade is captured while a failed re-probe leaves the
+ * previously recorded version intact.
+ */
+export function refreshAgentCliVersion(
+  agent: { cliVersion?: string },
+  detected: string | undefined,
+): void {
+  if (detected !== undefined) {
+    agent.cliVersion = detected;
+  }
+}
+
+/**
+ * Thrown from {@link runStartupVersionCheck} when the user selects
+ * "abort" in the retry/skip/abort prompt.  A distinct class so the
+ * caller can decide between exit codes / cleanup behavior.
+ */
+export class VersionCheckAbortError extends Error {
+  constructor() {
+    super("Version check aborted by user.");
+    this.name = "VersionCheckAbortError";
+  }
+}


### PR DESCRIPTION
## Summary

Adds visibility and update prompts for the `claude` / `codex` CLIs that AgentCoop drives:

- **Pane header** now shows the CLI name and installed CLI version next to the model name (e.g. `Agent A (author) — Claude Opus 4.7 v1.2.3`). The CLI name disambiguates panes when model names are shared or user-configured. When `modelDisplayName` already starts with the CLI name (e.g. `models.json` entries like `Claude Opus 4.7`), `formatPaneHeader` collapses the duplicate so the header reads `Claude Opus 4.7` rather than `Claude Claude Opus 4.7`. The version is detected once at pipeline start so it does not flicker mid-run, and is threaded through `renderApp` so no adapter changes are required.
- **Per-run recording**: the detected version is saved into `RunState` (`agentA.cliVersion` / `agentB.cliVersion`) and into the run-log header under a `version` line. It is refreshed at resume time so a CLI upgrade between runs is captured, not silently discarded. A failed re-probe on resume (e.g. `--version` crashed or its output could not be parsed) intentionally keeps the previously recorded version rather than blanking it, preserving the postmortem record — and the run-log header reads from `runState` (via `runState.agentA.cliVersion` / `runState.agentB.cliVersion`) rather than the raw probe result, so a failed re-probe preserves the postmortem record in the log path too, not just `RunState`.
- **Startup update check** runs after the fresh/resume branches join and `params` is finalized, so it never prompts for a CLI that is not used this run. It deduplicates the two agents' CLIs before running.
- **Channel-appropriate latest resolution**:
  - Claude → npm registry (`@anthropic-ai/claude-code`).
  - Codex → resolved from the binary's realpath against the npm global prefix (anchored on `lib/node_modules/@openai/codex/` so a project-local install at `<repo>/node_modules/@openai/codex/...` — reachable via `node_modules/.bin/codex` — falls through to `inconclusive` rather than getting a global update prompt), the pnpm global prefix (anchored on `/pnpm/global/` plus `/node_modules/@openai/codex/` so a real `pnpm add -g @openai/codex` install under e.g. `~/Library/pnpm/global/<N>/node_modules/@openai/codex/…`, `~/.local/share/pnpm/global/<N>/node_modules/…`, or `$PNPM_HOME/global/<N>/node_modules/…` is routed to the npm registry without reopening the project-local false positive — project-local pnpm uses `<repo>/node_modules/.pnpm/…` with no `global` segment), Homebrew formula anchored on the `codex` package segment and root-anchored on the Homebrew-default prefixes (`/opt/homebrew/Cellar/codex/`, `/usr/local/Cellar/codex/`, `/home/linuxbrew/.linuxbrew/Cellar/codex/`), Homebrew cask anchored likewise (`/opt/homebrew/Caskroom/codex/`, `/usr/local/Caskroom/codex/`, `/home/linuxbrew/.linuxbrew/Caskroom/codex/`), or a standalone install rooted at `~/.codex/` — specifically `~/.codex/bin/`, `~/.codex/versions/<ver>/`, or the current `~/.codex/packages/standalone/releases/` layout. Homebrew matches run before the npm marker check, so a formula install that bundles `libexec/lib/node_modules/@openai/codex/…` under `Cellar/codex/` resolves to the formula channel rather than npm. Homebrew anchoring also prevents a custom wrapper formula/cask (e.g. `Cellar/my-codex-wrapper/…`, `Caskroom/custom-codex/…`) **and** a copied tree under a non-Homebrew root (e.g. `/tmp/opt/homebrew/Cellar/codex/…`, `/Users/me/sandbox/usr/local/Caskroom/codex/…`) from being misclassified as the official `codex` package. The three Homebrew prefixes are Homebrew's documented defaults: Apple Silicon macOS (`/opt/homebrew`), Intel macOS (`/usr/local`), and Linuxbrew (`/home/linuxbrew/.linuxbrew`). Only these known subpaths under the running user's home directory count as a standalone install. Any unrecognized subpath inside `~/.codex/` (e.g. `~/.codex/tools/codex`, `~/.codex/tmp/codex`) and any `.codex` directory outside `\$HOME` (e.g. `/tmp/.codex/…`) fall through to `inconclusive` so the check is skipped rather than wrong. Likewise, any raw `Applications/` path that did not resolve through `realpath` into a Caskroom directory — system-wide (`/Applications/…`), home-rooted (`~/Applications/…`), or rogue (`/tmp/Applications/…`) — is treated as inconclusive rather than guessed as a cask.
- **Prompt flow**: if a newer version exists, AgentCoop prompts to update, pauses for the user to run their package manager, and re-runs `--version` on return. If the version is unchanged it offers retry / skip (proceed with the current version for this run) / abort — no silent fallback.
- **Config**: new `lastKnownVersions`, `skipVersionCheck`, and `lastVersionCheckAt` fields. `skipVersionCheck: true` disables the check entirely; the 24h throttle avoids hitting the registry on every run. Throttled/skipped runs still probe the installed version for the pane header via a lightweight `--version` parse — they do NOT call into the registry / Homebrew / GitHub. `lastVersionCheckAt` only advances after at least one CLI reached a real installed-vs-latest comparison — a run where every channel was inconclusive, or where the registry fetch failed, re-checks on the next start rather than being silently throttled for 24h. Network failures on non-throttled runs are logged but never fatal. Persistence of these fields uses a narrow JSON patch (`patchVersionCheckState` in `src/config.ts`) rather than a full `saveConfig` round-trip, so unknown top-level keys in `~/.agentcoop/config.json` (user-added fields, fields from a newer AgentCoop version) are preserved — mirroring the "don't rewrite unless dirty" guard in `runStartup()`. The patcher also merges `lastKnownVersions` against the existing nested object instead of replacing it, so unknown nested CLI entries (e.g. a `gemini` field added by a newer AgentCoop version) survive a claude/codex-only check.
- **Docs**: `CHANGELOG.md`, README "Terminal UI" ASCII diagram, a new "CLI update check" subsection under Prerequisites, and the configuration table are updated to reflect the new fields and behavior.

Closes #276

## Test plan

- [x] \`pnpm check\` (Biome) passes
- [x] \`pnpm tsc --noEmit\` passes
- [x] \`pnpm vitest run\` — all tests pass, including new coverage for the header-duplication collapse, for failure/inconclusive runs not advancing \`lastVersionCheckAt\`, and for a mixed run (one CLI successful, one inconclusive) advancing it
- [x] Pane header renders \`Agent A (author) — Claude Opus 4.7 v<installed>\` and \`Agent B (reviewer) — Codex GPT-5.4 v<installed>\` when versions are detected, without the "Claude Claude ..." duplication that the models.json display name + cliName prefix would otherwise produce
- [x] Pane header falls back to \`Agent A (author) — Claude Opus 4.7\` when version is undefined (no regression)
- [x] Fresh run where at least one CLI reached installed-vs-latest comparison: version-check writes \`lastKnownVersions\` and \`lastVersionCheckAt\`, and the recorded value lands in \`~/.agentcoop/runs/*.json\` and the run-log header
- [x] Fresh run where **every** CLI was inconclusive (custom layout) or the fetch failed: \`lastVersionCheckAt\` is NOT advanced, so the next run re-checks rather than being silently throttled for 24h
- [x] Resume run: version is re-detected and the saved \`cliVersion\` in \`RunState\` is refreshed to the current CLI build
- [x] Resume run with failed re-probe: saved \`cliVersion\` is preserved (not blanked) in \`RunState\` **and** in the new run-log header (both read from \`runState.agent*.cliVersion\`)
- [x] \`skipVersionCheck: true\` in \`~/.agentcoop/config.json\` suppresses the check and all network calls (verified by vi.fn spies on fetchJson / resolveBinary)
- [x] \`lastVersionCheckAt\` within the last 24h throttles the check (no network call, no install-source detection)
- [x] When a newer Claude version is published to npm, the update prompt fires with \`v<from> → v<to>\`
- [x] Codex install on npm global prefix (\`<prefix>/lib/node_modules/@openai/codex/...\`) resolves latest from the npm registry
- [x] Codex install on pnpm global prefix (\`~/Library/pnpm/global/<N>/node_modules/@openai/codex/…\` on macOS, \`~/.local/share/pnpm/global/<N>/node_modules/…\` on Linux, \`\$PNPM_HOME/global/<N>/node_modules/…\` when set, and the realpath-resolved \`.pnpm/@openai+codex@<ver>/node_modules/@openai/codex/…\` shape) resolves latest from the npm registry
- [x] Project-local pnpm layout (\`<repo>/node_modules/.pnpm/@openai+codex@<ver>/node_modules/@openai/codex/...\`) is reported as inconclusive — not guessed as a global pnpm install
- [x] Codex install resolved to a project-local \`node_modules/@openai/codex/...\` path (no \`lib/\` segment) is reported as inconclusive — not guessed as a global npm install
- [x] Codex install on Homebrew formula (\`/opt/homebrew/Cellar/codex/\`, \`/usr/local/Cellar/codex/\`, \`/home/linuxbrew/.linuxbrew/Cellar/codex/\`) resolves latest from formula metadata — including a formula that bundles \`node_modules/@openai/codex/...\` internally
- [x] Custom Homebrew formula (e.g. \`Cellar/my-codex-wrapper/…\`) is reported as inconclusive — not guessed as the official \`codex\` formula
- [x] Homebrew formula lookalike under a non-Homebrew root (e.g. \`/tmp/opt/homebrew/Cellar/codex/…\`, \`/Users/me/sandbox/usr/local/Cellar/codex/…\`, \`/var/tmp/home/linuxbrew/.linuxbrew/Cellar/codex/…\`) is reported as inconclusive — not guessed as an actual Homebrew install
- [x] Codex install on Homebrew cask (\`/opt/homebrew/Caskroom/codex/\`, \`/usr/local/Caskroom/codex/\`, \`/home/linuxbrew/.linuxbrew/Caskroom/codex/\`) resolves latest from cask metadata
- [x] Custom Homebrew cask (e.g. \`Caskroom/custom-codex/…\`) is reported as inconclusive — not guessed as the official \`codex\` cask
- [x] Homebrew cask lookalike under a non-Homebrew root (e.g. \`/tmp/opt/homebrew/Caskroom/codex/…\`, \`/Users/me/sandbox/usr/local/Caskroom/codex/…\`, \`/var/tmp/home/linuxbrew/.linuxbrew/Caskroom/codex/…\`) is reported as inconclusive — not guessed as an actual Homebrew install
- [x] Codex install under the known \`~/.codex/\` layouts (\`bin\`, \`versions/<ver>\`, current \`packages/standalone/releases/...\`) resolves latest from GitHub releases
- [x] Unrecognized subpath inside \`~/.codex/\` (e.g. \`~/.codex/tools/codex\`, \`~/.codex/tmp/codex\`, \`~/.codex/codex\`) is reported as inconclusive — not guessed as a GitHub-release install
- [x] \`.codex\` directory outside \$HOME (e.g. \`/tmp/.codex/codex\`) is reported as inconclusive and the check is skipped — not guessed as a GitHub-release install
- [x] Any \`Applications/\` path that did not resolve into Caskroom (\`/Applications/Codex.app/…\`, \`~/Applications/Codex.app/…\`, \`/tmp/Applications/codex\`) is reported as inconclusive — not guessed as a cask install
- [x] Unrecognized Codex install layout is reported as inconclusive and the check is skipped for that CLI
- [x] \"Update now?\" → yes, version unchanged on return → retry / skip / abort options appear and each behaves as documented
- [x] Network failure to registry/releases is logged but does not abort startup
- [x] Updating version-check state preserves unknown top-level keys in \`~/.agentcoop/config.json\` (covered by a new \`patchVersionCheckState\` test that seeds the file with unknown fields and asserts they survive)
- [x] Updating \`lastKnownVersions\` preserves unknown nested CLI entries (e.g. a forward-compatible \`gemini\` field) — covered by a new \`patchVersionCheckState\` test that seeds \`lastKnownVersions.gemini\` and asserts it survives a claude/codex update