### PR TITLE
Prompt on Stage 9 CI timeout and agent errors (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,19 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   cleanup path only runs after an explicit decline.  Stages 7 and 8 are
   unchanged — they already route CI failures through the engine's
   `dispatchError` prompt and must not double-ask.
+- Stage 9's `confirmRetry` prompt now also surfaces on CI pending-timeout
+  and findings-review / fix agent errors, not just on fix-budget
+  exhaustion.  Previously these three branches in `pollCiAndFix`
+  returned `passed: false` directly and the Done stage advanced to the
+  cleanup ("Delete local worktree?") prompt without giving the user a
+  chance to keep waiting or retry.  The callback signature is now a
+  discriminated `ConfirmRetryInfo` union (`exhausted` / `timeout` /
+  `agent_error`) so each reason carries its own metadata; on confirm,
+  timeout resumes polling, agent errors retry the same step with the
+  pre-incremented counter undone so a permanent failure cannot
+  prematurely exhaust the budget, and exhaustion resets the fix
+  counter (existing behavior).  Stages 7 and 8 still do not pass
+  `confirmRetry`, so their `dispatchError` flow is unaffected.
 - Stage 9's rebase handler now distinguishes an agent process failure
   from a BLOCKED verdict.  `RebaseResult` is a discriminated union
   (`completed` / `blocked` / `error`), and both Stage 9 call sites

--- a/README.md
+++ b/README.md
@@ -157,9 +157,12 @@ force-pushes) or **manual resolution**. Agent rebase is limited to
 one attempt per run when the agent completes or reports `BLOCKED`;
 a bare agent process failure surfaces the error detail and leaves
 the attempt budget intact so the user can retry. After any
-resolution, CI is re-validated; if the CI fix loop exhausts its
-budget, the user is asked whether to keep trying before cleanup
-runs, so a transient CI failure never silently ends the session.
+resolution, CI is re-validated; whenever the post-rebase CI poll
+cannot proceed — fix budget exhausted, pending timeout, or an agent
+error during findings review or fix — the user is asked whether to
+keep trying (timeout resumes polling; agent-error retries the same
+step; exhaustion resets the fix counter) before cleanup runs, so
+none of those branches can silently end the session.
 Once the user confirms the PR has been merged, the orchestrator
 stops any running services (e.g., Docker Compose), deletes the git
 worktree and its branch, and ends the agent sessions.  See

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1502,9 +1502,12 @@ Cleanup
        three outcomes:
        - `completed` — rebase succeeded and was force-pushed.
          The orchestrator polls CI. If CI passes, proceed to
-         merge confirmation; on exhausted retries the user is
-         asked (via `confirmRetry`) whether to keep trying, and
-         only cleanup when they decline.
+         merge confirmation; on every `pollCiAndFix` failure
+         path (fix-budget exhausted, pending timeout, or agent
+         error during findings review or fix) the user is
+         asked via `confirmRetry` whether to keep trying.
+         Cleanup only runs after an explicit decline, so the
+         session never ends silently on a transient blip.
        - `blocked` — the agent finished but reported `BLOCKED`.
          The user sees the agent's own explanation (no longer
          a generic "resolve manually" notice) and falls back to
@@ -1638,11 +1641,27 @@ Do not include any other commentary — just the keyword.
 - **CI re-validation.** After a successful rebase and force-push,
   the orchestrator polls CI and runs the CI fix loop if needed,
   because the rebase may have introduced regressions even if
-  local tests passed.  When the fix loop exhausts its attempt
-  budget, Stage 9 asks the user whether to keep trying (the
-  opt-in `confirmRetry` callback on `pollCiAndFix`); cleanup only
-  runs after an explicit decline, so the session never ends
-  silently on a transient CI blip.
+  local tests passed.  Stage 9's `confirmRetry` callback on
+  `pollCiAndFix` covers all three non-pass branches that would
+  otherwise terminate the stage silently:
+  - `exhausted` — the fix-attempt budget hit `maxFixAttempts`.
+    On confirm, the counter resets to 0 and the fix loop
+    re-enters.
+  - `timeout` — `pollTimeoutMs` (default 10 minutes) elapsed
+    while CI was still pending.  On confirm, polling resumes;
+    HEAD SHA is re-read at the top of the outer loop so a fix
+    that landed during the timeout window is automatically
+    picked up.
+  - `agent_error` — the findings-review or fix turn itself
+    failed (CLI crash, timeout, etc.).  On confirm, the same
+    step re-runs and the relevant counter is decremented to
+    undo the pre-increment, so a permanent failure cannot
+    silently exhaust the budget across retries.
+  Cleanup only runs after an explicit decline, so the session
+  never ends silently on a transient CI blip.  Stages 7 and 8
+  do not pass `confirmRetry` — they already route CI failures
+  through the engine's `dispatchError` prompt and must not
+  double-ask.
 - **Fallback to manual.** If the agent rebase fails, or if it
   was already attempted, the user is always offered manual
   resolution as a fallback.

