### PR TITLE
Document Stage 8 single-squash suggestion flow in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,19 @@ inside the TUI; Stage 1 is orchestrator-managed and runs beforehand.
 - **Stage 6 — Test plan:** Agent A verifies the PR test plan
 - **Stage 7 — Review:** Agent B reviews; Agent A addresses feedback
   (multi-round)
-- **Stage 8 — Squash:** Agent A consolidates branch commits into one or a
-  few meaningful commits and force-pushes. Skipped if the branch
-  already has only one commit or if the existing commits are
-  already clean.
+- **Stage 8 — Squash:** Agent A decides whether the branch is best
+  presented as several meaningful commits or a single squash.
+  - _Multiple commits:_ Agent A rewrites history and force-pushes,
+    then CI is re-polled.
+  - _Single commit:_ Agent A does **not** force-push. It drafts the
+    squash title and body and posts them as a PR comment. AgentCoop
+    then asks the user how to apply the squash — _Agent squashes
+    now_ (agent applies the drafted message and CI is re-polled) or
+    _Apply via GitHub_ (the drafted message is surfaced on the
+    Stage 9 merge-confirm screen so the user can paste it into
+    GitHub's "Squash and merge" dialog).
+
+  Skipped automatically if the branch already has only one commit.
 - **Stage 9 — Done:** Check for merge conflicts, optionally rebase, confirm
   merge with the user, and clean up resources
 


### PR DESCRIPTION
## Summary

The Stage 8 bullet in the README's \"How it works\" section only described the multi-commit, force-push path and claimed the stage is skipped \"if the existing commits are already clean\". That doesn't match current behavior. When Agent A decides a single squash is appropriate, it does **not** force-push — it drafts the squash title and body, posts them as a PR comment, and AgentCoop asks the user how to apply the squash:

- **Agent squashes now** — agent applies the drafted message and CI is re-polled.
- **Apply via GitHub** — the drafted message is surfaced on the Stage 9 merge-confirm screen so the user can paste it into GitHub's \"Squash and merge\" dialog.

This PR rewrites the Stage 8 bullet to cover both paths, explicitly mentions that the drafted commit message is posted for the user, and drops the inaccurate \"already clean\" skip condition. See [docs/pipeline.md — Stage 8: Squash commits](docs/pipeline.md) for the authoritative behavior.

> Note: this PR branches off \`main\` and edits only the Stage 8 bullet, so it may land with a trivial conflict against #286 (which edits the intro line and adds a Stage 1 bullet above). Both PRs together finish updating the \"How it works\" section.

Closes #287

## Test plan

- [x] Render README on GitHub and confirm the Stage 8 bullet mentions the single-commit suggestion path, the \"Agent squashes now\" vs \"Apply via GitHub\" choice, and no longer says \"already clean\"
- [x] Cross-check the Stage 8 bullet against [docs/pipeline.md — Stage 8: Squash commits](docs/pipeline.md)