### PR TITLE
Harden Codex adapter for newer CLI releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- AgentCoop-managed Codex runs now pin `approval_policy=never`
+  explicitly instead of inheriting the user's local Codex approval
+  setting. Fresh `codex exec` runs keep using
+  `-s danger-full-access`, while `codex exec resume` now prefers
+  `--json` for structured parsing and streaming on newer CLIs and
+  falls back to the legacy plain-text parser only when the installed
+  CLI explicitly rejects JSON resume.
 - Resuming Stage 8 from the `squashing` substate no longer re-sends the
   full planning prompt.  The handler now checks whether the squash
   already landed (commit count collapsed to 1) and jumps straight to

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -31,7 +31,7 @@ export interface AgentResult {
   usage?: TokenUsage;
 }
 
-export interface AgentStream {
+export interface AgentStream<TResult extends AgentResult = AgentResult> {
   /** Async iterator that yields output chunks as they arrive. */
   [Symbol.asyncIterator](): AsyncIterator<string>;
 
@@ -39,7 +39,7 @@ export interface AgentStream {
    * Resolves when the process exits with the final structured result.
    * Consuming the iterator is optional; `result` always resolves.
    */
-  result: Promise<AgentResult>;
+  result: Promise<TResult>;
 
   /** The underlying child process, exposed for cancellation. */
   child: ChildProcess;

--- a/src/codex-adapter.test.ts
+++ b/src/codex-adapter.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest";
 import type { AgentResult, AgentStream } from "./agent.js";
 import {
   buildCodexInvokeArgs,
+  buildCodexPlainTextResumeArgs,
   buildCodexResumeArgs,
   CodexStreamTransformer,
   detectCodexError,
@@ -194,7 +195,52 @@ describe("parseCodexJsonl", () => {
     expect(result.status).toBe("success");
   });
 
-  test("detects error events with retry messages", () => {
+  test("treats a terminal top-level error event as failure", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-error" }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "error",
+        message: "stream error: unexpected status 500",
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.status).toBe("error");
+    expect(result.responseText).toBe("stream error: unexpected status 500");
+    expect(result.sessionId).toBe("sess-error");
+  });
+
+  test("ignores retry-style top-level error when a later success completes the turn", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-retry-ok" }),
+      JSON.stringify({ type: "turn.started" }),
+      JSON.stringify({
+        type: "error",
+        message: "stream error: unexpected status 400; retrying 1/5",
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "recovered" },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 20, output_tokens: 5 },
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.status).toBe("success");
+    expect(result.responseText).toBe("recovered");
+    expect(result.sessionId).toBe("sess-retry-ok");
+    expect(result.usage).toEqual({
+      inputTokens: 20,
+      outputTokens: 5,
+      cachedInputTokens: 0,
+    });
+  });
+
+  test("later turn.failed overrides an earlier top-level error event", () => {
     const lines = [
       JSON.stringify({ type: "thread.started", thread_id: "sess-retry" }),
       JSON.stringify({ type: "turn.started" }),
@@ -210,7 +256,36 @@ describe("parseCodexJsonl", () => {
 
     const result = parseCodexJsonl(lines);
     expect(result.status).toBe("error");
+    expect(result.responseText).toBe("unexpected status 400");
     expect(result.sessionId).toBe("sess-retry");
+  });
+
+  test("ignores a later top-level error once turn.completed has already ended the turn", () => {
+    const lines = [
+      JSON.stringify({ type: "thread.started", thread_id: "sess-done" }),
+      JSON.stringify({
+        type: "item.completed",
+        item: { id: "item_0", type: "agent_message", text: "finished" },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: { input_tokens: 12, output_tokens: 3 },
+      }),
+      JSON.stringify({
+        type: "error",
+        message: "stream error after completion",
+      }),
+    ].join("\n");
+
+    const result = parseCodexJsonl(lines);
+    expect(result.status).toBe("success");
+    expect(result.responseText).toBe("finished");
+    expect(result.sessionId).toBe("sess-done");
+    expect(result.usage).toEqual({
+      inputTokens: 12,
+      outputTokens: 3,
+      cachedInputTokens: 0,
+    });
   });
 });
 
@@ -284,6 +359,79 @@ describe("extractCodexResumeResponse", () => {
     ].join("\n");
 
     expect(extractCodexResumeResponse(text)).toBe("");
+  });
+
+  test("does not treat standalone codex lines inside the response as a new marker", () => {
+    const text = [
+      BANNER,
+      "user",
+      "Show the raw transcript markers",
+      "codex",
+      "First line",
+      "codex",
+      "Still part of the response",
+      "tokens used",
+      "500",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe(
+      "First line\ncodex\nStill part of the response",
+    );
+  });
+
+  test("does not treat standalone tokens used lines inside the response as the footer", () => {
+    const text = [
+      BANNER,
+      "user",
+      "Show the raw transcript markers",
+      "codex",
+      "First line",
+      "tokens used",
+      "not the footer",
+      "Still part of the response",
+      "tokens used",
+      "500",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe(
+      "First line\ntokens used\nnot the footer\nStill part of the response",
+    );
+  });
+
+  test("does not strip a footer-like tail when the count is not a plain integer", () => {
+    const text = [
+      BANNER,
+      "user",
+      "Show the raw transcript markers",
+      "codex",
+      "First line",
+      "tokens used",
+      "123abc",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text)).toBe(
+      "First line\ntokens used\n123abc",
+    );
+  });
+
+  test("parses bare fallback output that starts with codex", () => {
+    const text = ["codex", "Done.", "tokens used", "50"].join("\n");
+    expect(extractCodexResumeResponse(text)).toBe("Done.");
+  });
+
+  test("uses the known prompt to disambiguate prompt-side codex markers", () => {
+    const prompt = ["Show these markers verbatim:", "codex"].join("\n");
+    const text = [
+      BANNER,
+      "user",
+      ...prompt.split("\n"),
+      "codex",
+      "Actual answer",
+      "tokens used",
+      "120",
+    ].join("\n");
+
+    expect(extractCodexResumeResponse(text, prompt)).toBe("Actual answer");
   });
 });
 
@@ -703,7 +851,15 @@ describe("buildCodexInvokeArgs", () => {
   test("builds invoke args with '-' placeholder for stdin", () => {
     const args = buildCodexInvokeArgs({});
 
-    expect(args).toEqual(["exec", "-s", "danger-full-access", "--json", "-"]);
+    expect(args).toEqual([
+      "exec",
+      "-s",
+      "danger-full-access",
+      "--json",
+      "-c",
+      "approval_policy=never",
+      "-",
+    ]);
   });
 
   test("includes -m when model is specified", () => {
@@ -721,10 +877,10 @@ describe("buildCodexInvokeArgs", () => {
     expect(args).not.toContain("--model");
   });
 
-  test("does not include -a flag (not supported by CLI)", () => {
+  test("uses approval_policy=never instead of a legacy approval flag", () => {
     const args = buildCodexInvokeArgs({});
     expect(args).not.toContain("-a");
-    expect(args).not.toContain("never");
+    expect(args).toContain("approval_policy=never");
   });
 
   test("includes -c reasoning effort when specified", () => {
@@ -759,16 +915,21 @@ describe("buildCodexInvokeArgs", () => {
 // buildCodexResumeArgs
 // ---------------------------------------------------------------------------
 describe("buildCodexResumeArgs", () => {
+  test("prefers JSON resume mode", () => {
+    const args = buildCodexResumeArgs("sess-abc", {});
+    expect(args).toContain("--json");
+  });
+
+  test("always includes approval_policy=never", () => {
+    const args = buildCodexResumeArgs("sess-abc", {});
+    expect(args).toContain("approval_policy=never");
+  });
+
   test("always includes -c sandbox_mode=danger-full-access", () => {
     const args = buildCodexResumeArgs("sess-abc", {});
 
     expect(args).toContain("-c");
     expect(args).toContain("sandbox_mode=danger-full-access");
-  });
-
-  test("does not include --json (resume outputs plain text)", () => {
-    const args = buildCodexResumeArgs("sess-abc", {});
-    expect(args).not.toContain("--json");
   });
 
   test("includes -c model override when model is specified", () => {
@@ -833,6 +994,23 @@ describe("buildCodexResumeArgs", () => {
     });
 
     expect(args).toContain("model_reasoning_effort=xhigh");
+  });
+});
+
+describe("buildCodexPlainTextResumeArgs", () => {
+  test("keeps the legacy fallback path plain-text only", () => {
+    const args = buildCodexPlainTextResumeArgs("sess-abc", {});
+    expect(args).not.toContain("--json");
+  });
+
+  test("always includes approval_policy=never", () => {
+    const args = buildCodexPlainTextResumeArgs("sess-abc", {});
+    expect(args).toContain("approval_policy=never");
+  });
+
+  test("always includes sandbox_mode=danger-full-access", () => {
+    const args = buildCodexPlainTextResumeArgs("sess-abc", {});
+    expect(args).toContain("sandbox_mode=danger-full-access");
   });
 });
 
@@ -924,6 +1102,25 @@ describe("extractCodexPlainTextTokens", () => {
 
   test("returns undefined for zero count", () => {
     expect(extractCodexPlainTextTokens("\ntokens used\n0\n")).toBeUndefined();
+  });
+
+  test("returns undefined for malformed numeric footer lines", () => {
+    expect(
+      extractCodexPlainTextTokens("\ncodex\nresponse\ntokens used\n123abc\n"),
+    ).toBeUndefined();
+  });
+
+  test("only treats the trailing footer as structural", () => {
+    const text = [
+      "codex",
+      "response",
+      "tokens used",
+      "not the footer",
+      "tokens used",
+      "229",
+    ].join("\n");
+
+    expect(extractCodexPlainTextTokens(text)).toBe(229);
   });
 });
 
@@ -1136,5 +1333,17 @@ describe("withXhighFallback", () => {
 
     expect(wrapped.child).toBe(originalChild);
     expect(retryFn).not.toHaveBeenCalled();
+  });
+
+  test("throws when the wrapped stream is iterated twice", () => {
+    const wrapped = withXhighFallback(makeMockStream(SUCCESS_RESULT), () =>
+      makeMockStream(SUCCESS_RESULT),
+    );
+
+    wrapped[Symbol.asyncIterator]();
+
+    expect(() => wrapped[Symbol.asyncIterator]()).toThrow(
+      /AgentStream can only be iterated once/,
+    );
   });
 });

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -65,6 +65,19 @@ export type CodexJsonEvent =
   | ErrorEvent
   | { type: string };
 
+type CodexTurnTerminalEvent =
+  | { type: "turn.completed" }
+  | { type: "turn.failed"; message: string };
+
+interface CodexBanner {
+  bannerText: string;
+  bodyStart: number;
+}
+
+interface CodexParsedResult extends AgentResult {
+  sawStructuredJson?: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // JSONL parser (codex exec --json)
 // ---------------------------------------------------------------------------
@@ -77,11 +90,11 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
 
   let sessionId: string | undefined;
   let responseText = "";
-  let failed = false;
-  let failMessage = "";
   let inputTokens = 0;
   let outputTokens = 0;
   let cachedInputTokens = 0;
+  let turnTerminalEvent: CodexTurnTerminalEvent | undefined;
+  let pendingErrorMessage: string | undefined;
 
   for (const line of lines) {
     let event: CodexJsonEvent;
@@ -112,12 +125,19 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
         outputTokens += e.usage.output_tokens ?? 0;
         cachedInputTokens += e.usage.cached_input_tokens ?? 0;
       }
+      turnTerminalEvent = { type: "turn.completed" };
+      pendingErrorMessage = undefined;
     }
 
     if (event.type === "turn.failed") {
       const e = event as TurnFailedEvent;
-      failed = true;
-      failMessage = e.error.message;
+      turnTerminalEvent = { type: "turn.failed", message: e.error.message };
+      pendingErrorMessage = undefined;
+    }
+
+    if (event.type === "error" && turnTerminalEvent === undefined) {
+      const e = event as ErrorEvent;
+      pendingErrorMessage = e.message;
     }
   }
 
@@ -126,12 +146,23 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
     ? { inputTokens, outputTokens, cachedInputTokens }
     : undefined;
 
-  if (failed) {
+  if (turnTerminalEvent?.type === "turn.failed") {
     return {
       sessionId,
-      responseText: failMessage,
+      responseText: turnTerminalEvent.message,
       status: "error",
-      errorType: detectCodexError(failMessage),
+      errorType: detectCodexError(turnTerminalEvent.message),
+      stderrText: "",
+      usage,
+    };
+  }
+
+  if (pendingErrorMessage !== undefined) {
+    return {
+      sessionId,
+      responseText: pendingErrorMessage,
+      status: "error",
+      errorType: detectCodexError(pendingErrorMessage),
       stderrText: "",
       usage,
     };
@@ -147,12 +178,127 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
   };
 }
 
+function hasStructuredCodexJsonEvent(output: string): boolean {
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "") continue;
+
+    try {
+      const event = JSON.parse(line) as { type?: unknown };
+      if (typeof event.type === "string") {
+        return true;
+      }
+    } catch {
+      // Ignore non-JSON lines; resume fallback detection only cares
+      // whether the CLI produced any structured JSON events at all.
+    }
+  }
+
+  return false;
+}
+
 // ---------------------------------------------------------------------------
-// Plain text parser (codex exec resume — does not support --json)
+// Plain text parser (codex exec resume fallback for older CLI versions)
 // ---------------------------------------------------------------------------
+
+function extractCodexBanner(text: string): CodexBanner | undefined {
+  const trimmed = text.trimStart();
+  const leadingWhitespaceLength = text.length - trimmed.length;
+  const bannerMatch =
+    /^OpenAI Codex[^\n]*\n--------\n[\s\S]*?\n--------(?:\n|$)/.exec(trimmed);
+
+  if (!bannerMatch) return undefined;
+
+  return {
+    bannerText: bannerMatch[0].trimEnd(),
+    bodyStart: leadingWhitespaceLength + bannerMatch[0].length,
+  };
+}
+
+function trimTrailingBlankLines(lines: string[]): string[] {
+  const trimmed = [...lines];
+  while (trimmed.length > 0 && trimmed[trimmed.length - 1]?.trim() === "") {
+    trimmed.pop();
+  }
+  return trimmed;
+}
+
+function parseTrailingIntegerLine(line: string): number | undefined {
+  const trimmed = line.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
+}
+
+function stripTrailingTokenFooter(lines: string[]): string[] {
+  const trimmed = trimTrailingBlankLines(lines);
+  if (trimmed.length < 2) return trimmed;
+
+  const tokenCount = parseTrailingIntegerLine(
+    trimmed[trimmed.length - 1] ?? "",
+  );
+  if (
+    trimmed[trimmed.length - 2] === "tokens used" &&
+    tokenCount !== undefined
+  ) {
+    return trimmed.slice(0, -2);
+  }
+
+  return trimmed;
+}
+
+function extractBannerStructuredResumeResponse(
+  text: string,
+): string | undefined {
+  const banner = extractCodexBanner(text);
+  if (!banner) return undefined;
+
+  const bodyLines = stripTrailingTokenFooter(
+    text.slice(banner.bodyStart).split("\n"),
+  );
+  if (bodyLines[0] !== "user") return undefined;
+
+  const assistantMarkerIndex = bodyLines.indexOf("codex", 1);
+  if (assistantMarkerIndex === -1) return undefined;
+
+  return bodyLines
+    .slice(assistantMarkerIndex + 1)
+    .join("\n")
+    .trim();
+}
+
+function extractBareResumeResponse(text: string): string | undefined {
+  const bodyLines = stripTrailingTokenFooter(text.split("\n"));
+  if (bodyLines[0] !== "codex") return undefined;
+  return bodyLines.slice(1).join("\n").trim();
+}
+
+function extractPromptAwareResumeResponse(
+  text: string,
+  expectedPrompt: string,
+): string | undefined {
+  const banner = extractCodexBanner(text);
+  if (!banner) return undefined;
+
+  const body = stripTrailingTokenFooter(
+    text.slice(banner.bodyStart).split("\n"),
+  );
+  const bodyText = body.join("\n");
+  const prefix = `user\n${expectedPrompt}\ncodex`;
+
+  if (!bodyText.startsWith(prefix)) return undefined;
+
+  const rest = bodyText.slice(prefix.length);
+  if (rest === "") return "";
+  if (!rest.startsWith("\n")) return undefined;
+  return rest.slice(1).trim();
+}
 
 /**
  * Extract the assistant response from `codex exec resume` plain text output.
+ * When `expectedPrompt` is provided, it is used to disambiguate prompt-side
+ * marker lines from the real assistant boundary.
  *
  * The output looks like:
  * ```
@@ -171,24 +317,27 @@ export function parseCodexJsonl(jsonl: string): AgentResult {
  * <count>
  * ```
  *
- * We extract the text between the last "codex\n" marker and the
- * trailing "tokens used\n" footer.
+ * We prefer the validated banner boundary and only treat a
+ * `tokens used` footer as structural when it is the real trailing
+ * footer. This avoids misparsing assistant responses that contain
+ * marker-like lines such as standalone `codex` or `tokens used`.
+ *
+ * When the original resume prompt is known, pass it as
+ * `expectedPrompt` so the parser can disambiguate prompt-side marker
+ * lines from the real assistant boundary.
  */
-export function extractCodexResumeResponse(text: string): string {
-  const codexMarker = "\ncodex\n";
-  const footerMarker = "\ntokens used\n";
-
-  const codexIdx = text.lastIndexOf(codexMarker);
-  if (codexIdx === -1) {
-    // Fallback: no recognizable structure, return trimmed text.
-    return text.trim();
-  }
-
-  const start = codexIdx + codexMarker.length;
-  const footerIdx = text.indexOf(footerMarker, start);
-  const end = footerIdx === -1 ? text.length : footerIdx;
-
-  return text.slice(start, end).trim();
+export function extractCodexResumeResponse(
+  text: string,
+  expectedPrompt?: string,
+): string {
+  return (
+    (expectedPrompt
+      ? extractPromptAwareResumeResponse(text, expectedPrompt)
+      : undefined) ??
+    extractBannerStructuredResumeResponse(text) ??
+    extractBareResumeResponse(text) ??
+    text.trim()
+  );
 }
 
 /**
@@ -209,19 +358,9 @@ export function extractCodexResumeResponse(text: string): string {
  * `session id:` line.
  */
 export function extractSessionId(text: string): string | undefined {
-  const sep = "--------";
-  const first = text.indexOf(sep);
-  if (first === -1) return undefined;
-
-  // The real Codex banner always starts the output.  Reject when the
-  // header is missing so that response body content is never mistaken
-  // for the banner.
-  if (!text.trimStart().startsWith("OpenAI Codex")) return undefined;
-
-  const second = text.indexOf(sep, first + sep.length);
-  if (second === -1) return undefined;
-  const banner = text.slice(first, second + sep.length);
-  const match = /^session id:\s*(\S+)/m.exec(banner);
+  const banner = extractCodexBanner(text);
+  if (!banner) return undefined;
+  const match = /^session id:\s*(\S+)/m.exec(banner.bannerText);
   return match?.[1];
 }
 
@@ -231,23 +370,25 @@ export function extractSessionId(text: string): string | undefined {
  * absent or the count is not a valid number.
  */
 export function extractCodexPlainTextTokens(text: string): number | undefined {
-  const marker = "\ntokens used\n";
-  const idx = text.lastIndexOf(marker);
-  if (idx === -1) return undefined;
-  const rest = text.slice(idx + marker.length).trim();
-  // The count may be on the first line only (ignore trailing content).
-  const firstLine = rest.split("\n")[0].trim();
-  const n = Number.parseInt(firstLine, 10);
-  return Number.isFinite(n) && n > 0 ? n : undefined;
+  const lines = trimTrailingBlankLines(text.split("\n"));
+  if (lines.length < 2 || lines[lines.length - 2] !== "tokens used") {
+    return undefined;
+  }
+
+  const n = parseTrailingIntegerLine(lines[lines.length - 1] ?? "");
+  return n !== undefined && n > 0 ? n : undefined;
 }
 
 export function parseCodexPlainText(
   text: string,
   exitCode: number | null,
   stderrText: string,
+  expectedPrompt?: string,
 ): AgentResult {
   const failed = exitCode !== 0;
-  const responseText = failed ? text.trim() : extractCodexResumeResponse(text);
+  const responseText = failed
+    ? text.trim()
+    : extractCodexResumeResponse(text, expectedPrompt);
   let errorType: AgentErrorType | undefined;
   if (failed) {
     errorType = detectCodexError(text + stderrText);
@@ -364,7 +505,14 @@ export function buildCodexInvokeArgs(opts: {
   model?: string;
   reasoningEffort?: CodexReasoningEffort;
 }): string[] {
-  const args = ["exec", "-s", "danger-full-access", "--json"];
+  const args = [
+    "exec",
+    "-s",
+    "danger-full-access",
+    "--json",
+    "-c",
+    "approval_policy=never",
+  ];
   if (opts.model) {
     args.push("-m", opts.model);
   }
@@ -379,8 +527,41 @@ export function buildCodexResumeArgs(
   sessionId: string,
   opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
 ): string[] {
-  // Note: `codex exec resume` does not support --json; output is plain text.
-  const args = ["exec", "resume", "-c", "sandbox_mode=danger-full-access"];
+  const args = [
+    "exec",
+    "resume",
+    "--json",
+    "-c",
+    "approval_policy=never",
+    "-c",
+    "sandbox_mode=danger-full-access",
+  ];
+  if (opts.model) {
+    args.push("-c", `model="${opts.model}"`);
+  }
+  if (opts.reasoningEffort) {
+    args.push("-c", `model_reasoning_effort=${opts.reasoningEffort}`);
+  }
+  args.push(sessionId, "-");
+  return args;
+}
+
+/**
+ * @internal Legacy compatibility path for older Codex CLIs that reject
+ * `codex exec resume --json`.
+ */
+export function buildCodexPlainTextResumeArgs(
+  sessionId: string,
+  opts: { model?: string; reasoningEffort?: CodexReasoningEffort },
+): string[] {
+  const args = [
+    "exec",
+    "resume",
+    "-c",
+    "approval_policy=never",
+    "-c",
+    "sandbox_mode=danger-full-access",
+  ];
   if (opts.model) {
     args.push("-c", `model="${opts.model}"`);
   }
@@ -399,15 +580,29 @@ function parseCodexInvokeOutput(
   output: string,
   code: number | null,
   stderrText: string,
-): AgentResult {
+): CodexParsedResult {
+  const sawStructuredJson = hasStructuredCodexJsonEvent(output);
+
   try {
     const parsed = parseCodexJsonl(output);
-    const result = { ...parsed, stderrText };
+    const result: CodexParsedResult = {
+      ...parsed,
+      stderrText,
+      sawStructuredJson,
+    };
     if (code !== 0 && result.status === "success") {
+      const fallbackResponseText =
+        result.responseText ||
+        output.trim() ||
+        stderrText.trim() ||
+        `codex exited with code ${code}`;
       return {
         ...result,
+        responseText: fallbackResponseText,
         status: "error",
-        errorType: detectCodexError(output + stderrText),
+        errorType: detectCodexError(
+          `${fallbackResponseText}\n${output}\n${stderrText}`,
+        ),
       };
     }
     return result;
@@ -418,8 +613,124 @@ function parseCodexInvokeOutput(
       status: code === 0 ? "success" : "error",
       errorType: code === 0 ? undefined : "unknown",
       stderrText,
+      sawStructuredJson,
     };
   }
+}
+
+function parseCodexResumeJsonOutput(
+  sessionId: string,
+  output: string,
+  code: number | null,
+  stderrText: string,
+): CodexParsedResult {
+  const result = parseCodexInvokeOutput(output, code, stderrText);
+  if (result.sessionId === undefined) {
+    result.sessionId = sessionId;
+  }
+  return result;
+}
+
+function parseCodexResumePlainTextOutput(
+  sessionId: string,
+  prompt: string,
+  output: string,
+  exitCode: number | null,
+  stderrText: string,
+): AgentResult {
+  const result = parseCodexPlainText(output, exitCode, stderrText, prompt);
+  if (result.sessionId === undefined) {
+    result.sessionId = sessionId;
+  }
+  return result;
+}
+
+function withConditionalFallback<
+  TPrimary extends AgentResult,
+  TFallback extends AgentResult = TPrimary,
+>(
+  stream: AgentStream<TPrimary>,
+  shouldRetry: (result: TPrimary) => boolean,
+  retryFn: () => AgentStream<TFallback>,
+): AgentStream<TPrimary | TFallback>;
+function withConditionalFallback<
+  TPrimary extends AgentResult,
+  TFallback extends AgentResult,
+>(
+  stream: AgentStream<TPrimary>,
+  shouldRetry: (result: TPrimary) => boolean,
+  retryFn: () => AgentStream<TFallback>,
+): AgentStream<TPrimary | TFallback> {
+  let retryStream: AgentStream<TFallback> | undefined;
+  let iterated = false;
+
+  function ensureRetryStream(): AgentStream<TFallback> {
+    retryStream ??= retryFn();
+    return retryStream;
+  }
+
+  const result: Promise<TPrimary | TFallback> = (async () => {
+    const firstResult = await stream.result;
+    if (shouldRetry(firstResult)) {
+      return ensureRetryStream().result;
+    }
+    return firstResult;
+  })();
+
+  async function* chunks(): AsyncGenerator<string> {
+    yield* stream;
+    const firstResult = await stream.result;
+    if (shouldRetry(firstResult)) {
+      yield* ensureRetryStream();
+    }
+  }
+
+  return {
+    [Symbol.asyncIterator]() {
+      if (iterated) {
+        throw new Error("AgentStream can only be iterated once");
+      }
+      iterated = true;
+      return chunks();
+    },
+    get child() {
+      return retryStream?.child ?? stream.child;
+    },
+    result,
+  };
+}
+
+function hasUnsupportedJsonResumeArgumentLine(text: string): boolean {
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.toLowerCase();
+    if (!line.includes("--json")) continue;
+
+    if (
+      line.includes("unexpected argument") ||
+      line.includes("unexpected option") ||
+      line.includes("unexpected flag") ||
+      line.includes("unknown argument") ||
+      line.includes("unknown option") ||
+      line.includes("unknown flag") ||
+      line.includes("unrecognized argument") ||
+      line.includes("unrecognized option") ||
+      line.includes("unrecognized flag") ||
+      line.includes("wasn't expected")
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function isUnsupportedJsonResumeFailure(result: CodexParsedResult): boolean {
+  if (result.status !== "error") return false;
+  if (result.sawStructuredJson) return false;
+
+  return hasUnsupportedJsonResumeArgumentLine(
+    `${result.responseText}\n${result.stderrText}`,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -439,40 +750,15 @@ function parseCodexInvokeOutput(
  * active child process, so that cancellation (Ctrl+C) kills the right
  * process even when the fallback retry is running.
  */
-export function withXhighFallback(
-  stream: AgentStream,
-  retryFn: () => AgentStream,
-): AgentStream {
-  // Shared state: if the first attempt fails with config_parsing, the
-  // retry stream is stored here so both the iterator and result can
-  // reference it.
-  let retryStream: AgentStream | undefined;
-
-  const result = stream.result.then((r) => {
-    if (r.status === "error" && r.errorType === "config_parsing") {
-      retryStream = retryFn();
-      return retryStream.result;
-    }
-    return r;
-  });
-
-  async function* chunks(): AsyncGenerator<string> {
-    yield* stream;
-    // After the first stream finishes, await the result to know whether
-    // a fallback was triggered.
-    await result;
-    if (retryStream) {
-      yield* retryStream;
-    }
-  }
-
-  return {
-    [Symbol.asyncIterator]: () => chunks(),
-    get child() {
-      return retryStream?.child ?? stream.child;
-    },
-    result,
-  };
+export function withXhighFallback<TResult extends AgentResult>(
+  stream: AgentStream<TResult>,
+  retryFn: () => AgentStream<TResult>,
+): AgentStream<TResult> {
+  return withConditionalFallback<TResult, TResult>(
+    stream,
+    (r) => r.status === "error" && r.errorType === "config_parsing",
+    retryFn,
+  );
 }
 
 export function createCodexAdapter(
@@ -517,47 +803,79 @@ export function createCodexAdapter(
       );
     },
     resume(sessionId, prompt, options?: InvokeOptions) {
-      function parseResume(
-        output: string,
-        exitCode: number | null,
-        stderr: string,
-      ): AgentResult {
-        const result = parseCodexPlainText(output, exitCode, stderr);
-        // Preserve the input session ID when the plain text output
-        // does not contain one (e.g. older CLI versions).
-        if (result.sessionId === undefined) {
-          result.sessionId = sessionId;
-        }
-        return result;
+      function makeTransformer(): CodexStreamTransformer {
+        const t = new CodexStreamTransformer();
+        if (options?.onUsage) t.onUsage = options.onUsage;
+        return t;
       }
 
-      // codex exec resume outputs plain text, not JSONL.
-      const stream = spawnAgent({
-        command: "codex",
-        args: buildCodexResumeArgs(sessionId, {
-          model,
-          reasoningEffort,
-        }),
-        cwd: options?.cwd,
-        parseResult: parseResume,
-        // No chunkTransformer for resume — plain text is already
-        // human-readable and can go directly to the UI.
-        inactivityTimeoutMs,
-        stdin: prompt,
-      });
-      if (reasoningEffort !== "xhigh") return stream;
-      return withXhighFallback(stream, () =>
-        spawnAgent({
+      function spawnJsonResumeAttempt(
+        retryReasoningEffort: CodexReasoningEffort,
+      ): AgentStream<CodexParsedResult> {
+        return spawnAgent({
           command: "codex",
           args: buildCodexResumeArgs(sessionId, {
             model,
-            reasoningEffort: "high",
+            reasoningEffort: retryReasoningEffort,
           }),
           cwd: options?.cwd,
-          parseResult: parseResume,
+          parseResult: (output, exitCode, stderrText) =>
+            parseCodexResumeJsonOutput(sessionId, output, exitCode, stderrText),
+          chunkTransformer: makeTransformer(),
           inactivityTimeoutMs,
           stdin: prompt,
-        }),
+        });
+      }
+
+      function spawnPlainTextResumeAttempt(
+        retryReasoningEffort: CodexReasoningEffort,
+      ): AgentStream {
+        return spawnAgent({
+          command: "codex",
+          args: buildCodexPlainTextResumeArgs(sessionId, {
+            model,
+            reasoningEffort: retryReasoningEffort,
+          }),
+          cwd: options?.cwd,
+          parseResult: (output, exitCode, stderrText) =>
+            parseCodexResumePlainTextOutput(
+              sessionId,
+              prompt,
+              output,
+              exitCode,
+              stderrText,
+            ),
+          inactivityTimeoutMs,
+          stdin: prompt,
+        });
+      }
+
+      function withReasoningFallback<TResult extends AgentResult>(
+        spawnAttempt: (
+          retryReasoningEffort: CodexReasoningEffort,
+        ) => AgentStream<TResult>,
+        retryReasoningEffort: CodexReasoningEffort,
+      ): AgentStream<TResult> {
+        const stream = spawnAttempt(retryReasoningEffort);
+        if (retryReasoningEffort !== "xhigh") return stream;
+        return withXhighFallback(stream, () => spawnAttempt("high"));
+      }
+
+      const jsonStream = withReasoningFallback(
+        spawnJsonResumeAttempt,
+        reasoningEffort,
+      );
+
+      return withConditionalFallback(
+        jsonStream,
+        isUnsupportedJsonResumeFailure,
+        // Keep transport fallback separate from reasoning fallback. Very old
+        // CLIs can reject `--json` and `xhigh` independently, so the
+        // plain-text retry re-probes the configured effort instead of
+        // assuming the JSON path already established the final supported
+        // reasoning level.
+        () =>
+          withReasoningFallback(spawnPlainTextResumeAttempt, reasoningEffort),
       );
     },
   };

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -1185,7 +1185,7 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(result.status).toBe("success");
   });
 
-  test("invoke does not include -a flag", () => {
+  test("invoke uses approval_policy=never instead of a legacy approval flag", () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
@@ -1194,7 +1194,7 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
 
     const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
     expect(spawnArgs).not.toContain("-a");
-    expect(spawnArgs).not.toContain("never");
+    expect(spawnArgs).toContain("approval_policy=never");
   });
 
   test("defaults reasoning effort to high when not specified", () => {
@@ -1231,16 +1231,30 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(spawnArgs).toContain("model_reasoning_effort=medium");
   });
 
-  test("resume passes prompt via stdin with '-' in args", async () => {
+  test("resume prefers JSON mode, streams agent text, and forwards usage", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
     const stdinData: string[] = [];
+    const streamedChunks: string[] = [];
+    const usages: {
+      inputTokens: number;
+      outputTokens: number;
+      cachedInputTokens: number;
+    }[] = [];
     (child.stdin as PassThrough).on("data", (chunk: Buffer) => {
       stdinData.push(chunk.toString());
     });
 
     const adapter = createCodexAdapter({ model: "gpt-5.3-codex" });
-    const stream = adapter.resume("sess-prev", "keep going");
+    const stream = adapter.resume("sess-prev", "keep going", {
+      onUsage: (usage) => usages.push(usage),
+    });
+
+    const iteratorDone = (async () => {
+      for await (const chunk of stream) {
+        streamedChunks.push(chunk);
+      }
+    })();
 
     const spawnArgs = mockSpawn.mock.calls[0]?.[1] as string[];
     expect(spawnArgs).toContain("resume");
@@ -1252,29 +1266,139 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     await new Promise((r) => setTimeout(r, 10));
     expect(stdinData.join("")).toBe("keep going");
     expect(spawnArgs).toContain("-c");
+    expect(spawnArgs).toContain("approval_policy=never");
     expect(spawnArgs).toContain("sandbox_mode=danger-full-access");
     expect(spawnArgs).toContain('model="gpt-5.3-codex"');
     expect(spawnArgs).toContain("model_reasoning_effort=high");
-    expect(spawnArgs).not.toContain("--json");
+    expect(spawnArgs).toContain("--json");
     expect(spawnArgs).not.toContain("-m");
 
     const resumeOutput = [
-      "OpenAI Codex v0.46.0 (research preview)",
-      "--------",
-      "workdir: /tmp",
-      "model: gpt-5.4",
-      "session id: sess-prev",
-      "--------",
-      "user",
-      "keep going",
-      "codex",
-      "Continued work done.",
-      "tokens used",
-      "150",
+      JSON.stringify({
+        type: "thread.started",
+        thread_id: "sess-prev",
+      }),
+      JSON.stringify({
+        type: "item.completed",
+        item: {
+          id: "item_0",
+          type: "agent_message",
+          text: "Continued work done.",
+        },
+      }),
+      JSON.stringify({
+        type: "turn.completed",
+        usage: {
+          input_tokens: 120,
+          output_tokens: 30,
+          cached_input_tokens: 10,
+        },
+      }),
     ].join("\n");
 
     emitStdout(child, resumeOutput);
     child.emit("close", 0);
+
+    const result = await stream.result;
+    await iteratorDone;
+    expect(result.responseText).toBe("Continued work done.");
+    expect(result.status).toBe("success");
+    expect(result.sessionId).toBe("sess-prev");
+    expect(streamedChunks.join("")).toBe("Continued work done.\n");
+    expect(usages).toEqual([
+      { inputTokens: 120, outputTokens: 30, cachedInputTokens: 10 },
+    ]);
+    expect(result.usage).toEqual({
+      inputTokens: 120,
+      outputTokens: 30,
+      cachedInputTokens: 10,
+    });
+  });
+
+  test("resume falls back to plain-text mode when --json is explicitly unsupported", async () => {
+    const jsonChild = createMockChild();
+    const plainChild = createMockChild();
+    mockSpawn.mockReturnValueOnce(jsonChild).mockReturnValueOnce(plainChild);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-prev", "keep going");
+
+    emitStderr(jsonChild, "error: unexpected argument '--json' found");
+    jsonChild.emit("close", 2);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+    const firstArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    const secondArgs = mockSpawn.mock.calls[1]?.[1] as string[];
+    expect(firstArgs).toContain("--json");
+    expect(secondArgs).not.toContain("--json");
+    expect(secondArgs).toContain("approval_policy=never");
+    expect(secondArgs).toContain("sandbox_mode=danger-full-access");
+
+    emitStdout(
+      plainChild,
+      [
+        "OpenAI Codex v0.46.0 (research preview)",
+        "--------",
+        "workdir: /tmp",
+        "model: gpt-5.4",
+        "session id: sess-prev",
+        "--------",
+        "user",
+        "keep going",
+        "codex",
+        "Continued work done.",
+        "tokens used",
+        "150",
+      ].join("\n"),
+    );
+    plainChild.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.responseText).toBe("Continued work done.");
+    expect(result.status).toBe("success");
+    expect(result.sessionId).toBe("sess-prev");
+    expect(result.usage).toBeUndefined();
+  });
+
+  test("resume falls back to plain-text mode for other explicit unsupported --json wording", async () => {
+    const jsonChild = createMockChild();
+    const plainChild = createMockChild();
+    mockSpawn.mockReturnValueOnce(jsonChild).mockReturnValueOnce(plainChild);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-prev", "keep going");
+
+    emitStderr(jsonChild, "error: unrecognized argument '--json'");
+    jsonChild.emit("close", 2);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+    const firstArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    const secondArgs = mockSpawn.mock.calls[1]?.[1] as string[];
+    expect(firstArgs).toContain("--json");
+    expect(secondArgs).not.toContain("--json");
+
+    emitStdout(
+      plainChild,
+      [
+        "OpenAI Codex v0.46.0 (research preview)",
+        "--------",
+        "workdir: /tmp",
+        "model: gpt-5.4",
+        "session id: sess-prev",
+        "--------",
+        "user",
+        "keep going",
+        "codex",
+        "Continued work done.",
+        "tokens used",
+        "150",
+      ].join("\n"),
+    );
+    plainChild.emit("close", 0);
 
     const result = await stream.result;
     expect(result.responseText).toBe("Continued work done.");
@@ -1282,15 +1406,223 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(result.sessionId).toBe("sess-prev");
   });
 
-  test("resume falls back to input sessionId when output has no session id line", async () => {
+  test("resume falls back to plain-text mode when --json is rejected on stdout", async () => {
+    const jsonChild = createMockChild();
+    const plainChild = createMockChild();
+    mockSpawn.mockReturnValueOnce(jsonChild).mockReturnValueOnce(plainChild);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-prev", "keep going");
+
+    emitStdout(jsonChild, "error: unexpected argument '--json' found");
+    jsonChild.emit("close", 2);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+    const firstArgs = mockSpawn.mock.calls[0]?.[1] as string[];
+    const secondArgs = mockSpawn.mock.calls[1]?.[1] as string[];
+    expect(firstArgs).toContain("--json");
+    expect(secondArgs).not.toContain("--json");
+
+    emitStdout(
+      plainChild,
+      [
+        "OpenAI Codex v0.46.0 (research preview)",
+        "--------",
+        "workdir: /tmp",
+        "model: gpt-5.4",
+        "session id: sess-prev",
+        "--------",
+        "user",
+        "keep going",
+        "codex",
+        "Continued work done.",
+        "tokens used",
+        "150",
+      ].join("\n"),
+    );
+    plainChild.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.responseText).toBe("Continued work done.");
+    expect(result.status).toBe("success");
+    expect(result.sessionId).toBe("sess-prev");
+  });
+
+  test("plain-text resume fallback uses the known prompt to avoid prompt-side codex markers", async () => {
+    const jsonChild = createMockChild();
+    const plainChild = createMockChild();
+    mockSpawn.mockReturnValueOnce(jsonChild).mockReturnValueOnce(plainChild);
+
+    const adapter = createCodexAdapter();
+    const prompt = ["keep going", "codex"].join("\n");
+    const stream = adapter.resume("sess-prev", prompt);
+
+    emitStderr(jsonChild, "error: unexpected argument '--json' found");
+    jsonChild.emit("close", 2);
+
+    await new Promise((r) => setTimeout(r, 10));
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+
+    emitStdout(
+      plainChild,
+      [
+        "OpenAI Codex v0.46.0 (research preview)",
+        "--------",
+        "workdir: /tmp",
+        "model: gpt-5.4",
+        "session id: sess-prev",
+        "--------",
+        "user",
+        ...prompt.split("\n"),
+        "codex",
+        "Continued work done.",
+        "tokens used",
+        "150",
+      ].join("\n"),
+    );
+    plainChild.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.responseText).toBe("Continued work done.");
+    expect(result.status).toBe("success");
+    expect(result.sessionId).toBe("sess-prev");
+  });
+
+  test("resume does not fall back for unrelated JSON resume failures", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-fail", "keep going");
+
+    emitStdout(
+      child,
+      [
+        JSON.stringify({ type: "thread.started", thread_id: "sess-fail" }),
+        JSON.stringify({
+          type: "turn.failed",
+          error: { message: "max turns reached" },
+        }),
+      ].join("\n"),
+    );
+    child.emit("close", 1);
+
+    const result = await stream.result;
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("error");
+    expect(result.errorType).toBe("max_turns");
+    expect(result.sessionId).toBe("sess-fail");
+  });
+
+  test("resume does not fall back when structured JSON output mentions --json", async () => {
+    const jsonChild = createMockChild();
+    const plainChild = createMockChild();
+    mockSpawn.mockReturnValueOnce(jsonChild).mockReturnValueOnce(plainChild);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-fail", "keep going");
+
+    emitStdout(
+      jsonChild,
+      [
+        JSON.stringify({ type: "thread.started", thread_id: "sess-fail" }),
+        JSON.stringify({
+          type: "turn.failed",
+          error: { message: "tool failed: unknown option '--json'" },
+        }),
+      ].join("\n"),
+    );
+    jsonChild.emit("close", 1);
+
+    emitStdout(
+      plainChild,
+      [
+        "OpenAI Codex v0.46.0 (research preview)",
+        "--------",
+        "workdir: /tmp",
+        "model: gpt-5.4",
+        "session id: sess-fail",
+        "--------",
+        "user",
+        "keep going",
+        "codex",
+        "unexpected fallback",
+        "tokens used",
+        "150",
+      ].join("\n"),
+    );
+    plainChild.emit("close", 0);
+
+    const result = await stream.result;
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("error");
+    expect(result.responseText).toBe("tool failed: unknown option '--json'");
+    expect(result.sessionId).toBe("sess-fail");
+  });
+
+  test("resume does not fall back when --json and unknown option are on different lines", async () => {
+    const jsonChild = createMockChild();
+    const plainChild = createMockChild();
+    mockSpawn.mockReturnValueOnce(jsonChild).mockReturnValueOnce(plainChild);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-fail", "keep going");
+
+    emitStderr(
+      jsonChild,
+      [
+        "For JSON output, pass '--json' to the CLI.",
+        "tool failed: unknown option '--sandbox'",
+      ].join("\n"),
+    );
+    jsonChild.emit("close", 1);
+
+    emitStdout(
+      plainChild,
+      [
+        "OpenAI Codex v0.46.0 (research preview)",
+        "--------",
+        "workdir: /tmp",
+        "model: gpt-5.4",
+        "session id: sess-fail",
+        "--------",
+        "user",
+        "keep going",
+        "codex",
+        "unexpected fallback",
+        "tokens used",
+        "150",
+      ].join("\n"),
+    );
+    plainChild.emit("close", 0);
+
+    const result = await stream.result;
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(result.status).toBe("error");
+    expect(result.responseText).toContain("--json");
+    expect(result.stderrText).toContain("unknown option '--sandbox'");
+    expect(result.sessionId).toBe("sess-fail");
+  });
+
+  test("resume falls back to input sessionId when JSON output has no thread.started event", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
     const adapter = createCodexAdapter();
     const stream = adapter.resume("sess-input", "keep going");
 
-    // Output without a "session id:" banner line (e.g. older CLI version).
-    emitStdout(child, "codex\nDone.\ntokens used\n50");
+    emitStdout(
+      child,
+      [
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item_0", type: "agent_message", text: "Done." },
+        }),
+        JSON.stringify({ type: "turn.completed" }),
+      ].join("\n"),
+    );
     child.emit("close", 0);
 
     const result = await stream.result;
@@ -1298,20 +1630,64 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     expect(result.status).toBe("success");
   });
 
-  test("resume preserves sessionId on error exit", async () => {
+  test("resume preserves sessionId on JSON error exit", async () => {
     const child = createMockChild();
     mockSpawn.mockReturnValue(child);
 
     const adapter = createCodexAdapter();
     const stream = adapter.resume("sess-err", "continue");
 
-    emitStdout(child, "Error: max turns reached");
+    emitStdout(
+      child,
+      JSON.stringify({
+        type: "turn.failed",
+        error: { message: "max turns reached" },
+      }),
+    );
     child.emit("close", 1);
 
     const result = await stream.result;
     expect(result.status).toBe("error");
     expect(result.errorType).toBe("max_turns");
     expect(result.sessionId).toBe("sess-err");
+  });
+
+  test("resume ignores a later top-level error after turn.completed", async () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter();
+    const stream = adapter.resume("sess-prev", "continue");
+
+    emitStdout(
+      child,
+      [
+        JSON.stringify({ type: "thread.started", thread_id: "sess-prev" }),
+        JSON.stringify({
+          type: "item.completed",
+          item: { id: "item_0", type: "agent_message", text: "Done." },
+        }),
+        JSON.stringify({
+          type: "turn.completed",
+          usage: { input_tokens: 25, output_tokens: 4 },
+        }),
+        JSON.stringify({
+          type: "error",
+          message: "stream error after completion",
+        }),
+      ].join("\n"),
+    );
+    child.emit("close", 0);
+
+    const result = await stream.result;
+    expect(result.status).toBe("success");
+    expect(result.responseText).toBe("Done.");
+    expect(result.sessionId).toBe("sess-prev");
+    expect(result.usage).toEqual({
+      inputTokens: 25,
+      outputTokens: 4,
+      cachedInputTokens: 0,
+    });
   });
 
   test("invoke with cwd passes working directory", () => {
@@ -1379,9 +1755,11 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     child.emit("close", 1);
 
     const result = await stream.result;
-    // Invalid JSONL skipped; non-zero exit triggers error status.
+    // Invalid JSONL skipped; non-zero exit triggers error status and keeps
+    // the raw output for diagnostics.
     expect(result.status).toBe("error");
     expect(result.errorType).toBe("unknown");
+    expect(result.responseText).toBe("garbage output");
   });
 
   test("captures stderr in result for diagnostics", async () => {
@@ -1430,6 +1808,7 @@ describe("Codex adapter invoke/resume (E2E with mock spawn)", () => {
     child.emit("close", 1);
 
     const result = await stream.result;
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
     expect(result.status).toBe("error");
     expect(result.errorType).toBe("config_parsing");
     expect(result.stderrText).toContain("invalid value");

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -3,7 +3,7 @@ import { spawn } from "node:child_process";
 import EventEmitter from "node:events";
 import type { AgentResult, AgentStream, ChunkTransformer } from "./agent.js";
 
-export interface SpawnAgentOptions {
+export interface SpawnAgentOptions<TResult extends AgentResult = AgentResult> {
   command: string;
   args: string[];
   cwd?: string;
@@ -11,7 +11,7 @@ export interface SpawnAgentOptions {
     output: string,
     exitCode: number | null,
     stderrText: string,
-  ) => AgentResult;
+  ) => TResult;
   /**
    * When provided, the async iterator yields transformed (display-friendly)
    * text instead of raw stdout chunks.  Raw chunks are still collected for
@@ -31,7 +31,9 @@ export interface SpawnAgentOptions {
   stdin?: string;
 }
 
-export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
+export function spawnAgent<TResult extends AgentResult = AgentResult>(
+  opts: SpawnAgentOptions<TResult>,
+): AgentStream<TResult> {
   let child: ReturnType<typeof spawn>;
   try {
     child = spawn(opts.command, opts.args, {
@@ -63,7 +65,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
     stubChild.kill = () => false;
     return {
       async *[Symbol.asyncIterator]() {},
-      result: Promise.resolve(errorResult),
+      result: Promise.resolve(errorResult as TResult),
       child: stubChild,
     };
   }
@@ -138,7 +140,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
     stderrChunks.push(data.toString());
   });
 
-  const result = new Promise<AgentResult>((resolve) => {
+  const result = new Promise<TResult>((resolve) => {
     child.on("error", (err) => {
       if (inactivityTimer) clearTimeout(inactivityTimer);
       if ("code" in err && (err as NodeJS.ErrnoException).code === "ENOENT") {
@@ -148,7 +150,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
           status: "error",
           errorType: "cli_not_found",
           stderrText: "",
-        });
+        } as TResult);
       } else {
         resolve({
           sessionId: undefined,
@@ -156,7 +158,7 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
           status: "error",
           errorType: "execution_error",
           stderrText: "",
-        });
+        } as TResult);
       }
     });
 
@@ -183,14 +185,14 @@ export function spawnAgent(opts: SpawnAgentOptions): AgentStream {
           signal,
           status: "error",
           errorType: "inactivity_timeout",
-        });
+        } as TResult);
       } else {
-        resolve({ ...parsed, exitCode: code, signal });
+        resolve({ ...parsed, exitCode: code, signal } as TResult);
       }
     });
   });
 
-  const stream: AgentStream = {
+  const stream: AgentStream<TResult> = {
     async *[Symbol.asyncIterator]() {
       while (true) {
         while (chunkQueue.length > 0) {


### PR DESCRIPTION
## Summary
- Pin AgentCoop-managed Codex runs to `approval_policy=never` while preserving the adapter's explicit sandbox settings for fresh and resumed turns.
- Prefer `codex exec resume --json` on newer Codex CLIs, route resumed streaming and usage through the structured JSON path, and fall back to the legacy plain-text parser only when the CLI explicitly rejects JSON resume.
- Harden terminal JSON error handling and plain-text resume parsing, and expand compatibility tests around retry-style errors, resume fallback behavior, and marker-like plain-text output.

Closes #277

## Test plan
- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm dlx markdownlint-cli2 "**/*.md"`
- [x] Verified fresh invoke args include `-c approval_policy=never` alongside `-s danger-full-access`.
- [x] Verified resumed runs prefer `--json`, keep `-c sandbox_mode=danger-full-access`, and forward streamed agent text and usage from JSON events.
- [x] Verified resume falls back to plain text only when the CLI explicitly rejects `--json`, and unrelated JSON resume failures remain terminal errors.
- [x] Verified top-level JSON `error` events only fail the turn when they are terminal, while retry-style errors followed by `turn.completed` remain successful.
- [x] Verified plain-text resume parsing handles marker-like `codex` and `tokens used` lines in assistant output without truncating the response.