--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -439,9 +439,10 @@ describe("pollCiAndFix", () => {
     );
 
     expect(confirmRetry).toHaveBeenCalledOnce();
-    // First arg is the exhausted attempt count (fixAttempts counter).
-    expect(confirmRetry.mock.calls[0][0]).toBe(2);
-    expect(confirmRetry.mock.calls[0][1]).toContain("still failing");
+    const info = confirmRetry.mock.calls[0][0];
+    expect(info.reason).toBe("exhausted");
+    expect(info.attempts).toBe(2);
+    expect(info.message).toContain("still failing");
     expect(result.passed).toBe(false);
   });
 
@@ -498,6 +499,303 @@ describe("pollCiAndFix", () => {
     // any extra prompt.
     expect(result.passed).toBe(false);
     expect(result.message).toContain("still failing after 1 fix attempt");
+  });
+
+  // -- confirmRetry: timeout --------------------------------------------------
+
+  test("confirmRetry true on timeout resumes polling", async () => {
+    // First polling cycle exceeds the timeout window; on the second
+    // cycle (after confirmRetry returns true) CI passes.
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    // `pending` until the user confirms the retry; `pass` thereafter.
+    let pendingPhase = true;
+    const getCiStatus = vi.fn().mockImplementation(() => {
+      return pendingPhase ? makeCiStatus("pending") : makeCiStatus("pass");
+    });
+
+    const confirmRetry = vi.fn().mockImplementation(async () => {
+      pendingPhase = false;
+      return true;
+    });
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        getCiStatus,
+        delay,
+        pollIntervalMs: 100,
+        pollTimeoutMs: 1000,
+        confirmRetry,
+      }),
+    );
+
+    expect(confirmRetry).toHaveBeenCalledOnce();
+    const info = confirmRetry.mock.calls[0][0];
+    expect(info.reason).toBe("timeout");
+    expect(info.seconds).toBe(1);
+    expect(info.message).toContain("still pending");
+    expect(result.passed).toBe(true);
+
+    vi.restoreAllMocks();
+  });
+
+  test("confirmRetry false on timeout returns passed: false", async () => {
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pending"));
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const confirmRetry = vi.fn().mockResolvedValue(false);
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        getCiStatus,
+        delay,
+        pollIntervalMs: 100,
+        pollTimeoutMs: 1000,
+        confirmRetry,
+      }),
+    );
+
+    expect(confirmRetry).toHaveBeenCalledOnce();
+    expect(confirmRetry.mock.calls[0][0].reason).toBe("timeout");
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("still pending");
+
+    vi.restoreAllMocks();
+  });
+
+  test("timeout without confirmRetry returns passed: false (regression guard)", async () => {
+    // Stages 7/8 do not pass `confirmRetry`; the timeout branch must
+    // continue to surface as a failure so the engine's
+    // `dispatchError` flow can prompt instead.
+    const getCiStatus = vi.fn().mockReturnValue(makeCiStatus("pending"));
+    let elapsed = 0;
+    const startTime = Date.now();
+    const delay = vi.fn().mockImplementation(async () => {
+      elapsed += 500;
+    });
+    vi.spyOn(Date, "now").mockImplementation(() => startTime + elapsed);
+
+    const result = await pollCiAndFix(
+      makeOpts({
+        getCiStatus,
+        delay,
+        pollIntervalMs: 100,
+        pollTimeoutMs: 1000,
+        // confirmRetry deliberately omitted.
+      }),
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("still pending");
+
+    vi.restoreAllMocks();
+  });
+
+  // -- confirmRetry: agent_error during findings review -----------------------
+
+  test("confirmRetry true on findings-review agent error retries without consuming budget", async () => {
+    // First findings-review attempt fails with an agent error;
+    // confirmRetry true re-runs the same review step.  The second
+    // attempt succeeds without pushing, so findings are acknowledged.
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "Unused variable",
+        file: "src/app.ts",
+        line: 10,
+        checkRunId: 500,
+        checkRunName: "ESLint",
+        commitSha: "abc123",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("same-sha");
+
+    let invokeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCall++;
+        if (invokeCall === 1) {
+          return makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "crash",
+              responseText: "",
+            }),
+          );
+        }
+        return makeStream(makeResult({ responseText: "Acknowledged." }));
+      }),
+      resume: vi.fn(),
+    };
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const confirmRetry = vi.fn().mockResolvedValue(true);
+
+    // maxFixAttempts=1 → maxFindingsReviews=1.  If the
+    // pre-incremented counter were not undone, the second attempt
+    // would short-circuit to "passed with findings" without invoking
+    // the agent again.
+    const result = await pollCiAndFix(
+      makeOpts({
+        agent,
+        getCiStatus,
+        getHeadSha,
+        maxFixAttempts: 1,
+        confirmRetry,
+      }),
+    );
+
+    expect(confirmRetry).toHaveBeenCalledOnce();
+    expect(confirmRetry.mock.calls[0][0].reason).toBe("agent_error");
+    expect(confirmRetry.mock.calls[0][0].detail).toContain("crash");
+    // Two invokes: the failed first attempt + the retry.  This proves
+    // the findingsReviews counter was decremented on retry.
+    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    expect(result.passed).toBe(true);
+
+    errorSpy.mockRestore();
+  });
+
+  test("confirmRetry false on findings-review agent error returns passed: false", async () => {
+    const findings: CiFinding[] = [
+      {
+        level: "warning",
+        message: "x",
+        file: "f",
+        line: 1,
+        checkRunId: 1,
+        checkRunName: "lint",
+        commitSha: "abc",
+      },
+    ];
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
+    const getHeadSha = vi.fn().mockReturnValue("sha");
+
+    const agent = makeAgent(
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "boom",
+        responseText: "",
+      }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const confirmRetry = vi.fn().mockResolvedValue(false);
+
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, getHeadSha, confirmRetry }),
+    );
+
+    expect(confirmRetry).toHaveBeenCalledOnce();
+    expect(confirmRetry.mock.calls[0][0].reason).toBe("agent_error");
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("Agent error during CI fix");
+
+    errorSpy.mockRestore();
+  });
+
+  // -- confirmRetry: agent_error during fix -----------------------------------
+
+  test("confirmRetry true on fix agent error retries without consuming budget", async () => {
+    // First fix attempt fails with an agent error; confirmRetry true
+    // re-runs the fix.  The retried attempt succeeds and CI passes.
+    const failedRun = makeCiRun({ conclusion: "failure" });
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(makeCiStatus("fail", [failedRun]))
+      .mockReturnValueOnce(makeCiStatus("fail", [failedRun]))
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    let invokeCall = 0;
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockImplementation(() => {
+        invokeCall++;
+        if (invokeCall === 1) {
+          return makeStream(
+            makeResult({
+              status: "error",
+              errorType: "execution_error",
+              stderrText: "boom",
+              responseText: "",
+            }),
+          );
+        }
+        return makeStream(makeResult({ responseText: "Fixed." }));
+      }),
+      resume: vi.fn(),
+    };
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const confirmRetry = vi.fn().mockResolvedValue(true);
+
+    // maxFixAttempts=1.  Without the counter decrement on retry, the
+    // second attempt would hit `fixAttempts >= maxFix` and bypass the
+    // fix entirely (or re-prompt as exhausted).
+    const result = await pollCiAndFix(
+      makeOpts({
+        agent,
+        getCiStatus,
+        collectFailureLogs,
+        maxFixAttempts: 1,
+        confirmRetry,
+      }),
+    );
+
+    expect(confirmRetry).toHaveBeenCalledOnce();
+    expect(confirmRetry.mock.calls[0][0].reason).toBe("agent_error");
+    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    expect(result.passed).toBe(true);
+
+    errorSpy.mockRestore();
+  });
+
+  test("confirmRetry false on fix agent error returns passed: false", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValue(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      );
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+    const agent = makeAgent(
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "boom",
+        responseText: "",
+      }),
+    );
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const confirmRetry = vi.fn().mockResolvedValue(false);
+
+    const result = await pollCiAndFix(
+      makeOpts({ agent, getCiStatus, collectFailureLogs, confirmRetry }),
+    );
+
+    expect(confirmRetry).toHaveBeenCalledOnce();
+    expect(confirmRetry.mock.calls[0][0].reason).toBe("agent_error");
+    expect(result.passed).toBe(false);
+    expect(result.message).toContain("Agent error during CI fix");
+
+    errorSpy.mockRestore();
   });
 
   // -- maxFixAttempts = 0 means no fix attempts -------------------------------

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -80,17 +80,39 @@ export interface CiPollOptions {
   /** Pipeline event emitter for diagnostic events. */
   events?: PipelineEventEmitter;
   /**
-   * Optional callback invoked when the fix-attempt budget is
-   * exhausted.  When set, the caller is asked whether to reset the
-   * attempt counter and keep trying instead of returning a failure.
+   * Optional callback invoked when CI cannot proceed via the normal
+   * fix loop — exhausted fix budget, pending timeout, or an agent
+   * error during findings review or fix.  When set, the caller is
+   * asked whether to keep trying instead of returning a failure.
    *
-   * Returning `true` resets `fixAttempts` and continues the loop;
-   * returning `false` falls through to the existing `passed: false`
-   * path.  Only wired from Stage 9 — stages 7 and 8 already present
-   * the engine's `dispatchError` prompt and must not double-ask.
+   * Returning `true` resumes the loop using the per-reason retry
+   * semantics described in {@link ConfirmRetryInfo}; returning
+   * `false` (or omitting the callback) falls through to the existing
+   * `passed: false` path.  Only wired from Stage 9 — stages 7 and 8
+   * already present the engine's `dispatchError` prompt and must
+   * not double-ask.
    */
-  confirmRetry?: (attempts: number, message: string) => Promise<boolean>;
+  confirmRetry?: (info: ConfirmRetryInfo) => Promise<boolean>;
 }
