### PR TITLE
Document Stage 1 in README pipeline list

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,16 @@ last completed stage or start fresh.
 
 ## How it works
 
-AgentCoop runs an 8-stage pipeline (stages 2–9) with two agents:
-Agent A (author — implements the issue) and Agent B (reviewer).
+AgentCoop runs a 9-stage pipeline with two agents: Agent A (author
+— implements the issue) and Agent B (reviewer). Stages 2–9 run
+inside the TUI; Stage 1 is orchestrator-managed and runs beforehand.
 
+- **Stage 1 — Bootstrap:** Orchestrator-managed, runs before the TUI
+  mounts. Bootstraps the repository (clone or fetch), detects the
+  default branch via `gh repo view`, creates the git worktree for
+  this issue, and on resume promotes the starting stage past
+  `Create PR` if a PR already exists so `gh pr create` is not
+  replayed.
 - **Stage 2 — Implement:** Agent A implements the issue in a git worktree
 - **Stage 3 — Self-check:** Agent A self-checks against quality criteria
 - **Stage 4 — Create PR:** Agent A opens a pull request


### PR DESCRIPTION
## Summary

The \"How it works\" section said *\"8-stage pipeline (stages 2–9)\"* and bulleted Stage 2 through Stage 9, skipping Stage 1 entirely. Stage 1 (Bootstrap) is a real orchestrator-managed stage documented in [docs/pipeline.md](docs/pipeline.md) — it bootstraps the repository, detects the default branch, creates the git worktree, and performs resume pre-flight. The Terminal UI section already references the Stage 1 bootstrap indicator, so a reader who chases that reference into the pipeline list currently finds nothing.

This PR rewrites the intro to describe a 9-stage pipeline split into an orchestrator-managed bootstrap and the TUI-visible stages, and adds a Stage 1 bullet summarizing its four sub-steps.

Closes #285

## Test plan

- [x] Render README on GitHub and confirm the Stage 1 bullet appears before Stage 2 and the intro no longer says \"8-stage pipeline (stages 2–9)\"
- [x] Cross-check the Stage 1 bullet against [docs/pipeline.md — Stage 1: Bootstrap](docs/pipeline.md)