### PR TITLE
Stop blocking on Stage 9 no-conflicts notice (#295)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
+- Stage 9's `check_conflicts` recheck no longer blocks on a press-enter
+  prompt when GitHub reports `MERGEABLE`.  The "no conflicts" result is
+  now folded into the redrawn merge-confirm screen as a one-shot notice
+  and the inner loop returns to `confirmMerge` immediately.
+  `waitForManualResolve` stays reserved for the cases where the user
+  actually has manual work to do (post-rebase / already-attempted
+  CONFLICTING).
 - Stage 9 no longer silently ends the session when the post-rebase CI fix
   loop exhausts its attempt budget.  `pollCiAndFix` now accepts an
   opt-in `confirmRetry` callback that Stage 9 wires to the TUI; when the

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -162,7 +162,7 @@ export const en: Messages = {
     "Pipeline completed, but merge conflicts with main detected.",
   "pipeline.unknownMergeable":
     "Could not determine merge status after retries.",
-  "pipeline.noConflicts": "No conflicts found — already up to date with main.",
+  "pipeline.noConflicts": "No conflicts — branch is up to date with main.",
   "pipeline.rebaseFailed":
     "Agent could not resolve conflicts. Please resolve manually.",
   "pipeline.rebaseAgentError": (detail) =>

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -194,7 +194,7 @@ export const ko: Messages = {
   "pipeline.conflictsDetected":
     "파이프라인이 완료되었지만 main과 병합 충돌이 감지되었습니다.",
   "pipeline.unknownMergeable": "재시도 후에도 병합 상태를 확인할 수 없습니다.",
-  "pipeline.noConflicts": "충돌이 없습니다 — main과 이미 최신 상태입니다.",
+  "pipeline.noConflicts": "충돌 없음 — 브랜치가 main과 최신 상태입니다.",
   "pipeline.rebaseFailed":
     "에이전트가 충돌을 해결하지 못했습니다. 수동으로 해결해 주세요.",
   "pipeline.rebaseAgentError": (detail) =>

--- a/src/pipeline.test.ts
+++ b/src/pipeline.test.ts
@@ -2104,9 +2104,11 @@ describe("createDoneStageHandler", () => {
 
   // ---- askMerge "check_conflicts" sub-path --------------------------------
 
-  test("check_conflicts → MERGEABLE shows noConflicts message and loops back", async () => {
+  test("check_conflicts → MERGEABLE folds noConflicts notice into next confirmMerge and loops back", async () => {
     // User selects "check_conflicts" first time (no conflicts),
-    // then "merged" on the loop-back.
+    // then "merged" on the loop-back.  The "no conflicts" result
+    // must NOT block on a press-enter prompt (#295) — instead it
+    // folds into the redrawn confirmMerge as a transient notice.
     const confirmMerge = vi
       .fn()
       .mockResolvedValueOnce("check_conflicts")
@@ -2125,13 +2127,55 @@ describe("createDoneStageHandler", () => {
     const result = await stage.handler(ctx);
     // checkMergeable: once at entry (MERGEABLE), once inside askMerge.
     expect(opts.checkMergeable).toHaveBeenCalledTimes(2);
-    // "No conflicts" message shown via waitForManualResolve.
-    expect(waitForManualResolve).toHaveBeenCalledWith(
-      expect.stringContaining("No conflicts"),
-    );
+    // "No conflicts" must NOT be surfaced via the blocking
+    // press-enter prompt — that's reserved for genuine manual work.
+    expect(waitForManualResolve).not.toHaveBeenCalled();
+    // The redrawn confirmMerge carries the no-conflicts notice.
     expect(confirmMerge).toHaveBeenCalledTimes(2);
+    const secondCallMessage = confirmMerge.mock.calls[1]?.[0] as string;
+    expect(secondCallMessage).toContain("No conflicts");
+    // First confirmMerge (initial entry) does not carry the notice.
+    const firstCallMessage = confirmMerge.mock.calls[0]?.[0] as string;
+    expect(firstCallMessage).not.toContain("No conflicts");
     expect(opts.cleanup).toHaveBeenCalledOnce();
     expect(result.outcome).toBe("completed");
+  });
+
+  test("check_conflicts → MERGEABLE notice is one-shot — cleared after the redraw consumes it", async () => {
+    // After the no-conflicts notice has been folded into one redraw,
+    // a subsequent confirmMerge invocation must be clean.  Here the
+    // user picks check_conflicts (MERGEABLE → notice set), accepts
+    // the notice-carrying redraw with another check_conflicts
+    // (state UNKNOWN → user exits), so we can inspect both calls.
+    const checkMergeable = vi
+      .fn()
+      .mockResolvedValueOnce("MERGEABLE") // initial entry
+      .mockResolvedValueOnce("MERGEABLE") // first check_conflicts
+      .mockResolvedValueOnce("UNKNOWN"); // second check_conflicts
+    const confirmMerge = vi
+      .fn()
+      .mockResolvedValueOnce("check_conflicts")
+      .mockResolvedValueOnce("check_conflicts");
+    const handleUnknownMergeable = vi.fn().mockResolvedValue("exit");
+    const opts = makeDoneOpts({
+      checkMergeable,
+      prompt: { confirmMerge, handleUnknownMergeable },
+    });
+    const stage = createDoneStageHandler(opts);
+    const ctx: StageContext = {
+      ...BASE_CTX,
+      iteration: 0,
+      lastAutoIteration: false,
+      userInstruction: undefined,
+    };
+    await stage.handler(ctx);
+    // First redraw (entry) has no notice; second (after the
+    // MERGEABLE recheck) carries it exactly once.
+    expect(confirmMerge).toHaveBeenCalledTimes(2);
+    const firstMsg = confirmMerge.mock.calls[0]?.[0] as string;
+    const secondMsg = confirmMerge.mock.calls[1]?.[0] as string;
+    expect(firstMsg).not.toContain("No conflicts");
+    expect(secondMsg).toContain("No conflicts");
   });
 
   test("check_conflicts → CONFLICTING → rebase succeeds → CI → loops back", async () => {
@@ -2325,8 +2369,7 @@ describe("createDoneStageHandler", () => {
       .fn()
       .mockResolvedValueOnce("CONFLICTING") // initial mergeableLoop
       .mockResolvedValueOnce("MERGEABLE") // afterResolution
-      .mockResolvedValueOnce("MERGEABLE") // afterResolution (CI pass)
-      .mockResolvedValueOnce("CONFLICTING"); // inside askMerge
+      .mockResolvedValueOnce("CONFLICTING"); // inside askMerge — guard fires
     const handleConflict = vi.fn().mockResolvedValue("agent_rebase");
     const rebaseOntoMain = vi
       .fn()

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -1224,12 +1224,21 @@ export function createDoneStageHandler(
     const detect =
       options.detectClipboardSupport ?? defaultDetectClipboardSupport;
     const write = options.writeToClipboard ?? defaultWriteToClipboard;
+    // Carries a one-shot status notice (e.g. "no conflicts") into the
+    // next confirmMerge redraw so a successful check_conflicts loops
+    // back without blocking on a press-enter prompt.
+    let transientNotice: string | undefined;
     for (;;) {
       const hint = options.getSquashMergeHint?.();
       const candidates = hint ? detect() : [];
       const clipboardAvailable = candidates.length > 0;
       const hotkeys: InputHotkey[] = [];
-      const sections: string[] = [summary];
+      const sections: string[] = [];
+      if (transientNotice) {
+        sections.push(transientNotice);
+        transientNotice = undefined;
+      }
+      sections.push(summary);
       if (hint) {
         // Generate per-render unique sentinel ids so that agent-generated
         // title/body content containing a literal `{{hk:title}}` /
@@ -1320,10 +1329,10 @@ export function createDoneStageHandler(
         }
 
         if (state === "MERGEABLE") {
-          await options.prompt.waitForManualResolve(m["pipeline.noConflicts"]);
-          if (ctx.signal?.aborted) {
-            return { outcome: "completed", message: "" };
-          }
+          // No conflicts — fold a brief notice into the next
+          // confirmMerge redraw rather than blocking on a press-enter
+          // prompt (#295).  The user has nothing to resolve.
+          transientNotice = m["pipeline.noConflicts"];
           break; // back to confirmMerge
         }
 


### PR DESCRIPTION
## Summary

When the user picks `[c] check_conflicts` at the Stage 9 merge prompt and GitHub reports the PR as `MERGEABLE`, the pipeline previously surfaced the result via `waitForManualResolve(pipeline.noConflicts)` and made the user press enter before looping back to `confirmMerge`. That blocking prompt is reserved for cases where the user actually has manual work to do (post-rebase / already-attempted `CONFLICTING`); when there is nothing to resolve, the press-enter cue misrepresents the state and breaks the rest of the pipeline's single-key hotkey convention.

This PR treats `MERGEABLE` as a no-op confirmation:

- `askMerge` now stashes a one-shot `transientNotice` carrying `pipeline.noConflicts` and immediately loops back to `confirmMerge`, which folds the notice into its next redraw and clears it.
- `pipeline.noConflicts` copy in `en.ts` / `ko.ts` is reworded to read as a status notice rather than a press-enter cue ("No conflicts — branch is up to date with main." / "충돌 없음 — 브랜치가 main과 최신 상태입니다.").
- `CONFLICTING`, `UNKNOWN`, and post-rebase / already-attempted `CONFLICTING` branches keep their existing behavior — the latter still calls `waitForManualResolve` because manual work is genuinely required.
- The existing `check_conflicts → MERGEABLE` test is updated to assert that `waitForManualResolve` is not invoked and that the next `confirmMerge` carries the notice.
- A new test confirms the notice is one-shot — cleared after the next `confirmMerge` consumes it — so a later redraw cannot leak a stale "no conflicts" line.

Closes #295

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` reports no new findings
- [x] `pnpm vitest run` passes (full suite, including the updated and new `check_conflicts → MERGEABLE` tests)
- [x] Manual smoke: at the Stage 9 merge prompt, press `[c] check_conflicts` against a branch already up to date with `main` — confirm the prompt redraws once with a "No conflicts" notice on top and immediately accepts hotkeys again, with no press-enter step (covered headlessly via `askMerge` + mocked prompts in `pipeline.test.ts` 2107 and the new one-shot test 2152, both passing)
- [x] Manual smoke: trigger the `UNKNOWN` path (transient `gh` failure) — confirm the existing `[r] recheck / [e] exit` hotkey prompt still appears (covered by `check_conflicts → UNKNOWN → user exits` 2402 and `→ user rechecks` 2427, both passing)
- [x] Manual smoke: trigger the post-rebase / already-attempted `CONFLICTING` path — confirm `waitForManualResolve` still blocks for manual resolution (covered by `check_conflicts respects rebaseAttempted guard across loop-backs` 2363, passing)