### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## [0.2.0] - 2026-04-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-29
+
 ### Added
 
 - Agent pane headers now include the CLI name and installed CLI
@@ -263,4 +265,5 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Initial public release of AgentCoop.
 
+[0.2.0]: https://github.com/aicers/agentcoop/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/aicers/agentcoop/tree/0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcoop",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.12.1",


### PR DESCRIPTION
## Summary

- Bump `package.json` version from `0.1.0` to `0.2.0`.
- Promote the `Unreleased` CHANGELOG entries under a new `[0.2.0] - 2026-04-29` section and add the compare link.

Part of #302

## Test plan

- [x] `pnpm tsc --noEmit`
- [x] `pnpm biome check`
- [x] `pnpm vitest run`