+
+/**
+ * Discriminated reason for which {@link CiPollOptions.confirmRetry}
+ * is being invoked.  Each reason carries the metadata its prompt
+ * needs to render and is mapped to a distinct retry semantic:
+ *
+ * - `exhausted` — the fix-attempt budget hit `maxFixAttempts`.
+ *   Retry resets the counter to 0 and re-enters the fix loop.
+ * - `timeout` — `pollTimeoutMs` elapsed while CI was still pending.
+ *   Retry resumes the polling loop without consuming any budget.
+ * - `agent_error` — the agent process itself failed during a
+ *   findings-review or fix turn.  Retry re-runs the same step and
+ *   the relevant counter is decremented to undo the pre-increment
+ *   so a permanent failure cannot prematurely exhaust the budget.
+ */
+export type ConfirmRetryInfo =
+  | { reason: "exhausted"; attempts: number; message: string }
+  | { reason: "timeout"; seconds: number; message: string }
+  | { reason: "agent_error"; detail: string; message: string };
 
 export interface CiPollResult {
   /** Whether CI ultimately passed. */
@@ -238,10 +260,22 @@ export async function pollCiAndFix(
     });
 
     if (timedOut) {
-      return {
-        passed: false,
-        message: t()["ci.pendingTimeout"](Math.round(pollTimeout / 1000)),
-      };
+      const timeoutSeconds = Math.round(pollTimeout / 1000);
+      const timeoutMessage = t()["ci.pendingTimeout"](timeoutSeconds);
+      if (options.confirmRetry) {
+        const keepWaiting = await options.confirmRetry({
+          reason: "timeout",
+          seconds: timeoutSeconds,
+          message: timeoutMessage,
+        });
+        if (keepWaiting) {
+          // Resume polling.  HEAD SHA is re-read at the top of the
+          // outer loop, so a fix that landed during the timeout
+          // window is automatically picked up.
+          continue;
+        }
+      }
+      return { passed: false, message: timeoutMessage };
     }
 
     if (
@@ -295,10 +329,23 @@ export async function pollCiAndFix(
       if (reviewResult.status === "error") {
         logAgentFailure(reviewResult, "during CI findings review");
         const detail = buildErrorDetail(reviewResult);
-        return {
-          passed: false,
-          message: t()["ci.agentError"](detail),
-        };
+        const errorMessage = t()["ci.agentError"](detail);
+        if (options.confirmRetry) {
+          const keepTrying = await options.confirmRetry({
+            reason: "agent_error",
+            detail,
+            message: errorMessage,
+          });
+          if (keepTrying) {
+            // Re-run the same findings-review step.  Undo the
+            // pre-increment of `findingsReviews` so a permanent
+            // agent failure cannot silently exhaust the review
+            // budget across user-confirmed retries.
+            findingsReviews--;
+            continue;
+          }
+        }
+        return { passed: false, message: errorMessage };
       }
 
       const shaAfterReview = readHeadSha(ctx.worktreePath);
@@ -316,10 +363,11 @@ export async function pollCiAndFix(
     if (fixAttempts >= maxFix) {
       const exhaustedMessage = t()["ci.stillFailing"](maxFix);
       if (options.confirmRetry) {
-        const keepTrying = await options.confirmRetry(
-          fixAttempts,
-          exhaustedMessage,
-        );
+        const keepTrying = await options.confirmRetry({
+          reason: "exhausted",
+          attempts: fixAttempts,
+          message: exhaustedMessage,
+        });
         if (keepTrying) {
           // Reset the budget and loop once more before re-checking CI.
           fixAttempts = 0;
@@ -374,10 +422,22 @@ export async function pollCiAndFix(
     if (fixResult.status === "error") {
       logAgentFailure(fixResult, "during CI fix");
       const detail = buildErrorDetail(fixResult);
-      return {
-        passed: false,
-        message: t()["ci.agentError"](detail),
-      };
+      const errorMessage = t()["ci.agentError"](detail);
+      if (options.confirmRetry) {
+        const keepTrying = await options.confirmRetry({
+          reason: "agent_error",
+          detail,
+          message: errorMessage,
+        });
+        if (keepTrying) {
+          // Re-run the same fix step.  Undo the pre-increment of
+          // `fixAttempts` so a permanent agent failure cannot
+          // silently exhaust the fix budget across retries.
+          fixAttempts--;
+          continue;
+        }
+      }
+      return { passed: false, message: errorMessage };
     }
 
     // Agent pushed a fix — loop back to poll CI again.

--- a/src/done-prompt-options.test.ts
+++ b/src/done-prompt-options.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import type { ConfirmRetryInfo } from "./ci-poll.js";
+import { buildDoneConfirmRetryPrompt } from "./done-prompt-options.js";
+
+// Verifies the wiring used by `src/index.ts` to translate a
+// ConfirmRetryInfo into the localized prompt shown to the user via
+// `tuiPrompt.confirmCleanup`.  Without this guard, a missing `reason`
+// branch in the helper would silently fall through and not surface in
+// either ci-poll or pipeline tests.
+describe("buildDoneConfirmRetryPrompt", () => {
+  test("exhausted reason renders the still-failing message", () => {
+    const info: ConfirmRetryInfo = {
+      reason: "exhausted",
+      attempts: 3,
+      message: "irrelevant",
+    };
+    const prompt = buildDoneConfirmRetryPrompt(info);
+    expect(prompt).toContain("3");
+    expect(prompt).toContain("Keep trying");
+  });
+
+  test("timeout reason renders the still-pending message with seconds", () => {
+    const info: ConfirmRetryInfo = {
+      reason: "timeout",
+      seconds: 600,
+      message: "irrelevant",
+    };
+    const prompt = buildDoneConfirmRetryPrompt(info);
+    expect(prompt).toContain("600");
+    expect(prompt).toContain("pending");
+    expect(prompt).toContain("Keep waiting");
+  });
+
+  test("agent_error reason renders the agent-error message with detail", () => {
+    const info: ConfirmRetryInfo = {
+      reason: "agent_error",
+      detail: "exit code 1: segfault",
+      message: "irrelevant",
+    };
+    const prompt = buildDoneConfirmRetryPrompt(info);
+    expect(prompt).toContain("Agent error");
+    expect(prompt).toContain("exit code 1: segfault");
+    expect(prompt).toContain("Retry");
+  });
+});

--- a/src/done-prompt-options.ts
+++ b/src/done-prompt-options.ts
@@ -1,3 +1,5 @@
+import type { ConfirmRetryInfo } from "./ci-poll.js";
+import { t } from "./i18n/index.js";
 import type { DoneStageOptions, UserPrompt } from "./pipeline.js";
 
 /**
@@ -54,4 +56,24 @@ export function createDonePromptOptions(
       if (tuiPrompt) return tuiPrompt.waitForManualResolve(msg);
     },
   };
+}
+
+/**
+ * Map a {@link ConfirmRetryInfo} record to the localized prompt
+ * string shown in Stage 9's keep-trying confirmation.  Centralised
+ * so a missing `reason` branch is caught here as a TypeScript error
+ * and verified by a focused unit test, instead of silently falling
+ * through to a fallback in `index.ts` where it would not surface in
+ * either ci-poll or pipeline tests.
+ */
+export function buildDoneConfirmRetryPrompt(info: ConfirmRetryInfo): string {
+  const m = t();
+  switch (info.reason) {
+    case "exhausted":
+      return m["ci.retryPrompt"](info.attempts);
+    case "timeout":
+      return m["ci.timeoutRetryPrompt"](info.seconds);
+    case "agent_error":
+      return m["ci.agentErrorRetryPrompt"](info.detail);
+  }
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -277,6 +277,10 @@ export const en: Messages = {
     `CI still failing after ${attempts} fix attempt(s).`,
   "ci.retryPrompt": (attempts) =>
     `CI still failing after ${attempts} fix attempt(s). Keep trying?`,
+  "ci.timeoutRetryPrompt": (seconds) =>
+    `CI checks still pending after ${seconds}s. Keep waiting?`,
+  "ci.agentErrorRetryPrompt": (detail) =>
+    `Agent error during CI fix: ${detail}. Retry?`,
   "ci.agentError": (detail) => `Agent error during CI fix: ${detail}`,
   "squash.completed": "Commits squashed and CI passed.",
   "squash.singleCommitSkip": "Single commit — skipping squash.",

--- a/src/i18n/index.test.ts
+++ b/src/i18n/index.test.ts
@@ -89,6 +89,8 @@ describe("catalogs are complete", () => {
       "ci.pendingTimeout": [30],
       "ci.stillFailing": [3],
       "ci.retryPrompt": [3],
+      "ci.timeoutRetryPrompt": [600],
+      "ci.agentErrorRetryPrompt": ["crash"],
       "ci.agentError": ["timeout"],
       "review.approved": [2],
       "review.unresolvedItems": ["Review approved.", "item 1"],

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -318,6 +318,10 @@ export const ko: Messages = {
     `${attempts}회 수정 시도 후에도 CI가 여전히 실패합니다.`,
   "ci.retryPrompt": (attempts) =>
     `${attempts}회 수정 시도 후에도 CI가 여전히 실패합니다. 계속 시도할까요?`,
+  "ci.timeoutRetryPrompt": (seconds) =>
+    `CI 검사가 ${seconds}초 후에도 보류 중입니다. 계속 기다릴까요?`,
+  "ci.agentErrorRetryPrompt": (detail) =>
+    `CI 수정 중 에이전트 오류: ${detail}. 다시 시도할까요?`,
   "ci.agentError": (detail) => `CI 수정 중 에이전트 오류: ${detail}`,
   "squash.completed": "커밋이 스쿼시되고 CI를 통과했습니다.",
   "squash.singleCommitSkip": "커밋이 하나뿐이므로 스쿼시를 건너뜁니다.",

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -262,6 +262,8 @@ export interface Messages {
   "ci.passedWithFindings": string;
   "ci.stillFailing": (attempts: number) => string;
   "ci.retryPrompt": (attempts: number) => string;
+  "ci.timeoutRetryPrompt": (seconds: number) => string;
+  "ci.agentErrorRetryPrompt": (detail: string) => string;
   "ci.agentError": (detail: string) => string;
   "squash.completed": string;
   "squash.singleCommitSkip": string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,10 @@ import {
   loadConfig,
   patchVersionCheckState,
 } from "./config.js";
-import { createDonePromptOptions } from "./done-prompt-options.js";
+import {
+  buildDoneConfirmRetryPrompt,
+  createDonePromptOptions,
+} from "./done-prompt-options.js";
 import { getGitHubUsername, getIssue } from "./github.js";
 import { initI18n, t } from "./i18n/index.js";
 import {
@@ -853,12 +856,13 @@ try {
         issueBody,
         // Stage 9 bypasses the engine's dispatchError prompt (the
         // Done stage consumes pollCiAndFix inline), so without this
-        // opt-in prompt an exhausted fix loop silently ends the
-        // session.  Ask the user whether to keep retrying — `true`
-        // resets the attempt budget; `false` lets cleanup run.
-        confirmRetry: async (attempts) => {
+        // opt-in prompt the fix-exhausted, pending-timeout, and
+        // agent-error branches would silently end the session.  Ask
+        // the user whether to keep trying — `true` resumes per the
+        // semantics in `ConfirmRetryInfo`; `false` lets cleanup run.
+        confirmRetry: async (info) => {
           if (!tuiPrompt) return false;
-          return tuiPrompt.confirmCleanup(t()["ci.retryPrompt"](attempts));
+          return tuiPrompt.confirmCleanup(buildDoneConfirmRetryPrompt(info));
         },
       });
     },


### PR DESCRIPTION
## Summary

`pollCiAndFix` returns `passed: false` from four branches, but before this change only the fix-budget exhaustion branch consulted `confirmRetry`. In Stage 9, the other three branches — pending timeout, findings-review agent error, and fix agent error — silently advanced straight to the cleanup prompt, giving the user no chance to keep waiting or retry.

This PR generalises `confirmRetry` to take a discriminated `ConfirmRetryInfo` union (`exhausted` / `timeout` / `agent_error`) and wires it into all three previously-silent branches:

- **`timeout`** — on confirm, the polling loop resumes; HEAD SHA is re-read at the top of the outer loop so a fix that landed during the timeout window is automatically picked up. No counter is touched.
- **`agent_error`** (findings review or fix) — on confirm, the same step re-runs and the relevant pre-incremented counter (`findingsReviews` or `fixAttempts`) is decremented to undo the increment, so a permanent agent failure cannot silently exhaust the budget across user-confirmed retries.
- **`exhausted`** — unchanged behavior; on confirm, `fixAttempts = 0` and the fix loop re-enters.

A small `buildDoneConfirmRetryPrompt` helper centralises the reason-to-i18n-key mapping so a missing branch is caught at compile time and verified by a focused unit test, instead of falling through silently in `index.ts`.

Stages 7 and 8 do not pass `confirmRetry`, so their `dispatchError` flow is unaffected and they continue to surface CI failures via the engine prompt — no double-asking.

Closes #297

## Test plan

- [x] `pnpm vitest run` — full suite passes (2015 tests)
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm biome check` on changed files — clean
- [x] New `src/ci-poll.test.ts` cases cover all three new retry paths plus a regression guard for stages 7/8 (no `confirmRetry` passed → `passed: false`)
- [x] New `src/done-prompt-options.test.ts` verifies the wiring helper renders the correct i18n string per `reason`
- [x] Manual: drive Stage 9 with a CI pending-timeout and confirm the new "Keep waiting?" prompt appears, and that declining triggers cleanup — verified via composed unit tests (`ci-poll.test.ts` "confirmRetry true on timeout resumes polling" + "confirmRetry false on timeout returns passed: false"; `done-prompt-options.test.ts` confirms the `timeout` reason renders "still pending after Ns. Keep waiting?"); true end-to-end requires forcing a 10-minute real CI hang
- [x] Manual: drive Stage 9 with a findings-review agent error and confirm the new "Retry?" prompt appears — verified via `ci-poll.test.ts` "confirmRetry true/false on findings-review agent error" + `done-prompt-options.test.ts` confirming `agent_error` reason renders "Agent error during CI fix: <detail>. Retry?"
- [x] Manual: drive Stage 9 with a fix agent error and confirm the new "Retry?" prompt appears — verified via `ci-poll.test.ts` "confirmRetry true/false on fix agent error"; uses the same `agent_error` reason and prompt as item above
- [x] Manual: confirm Stages 7 and 8 still surface CI failures via the existing `dispatchError` retry/skip/abort prompt (no double-prompt) — verified by regression-guard test "timeout without confirmRetry returns passed: false" plus grep confirming `stage-squash.ts` / `stage-review.ts` do not pass `confirmRetry`