### PR TITLE
Cap Stage 9 merge prompt to keep choice lines visible (#293)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,24 +109,36 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   user can then either let the agent perform the squash (which reruns CI)
   or apply the suggestion via GitHub's "Squash and merge" at merge time
   (which avoids the extra CI cycle).
-- Stage 9 (Done) merge-confirm screen now prints the suggested squash title,
-  body, and PR URL inline when the squash stage finished via the
+- Stage 9 (Done) merge-confirm screen now surfaces the suggested squash
+  title and PR URL inline when the squash stage finished via the
   squash-suggestion comment path, so the user can copy-paste without opening
-  the browser.
+  the browser.  The body is represented by a one-line summary (`Suggested
+  body: N lines`) rather than being inlined verbatim, since a long body
+  otherwise pushed the merge-confirm choice lines off the bottom of the
+  terminal viewport with no way to scroll them back into view.  The full
+  body remains accessible through the `[b]` clipboard hotkey and the linked
+  PR comment.
 - Stage 9 (Done) merge-confirm screen now renders `[t] copy` / `[b] copy`
-  hotkey hints next to the suggested squash title and body when the terminal
-  can write to the system clipboard.  Pressing `t` copies the title and `b`
-  copies the body (each independently, so the values line up with GitHub's
-  separate "Squash and merge" title / body fields).  A small clipboard
-  utility detects the environment and returns an ordered candidate list
-  (`pbcopy` / `wl-copy` / `xclip` on local sessions, OSC 52 first on SSH
-  sessions, OSC 52 as fallback everywhere stdout is a TTY), and the writer
-  tries candidates in order until one succeeds.  When no candidate is
-  reachable, the hints are not rendered at all — the user falls back to
-  drag-select as before, rather than seeing a hint that silently does
-  nothing.  Per-hotkey status (`copy` / `copied` / `copy failed`) is
-  reflected in the label; `copied` auto-reverts after ~1s, `copy failed`
-  persists until the next re-render.
+  hotkey hints next to the suggested squash title and the body summary
+  when the terminal can write to the system clipboard.  Pressing `t` copies
+  the title and `b` copies the body (each independently, so the values line
+  up with GitHub's separate "Squash and merge" title / body fields).  A
+  small clipboard utility detects the environment and returns an ordered
+  candidate list (`pbcopy` / `wl-copy` / `xclip` on local sessions, OSC 52
+  first on SSH sessions, OSC 52 as fallback everywhere stdout is a TTY),
+  and the writer tries candidates in order until one succeeds.  When no
+  candidate is reachable, the hints are not rendered at all — the user
+  falls back to opening the PR comment, rather than seeing a hint that
+  silently does nothing.  Per-hotkey status (`copy` / `copied` / `copy
+  failed`) is reflected in the label; `copied` auto-reverts after ~1s,
+  `copy failed` persists until the next re-render.
+- Stage 9's merge-confirm prompt now caps the height of the InputArea so
+  even an unexpectedly long prompt cannot push the choice / input lines
+  past the bottom of the terminal viewport.  When the message would
+  overflow, the tail is replaced with a single `…(truncated)` marker so
+  the choice lines stay visible.  Pathologically long suggested squash
+  titles (>120 characters or containing embedded newlines) are also
+  ellipsized at the assembly stage.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,7 +138,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   overflow, the tail is replaced with a single `…(truncated)` marker so
   the choice lines stay visible.  Pathologically long suggested squash
   titles (>120 characters or containing embedded newlines) are also
-  ellipsized at the assembly stage.
+  ellipsized at the assembly stage.  Each rendered prompt line — message
+  rows and choice rows alike — is rendered with `wrap="truncate-end"` so
+  a long single-line title or hint cannot wrap to multiple terminal rows
+  on a narrow terminal, which would otherwise break the row budget.
 
 ### Changed
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1569,7 +1569,10 @@ Cleanup
    long, the InputArea also caps its height so the choice /
    text-input line is always visible.  When the message would
    exceed that cap, the tail is replaced with a single
-   `…(truncated)` marker.
+   `…(truncated)` marker.  Each rendered line — message rows and
+   choice rows — also uses `wrap="truncate-end"` so a long
+   single-line title or hint cannot wrap to multiple rendered
+   rows on a narrow terminal, keeping the row budget accurate.
 
 **Agent rebase prompt:**
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1545,16 +1545,31 @@ Cleanup
      the PR. Each action is individually selectable.
 
    When a squash suggestion is live in a PR comment, the
-   merge-confirm screen also renders `[t] copy` / `[b] copy`
-   hotkey hints next to the suggested title and body.  Pressing
-   `t` or `b` writes the corresponding value to the system
-   clipboard (via `pbcopy` / `wl-copy` / `xclip` on local
-   sessions, or OSC 52 on SSH) so the user can paste it straight
-   into GitHub's "Squash and merge" dialog.  If the environment
-   can reach neither a native clipboard tool nor an OSC 52–capable
-   stdout, the hints are not rendered — the user falls back to
-   drag-select without being told about a feature that cannot
-   work here.
+   merge-confirm screen renders the suggested title verbatim
+   (ellipsized if pathologically long) and a one-line summary of
+   the body (`Suggested body: N lines`).  The full body is _not_
+   inlined: a long body would otherwise push the choice lines off
+   the bottom of the terminal viewport with no way to scroll them
+   back, since Ink renders in-place without an alt-screen.  The
+   PR URL is shown right below so the user can open the comment
+   to read the body.
+
+   When the terminal can write to the system clipboard, the
+   screen also renders `[t] copy` / `[b] copy` hotkey hints next
+   to the title and body-summary lines.  Pressing `t` or `b`
+   writes the corresponding value (the full title / the full
+   body) to the system clipboard via `pbcopy` / `wl-copy` /
+   `xclip` on local sessions, or OSC 52 on SSH.  If the
+   environment can reach neither a native clipboard tool nor an
+   OSC 52–capable stdout, the hints are not rendered — the user
+   falls back to opening the PR comment without being told about
+   a feature that cannot work here.
+
+   As a defensive measure against any future prompt growing
+   long, the InputArea also caps its height so the choice /
+   text-input line is always visible.  When the message would
+   exceed that cap, the tail is replaced with a single
+   `…(truncated)` marker.
 
 **Agent rebase prompt:**
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -150,6 +150,11 @@ export const en: Messages = {
     "message is in a PR comment.",
   "pipeline.suggestedSquashTitle": "Suggested title:",
   "pipeline.suggestedSquashBody": "Suggested body:",
+  "pipeline.suggestedSquashBodyLines": (lines) =>
+    `${lines} ${lines === 1 ? "line" : "lines"}`,
+  "pipeline.suggestedSquashBodyCopyHint":
+    "press the hotkey to copy, or view in the PR comment",
+  "pipeline.suggestedSquashBodyViewInPr": "view in the PR comment",
   "pipeline.prUrl": (url) => `PR: ${url}`,
   "pipeline.worktreeCleanedUp": "Worktree cleaned up.",
   "pipeline.worktreePreserved": "Worktree preserved (merge not confirmed).",
@@ -244,6 +249,7 @@ export const en: Messages = {
   "input.copy": "copy",
   "input.copied": "copied",
   "input.copyFailed": "copy failed",
+  "input.truncated": "…(truncated)",
 
   // ---- agent pane / labels ------------------------------------------------
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -184,6 +184,10 @@ export const ko: Messages = {
     "이 저장소가 'Squash and merge'를 허용한다면, 제안된 커밋 메시지가 PR 코멘트에 있습니다.",
   "pipeline.suggestedSquashTitle": "제안 제목:",
   "pipeline.suggestedSquashBody": "제안 본문:",
+  "pipeline.suggestedSquashBodyLines": (lines) => `${lines}줄`,
+  "pipeline.suggestedSquashBodyCopyHint":
+    "단축키로 복사하거나 PR 코멘트에서 확인",
+  "pipeline.suggestedSquashBodyViewInPr": "PR 코멘트에서 확인",
   "pipeline.prUrl": (url) => `PR: ${url}`,
   "pipeline.worktreeCleanedUp": "워크트리가 정리되었습니다.",
   "pipeline.worktreePreserved": "워크트리가 보존되었습니다 (병합 미확인).",
@@ -282,6 +286,7 @@ export const ko: Messages = {
   "input.copy": "복사",
   "input.copied": "복사됨",
   "input.copyFailed": "복사 실패",
+  "input.truncated": "…(잘림)",
 
   // ---- agent pane / labels ------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -142,6 +142,9 @@ export interface Messages {
   "pipeline.mergeConfirmSquashTip": string;
   "pipeline.suggestedSquashTitle": string;
   "pipeline.suggestedSquashBody": string;
+  "pipeline.suggestedSquashBodyLines": (lines: number) => string;
+  "pipeline.suggestedSquashBodyCopyHint": string;
+  "pipeline.suggestedSquashBodyViewInPr": string;
   "pipeline.prUrl": (url: string) => string;
   "pipeline.worktreeCleanedUp": string;
   "pipeline.worktreePreserved": string;
@@ -236,6 +239,7 @@ export interface Messages {
   "input.copy": string;
   "input.copied": string;
   "input.copyFailed": string;
+  "input.truncated": string;
 
   // ---- agent pane / labels ------------------------------------------------
 

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -1148,17 +1148,25 @@ describe("createDoneStageHandler", () => {
     const message = confirmMerge.mock.calls[0][0] as string;
     expect(message).toContain("Squash and merge");
     expect(message).toContain("Fix widget rendering");
-    expect(message).toContain("Closes #5");
     expect(message).toContain("https://github.com/org/repo/pull/123");
-    // Title and body sit on their own lines with no inline prefix so that
+    // Title sits on its own line with no inline prefix so that
     // triple-click selects exactly the value.
     expect(message).toContain("Suggested title:\nFix widget rendering\n");
-    expect(message).toContain("Suggested body:\nBody line\n\nCloses #5");
     expect(message).not.toMatch(/Suggested title: Fix widget rendering/);
+    // Body content is NOT inlined — only a one-line summary appears,
+    // since a long body otherwise pushes the choice lines off the
+    // visible viewport (#293).  The clipboard-unavailable branch shows
+    // a "view in the PR comment" hint instead of an inline copy
+    // affordance.
+    expect(message).not.toContain("Closes #5");
+    expect(message).not.toContain("Body line");
+    expect(message).toContain(
+      "Suggested body: 3 lines\nview in the PR comment",
+    );
     // Blank lines separate each labelled section from surrounding content.
     expect(message).toContain("\n\nSuggested title:");
     expect(message).toContain("\n\nSuggested body:");
-    expect(message).toMatch(/Closes #5\n\nPR: https:\/\//);
+    expect(message).toMatch(/PR: https:\/\//);
   });
 
   test("MERGEABLE: clipboard available embeds sentinels and forwards hotkeys", async () => {
@@ -1196,9 +1204,12 @@ describe("createDoneStageHandler", () => {
     expect(message).toContain(
       `Suggested title: ${titleSentinel?.[0]}\nFix widget`,
     );
-    expect(message).toContain(
-      `Suggested body: ${bodySentinel?.[0]}\nBody line`,
-    );
+    // Body is summarised on a single line — no body content is
+    // inlined.  The body hotkey sentinel sits next to the line-count
+    // summary (#293).
+    expect(message).toContain(`Suggested body: 3 lines ${bodySentinel?.[0]}`);
+    expect(message).not.toContain("Body line");
+    expect(message).not.toContain("Closes #5");
     expect(hotkeys).toHaveLength(2);
     expect(hotkeys[0].id).toMatch(/^title-[0-9a-f]+$/);
     expect(hotkeys[0].key).toBe("t");
@@ -1245,18 +1256,31 @@ describe("createDoneStageHandler", () => {
       string,
       { id: string; key: string; onPress: () => Promise<"ok" | "error"> }[],
     ];
-    // The literal `{{hk:title}}` / `{{hk:body}}` substrings from the
-    // user-authored content must survive untouched (they still appear in
-    // the message text), and the real sentinels are distinct per-render
-    // ids with a random suffix.
+    // The title still ships verbatim, so a literal `{{hk:title}}`
+    // substring inside the title must not collide with the real
+    // per-render sentinel ids (which carry a random suffix).
     expect(message).toContain("Docs: document {{hk:title}} placeholder");
-    expect(message).toContain(
+    // Body is no longer inlined (#293), so the body's literal
+    // sentinel-looking substrings do not appear in the rendered
+    // message at all.  The body sentinel must still be the
+    // per-render one with a random suffix.
+    expect(message).not.toContain(
       "Explain {{hk:body}} and {{hk:title}} in the guide",
     );
     expect(hotkeys[0].id).toMatch(/^title-[0-9a-f]+$/);
     expect(hotkeys[0].id).not.toBe("title");
     expect(hotkeys[1].id).toMatch(/^body-[0-9a-f]+$/);
     expect(hotkeys[1].id).not.toBe("body");
+    // The body's clipboard hotkey still copies the full original body,
+    // including the sentinel-looking substrings, when invoked.
+    await hotkeys[1].onPress();
+    const writeToClipboardSpy = opts.writeToClipboard as unknown as ReturnType<
+      typeof vi.fn
+    >;
+    expect(writeToClipboardSpy).toHaveBeenCalledWith(
+      "Explain {{hk:body}} and {{hk:title}} in the guide",
+      ["pbcopy"],
+    );
   });
 
   test("MERGEABLE: clipboard unavailable omits sentinels and forwards no hotkeys", async () => {
@@ -1390,6 +1414,97 @@ describe("createDoneStageHandler", () => {
     expect(second).toBe("merged");
     // Spy must NOT have been called again — fallback was taken.
     expect(tuiConfirmMerge).toHaveBeenCalledOnce();
+  });
+
+  // #293 regression: a long squash body must not be inlined into the
+  // confirmMerge message, so the choice / input lines are guaranteed
+  // to remain visible regardless of body length.
+  test("MERGEABLE: long body content is not inlined; only line count is rendered", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const longBody = Array.from(
+      { length: 80 },
+      (_, i) => `body line ${i}`,
+    ).join("\n");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => ({
+        title: "Fix widget",
+        body: longBody,
+        prUrl: "https://github.com/org/repo/pull/9",
+      }),
+      detectClipboardSupport: () => ["pbcopy"],
+      writeToClipboard: vi.fn().mockResolvedValue("ok"),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    const [message] = confirmMerge.mock.calls[0] as [string, unknown];
+    // None of the body's individual lines should appear in the
+    // rendered prompt — they only live inside the clipboard payload
+    // and the PR comment.
+    expect(message).not.toMatch(/^body line \d+$/m);
+    expect(message).toMatch(/Suggested body: 80 lines \{\{hk:body-/);
+    // The total number of `\n` in the rendered message stays small —
+    // proportional to the static prompt structure, not the 80-line
+    // body — so the choice lines cannot be pushed off-screen.
+    const lineCount = message.split("\n").length;
+    expect(lineCount).toBeLessThan(15);
+  });
+
+  test("MERGEABLE: ellipsizes a pathologically long title", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const longTitle = `Fix ${"x".repeat(500)}`;
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => ({
+        title: longTitle,
+        body: "body",
+      }),
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    const [message] = confirmMerge.mock.calls[0] as [string, unknown];
+    expect(message).not.toContain(longTitle);
+    expect(message).toMatch(/Fix x{100,}…/);
+  });
+
+  test("MERGEABLE: clipboard unavailable shows view-in-PR hint instead of copy affordance", async () => {
+    const confirmMerge = vi.fn().mockResolvedValue("merged");
+    const opts = makeDoneOpts({
+      prompt: { confirmMerge },
+      getSquashMergeHint: () => ({
+        title: "Fix widget",
+        body: "Body line\n\nCloses #5",
+        prUrl: "https://github.com/org/repo/pull/9",
+      }),
+      detectClipboardSupport: () => [],
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    const [message] = confirmMerge.mock.calls[0] as [string, unknown];
+    expect(message).toContain(
+      "Suggested body: 3 lines\nview in the PR comment",
+    );
+    expect(message).toContain("https://github.com/org/repo/pull/9");
+    expect(message).not.toContain("Body line");
+    expect(message).not.toContain("Closes #5");
   });
 
   test("MERGEABLE: omits hint when getSquashMergeHint returns undefined", async () => {

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1247,7 +1247,7 @@ export function createDoneStageHandler(
           const label = clipboardAvailable
             ? `${m["pipeline.suggestedSquashTitle"]} {{hk:${titleSentinelId}}}`
             : m["pipeline.suggestedSquashTitle"];
-          tipSections.push(`${label}\n${hint.title}`);
+          tipSections.push(`${label}\n${ellipsizeTitle(hint.title)}`);
           if (clipboardAvailable) {
             hotkeys.push({
               id: titleSentinelId,
@@ -1257,16 +1257,28 @@ export function createDoneStageHandler(
           }
         }
         if (hint.body) {
-          const label = clipboardAvailable
-            ? `${m["pipeline.suggestedSquashBody"]} {{hk:${bodySentinelId}}}`
-            : m["pipeline.suggestedSquashBody"];
-          tipSections.push(`${label}\n${hint.body}`);
+          // Render only a one-line summary so a long squash body cannot
+          // push the choice lines past the terminal viewport (#293).  The
+          // full body remains accessible via the `[b]` clipboard hotkey
+          // and the PR comment linked below.
+          const lineCount = countLines(bodyValue);
+          const lineSummary = m["pipeline.suggestedSquashBodyLines"](lineCount);
           if (clipboardAvailable) {
+            tipSections.push(
+              `${m["pipeline.suggestedSquashBody"]} ${lineSummary} ` +
+                `{{hk:${bodySentinelId}}}\n` +
+                `${m["pipeline.suggestedSquashBodyCopyHint"]}`,
+            );
             hotkeys.push({
               id: bodySentinelId,
               key: "b",
               onPress: () => write(bodyValue, candidates),
             });
+          } else {
+            tipSections.push(
+              `${m["pipeline.suggestedSquashBody"]} ${lineSummary}\n` +
+                `${m["pipeline.suggestedSquashBodyViewInPr"]}`,
+            );
           }
         }
         if (hint.prUrl) {
@@ -1388,6 +1400,29 @@ export function createDoneStageHandler(
       }
     }
   }
+}
+
+/**
+ * Cap the title rendered inside `confirmMerge` so a pathologically long
+ * single-line title cannot wrap to multiple rows and reintroduce the
+ * #293 viewport overflow that the body-suppression fix addressed.  The
+ * limit is conservative: standard git title conventions sit at 50–72
+ * characters, so 120 leaves headroom for unusual but legitimate titles
+ * and only ellipsizes truly excessive ones.
+ */
+const MAX_SQUASH_TITLE_CHARS = 120;
+function ellipsizeTitle(title: string): string {
+  // Collapse embedded newlines first — a "title" that contains them is
+  // already malformed and would otherwise wrap on its own.
+  const flat = title.replace(/\r?\n/g, " ");
+  if (flat.length <= MAX_SQUASH_TITLE_CHARS) return flat;
+  return `${flat.slice(0, MAX_SQUASH_TITLE_CHARS - 1)}…`;
+}
+
+/** Count lines in a body string, treating an empty value as 0 lines. */
+function countLines(body: string): number {
+  if (body.length === 0) return 0;
+  return body.split("\n").length;
 }
 
 /**

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -86,12 +86,50 @@ interface VisibilityBudgetOptions {
   paneHeaderTexts?: readonly string[];
 }
 
-/** Compute the height of the InputArea in terminal rows. */
-export function inputAreaHeight(request: InputRequest | null): number {
+/**
+ * Minimum rows the InputArea is always allowed to consume (one message
+ * line + one choice/input line).  Used as a floor when capping the
+ * area's height to prevent the cap collapsing the input out of sight.
+ */
+export const MIN_INPUT_AREA_ROWS = 2;
+
+/**
+ * Compute the height of the InputArea in terminal rows.  When
+ * `terminalHeight` is supplied, the result is capped so that at least
+ * `MIN_PANE_CONTENT * 2` rows remain available for the agent panes
+ * plus the minimum status-bar height.  This prevents a long prompt
+ * message — for example a Stage 9 squash hint — from pushing the
+ * choice lines off the bottom of the viewport (#293).
+ */
+export function inputAreaHeight(
+  request: InputRequest | null,
+  terminalHeight?: number,
+): number {
+  const raw = computeRawInputAreaHeight(request);
+  if (terminalHeight === undefined) return raw;
+  return Math.min(raw, computeInputAreaCap(terminalHeight));
+}
+
+function computeRawInputAreaHeight(request: InputRequest | null): number {
   if (!request) return 1;
   const messageLines = request.message.split("\n").length;
   if (request.choices) return messageLines + request.choices.length;
   return messageLines + 1;
+}
+
+/**
+ * Cap on rows the InputArea is allowed to consume.  Reserves the
+ * minimum status-bar height (4 rows when key hints are hidden) and
+ * `MIN_PANE_CONTENT * 2` rows for agent-pane content, then floors at
+ * `MIN_INPUT_AREA_ROWS` so the input line itself never disappears.
+ */
+export function computeInputAreaCap(terminalHeight: number): number {
+  const minStatusBar = 4;
+  const reservedForPanes = MIN_PANE_CONTENT * 2;
+  return Math.max(
+    MIN_INPUT_AREA_ROWS,
+    terminalHeight - minStatusBar - reservedForPanes,
+  );
 }
 
 /**
@@ -350,7 +388,11 @@ export function App({
   }, [emitter]);
 
   // Compute visibility flags based on terminal dimensions.
-  const inputHeight = inputAreaHeight(inputRequest);
+  const inputAreaCap =
+    terminalHeight !== undefined
+      ? computeInputAreaCap(terminalHeight)
+      : undefined;
+  const inputHeight = inputAreaHeight(inputRequest, terminalHeight);
   const labelA = messages["agent.labelARole"];
   const labelB = messages["agent.labelBRole"];
   const cliNameA = cliTypeA ? cliDisplayName(cliTypeA) : undefined;
@@ -567,7 +609,11 @@ export function App({
         initialReviewCount={initialReviewCount}
         firstExecutingStage={firstExecutingStage}
       />
-      <InputArea request={inputRequest} onSubmit={handleSubmit} />
+      <InputArea
+        request={inputRequest}
+        onSubmit={handleSubmit}
+        maxRows={inputAreaCap}
+      />
     </Box>
   );
 }

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -176,7 +176,7 @@ export function InputArea({ request, onSubmit, maxRows }: InputAreaProps) {
       <Box flexDirection="column" paddingX={1} flexShrink={0}>
         {renderMessageLines(renderedMessage, hotkeyById, hotkeyStatus)}
         {request.choices.map((c, i) => (
-          <Text key={c.value}>
+          <Text key={c.value} wrap="truncate-end">
             {"  "}
             <Text bold color="cyan">
               {i + 1}
@@ -213,6 +213,13 @@ export function InputArea({ request, onSubmit, maxRows }: InputAreaProps) {
  * Render `message` line-by-line, substituting `{{hk:<id>}}` tokens
  * with inline hint labels driven by `status`.  Sentinels referring to
  * unknown ids fall through as literal text so caller bugs surface.
+ *
+ * `wrap="truncate-end"` is applied to each per-line `<Text>` so a long
+ * source line cannot wrap to multiple rendered rows on a narrow
+ * terminal, which would otherwise push the choice / text-input row
+ * past the terminal viewport (#293).  With this guarantee the
+ * newline-based row counting in `truncateMessageToFit` and
+ * `inputAreaHeight` accurately matches the rendered row count.
  */
 function renderMessageLines(
   message: string,
@@ -225,12 +232,14 @@ function renderMessageLines(
     if (parts.length === 1 && parts[0].kind === "text") {
       return (
         // biome-ignore lint/suspicious/noArrayIndexKey: message lines never reorder
-        <Text key={lineIdx}>{line || " "}</Text>
+        <Text key={lineIdx} wrap="truncate-end">
+          {line || " "}
+        </Text>
       );
     }
     return (
       // biome-ignore lint/suspicious/noArrayIndexKey: message lines never reorder
-      <Text key={lineIdx}>
+      <Text key={lineIdx} wrap="truncate-end">
         {parts.map((part, partIdx) => {
           const partKey = `${lineIdx}:${partIdx}`;
           if (part.kind === "text") {

--- a/src/ui/InputArea.tsx
+++ b/src/ui/InputArea.tsx
@@ -40,6 +40,14 @@ export interface InputRequest {
 export interface InputAreaProps {
   request: InputRequest | null;
   onSubmit: (value: string) => void;
+  /**
+   * Hard cap on how many terminal rows the input area is allowed to
+   * consume.  When the message + choices/textinput would exceed this
+   * cap, the message is truncated tail-first and the last visible line
+   * becomes a `…(truncated)` marker.  This keeps the choice / text-input
+   * line on screen when a caller passes a long message (#293).
+   */
+  maxRows?: number;
 }
 
 type HotkeyStatus = "idle" | "copied" | "failed";
@@ -49,7 +57,7 @@ const SENTINEL_REGEX = /\{\{hk:([a-zA-Z0-9_-]+)\}\}/g;
 
 // ---- component ---------------------------------------------------------------
 
-export function InputArea({ request, onSubmit }: InputAreaProps) {
+export function InputArea({ request, onSubmit, maxRows }: InputAreaProps) {
   const [text, setText] = useState("");
   const [hotkeyStatus, setHotkeyStatus] = useState<
     Record<string, HotkeyStatus>
@@ -154,10 +162,19 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
 
   const hotkeyById = new Map((hotkeys ?? []).map((h) => [h.id, h]));
 
+  const truncatedLabel = t()["input.truncated"];
+  const reservedRows = request.choices ? request.choices.length : 1;
+  const renderedMessage = truncateMessageToFit(
+    request.message,
+    maxRows,
+    reservedRows,
+    truncatedLabel,
+  );
+
   if (request.choices) {
     return (
       <Box flexDirection="column" paddingX={1} flexShrink={0}>
-        {renderMessageLines(request.message, hotkeyById, hotkeyStatus)}
+        {renderMessageLines(renderedMessage, hotkeyById, hotkeyStatus)}
         {request.choices.map((c, i) => (
           <Text key={c.value}>
             {"  "}
@@ -174,7 +191,7 @@ export function InputArea({ request, onSubmit }: InputAreaProps) {
 
   return (
     <Box flexDirection="column" paddingX={1} flexShrink={0}>
-      {renderMessageLines(request.message, hotkeyById, hotkeyStatus)}
+      {renderMessageLines(renderedMessage, hotkeyById, hotkeyStatus)}
       <Box>
         <Text bold color="cyan">
           {">"}{" "}
@@ -244,6 +261,28 @@ function renderMessageLines(
       </Text>
     );
   });
+}
+
+/**
+ * Cap `message` so its line count plus `reservedRows` (choices or the
+ * text-input line) does not exceed `maxRows`.  When truncation is
+ * needed, the tail is replaced with a single `truncatedLabel` line so
+ * the choice / input line stays visible.  Returns the message
+ * unchanged when no cap is supplied or the message already fits.
+ */
+export function truncateMessageToFit(
+  message: string,
+  maxRows: number | undefined,
+  reservedRows: number,
+  truncatedLabel: string,
+): string {
+  if (maxRows === undefined) return message;
+  const messageBudget = maxRows - reservedRows;
+  if (messageBudget <= 0) return truncatedLabel;
+  const lines = message.split("\n");
+  if (lines.length <= messageBudget) return message;
+  if (messageBudget === 1) return truncatedLabel;
+  return [...lines.slice(0, messageBudget - 1), truncatedLabel].join("\n");
 }
 
 function filterChoiceCollisions(

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -22,12 +22,19 @@ import {
   splitIntoRows,
 } from "./AgentPane.js";
 import {
+  computeInputAreaCap,
   computeLayoutWidth,
   computeVisibilityFlags,
   inputAreaHeight,
+  MIN_INPUT_AREA_ROWS,
+  MIN_PANE_CONTENT,
   useTerminalHeight,
 } from "./App.js";
-import { InputArea, type InputRequest } from "./InputArea.js";
+import {
+  InputArea,
+  type InputRequest,
+  truncateMessageToFit,
+} from "./InputArea.js";
 import { fitInfoSegments, formatElapsed, StatusBar } from "./StatusBar.js";
 import { cliDisplayName, formatTokenCount, TokenBar } from "./TokenBar.js";
 import {
@@ -2949,6 +2956,121 @@ describe("inputAreaHeight", () => {
         choices: [{ label: "A", value: "a" }],
       }),
     ).toBe(4);
+  });
+
+  // #293: when terminalHeight is supplied, the height is clamped so a
+  // very tall prompt cannot starve the agent panes of their reserved
+  // MIN_PANE_CONTENT*2 rows.
+  test("clamps to computeInputAreaCap when terminalHeight is supplied", () => {
+    const tall: InputRequest = {
+      message: Array.from({ length: 80 }, (_, i) => `line ${i}`).join("\n"),
+      choices: [{ label: "A", value: "a" }],
+    };
+    const cap = computeInputAreaCap(50);
+    expect(inputAreaHeight(tall, 50)).toBe(cap);
+    expect(inputAreaHeight(tall, 50)).toBeLessThan(81);
+  });
+
+  test("returns raw height when it fits under the cap", () => {
+    const small: InputRequest = {
+      message: "Choose:",
+      choices: [
+        { label: "A", value: "a" },
+        { label: "B", value: "b" },
+      ],
+    };
+    expect(inputAreaHeight(small, 50)).toBe(3);
+  });
+});
+
+// ---- computeInputAreaCap -----------------------------------------------------
+
+describe("computeInputAreaCap", () => {
+  test("floors at MIN_INPUT_AREA_ROWS so the input never collapses entirely", () => {
+    expect(computeInputAreaCap(0)).toBe(MIN_INPUT_AREA_ROWS);
+    expect(computeInputAreaCap(5)).toBe(MIN_INPUT_AREA_ROWS);
+  });
+
+  test("scales with terminal height, reserving panes + status bar", () => {
+    // Reserves: status bar (4) + MIN_PANE_CONTENT*2.
+    expect(computeInputAreaCap(50)).toBe(50 - 4 - MIN_PANE_CONTENT * 2);
+    expect(computeInputAreaCap(24)).toBe(24 - 4 - MIN_PANE_CONTENT * 2);
+  });
+});
+
+// ---- truncateMessageToFit ----------------------------------------------------
+
+describe("truncateMessageToFit", () => {
+  test("returns message unchanged when no maxRows is supplied", () => {
+    const msg = "a\nb\nc\nd\ne\nf";
+    expect(truncateMessageToFit(msg, undefined, 1, "...")).toBe(msg);
+  });
+
+  test("returns message unchanged when it already fits", () => {
+    const msg = "a\nb\nc";
+    // 3 message lines + 1 reserved = 4 rows; cap of 5 means it fits.
+    expect(truncateMessageToFit(msg, 5, 1, "...")).toBe(msg);
+  });
+
+  test("truncates tail to a single marker line when needed", () => {
+    const msg = "a\nb\nc\nd\ne";
+    // cap = 4, reserved = 1 → message budget 3 → keep 2 + marker.
+    expect(truncateMessageToFit(msg, 4, 1, "...")).toBe("a\nb\n...");
+  });
+
+  test("returns just the marker when budget is 1 row", () => {
+    const msg = "a\nb\nc";
+    // cap=2, reserved=1 → budget=1 → only the marker line fits.
+    expect(truncateMessageToFit(msg, 2, 1, "...")).toBe("...");
+  });
+
+  test("returns the marker when budget is non-positive", () => {
+    expect(truncateMessageToFit("a\nb", 1, 1, "...")).toBe("...");
+    expect(truncateMessageToFit("a\nb", 1, 5, "...")).toBe("...");
+  });
+});
+
+// ---- InputArea: maxRows truncation ------------------------------------------
+
+describe("InputArea maxRows truncation (issue #293 safety net)", () => {
+  test("renders truncation marker when message exceeds maxRows budget", () => {
+    const longMessage = Array.from(
+      { length: 30 },
+      (_, i) => `body line ${i}`,
+    ).join("\n");
+    const request: InputRequest = {
+      message: longMessage,
+      choices: [
+        { label: "Yes", value: "yes" },
+        { label: "No", value: "no" },
+      ],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} maxRows={6} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("…(truncated)");
+    // Last "body line" rendered must be well below 30 — proves the
+    // tail was dropped, not the head.
+    expect(frame).toContain("body line 0");
+    expect(frame).not.toContain("body line 29");
+    // Choice lines stay visible.
+    expect(frame).toContain("Yes");
+    expect(frame).toContain("No");
+  });
+
+  test("does not truncate when message already fits", () => {
+    const request: InputRequest = {
+      message: "Short prompt",
+      choices: [{ label: "OK", value: "ok" }],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} maxRows={10} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("…(truncated)");
+    expect(frame).toContain("Short prompt");
+    expect(frame).toContain("OK");
   });
 });
 

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -3072,6 +3072,65 @@ describe("InputArea maxRows truncation (issue #293 safety net)", () => {
     expect(frame).toContain("Short prompt");
     expect(frame).toContain("OK");
   });
+
+  // ink-testing-library renders at a fixed 100 columns. A 200-char
+  // single-line message would normally wrap to 2 rendered rows on a
+  // 100-col terminal, breaking the newline-based row budget and
+  // pushing the choice lines past the viewport (#293).  With each
+  // per-line `<Text>` rendered with `wrap="truncate-end"`, every
+  // source line stays at exactly one rendered row, and the choice
+  // lines remain visible.
+  test("a long single-line message renders as one row, choices stay visible", () => {
+    const longLine = "x".repeat(200);
+    const request: InputRequest = {
+      message: longLine,
+      choices: [
+        { label: "Yes", value: "yes" },
+        { label: "No", value: "no" },
+      ],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    // Total rendered rows: 1 message line + 2 choice lines = 3.
+    expect(lines.length).toBe(3);
+    // The single message row is truncated with `…`.
+    expect(lines[0]).toMatch(/x+…$/);
+    expect(lines[0].length).toBeLessThanOrEqual(100);
+    // Choices are still visible (would have been pushed off if the
+    // long line had wrapped to 2 rendered rows).
+    expect(frame).toContain("Yes");
+    expect(frame).toContain("No");
+  });
+
+  // The same protection applies to messages with hotkey sentinels
+  // embedded in a long line — the outer-`<Text>` `truncate-end`
+  // wraps the composed (substituted) text so the hint segments
+  // can't push the line into a second wrapped row either.
+  test("a long message line containing a sentinel still renders as one row", () => {
+    const longPrefix = "y".repeat(180);
+    const request: InputRequest = {
+      message: `${longPrefix} {{hk:copy}}`,
+      hotkeys: [
+        {
+          id: "copy",
+          key: "c",
+          onPress: async () => "ok" as const,
+        },
+      ],
+      choices: [{ label: "OK", value: "ok" }],
+    };
+    const { lastFrame } = render(
+      <InputArea request={request} onSubmit={() => {}} />,
+    );
+    const frame = lastFrame() ?? "";
+    const lines = frame.split("\n");
+    expect(lines.length).toBe(2);
+    expect(lines[0].length).toBeLessThanOrEqual(100);
+    expect(frame).toContain("OK");
+  });
 });
 
 // ---- fitInfoSegments ---------------------------------------------------------


### PR DESCRIPTION
## Summary

Stage 9's merge-confirm prompt inlined the suggested squash commit body verbatim. When the body was long the InputArea grew past the terminal height, pushing the `1 — …` / `2 — …` choice lines off the bottom of the viewport. Ink renders in-place without an alt-screen, so the hidden choices could not be scrolled back into view and the prompt appeared frozen.

- `askMerge` (`src/pipeline.ts`) now renders a one-line `Suggested body: N lines` summary instead of inlining the body. The full body stays reachable via the existing `[b]` clipboard hotkey, and the linked PR comment is shown as the fallback.
- When the clipboard is unavailable, the body line shows a `view in the PR comment` hint instead of a copy affordance.
- Suggested titles are ellipsized to 120 chars (and any embedded newlines collapsed) so a pathological title can't wrap to multiple rows and reintroduce the same overflow.
- Added new i18n keys (`pipeline.suggestedSquashBodyLines`, `pipeline.suggestedSquashBodyCopyHint`, `pipeline.suggestedSquashBodyViewInPr`, `input.truncated`) for both en and ko.

As a defensive safety net for any future prompt that grows long:

- `inputAreaHeight` in `src/ui/App.tsx` accepts an optional `terminalHeight` and clamps to `computeInputAreaCap(...)`, reserving the status-bar minimum + `MIN_PANE_CONTENT * 2` rows for the agent panes. A `MIN_INPUT_AREA_ROWS = 2` floor prevents the input from collapsing entirely.
- `InputArea` accepts a `maxRows` prop and truncates tail-first via `truncateMessageToFit`, replacing the dropped tail with a single `…(truncated)` marker so the choice / text-input line is always visible.
- Each rendered prompt line (message rows and choice rows alike) is rendered with `wrap="truncate-end"` so a long single-line title or hint cannot wrap to multiple rendered rows on a narrow terminal. Without this, a single source line could span two or more terminal rows even though `truncateMessageToFit` and `inputAreaHeight` count it as one — `wrap="truncate-end"` keeps the source-line / rendered-row mapping 1:1 (visible `…` marker on truncation).

Closes #293

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` is clean for changed files
- [x] `pnpm vitest run` — full suite (2004 tests across 44 files) green
- [x] New regression test: 80-line body produces a `<15`-line prompt with no `body line N` content rendered
- [x] New test: pathologically long title is ellipsized (`Fix x{100,}…`)
- [x] New test: clipboard-unavailable path shows `view in the PR comment` instead of copy affordance
- [x] New test: `InputArea maxRows` truncates a 30-line message to fit a 6-row cap, preserves head + choice lines, drops the tail, renders `…(truncated)` marker
- [x] New tests cover `computeInputAreaCap` floor + reservation math and `truncateMessageToFit` edge cases (no cap, fits, head+marker, marker-only, non-positive budget)
- [x] New regression test: a 200-char single-line message renders as exactly one row at the default 100-col render width (would previously wrap to two rows and push the choice lines off-screen)
- [x] New regression test: a long message line containing a hotkey sentinel still renders as one row (verifies that the outer `<Text wrap="truncate-end">` truncates the composed text including nested `<Text>` children)
- [x] Manual: run a `SUGGESTED_SINGLE` flow with a 60+ line body in a 50-row terminal — the `1 — …` / `2 — …` choice lines remain visible; pressing `[b]` copies the full body