### PR TITLE
Move squash-suggestion comment authoring from agent to code (#304)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Stage 8 (Squash) no longer asks the agent to author the
+  marker-delimited squash-suggestion PR comment.  The agent now
+  drafts the title and body inside a `<<<TITLE>>>` / `<<<BODY>>>`
+  envelope, and agentcoop builds the marker block (with correct
+  fence sizing) and PATCH/POSTs the comment idempotently.  The
+  formatter and parser are pinned in lock-step by a round-trip
+  unit test.  This eliminates a class of malformed-comment
+  failures where a missing end marker or unterminated fence in the
+  agent-authored comment would silently flip the stage to
+  `blocked` after the verdict cleanly returned `SUGGESTED_SINGLE`.
+- `findLatestCommentWithMarker` now returns `{ id, body }` instead
+  of just the body so callers that need to PATCH an existing
+  comment can do so without a second lookup.  Read-only callers
+  destructure `.body`.
+
 ## [0.2.0] - 2026-04-29
 
 ### Added
@@ -263,5 +282,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Initial public release of AgentCoop.
 
+[Unreleased]: https://github.com/aicers/agentcoop/compare/0.2.0...HEAD
 [0.2.0]: https://github.com/aicers/agentcoop/compare/0.1.0...0.2.0
 [0.1.0]: https://github.com/aicers/agentcoop/tree/0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,19 +18,33 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   failures where a missing end marker or unterminated fence in the
   agent-authored comment would silently flip the stage to
   `blocked` after the verdict cleanly returned `SUGGESTED_SINGLE`.
-  Envelope detection is strict — all four tags must appear on
-  their own lines, in order — so a multi-commit reply that merely
-  mentions the tag names in prose still falls through to the
-  existing verdict flow instead of pre-empting it with a
-  malformed-envelope block.  When the shape is detected but
-  content is empty, the stage sends one focused clarification turn
-  asking for either a valid envelope or a SQUASHED_MULTI / BLOCKED
-  keyword before blocking, preserving the recoverable-mistake path
-  that the verdict-clarification round already provides.
+  Envelope detection keys off a `<<<TITLE>>>` open tag on its own
+  line — prose that merely mentions the tag names mid-sentence or
+  in backticks never produces a tag on a line by itself, so a
+  multi-commit reply that quotes the tags still falls through to
+  the existing verdict flow instead of pre-empting it with a
+  malformed-envelope block.  Once envelope intent is declared, any
+  structural break (a missing close tag, an absent body section,
+  empty title or body content) classifies as malformed and routes
+  into a focused clarification turn that asks for either a valid
+  envelope or a SQUASHED_MULTI / BLOCKED keyword.  This preserves
+  the recoverable-mistake path the verdict-clarification round
+  already provides — a dropped close tag is exactly the kind of
+  formatting-only mistake the clarification turn was meant to
+  repair.
 - `findLatestCommentWithMarker` now returns `{ id, body }` instead
   of just the body so callers that need to PATCH an existing
   comment can do so without a second lookup.  Read-only callers
-  destructure `.body`.
+  destructure `.body`.  Errors from the underlying `gh api` call
+  propagate to the caller — they are no longer swallowed into
+  `undefined`.  Write-side callers like `postOrUpdateSquashSuggestion`
+  must distinguish "no matching comment" from "lookup failed" so a
+  transient auth / network / rate-limit failure does not turn an
+  idempotent PATCH into a duplicate POST; the squash stage converts
+  any thrown lookup error into a `blocked` outcome instead.
+  Read-only callers (`getSquashMergeHint` in `index.ts`, the
+  in-handler `findSuggestionCommentBody` adapter) wrap the call in
+  `try`/`catch` to silently degrade to "no matching comment".
 
 ## [0.2.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,13 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   legitimately documents the envelope contract (plausible for
   issue #304 itself) is not truncated at an in-body literal close
   marker; in-body literal tags are absorbed as content and only
-  the final own-line `<<</BODY>>>` terminates the envelope.
+  the final own-line `<<</BODY>>>` terminates the envelope.  The
+  structural close tag must additionally be the last non-blank
+  line of the response, so an envelope where the agent forgot the
+  real close tag while including an example `<<</BODY>>>` line in
+  body content classifies as malformed (and routes into the
+  clarification turn) instead of being silently accepted with a
+  truncated body.
 - `findLatestCommentWithMarker` now returns `{ id, body }` instead
   of just the body so callers that need to PATCH an existing
   comment can do so without a second lookup.  Read-only callers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   failures where a missing end marker or unterminated fence in the
   agent-authored comment would silently flip the stage to
   `blocked` after the verdict cleanly returned `SUGGESTED_SINGLE`.
+  Envelope detection is strict — all four tags must appear on
+  their own lines, in order — so a multi-commit reply that merely
+  mentions the tag names in prose still falls through to the
+  existing verdict flow instead of pre-empting it with a
+  malformed-envelope block.  When the shape is detected but
+  content is empty, the stage sends one focused clarification turn
+  asking for either a valid envelope or a SQUASHED_MULTI / BLOCKED
+  keyword before blocking, preserving the recoverable-mistake path
+  that the verdict-clarification round already provides.
 - `findLatestCommentWithMarker` now returns `{ id, body }` instead
   of just the body so callers that need to PATCH an existing
   comment can do so without a second lookup.  Read-only callers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,29 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   Read-only callers (`getSquashMergeHint` in `index.ts`, the
   in-handler `findSuggestionCommentBody` adapter) wrap the call in
   `try`/`catch` to silently degrade to "no matching comment".
+- `parseSquashSuggestionBlock` now anchors both markers to whole
+  lines and requires the end-marker line to appear at or after the
+  body's closing fence.  This prevents a literal end marker
+  embedded inside the body fenced block from truncating the parse:
+  the body fence absorbs that occurrence as content, and only a
+  free-standing end-marker line — emitted by the formatter after
+  the body fence closes — counts as the delimiter.  A round-trip
+  test pins the property for body content that mentions the end
+  marker.
+- The post-verdict path no longer promotes a historical
+  squash-suggestion comment on the PR to a SUGGESTED_SINGLE
+  outcome.  A SUGGESTED_SINGLE outcome must be backed by a current
+  `<<<TITLE>>> / <<<BODY>>>` envelope from this run.  When the
+  verdict resolves to SUGGESTED_SINGLE without an envelope, the
+  same focused clarification turn used for the malformed case
+  fires (asking for either a valid envelope or SQUASHED_MULTI /
+  BLOCKED).  The deterministic fallback chain similarly drops the
+  "valid marker block on PR → SUGGESTED_SINGLE" rule; without an
+  envelope from this run, the only deterministic signals are
+  commit-count collapse (SQUASHED_MULTI) or BLOCKED.  This closes
+  the stale-suggestion propagation problem issue #304 was meant to
+  fix, which an earlier revision still permitted via the verdict
+  path.
 
 ## [0.2.0] - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the existing verdict flow instead of pre-empting it with a
   malformed-envelope block.  Once envelope intent is declared, any
   structural break (a missing close tag, an absent body section,
-  empty title or body content) classifies as malformed and routes
-  into a focused clarification turn that asks for either a valid
-  envelope or a SQUASHED_MULTI / BLOCKED keyword.  This preserves
+  empty title, or empty / whitespace-only body content) classifies
+  as malformed and routes into a focused clarification turn that
+  asks for either a valid envelope or a SQUASHED_MULTI / BLOCKED
+  keyword.  This preserves
   the recoverable-mistake path the verdict-clarification round
   already provides — a dropped close tag is exactly the kind of
   formatting-only mistake the clarification turn was meant to
@@ -42,9 +43,17 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   transient auth / network / rate-limit failure does not turn an
   idempotent PATCH into a duplicate POST; the squash stage converts
   any thrown lookup error into a `blocked` outcome instead.
-  Read-only callers (`getSquashMergeHint` in `index.ts`, the
-  in-handler `findSuggestionCommentBody` adapter) wrap the call in
-  `try`/`catch` to silently degrade to "no matching comment".
+  `getSquashMergeHint` in `index.ts` wraps the call in `try`/`catch`
+  to silently degrade — the hint is purely cosmetic.  The squash
+  handler's read-side `findSuggestionCommentBody` adapter no longer
+  silently degrades: errors propagate to the caller, and the
+  `awaiting_user_choice` resume path now blocks on a lookup failure
+  instead of falling through to a fresh planning run.  Falling
+  through on this stateful path could re-invoke the agent and
+  re-author the suggestion or change the branch decision after the
+  user had already been presented with one; blocking leaves
+  `squashSubStep` at `awaiting_user_choice` so a retry once `gh`
+  recovers re-presents the existing choice.
 - `parseSquashSuggestionBlock` now anchors both markers to whole
   lines and requires the end-marker line to appear at or after the
   body's closing fence.  This prevents a literal end marker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the recoverable-mistake path the verdict-clarification round
   already provides — a dropped close tag is exactly the kind of
   formatting-only mistake the clarification turn was meant to
-  repair.
+  repair.  The body's structural close tag is anchored to the LAST
+  own-line `<<</BODY>>>` after BODY_OPEN, so a body that
+  legitimately documents the envelope contract (plausible for
+  issue #304 itself) is not truncated at an in-body literal close
+  marker; in-body literal tags are absorbed as content and only
+  the final own-line `<<</BODY>>>` terminates the envelope.
 - `findLatestCommentWithMarker` now returns `{ id, body }` instead
   of just the body so callers that need to PATCH an existing
   comment can do so without a second lookup.  Read-only callers

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1355,7 +1355,10 @@ and classifies the response as one of three outcomes:
   BODY_OPEN so a body that legitimately documents the envelope
   contract (plausible for issue #304 itself) is not truncated at
   an in-body literal close tag — only the final own-line
-  `<<</BODY>>>` terminates the envelope,
+  `<<</BODY>>>` terminates the envelope, and that close tag must
+  be the last non-blank line of the response so a forgotten real
+  close tag (with an in-body example present) classifies as
+  malformed instead of silently truncating the body,
   then `postOrUpdateSquashSuggestion` PATCHes the prior comment by
   id (when one exists) or POSTs a fresh one.  A transient lookup
   failure inside the write helper (auth, network, rate-limit) is

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1351,6 +1351,11 @@ and classifies the response as one of three outcomes:
   non-empty content) → agentcoop calls
   `buildSquashSuggestionComment` to render the canonical marker
   block (asserts round-trip parseability as defense-in-depth),
+  BODY_CLOSE is anchored to the LAST own-line `<<</BODY>>>` after
+  BODY_OPEN so a body that legitimately documents the envelope
+  contract (plausible for issue #304 itself) is not truncated at
+  an in-body literal close tag — only the final own-line
+  `<<</BODY>>>` terminates the envelope,
   then `postOrUpdateSquashSuggestion` PATCHes the prior comment by
   id (when one exists) or POSTs a fresh one.  A transient lookup
   failure inside the write helper (auth, network, rate-limit) is

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1338,7 +1338,12 @@ cleanup stays in Stage 9.
 
 **Envelope-driven SUGGESTED_SINGLE shortcut:** Before running the
 verdict turn, the handler scans the work response for the
-`<<<TITLE>>>` / `<<<BODY>>>` envelope.  Three outcomes:
+`<<<TITLE>>>` / `<<<BODY>>>` envelope.  Detection is **strict** —
+all four tags must appear on their own lines, in the order
+TITLE_OPEN → TITLE_CLOSE → BODY_OPEN → BODY_CLOSE — so that prose
+which merely mentions the tag names (e.g. backtick-quoted in a
+multi-commit reply explaining why the envelope was not used) is
+not mistaken for an envelope attempt.  Three outcomes:
 
 - **Well-formed envelope** → agentcoop calls
   `buildSquashSuggestionComment` to render the canonical marker
@@ -1349,12 +1354,22 @@ verdict turn, the handler scans the work response for the
   handler proceeds directly to the user-choice path.  A
   `pipeline:verdict` event with keyword `SUGGESTED_SINGLE` is
   emitted so telemetry consumers see the verdict.
-- **Malformed envelope** (at least one of the four tags present,
-  but the envelope cannot be parsed — missing close tag, empty
-  title, empty body, etc.) → fail closed with `blocked` and an
-  actionable error message.  The agent has signalled intent to
-  take the SUGGESTED_SINGLE branch; falling through to the verdict
-  turn would silently mask the formatting failure.
+- **Malformed envelope** (all four tags on their own lines and in
+  order, but content is empty — empty title or empty body) → send
+  one focused **clarification turn** asking the agent to reply
+  with either a valid envelope or a `SQUASHED_MULTI` /
+  `BLOCKED` keyword (no other commentary).  Re-parse the retry:
+  - Valid envelope → author and post the comment, proceed to the
+    user-choice path.
+  - `SQUASHED_MULTI` keyword → run the CI poll path.
+  - `BLOCKED` keyword → existing blocked flow.
+  - Anything else (still malformed, missing, or a bare
+    `SUGGESTED_SINGLE` keyword without an envelope) → fail closed
+    with `blocked` and surface both responses for diagnostics.
+  The clarification preserves the recoverable-mistake path the
+  verdict-clarification round already provides, so a single
+  formatting slip does not dump the user into "Give instruction /
+  Halt" with no context.
 - **Envelope absent** → fall through to the existing verdict /
   clarification chain.  Envelope absence on its own is not a
   SUGGESTED_SINGLE signal: the agent could be in the
@@ -1422,7 +1437,11 @@ the fallback chain.
 planning ──┬── (envelope ok)         → awaiting_user_choice
            │       ├── (agent)  → squashing → ci_poll → done
            │       └── (github) → applied_via_github (stage done)
-           ├── (envelope malformed)  → blocked
+           ├── (envelope malformed)  → clarify
+           │       ├── (envelope ok)        → awaiting_user_choice (as above)
+           │       ├── (SQUASHED_MULTI)     → ci_poll → done
+           │       ├── (BLOCKED)            → blocked
+           │       └── (still unrecoverable) → blocked
            └── (envelope absent)     → verdict
                 ├── (SQUASHED_MULTI)   → ci_poll → done
                 ├── (SUGGESTED_SINGLE) → awaiting_user_choice (as above)

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1338,27 +1338,34 @@ cleanup stays in Stage 9.
 
 **Envelope-driven SUGGESTED_SINGLE shortcut:** Before running the
 verdict turn, the handler scans the work response for the
-`<<<TITLE>>>` / `<<<BODY>>>` envelope.  Detection is **strict** —
-all four tags must appear on their own lines, in the order
-TITLE_OPEN → TITLE_CLOSE → BODY_OPEN → BODY_CLOSE — so that prose
-which merely mentions the tag names (e.g. backtick-quoted in a
-multi-commit reply explaining why the envelope was not used) is
-not mistaken for an envelope attempt.  Three outcomes:
+`<<<TITLE>>>` / `<<<BODY>>>` envelope.  Detection keys off a
+`<<<TITLE>>>` open tag on its own line — prose that merely names
+the tags mid-sentence or in backticks (e.g. a multi-commit reply
+explaining why the envelope was not used) never produces a tag on
+a line by itself, so it does not register as envelope intent.
+Once envelope intent is declared, the parser walks the structure
+and classifies the response as one of three outcomes:
 
-- **Well-formed envelope** → agentcoop calls
+- **Well-formed envelope** (TITLE_OPEN → TITLE_CLOSE → BODY_OPEN
+  → BODY_CLOSE all present on their own lines, in order, with
+  non-empty content) → agentcoop calls
   `buildSquashSuggestionComment` to render the canonical marker
   block (asserts round-trip parseability as defense-in-depth),
   then `postOrUpdateSquashSuggestion` PATCHes the prior comment by
-  id (when one exists) or POSTs a fresh one.  The verdict turn is
-  skipped — the envelope is the SUGGESTED_SINGLE signal — and the
-  handler proceeds directly to the user-choice path.  A
-  `pipeline:verdict` event with keyword `SUGGESTED_SINGLE` is
-  emitted so telemetry consumers see the verdict.
-- **Malformed envelope** (all four tags on their own lines and in
-  order, but content is empty — empty title or empty body) → send
-  one focused **clarification turn** asking the agent to reply
-  with either a valid envelope or a `SQUASHED_MULTI` /
-  `BLOCKED` keyword (no other commentary).  Re-parse the retry:
+  id (when one exists) or POSTs a fresh one.  A transient lookup
+  failure inside the write helper (auth, network, rate-limit) is
+  surfaced as a `blocked` outcome rather than POSTing a duplicate
+  suggestion comment.  The verdict turn is skipped — the envelope
+  is the SUGGESTED_SINGLE signal — and the handler proceeds
+  directly to the user-choice path.  A `pipeline:verdict` event
+  with keyword `SUGGESTED_SINGLE` is emitted so telemetry
+  consumers see the verdict.
+- **Malformed envelope** (envelope intent declared but the
+  structure is broken: a missing close tag, an absent body
+  section, or empty title / body content) → send one focused
+  **clarification turn** asking the agent to reply with either a
+  valid envelope or a `SQUASHED_MULTI` / `BLOCKED` keyword (no
+  other commentary).  Re-parse the retry:
   - Valid envelope → author and post the comment, proceed to the
     user-choice path.
   - `SQUASHED_MULTI` keyword → run the CI poll path.
@@ -1368,12 +1375,18 @@ not mistaken for an envelope attempt.  Three outcomes:
     with `blocked` and surface both responses for diagnostics.
   The clarification preserves the recoverable-mistake path the
   verdict-clarification round already provides, so a single
-  formatting slip does not dump the user into "Give instruction /
-  Halt" with no context.
-- **Envelope absent** → fall through to the existing verdict /
-  clarification chain.  Envelope absence on its own is not a
-  SUGGESTED_SINGLE signal: the agent could be in the
-  SQUASHED_MULTI branch, or BLOCKED, or simply ambiguous.
+  formatting slip — including a dropped close tag, exactly the
+  failure mode that caused the original issue — does not dump the
+  user into "Give instruction / Halt" with no context.  Falling
+  through to the verdict path instead would either hard-block
+  opaquely (when the verdict comes back as SUGGESTED_SINGLE
+  without an envelope to draw from) or quietly reuse a stale
+  prior suggestion comment from an earlier run.
+- **Envelope absent** (no `<<<TITLE>>>` tag on its own line) →
+  fall through to the existing verdict / clarification chain.
+  Envelope absence on its own is not a SUGGESTED_SINGLE signal:
+  the agent could be in the SQUASHED_MULTI branch, or BLOCKED,
+  or simply ambiguous.
 
 **Verdict handling** (only reached when the envelope is absent):
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1393,31 +1393,22 @@ and classifies the response as one of three outcomes:
 - `SQUASHED_MULTI` → poll CI after the force-push (existing
   behaviour, up to 3 internal fix attempts) and finish with
   `squash.completed` when CI passes.
-- `SUGGESTED_SINGLE` → defense-in-depth check that a fully
-  parseable suggestion block is present in the squash-suggestion
-  PR comment before asking the user.  "Parseable" means both
-  markers are present **and** `parseSquashSuggestionBlock`
-  succeeds (the block contains a `**Title**` label followed by a
-  well-formed fenced block).  A bare start marker or a block
-  missing the `**Title**` label / the end marker fails closed
-  with `blocked` rather than completing as if the suggestion were
-  valid — Stage 9 reads the same block to render the inline
-  preview, so a malformed block would leave the merge-confirm
-  screen blank.  This path runs only when an earlier run (or the
-  legacy agent-authored fallback) left a comment behind; on the
-  primary path, the comment was just authored by agentcoop and
-  has already been asserted parseable.  Once validated, ask the
-  user via `chooseSquashApplyMode` (skipped when the startup
-  `squashApplyPolicy` is `"auto"`, in which case the handler
-  proceeds as if the user picked `"agent"`):
-  - **"Agent squashes now"** → send a follow-up prompt on the
-    same session telling the agent to perform the squash using
-    the message it already drafted, then run the post-squash CI
-    poll loop.
-  - **"Apply via GitHub"** → finish the stage with
-    `squash.messageAppended` and persist
-    `squashSubStep === "applied_via_github"` so Stage 9 surfaces
-    the suggestion in the merge-confirm screen.  No CI rerun.
+- `SUGGESTED_SINGLE` → the agent declared SUGGESTED_SINGLE in the
+  verdict turn but never provided a `<<<TITLE>>> / <<<BODY>>>`
+  envelope in any earlier response.  Agentcoop does **not**
+  consume a historical squash-suggestion comment from an earlier
+  run as evidence here — that would propagate the stale-suggestion
+  problem this stage was redesigned to fix (issue #304).  Instead,
+  the same focused envelope clarification turn used for the
+  malformed case fires, asking for either a valid envelope or a
+  `SQUASHED_MULTI` / `BLOCKED` keyword.  On retry: a valid
+  envelope → author and post the comment + ask the user;
+  `SQUASHED_MULTI` → CI poll; `BLOCKED` → blocked; anything else
+  → blocked with both responses surfaced.  Before sending the
+  clarification, the PR-merged guard fires so a concurrent merge
+  during the verdict round short-circuits to `alreadyMerged`
+  instead of asking the agent to draft a suggestion for a closed
+  branch.
 - `BLOCKED` → existing blocked flow.
 
 **Ambiguous response handling:** Same internal clarification
@@ -1428,16 +1419,18 @@ fails, the handler runs a **deterministic fallback chain**:
    snapshot taken at stage entry, treat as `SQUASHED_MULTI` (the
    force-push has already happened — that hard-to-undo side
    effect must be detected first).
-2. Else, fetch the squash-suggestion PR comment and check for a
-   fully parseable suggestion block (markers present **and**
-   `parseSquashSuggestionBlock` returns a value).  If present,
-   treat as `SUGGESTED_SINGLE`; a malformed block (e.g. only the
-   start marker) is treated as missing.
+2. Else, run the PR-merged guard.  If the PR was concurrently
+   merged on GitHub, return `alreadyMerged` instead of falling
+   through to BLOCKED.
 3. Else, treat as `BLOCKED`.
 
-The order matters: checking the commit count first prevents a
-completed squash from being misclassified as a SINGLE suggestion
-when an earlier run left a stale marker comment on the PR.
+The fallback chain deliberately does **not** promote a historical
+squash-suggestion comment on the PR to a `SUGGESTED_SINGLE`
+verdict.  Without an envelope from this run, the only
+deterministic signals are commit-count collapse (`SQUASHED_MULTI`)
+or `BLOCKED`.  Promoting a stale marker block here would
+re-introduce the stale-suggestion propagation issue #304 was
+written to fix.
 
 The derived verdict is emitted as a `pipeline:verdict` event just
 like a parsed-keyword verdict, so telemetry consumers see every
@@ -1457,8 +1450,13 @@ planning ──┬── (envelope ok)         → awaiting_user_choice
            │       └── (still unrecoverable) → blocked
            └── (envelope absent)     → verdict
                 ├── (SQUASHED_MULTI)   → ci_poll → done
-                ├── (SUGGESTED_SINGLE) → awaiting_user_choice (as above)
-                └── (BLOCKED)          → user chooses
+                ├── (SUGGESTED_SINGLE) → clarify  (no stale-comment promotion;
+                │                        a current envelope is required)
+                │       ├── (envelope ok)        → awaiting_user_choice
+                │       ├── (SQUASHED_MULTI)     → ci_poll → done
+                │       ├── (BLOCKED)            → blocked
+                │       └── (still unrecoverable) → blocked
+                └── (BLOCKED)          → blocked
 ```
 
 `RunState.squashSubStep` persists the current substate so resume

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1362,7 +1362,8 @@ and classifies the response as one of three outcomes:
   consumers see the verdict.
 - **Malformed envelope** (envelope intent declared but the
   structure is broken: a missing close tag, an absent body
-  section, or empty title / body content) → send one focused
+  section, or empty / whitespace-only title or body content) →
+  send one focused
   **clarification turn** asking the agent to reply with either a
   valid envelope or a `SQUASHED_MULTI` / `BLOCKED` keyword (no
   other commentary).  Re-parse the retry:
@@ -1468,7 +1469,14 @@ re-enters at the correct point:
   the verdict path); if present, re-present the user choice without
   re-invoking the agent.  If absent or malformed, fall back to
   `planning` rather than re-presenting a choice the user could not
-  act on.  If
+  act on.  If the comment lookup itself **throws** (a transient
+  `gh api` failure: auth, network, rate limit), the stage fails
+  closed with `blocked` and leaves `squashSubStep` at
+  `awaiting_user_choice` so a retry once `gh` recovers re-presents
+  the existing choice — silently degrading to "no matching comment"
+  here would fall through to a fresh planning run, re-invoke the
+  agent, and could re-author the suggestion or change the branch
+  decision after the user had already been asked about one.  If
   the user then picks "agent squashes now" but no agent session is
   available (neither the saved run state nor the current verdict
   produced a session ID), the stage fails closed with `blocked`

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -142,16 +142,18 @@ The standard PR sync instructions appear in stages 5 through 8:
 
 The squash stage extends this contract with a marker-delimited
 **squash suggestion block**.  When a single commit is the right
-shape for the branch, the agent posts the proposed title and body
-as a PR comment whose body contains the marker block
-`<!-- agentcoop:squash-suggestion:start -->` …
-`<!-- agentcoop:squash-suggestion:end -->` instead of force-pushing.
-The comment is updated idempotently — re-runs PATCH any prior
-squash-suggestion comment rather than appending a new one so the
-timeline stays close to the "Squash and merge" dropdown.  The
-Stage 9 merge-confirm screen reads this block back so the user can
-apply the message via GitHub's "Squash and merge" without opening
-the browser.
+shape for the branch, the agent drafts the proposed title and body
+inside a `<<<TITLE>>>` / `<<<BODY>>>` envelope in its reply, and
+agentcoop authors the marker-delimited PR comment
+(`<!-- agentcoop:squash-suggestion:start -->` …
+`<!-- agentcoop:squash-suggestion:end -->`) from those fields
+deterministically — fence sizing, marker placement, and idempotent
+PATCH/POST bookkeeping are all owned by the code, not the agent.
+Re-runs PATCH any prior squash-suggestion comment rather than
+appending a new one so the timeline stays close to the "Squash and
+merge" dropdown.  The Stage 9 merge-confirm screen reads this block
+back so the user can apply the message via GitHub's "Squash and
+merge" without opening the browser.
 
 ### Issue-implementation reconciliation
 
@@ -1259,11 +1261,12 @@ avoiding re-execution of already-completed work within a round.
 
 **Agent:** A\
 **Purpose:** Decide whether the branch is best presented as a
-single squash commit (in which case the agent posts the suggested
-message as a PR comment and lets GitHub's "Squash and merge"
-apply it at merge time) or several meaningful commits (rewrite
-history and force-push).  Skipped automatically if the branch has
-only one commit.
+single squash commit (in which case the agent drafts the suggested
+title and body and agentcoop posts the marker-delimited PR comment,
+letting GitHub's "Squash and merge" apply the message at merge
+time) or several meaningful commits (rewrite history and
+force-push).  Skipped automatically if the branch has only one
+commit.
 
 The single-commit suggestion path was added to avoid wasting an
 extra CI cycle on a force-push that GitHub's "Squash and merge"
@@ -1276,37 +1279,25 @@ The work prompt asks the agent to:
 1. Sync the PR description (standard PR-sync instructions).
 2. Decide whether the work belongs in **one** commit or **several**.
 3. Branch on that decision:
-   - **Single commit appropriate:** do not rewrite history.  Draft
-     the squash title and body, then post them as a PR comment whose
-     body contains the marker block
-     `<!-- agentcoop:squash-suggestion:start -->` …
-     `<!-- agentcoop:squash-suggestion:end -->`.  Inside the marker
-     block, each field is wrapped in its own CommonMark fenced code
-     block under a `**Title**` / `**Body**` label.  GitHub renders a
-     one-click copy icon on a fenced block, and the fence preserves
-     content verbatim so Markdown-active characters (`*`, `` ` ``,
-     `_`, leading `#`, `>`, backslashes) survive a drag-select
-     paste.
-
-     The opening and closing fence length is computed independently
-     for each field as
-     `fence_len = max(longest run of backticks in the content, 2) + 1`
-     (minimum 3).  This lets a body that itself contains a
-     triple-backtick code sample (e.g. a README excerpt) round up
-     to a four-or-more-backtick outer fence so the inner fence does
-     not close the outer block early.  Stage 9 reads the same block
-     via `parseSquashSuggestionBlock`, which mirrors the CommonMark
-     rule (closing fence ≥ opening, same character).  Only the
-     fenced format is accepted — the earlier `**Title:** …` /
-     `**Body:** …` plain-text format was supported for one release
-     cycle and has since been removed; a stale legacy block is
-     treated as missing.
-
-     Post idempotently: if a prior comment with the same start
-     marker exists, edit it via `gh api --method PATCH
-     /repos/{owner}/{repo}/issues/comments/{id}` so the timeline
-     does not accumulate duplicates.  The PR body is left untouched.
-     Do not force-push.
+   - **Single commit appropriate:** do not rewrite history, do not
+     force-push, and do not post or edit any PR comment yourself.
+     Draft the squash title and body, then reply with them wrapped
+     in a `<<<TITLE>>>...<<</TITLE>>>` / `<<<BODY>>>...<<</BODY>>>`
+     envelope.  agentcoop parses the envelope, builds the
+     marker-delimited PR comment from those fields
+     (`<!-- agentcoop:squash-suggestion:start -->` …
+     `<!-- agentcoop:squash-suggestion:end -->`, with each field
+     under a `**Title**` / `**Body**` label inside its own fenced
+     code block), and PATCH/POSTs the comment idempotently.  Fence
+     sizing follows the CommonMark rule
+     `fence_len = max(longest backtick run in content, 2) + 1`
+     (minimum 3) so a body that itself contains triple-backtick
+     samples gets a four-or-more-backtick outer fence and the inner
+     fence cannot close the outer block early.  Stage 9 reads the
+     same block via `parseSquashSuggestionBlock` (closing fence ≥
+     opening, same character) to render the inline preview.  The
+     formatter and parser are pinned in lock-step by a round-trip
+     unit test.
    - **Multiple commits appropriate:** consolidate the branch
      commits — using `git reset --soft {baseSha}` + `git commit` or
      interactive rebase — write clear messages, and force-push
@@ -1321,8 +1312,8 @@ of the following keywords:
 - SQUASHED_MULTI — if you rewrote history into multiple meaningful
   commits and force-pushed
 - SUGGESTED_SINGLE — if a single commit is appropriate and you
-  posted the suggested title/body as a PR comment containing the
-  marker block (no force-push)
+  drafted the suggested title and body in the
+  `<<<TITLE>>>` / `<<<BODY>>>` envelope (no force-push)
 - BLOCKED — if you could not complete either path and need user
   intervention
 
@@ -1345,24 +1336,52 @@ open PR.  Stage 8 cannot reuse Stage 9's `ensurePrStillOpen`
 helper because the Done stage owns the worktree lifecycle —
 cleanup stays in Stage 9.
 
-**Verdict handling:**
+**Envelope-driven SUGGESTED_SINGLE shortcut:** Before running the
+verdict turn, the handler scans the work response for the
+`<<<TITLE>>>` / `<<<BODY>>>` envelope.  Three outcomes:
+
+- **Well-formed envelope** → agentcoop calls
+  `buildSquashSuggestionComment` to render the canonical marker
+  block (asserts round-trip parseability as defense-in-depth),
+  then `postOrUpdateSquashSuggestion` PATCHes the prior comment by
+  id (when one exists) or POSTs a fresh one.  The verdict turn is
+  skipped — the envelope is the SUGGESTED_SINGLE signal — and the
+  handler proceeds directly to the user-choice path.  A
+  `pipeline:verdict` event with keyword `SUGGESTED_SINGLE` is
+  emitted so telemetry consumers see the verdict.
+- **Malformed envelope** (at least one of the four tags present,
+  but the envelope cannot be parsed — missing close tag, empty
+  title, empty body, etc.) → fail closed with `blocked` and an
+  actionable error message.  The agent has signalled intent to
+  take the SUGGESTED_SINGLE branch; falling through to the verdict
+  turn would silently mask the formatting failure.
+- **Envelope absent** → fall through to the existing verdict /
+  clarification chain.  Envelope absence on its own is not a
+  SUGGESTED_SINGLE signal: the agent could be in the
+  SQUASHED_MULTI branch, or BLOCKED, or simply ambiguous.
+
+**Verdict handling** (only reached when the envelope is absent):
 
 - `SQUASHED_MULTI` → poll CI after the force-push (existing
   behaviour, up to 3 internal fix attempts) and finish with
   `squash.completed` when CI passes.
-- `SUGGESTED_SINGLE` → verify a fully parseable suggestion block is
-  present in the squash-suggestion PR comment before asking the
-  user.  "Parseable" means both markers are present **and**
-  `parseSquashSuggestionBlock` succeeds (the block contains a
-  `**Title**` label followed by a well-formed fenced block).  A
-  bare start marker or a block missing the `**Title**` label / the
-  end marker fails closed with `blocked` rather than completing as
-  if the suggestion were valid — Stage 9 reads the same block via
-  `parseSquashSuggestionBlock` to render the inline preview, so a
-  malformed block would leave the merge-confirm screen blank.  Once
-  validated, ask the user via `chooseSquashApplyMode` (skipped when
-  the startup `squashApplyPolicy` is `"auto"`, in which case the
-  handler proceeds as if the user picked `"agent"`):
+- `SUGGESTED_SINGLE` → defense-in-depth check that a fully
+  parseable suggestion block is present in the squash-suggestion
+  PR comment before asking the user.  "Parseable" means both
+  markers are present **and** `parseSquashSuggestionBlock`
+  succeeds (the block contains a `**Title**` label followed by a
+  well-formed fenced block).  A bare start marker or a block
+  missing the `**Title**` label / the end marker fails closed
+  with `blocked` rather than completing as if the suggestion were
+  valid — Stage 9 reads the same block to render the inline
+  preview, so a malformed block would leave the merge-confirm
+  screen blank.  This path runs only when an earlier run (or the
+  legacy agent-authored fallback) left a comment behind; on the
+  primary path, the comment was just authored by agentcoop and
+  has already been asserted parseable.  Once validated, ask the
+  user via `chooseSquashApplyMode` (skipped when the startup
+  `squashApplyPolicy` is `"auto"`, in which case the handler
+  proceeds as if the user picked `"agent"`):
   - **"Agent squashes now"** → send a follow-up prompt on the
     same session telling the agent to perform the squash using
     the message it already drafted, then run the post-squash CI
@@ -1400,12 +1419,14 @@ the fallback chain.
 **`SquashSubStep` state machine:**
 
 ```text
-planning → verdict
-        ├── (SQUASHED_MULTI)   → ci_poll → done
-        ├── (SUGGESTED_SINGLE) → awaiting_user_choice
-        │       ├── (agent)  → squashing → ci_poll → done
-        │       └── (github) → applied_via_github (stage done)
-        └── (BLOCKED)         → user chooses
+planning ──┬── (envelope ok)         → awaiting_user_choice
+           │       ├── (agent)  → squashing → ci_poll → done
+           │       └── (github) → applied_via_github (stage done)
+           ├── (envelope malformed)  → blocked
+           └── (envelope absent)     → verdict
+                ├── (SQUASHED_MULTI)   → ci_poll → done
+                ├── (SUGGESTED_SINGLE) → awaiting_user_choice (as above)
+                └── (BLOCKED)          → user chooses
 ```
 
 `RunState.squashSubStep` persists the current substate so resume

--- a/src/fetch-pr-comments.test.ts
+++ b/src/fetch-pr-comments.test.ts
@@ -96,12 +96,16 @@ describe("findLatestCommentWithMarker", () => {
     });
   });
 
-  test("returns undefined when the gh call throws", () => {
+  test("propagates errors when the gh call throws", () => {
+    // Issue #304 reviewer round 2: lookup failures must surface to the
+    // caller so the write side can distinguish "no matching comment"
+    // from "lookup failed" and refuse to POST a duplicate suggestion
+    // comment on a transient API blip.
     mockExecFileSync.mockImplementation(() => {
       throw new Error("boom");
     });
-    expect(
-      findLatestCommentWithMarker("org", "repo", 1, MARKER),
-    ).toBeUndefined();
+    expect(() => findLatestCommentWithMarker("org", "repo", 1, MARKER)).toThrow(
+      "boom",
+    );
   });
 });

--- a/src/fetch-pr-comments.test.ts
+++ b/src/fetch-pr-comments.test.ts
@@ -72,18 +72,28 @@ describe("findLatestCommentWithMarker", () => {
     ).toBeUndefined();
   });
 
-  test("returns the body of the latest matching comment", () => {
+  test("returns the id and body of the latest matching comment", () => {
     // Older matching comment followed by a newer matching comment —
     // the newer one wins.
     const page = [
-      { body: `older ${MARKER} v1`, user: { login: "a" } },
-      { body: "noise", user: { login: "b" } },
-      { body: `newer ${MARKER} v2`, user: { login: "a" } },
+      { id: 11, body: `older ${MARKER} v1`, user: { login: "a" } },
+      { id: 12, body: "noise", user: { login: "b" } },
+      { id: 13, body: `newer ${MARKER} v2`, user: { login: "a" } },
     ];
     mockExecFileSync.mockReturnValue(JSON.stringify([page]));
-    expect(findLatestCommentWithMarker("org", "repo", 1, MARKER)).toBe(
-      `newer ${MARKER} v2`,
-    );
+    expect(findLatestCommentWithMarker("org", "repo", 1, MARKER)).toEqual({
+      id: 13,
+      body: `newer ${MARKER} v2`,
+    });
+  });
+
+  test("returns id undefined when API response omits id", () => {
+    const page = [{ body: `body ${MARKER}`, user: { login: "a" } }];
+    mockExecFileSync.mockReturnValue(JSON.stringify([page]));
+    expect(findLatestCommentWithMarker("org", "repo", 1, MARKER)).toEqual({
+      id: undefined,
+      body: `body ${MARKER}`,
+    });
   });
 
   test("returns undefined when the gh call throws", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -876,15 +876,22 @@ try {
     getSquashMergeHint: () => {
       if (runState.squashSubStep !== "applied_via_github") return undefined;
       const prNum = runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
-      const commentBody =
-        prNum !== undefined
-          ? findLatestCommentWithMarker(
-              owner,
-              repo,
-              prNum,
-              SQUASH_SUGGESTION_START_MARKER,
-            )?.body
-          : undefined;
+      // Read-side: silently degrade to "no comment" on transient
+      // lookup failure; this hint is purely cosmetic and the write
+      // side has its own error-propagating path.
+      let commentBody: string | undefined;
+      if (prNum !== undefined) {
+        try {
+          commentBody = findLatestCommentWithMarker(
+            owner,
+            repo,
+            prNum,
+            SQUASH_SUGGESTION_START_MARKER,
+          )?.body;
+        } catch {
+          commentBody = undefined;
+        }
+      }
       const suggestion = parseSquashSuggestionBlock(commentBody);
       const prUrl =
         prNum !== undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -883,7 +883,7 @@ try {
               repo,
               prNum,
               SQUASH_SUGGESTION_START_MARKER,
-            )
+            )?.body
           : undefined;
       const suggestion = parseSquashSuggestionBlock(commentBody);
       const prUrl =

--- a/src/pr-comments.ts
+++ b/src/pr-comments.ts
@@ -13,6 +13,7 @@ import type { ReviewSubStep, RunState } from "./run-state.js";
 // ---- types ---------------------------------------------------------------
 
 export interface PrComment {
+  id?: number;
   body: string;
   user: { login: string };
 }
@@ -110,33 +111,64 @@ export function postPrComment(
   );
 }
 
+/**
+ * Edit an existing issue/PR comment by id.
+ *
+ * The body is sent via stdin as a JSON request payload so that
+ * arbitrary multi-line content (including leading `@`, fences, and
+ * other characters that confuse `gh api`'s `-f key=value` parsing)
+ * is preserved verbatim.
+ */
+export function patchPrComment(
+  owner: string,
+  repo: string,
+  commentId: number,
+  body: string,
+): void {
+  execFileSync(
+    "gh",
+    [
+      "api",
+      "--method",
+      "PATCH",
+      `/repos/${owner}/${repo}/issues/comments/${commentId}`,
+      "--input",
+      "-",
+    ],
+    { encoding: "utf-8", input: JSON.stringify({ body }) },
+  );
+}
+
 // ---- marker-lookup helper ------------------------------------------------
 
 /**
  * Find the most recent PR comment whose body contains `marker`.
  *
- * Returns the body of the latest matching comment (the last one in
- * chronological order returned by `gh`), or `undefined` when no
+ * Returns `{ id, body }` for the latest matching comment (the last one
+ * in chronological order returned by `gh`), or `undefined` when no
  * comment matches, the PR cannot be resolved, or the API call fails.
  *
- * Callers that need the suggestion text parsed should wrap the
- * returned body with a parser (e.g. `parseSquashSuggestionBlock`).
+ * The id is required by callers that want to PATCH the comment
+ * idempotently rather than posting a new one; read-only callers can
+ * destructure `.body`.  When the upstream API response omits the id
+ * (older fixtures, manual stubs), id is `undefined` and PATCH callers
+ * must fall back to POST.
  */
 export function findLatestCommentWithMarker(
   owner: string,
   repo: string,
   prNumber: number,
   marker: string,
-): string | undefined {
+): { id: number | undefined; body: string } | undefined {
   let comments: PrComment[];
   try {
     comments = fetchPrComments(owner, repo, prNumber);
   } catch {
     return undefined;
   }
-  let latest: string | undefined;
+  let latest: { id: number | undefined; body: string } | undefined;
   for (const c of comments) {
-    if (c.body.includes(marker)) latest = c.body;
+    if (c.body.includes(marker)) latest = { id: c.id, body: c.body };
   }
   return latest;
 }

--- a/src/pr-comments.ts
+++ b/src/pr-comments.ts
@@ -145,8 +145,17 @@ export function patchPrComment(
  * Find the most recent PR comment whose body contains `marker`.
  *
  * Returns `{ id, body }` for the latest matching comment (the last one
- * in chronological order returned by `gh`), or `undefined` when no
- * comment matches, the PR cannot be resolved, or the API call fails.
+ * in chronological order returned by `gh`), or `undefined` only when
+ * the lookup succeeded and no comment matched.
+ *
+ * Errors from the underlying `gh api` call (network, auth, rate
+ * limit) propagate to the caller — they are NOT swallowed into
+ * `undefined`.  Write-side callers like
+ * `postOrUpdateSquashSuggestion` must distinguish "no matching
+ * comment" from "lookup failed" so a transient failure does not turn
+ * an idempotent PATCH into a duplicate POST.  Read-only callers that
+ * prefer to silently degrade should wrap this with `try`/`catch`
+ * themselves.
  *
  * The id is required by callers that want to PATCH the comment
  * idempotently rather than posting a new one; read-only callers can
@@ -160,12 +169,7 @@ export function findLatestCommentWithMarker(
   prNumber: number,
   marker: string,
 ): { id: number | undefined; body: string } | undefined {
-  let comments: PrComment[];
-  try {
-    comments = fetchPrComments(owner, repo, prNumber);
-  } catch {
-    return undefined;
-  }
+  const comments = fetchPrComments(owner, repo, prNumber);
   let latest: { id: number | undefined; body: string } | undefined;
   for (const c of comments) {
     if (c.body.includes(marker)) latest = { id: c.id, body: c.body };

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -744,35 +744,37 @@ describe("createSquashStageHandler", () => {
 
   // -- SUGGESTED_SINGLE: user picks "agent" ----------------------------------
 
-  test("SUGGESTED_SINGLE + user picks agent → follow-up + CI poll runs", async () => {
-    const prBodyWithMarker = `Hello\n${SQUASH_SUGGESTION_START_MARKER}\n## Suggested squash commit\n\n**Title**\n\n\`\`\`text\nMy title\n\`\`\`\n\n**Body**\n\n\`\`\`text\nLine\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
-    let resumeCall = 0;
-    const resumeResults = [
-      makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-      makeStream(
-        makeResult({
-          sessionId: "sess-followup",
-          responseText: "Squashed and pushed.",
-        }),
-      ),
-    ];
+  test("SUGGESTED_SINGLE envelope + user picks agent → follow-up + CI poll runs", async () => {
+    // Envelope-driven SUGGESTED_SINGLE shortcut: agent returns the
+    // title/body envelope on the work turn, agentcoop authors and posts
+    // the comment, asks the user, and on "agent" sends one follow-up
+    // squash prompt before polling CI.  No verdict turn fires.
+    const envelopeText =
+      "<<<TITLE>>>\nMy title\n<<</TITLE>>>\n\n<<<BODY>>>\nLine\n<<</BODY>>>";
     const agent: AgentAdapter = {
-      invoke: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(
-            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
-          ),
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelopeText,
+          }),
         ),
-      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+      ),
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      ),
     };
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
-    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
     const onSquashSubStep = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      findSuggestionCommentBody,
+      postSuggestionComment: vi.fn(),
       onSquashSubStep,
     });
     const stage = createSquashStageHandler(opts);
@@ -781,7 +783,8 @@ describe("createSquashStageHandler", () => {
     expect(result.outcome).toBe("completed");
     expect(result.message).toContain("CI passed");
     expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
-    expect(agent.resume).toHaveBeenCalledTimes(2); // verdict + follow-up
+    // No verdict turn — only the agent-squash follow-up resume.
+    expect(agent.resume).toHaveBeenCalledTimes(1);
     expect(opts.getCiStatus).toHaveBeenCalled();
     const states = onSquashSubStep.mock.calls.map((c) => c[0]);
     expect(states).toContain("planning");
@@ -792,30 +795,27 @@ describe("createSquashStageHandler", () => {
 
   // -- SUGGESTED_SINGLE: user picks "github" ---------------------------------
 
-  test("SUGGESTED_SINGLE + user picks github → no CI poll, applied_via_github", async () => {
-    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+  test("SUGGESTED_SINGLE envelope + user picks github → no CI poll, applied_via_github", async () => {
+    const envelopeText =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
     const agent: AgentAdapter = {
-      invoke: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(
-            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
-          ),
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelopeText,
+          }),
         ),
-      resume: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-        ),
+      ),
+      resume: vi.fn(),
     };
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
-    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
     const onSquashSubStep = vi.fn();
     const getCiStatus = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      findSuggestionCommentBody,
+      postSuggestionComment: vi.fn(),
       onSquashSubStep,
       getCiStatus,
     });
@@ -829,9 +829,28 @@ describe("createSquashStageHandler", () => {
     expect(states[states.length - 1]).toBe("applied_via_github");
   });
 
-  // -- SUGGESTED_SINGLE missing marker → BLOCKED -----------------------------
-
-  test("SUGGESTED_SINGLE with missing marker block → blocked", async () => {
+  // -- verdict SUGGESTED_SINGLE without envelope → clarification, then BLOCKED
+  //
+  // Issue #304 reviewer round 3: a SUGGESTED_SINGLE outcome must be
+  // backed by a current title/body envelope from this run.  The agent
+  // never returned an envelope on the work turn, then the verdict turn
+  // emitted SUGGESTED_SINGLE without one.  Agentcoop must NOT consume a
+  // historical PR comment — instead it sends the envelope clarification
+  // turn.  When the retry also fails to produce an envelope (and is not
+  // SQUASHED_MULTI / BLOCKED), the stage blocks with an explanation.
+  test("verdict SUGGESTED_SINGLE without envelope → clarification asked, blocked when retry still has no envelope", async () => {
+    const findSuggestionCommentBody = vi.fn().mockReturnValue(
+      // Stale historical comment (from a prior run) on the PR.  The
+      // post-verdict path must NOT consume this as evidence.
+      `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nstale\n\`\`\`\n\n**Body**\n\n\`\`\`text\nstale body\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`,
+    );
+    let resumeCall = 0;
+    const resumeResults = [
+      // Verdict turn → SUGGESTED_SINGLE without an envelope.
+      makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+      // Envelope clarification retry → still no envelope, just prose.
+      makeStream(makeResult({ responseText: "still no envelope" })),
+    ];
     const agent: AgentAdapter = {
       invoke: vi
         .fn()
@@ -840,28 +859,47 @@ describe("createSquashStageHandler", () => {
             makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
           ),
         ),
-      resume: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-        ),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
     };
+    const chooseSquashApplyMode = vi.fn();
+    const postSuggestionComment = vi.fn();
     const opts = makeOpts({
       agent,
-      findSuggestionCommentBody: vi
-        .fn()
-        .mockReturnValue("body without any marker"),
+      findSuggestionCommentBody,
+      chooseSquashApplyMode,
+      postSuggestionComment,
     });
     const stage = createSquashStageHandler(opts);
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("envelope still unrecoverable");
+    // The stale historical comment must NOT have been consumed.
+    expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+    expect(postSuggestionComment).not.toHaveBeenCalled();
+    // Verdict turn + clarification turn = 2 resume calls.
+    expect(agent.resume).toHaveBeenCalledTimes(2);
   });
 
-  // -- PR already merged short-circuit ---------------------------------------
-
-  test("SUGGESTED_SINGLE + PR already merged before user prompt → alreadyMerged, no chooseSquashApplyMode call", async () => {
-    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+  // Companion: when the verdict-SUGGESTED_SINGLE clarification retry
+  // produces a valid envelope, the stage authors and posts the comment
+  // from the FRESH envelope (not the stale historical comment).
+  test("verdict SUGGESTED_SINGLE without envelope → clarification recovers via valid envelope retry", async () => {
+    const findSuggestionCommentBody = vi
+      .fn()
+      .mockReturnValue(
+        `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nstale\n\`\`\`\n\n**Body**\n\n\`\`\`text\nstale body\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`,
+      );
+    let resumeCall = 0;
+    const resumeResults = [
+      makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+      makeStream(
+        makeResult({
+          responseText:
+            "<<<TITLE>>>\nFresh title\n<<</TITLE>>>\n\n<<<BODY>>>\nFresh body\n<<</BODY>>>",
+        }),
+      ),
+    ];
     const agent: AgentAdapter = {
       invoke: vi
         .fn()
@@ -870,21 +908,58 @@ describe("createSquashStageHandler", () => {
             makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
           ),
         ),
-      resume: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+    };
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+    const postSuggestionComment = vi.fn();
+    const opts = makeOpts({
+      agent,
+      findSuggestionCommentBody,
+      chooseSquashApplyMode,
+      postSuggestionComment,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(postSuggestionComment).toHaveBeenCalledTimes(1);
+    // The posted body comes from the FRESH retry envelope, not the
+    // stale historical comment.
+    const postedBody = postSuggestionComment.mock.calls[0][3] as string;
+    expect(postedBody).toContain("Fresh title");
+    expect(postedBody).toContain("Fresh body");
+    expect(postedBody).not.toContain("stale");
+  });
+
+  // -- PR already merged short-circuit ---------------------------------------
+
+  test("envelope SUGGESTED_SINGLE + PR already merged before user prompt → alreadyMerged, no chooseSquashApplyMode call", async () => {
+    const envelopeText =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelopeText,
+          }),
         ),
+      ),
+      resume: vi.fn(),
     };
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
-    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const postSuggestionComment = vi.fn();
+    // `findPrNumber` returns `undefined` once the PR is merged because
+    // `gh pr list` filters to open PRs by default.
+    const findPrNumber = vi.fn().mockReturnValue(undefined);
     const queryPrState = vi.fn().mockReturnValue("MERGED");
     const onSquashSubStep = vi.fn();
     const getCiStatus = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      findSuggestionCommentBody,
+      postSuggestionComment,
+      findPrNumber,
       queryPrState,
       onSquashSubStep,
       getCiStatus,
@@ -895,44 +970,40 @@ describe("createSquashStageHandler", () => {
     expect(result.outcome).toBe("completed");
     expect(result.message).toContain("already merged");
     expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+    expect(postSuggestionComment).not.toHaveBeenCalled();
     expect(getCiStatus).not.toHaveBeenCalled();
     expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
     // Sub-step must be cleared so a resume does not re-enter the dead choice.
     expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
   });
 
-  // Regression for issue #274 reviewer round 1: on the immediate
-  // SUGGESTED_SINGLE branch, the PR-merged guard must also run
-  // BEFORE the suggestion-comment lookup.  `findPrNumber` uses
-  // `gh pr list` (open PRs only), so a concurrent merge would make
-  // the comment lookup return `undefined` and the stage would flip
-  // to `BLOCKED` instead of short-circuiting to `alreadyMerged`.
-  test("SUGGESTED_SINGLE + concurrent merge hides the PR from findPrNumber → alreadyMerged, not blocked", async () => {
+  // Regression for issue #274 reviewer round 1, retained for the
+  // envelope path: when the PR is merged concurrently and `findPrNumber`
+  // returns `undefined`, the SUGGESTED_SINGLE branch must short-circuit
+  // to `alreadyMerged` rather than blocking on the missing PR number.
+  test("envelope SUGGESTED_SINGLE + concurrent merge hides the PR from findPrNumber → alreadyMerged, not blocked", async () => {
+    const envelopeText =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
     const agent: AgentAdapter = {
-      invoke: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(
-            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
-          ),
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelopeText,
+          }),
         ),
-      resume: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-        ),
+      ),
+      resume: vi.fn(),
     };
-    // `findPrNumber` returns `undefined` once the PR is merged
-    // because `gh pr list` filters to open PRs by default.
     const findPrNumber = vi.fn().mockReturnValue(undefined);
-    const findSuggestionCommentBody = vi.fn();
+    const postSuggestionComment = vi.fn();
     const chooseSquashApplyMode = vi.fn();
     const queryPrState = vi.fn().mockReturnValue("MERGED");
     const onSquashSubStep = vi.fn();
     const opts = makeOpts({
       agent,
       findPrNumber,
-      findSuggestionCommentBody,
+      postSuggestionComment,
       chooseSquashApplyMode,
       queryPrState,
       onSquashSubStep,
@@ -942,45 +1013,38 @@ describe("createSquashStageHandler", () => {
 
     expect(result.outcome).toBe("completed");
     expect(result.message).toContain("already merged");
-    // Guard runs before the comment lookup.
-    expect(findPrNumber).not.toHaveBeenCalled();
-    expect(findSuggestionCommentBody).not.toHaveBeenCalled();
+    expect(postSuggestionComment).not.toHaveBeenCalled();
     expect(chooseSquashApplyMode).not.toHaveBeenCalled();
     expect(queryPrState).toHaveBeenCalledWith("org", "repo", "issue-42");
     expect(onSquashSubStep).toHaveBeenLastCalledWith(undefined);
   });
 
-  test("user picks agent, but PR merges between query and follow-up → alreadyMerged, no sendFollowUp call", async () => {
-    const prBodyWithMarker = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+  test("envelope + user picks agent, but PR merges between user choice and follow-up → alreadyMerged, no follow-up resume", async () => {
+    const envelopeText =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
     const agent: AgentAdapter = {
-      invoke: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(
-            makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
-          ),
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelopeText,
+          }),
         ),
-      resume: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-        ),
+      ),
+      resume: vi.fn(),
     };
-    // First guardIfPrMerged call (before askUserAndApply) returns OPEN so
-    // the user prompt runs; the second guard call (inside askUserAndApply
-    // before the "agent" branch) returns MERGED.
-    const queryPrState = vi
-      .fn()
-      .mockReturnValueOnce("OPEN")
-      .mockReturnValueOnce("MERGED");
+    // First guard call (askUserAndApply, before "agent" follow-up)
+    // returns MERGED — by that point the user has already picked
+    // "agent" in `chooseSquashApplyMode`.
+    const queryPrState = vi.fn().mockReturnValue("MERGED");
     const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
-    const findSuggestionCommentBody = vi.fn().mockReturnValue(prBodyWithMarker);
+    const postSuggestionComment = vi.fn();
     const onSquashSubStep = vi.fn();
     const getCiStatus = vi.fn();
     const opts = makeOpts({
       agent,
       chooseSquashApplyMode,
-      findSuggestionCommentBody,
+      postSuggestionComment,
       queryPrState,
       onSquashSubStep,
       getCiStatus,
@@ -991,8 +1055,9 @@ describe("createSquashStageHandler", () => {
     expect(result.outcome).toBe("completed");
     expect(result.message).toContain("already merged");
     expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
-    // Only the verdict resume happened — no follow-up squash resume.
-    expect(agent.resume).toHaveBeenCalledTimes(1);
+    // No resume — the merged guard fired before sending the follow-up
+    // squash prompt.
+    expect(agent.resume).not.toHaveBeenCalled();
     expect(getCiStatus).not.toHaveBeenCalled();
     const states = onSquashSubStep.mock.calls.map((c) => c[0]);
     // Never transitioned to "squashing".
@@ -1043,19 +1108,27 @@ describe("createSquashStageHandler", () => {
       expect(result.message).toContain("CI passed");
     });
 
-    test("count unchanged AND marker present → SUGGESTED_SINGLE", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nsuggested\n\`\`\`\n\n**Body**\n\n\`\`\`text\nsuggested body\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
-      const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+    // Issue #304 reviewer round 3: a historical squash-suggestion
+    // comment on the PR must NOT be promoted to a SUGGESTED_SINGLE
+    // verdict by the deterministic fallback chain.  Without an
+    // envelope from this run, the only deterministic signals are
+    // commit-count collapse (SQUASHED_MULTI) or BLOCKED.
+    test("count unchanged AND stale marker present → BLOCKED (no stale-comment promotion)", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nstale\n\`\`\`\n\n**Body**\n\n\`\`\`text\nstale body\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+      const chooseSquashApplyMode = vi.fn();
+      const postSuggestionComment = vi.fn();
       const opts = makeOpts({
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi.fn().mockReturnValue(2),
         findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
         chooseSquashApplyMode,
+        postSuggestionComment,
       });
       const stage = createSquashStageHandler(opts);
       const result = await stage.handler(BASE_CTX);
-      expect(result.outcome).toBe("completed");
-      expect(chooseSquashApplyMode).toHaveBeenCalled();
+      expect(result.outcome).toBe("blocked");
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      expect(postSuggestionComment).not.toHaveBeenCalled();
     });
 
     test("neither → BLOCKED", async () => {
@@ -1427,52 +1500,43 @@ describe("createSquashStageHandler", () => {
     });
   });
 
-  // -- verdict session id persistence (issue #252 review round 5) -----------
+  // -- session id persistence (issue #252 review round 5) ------------------
   //
-  // `resolveVerdict()` may surface a session id that differs from the
-  // planning turn's (adapters can update the id on follow-up turns).
-  // Stage 8 must persist the latest verdict session id via
+  // The envelope-driven shortcut posts the comment from the work-turn
+  // session id, then the user-choice flow resumes that same session for
+  // the agent-squash follow-up.  The session id from the planning turn
+  // (where the agent emitted the envelope) MUST be persisted via
   // `ctx.onSessionId` BEFORE entering `awaiting_user_choice`, so that a
-  // resume + user "agent" choice continues the exact conversation that
-  // drafted the squash-suggestion comment — not the older planning session.
-  describe("verdict session id persistence", () => {
-    test("SUGGESTED_SINGLE persists verdict session (distinct from planning) before awaiting choice", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+  // resume + user "agent" choice continues the same conversation that
+  // drafted the squash-suggestion comment.
+  describe("session id persistence", () => {
+    test("envelope shortcut persists planning session before awaiting choice", async () => {
+      const envelopeText =
+        "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
       const invoke = vi.fn().mockReturnValue(
         makeStream(
           makeResult({
             sessionId: "sess-planning",
-            responseText: "Drafted suggestion.",
+            responseText: envelopeText,
           }),
         ),
       );
-      // Verdict turn surfaces a different session id.
-      const resume = vi
-        .fn()
-        .mockReturnValueOnce(
-          makeStream(
-            makeResult({
-              sessionId: "sess-verdict",
-              responseText: "SUGGESTED_SINGLE",
-            }),
-          ),
-        )
-        // Later follow-up for the agent squash path.
-        .mockReturnValueOnce(
-          makeStream(
-            makeResult({
-              sessionId: "sess-followup",
-              responseText: "Squashed and pushed.",
-            }),
-          ),
-        );
+      // Follow-up resume for the agent-squash path.
+      const resume = vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      );
       const agent: AgentAdapter = { invoke, resume };
 
       const sessionCalls: Array<[string, string]> = [];
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
       const opts = makeOpts({
         agent,
-        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
+        postSuggestionComment: vi.fn(),
         chooseSquashApplyMode,
       });
       const stage = createSquashStageHandler(opts);
@@ -1482,17 +1546,14 @@ describe("createSquashStageHandler", () => {
       });
 
       const persisted = sessionCalls.map(([, sid]) => sid);
-      // The verdict session id must have been persisted before the
-      // user-choice prompt.  It must also precede the follow-up turn,
-      // so a resume after that point would pick the correct session.
-      const verdictIndex = persisted.indexOf("sess-verdict");
-      expect(verdictIndex).toBeGreaterThanOrEqual(0);
+      // Planning session must have been persisted before the
+      // user-choice prompt — so a resume after that point would pick
+      // the conversation that drafted the suggestion.
+      expect(persisted).toContain("sess-planning");
 
-      // chooseSquashApplyMode was called exactly once, and for "agent"
-      // the follow-up resume was sent on the verdict session id.
       expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
-      // resume calls: 0 = verdict check, 1 = agent squash follow-up.
-      expect(resume.mock.calls[1][0]).toBe("sess-verdict");
+      // The follow-up resume goes to the planning session.
+      expect(resume.mock.calls[0][0]).toBe("sess-planning");
     });
 
     test("resume from awaiting_user_choice + user picks agent resumes the verdict session id via getSavedAgentSessionId", async () => {
@@ -1581,8 +1642,11 @@ describe("createSquashStageHandler", () => {
       expect(keywords).toContain("SQUASHED_MULTI");
     });
 
-    test("emits SUGGESTED_SINGLE when marker block is present", async () => {
-      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\ns\n\`\`\`\n\n**Body**\n\n\`\`\`text\ns body\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
+    // Issue #304 reviewer round 3: a stale historical comment must NOT
+    // promote the deterministic fallback to SUGGESTED_SINGLE.  Without
+    // an envelope from this run, the fallback emits BLOCKED.
+    test("emits BLOCKED when only a stale marker block is present (no current envelope)", async () => {
+      const prBody = `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nstale\n\`\`\`\n\n**Body**\n\n\`\`\`text\nstale body\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
       const events = new PipelineEventEmitter();
       const handler = vi.fn();
       events.on("pipeline:verdict", handler);
@@ -1590,13 +1654,13 @@ describe("createSquashStageHandler", () => {
         agent: makeAmbiguousAgent(),
         countBranchCommits: vi.fn().mockReturnValue(2),
         findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
-        chooseSquashApplyMode: vi.fn().mockResolvedValue("github"),
       });
       const stage = createSquashStageHandler(opts);
       await stage.handler({ ...BASE_CTX, events });
 
       const keywords = handler.mock.calls.map((c) => c[0].keyword);
-      expect(keywords).toContain("SUGGESTED_SINGLE");
+      expect(keywords).toContain("BLOCKED");
+      expect(keywords).not.toContain("SUGGESTED_SINGLE");
     });
 
     test("emits BLOCKED when neither signal is present", async () => {
@@ -1741,38 +1805,39 @@ describe("createSquashStageHandler", () => {
   // -- squashApplyPolicy: auto vs ask --------------------------------------
 
   describe("squashApplyPolicy", () => {
+    const ENVELOPE_TEXT =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+
     function makePrCommentBody(): string {
       return `${SQUASH_SUGGESTION_START_MARKER}\n**Title**\n\n\`\`\`text\nT\n\`\`\`\n\n**Body**\n\n\`\`\`text\nB\n\`\`\`\n${SQUASH_SUGGESTION_END_MARKER}`;
     }
 
     test("policy=auto skips chooseSquashApplyMode and proceeds as agent", async () => {
-      const prBody = makePrCommentBody();
-      const resumeResults = [
-        makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-        makeStream(
-          makeResult({
-            sessionId: "sess-followup",
-            responseText: "Squashed and pushed.",
-          }),
-        ),
-      ];
-      let resumeCall = 0;
       const agent: AgentAdapter = {
-        invoke: vi
-          .fn()
-          .mockReturnValue(
-            makeStream(
-              makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
-            ),
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-squash",
+              responseText: ENVELOPE_TEXT,
+            }),
           ),
-        resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
+        ),
+        // Single follow-up resume for the agent-squash branch.
+        resume: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-followup",
+              responseText: "Squashed and pushed.",
+            }),
+          ),
+        ),
       };
       const chooseSquashApplyMode = vi.fn();
       const onSquashSubStep = vi.fn();
       const opts = makeOpts({
         agent,
         chooseSquashApplyMode,
-        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
+        postSuggestionComment: vi.fn(),
         onSquashSubStep,
         squashApplyPolicy: "auto",
       });
@@ -1783,8 +1848,9 @@ describe("createSquashStageHandler", () => {
       expect(result.message).toContain("CI passed");
       // Policy prompt never fired.
       expect(chooseSquashApplyMode).not.toHaveBeenCalled();
-      // Followed the "agent" branch: verdict resume + follow-up resume.
-      expect(agent.resume).toHaveBeenCalledTimes(2);
+      // No verdict turn under the envelope shortcut — only the
+      // agent-squash follow-up resume.
+      expect(agent.resume).toHaveBeenCalledTimes(1);
       expect(opts.getCiStatus).toHaveBeenCalled();
       const states = onSquashSubStep.mock.calls.map((c) => c[0]);
       expect(states).toContain("squashing");
@@ -1793,20 +1859,16 @@ describe("createSquashStageHandler", () => {
     });
 
     test("policy=ask still calls chooseSquashApplyMode and honors the user choice", async () => {
-      const prBody = makePrCommentBody();
       const agent: AgentAdapter = {
-        invoke: vi
-          .fn()
-          .mockReturnValue(
-            makeStream(
-              makeResult({ sessionId: "sess-squash", responseText: "Plan." }),
-            ),
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-squash",
+              responseText: ENVELOPE_TEXT,
+            }),
           ),
-        resume: vi
-          .fn()
-          .mockReturnValue(
-            makeStream(makeResult({ responseText: "SUGGESTED_SINGLE" })),
-          ),
+        ),
+        resume: vi.fn(),
       };
       const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
       const onSquashSubStep = vi.fn();
@@ -1814,7 +1876,7 @@ describe("createSquashStageHandler", () => {
       const opts = makeOpts({
         agent,
         chooseSquashApplyMode,
-        findSuggestionCommentBody: vi.fn().mockReturnValue(prBody),
+        postSuggestionComment: vi.fn(),
         onSquashSubStep,
         getCiStatus,
         squashApplyPolicy: "ask",
@@ -2160,6 +2222,27 @@ describe("buildSquashSuggestionComment ↔ parseSquashSuggestionBlock round-trip
     roundTrip({
       title: "Document the marker block",
       body: `The marker is \`${SQUASH_SUGGESTION_START_MARKER}\`.`,
+    });
+  });
+
+  // Issue #304 reviewer round 3 #2: a literal end marker inside the
+  // body must not truncate the parse.  The formatter writes body
+  // content verbatim inside a CommonMark fenced block, so a literal
+  // end-marker line lives INSIDE that fence.  The parser has to
+  // require a free-standing end-marker line at or after the body's
+  // closing fence — `indexOf` over the whole comment body would stop
+  // at the in-fence occurrence and break the round-trip.
+  test("body containing the end marker as a literal string on its own line", () => {
+    roundTrip({
+      title: "Document both markers",
+      body: `Markers used by Stage 8:\n\n${SQUASH_SUGGESTION_START_MARKER}\n${SQUASH_SUGGESTION_END_MARKER}`,
+    });
+  });
+
+  test("body containing both start and end markers as literal strings", () => {
+    roundTrip({
+      title: "Reference the marker block in commit",
+      body: `Stage 8 wraps the suggestion in:\n\n${SQUASH_SUGGESTION_START_MARKER}\n...\n${SQUASH_SUGGESTION_END_MARKER}\n\nCloses #304`,
     });
   });
 });

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -1256,6 +1256,44 @@ describe("createSquashStageHandler", () => {
       expect(opts.agent.invoke).toHaveBeenCalled();
     });
 
+    // Regression for issue #304 reviewer round 4: a transient
+    // `gh api` failure on this stateful resume path must NOT silently
+    // degrade to "no matching comment" — that would fall through to a
+    // fresh planning run, re-invoke the agent, and could re-author
+    // the suggestion or change the branch decision after the user has
+    // already been asked about one.  Block instead, leaving the
+    // sub-step at `awaiting_user_choice` so retry once `gh` recovers
+    // re-presents the existing choice.
+    test("awaiting_user_choice with lookup error → blocked, no fresh planning, no user choice", async () => {
+      const findSuggestionCommentBody = vi.fn(() => {
+        throw new Error("gh api: 503 Service Unavailable");
+      });
+      const findPrNumber = vi.fn().mockReturnValue(42);
+      const chooseSquashApplyMode = vi.fn();
+      const onSquashSubStep = vi.fn();
+      const opts = makeOpts({
+        savedSquashSubStep: "awaiting_user_choice",
+        findSuggestionCommentBody,
+        findPrNumber,
+        chooseSquashApplyMode,
+        onSquashSubStep,
+      });
+      const stage = createSquashStageHandler(opts);
+      const result = await stage.handler(BASE_CTX);
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.message).toContain("503 Service Unavailable");
+      expect(findSuggestionCommentBody).toHaveBeenCalledTimes(1);
+      expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+      expect(opts.agent.invoke).not.toHaveBeenCalled();
+      // Sub-step must remain `awaiting_user_choice` so a retry once
+      // `gh` recovers re-presents the choice.  The handler does not
+      // emit any sub-step transition on this error path.
+      const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+      expect(states).not.toContain(undefined);
+      expect(states).not.toContain("planning");
+    });
+
     // Regression for issue #274 reviewer round 1: resuming from
     // `awaiting_user_choice` must check the PR lifecycle BEFORE
     // reading the suggestion comment.  `findPrNumber` uses
@@ -2342,6 +2380,24 @@ describe("parseSquashEnvelope", () => {
 
   test("returns malformed for empty body", () => {
     const text = "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n\n\n<<</BODY>>>";
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("body");
+    }
+  });
+
+  // Regression for issue #304 reviewer round 4: a body that contains
+  // only whitespace (spaces, tabs, blank lines) must classify as
+  // malformed, not ok.  The previous emptiness check `body === ""`
+  // missed this case because the body parser preserves internal
+  // indentation by design — it only strips leading and trailing
+  // newlines.  Without this check, a whitespace-only payload would
+  // be authored as a "valid" squash suggestion, exactly the class of
+  // mechanical formatting failure that #304 was meant to remove.
+  test("returns malformed for whitespace-only body", () => {
+    const text =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n   \n\t\n  \t  \n<<</BODY>>>";
     const result = parseSquashEnvelope(text);
     expect(result.kind).toBe("malformed");
     if (result.kind === "malformed") {

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -2212,19 +2212,40 @@ describe("parseSquashEnvelope", () => {
     expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
   });
 
-  test("returns missing when TITLE close tag is absent (treated as not-an-envelope)", () => {
-    // Under strict shape detection, an absent close tag is
-    // indistinguishable from "the agent did not use the envelope".
-    // The caller falls through to the verdict flow rather than
-    // hard-blocking.
+  // Issue #304 reviewer round 2: when the TITLE_OPEN tag is on its own
+  // line, the agent has clearly declared envelope intent — that is not
+  // something stray prose produces.  A subsequent missing close tag,
+  // missing body section, or out-of-order tag is a recoverable
+  // formatting mistake, so it must classify as `malformed` and route
+  // into the clarification turn rather than `missing` (which would
+  // fall through to the verdict path and either hard-block opaquely
+  // or reuse a stale prior suggestion comment).
+  test("returns malformed when TITLE close tag is absent", () => {
     const text = "<<<TITLE>>>\nFix widget\n\n<<<BODY>>>\nB\n<<</BODY>>>";
-    expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("<<</TITLE>>>");
+    }
   });
 
-  test("returns missing when BODY close tag is absent (treated as not-an-envelope)", () => {
+  test("returns malformed when BODY close tag is absent", () => {
     const text =
       "<<<TITLE>>>\nFix widget\n<<</TITLE>>>\n\n<<<BODY>>>\nFirst line.";
-    expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("<<</BODY>>>");
+    }
+  });
+
+  test("returns malformed when BODY section is absent after a closed title envelope", () => {
+    const text = "<<<TITLE>>>\nFix widget\n<<</TITLE>>>\n\nplain prose";
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("<<<BODY>>>");
+    }
   });
 
   test("returns malformed for empty title", () => {
@@ -2316,6 +2337,30 @@ describe("postOrUpdateSquashSuggestion", () => {
 
     expect(patch).not.toHaveBeenCalled();
     expect(post).toHaveBeenCalledWith("org", "repo", 42, "new body");
+  });
+
+  // Issue #304 reviewer round 2: a transient `gh` failure during the
+  // prior-comment lookup must NOT be silently treated as "no prior
+  // comment".  Doing so would turn an idempotent PATCH into a
+  // duplicate POST on every transient blip, defeating the whole point
+  // of moving the bookkeeping into deterministic code.
+  test("propagates errors from findLatest and does not POST a duplicate", () => {
+    const findLatest = vi.fn().mockImplementation(() => {
+      throw new Error("rate limited");
+    });
+    const patch = vi.fn();
+    const post = vi.fn();
+
+    expect(() =>
+      postOrUpdateSquashSuggestion("org", "repo", 42, "new body", {
+        findLatest,
+        patch,
+        post,
+      }),
+    ).toThrow("rate limited");
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(post).not.toHaveBeenCalled();
   });
 });
 
@@ -2641,5 +2686,154 @@ describe("envelope-driven SUGGESTED_SINGLE flow", () => {
     expect(result.outcome).toBe("completed");
     expect(opts.agent.resume).toHaveBeenCalled();
     expect(opts.postSuggestionComment).not.toHaveBeenCalled();
+  });
+
+  // Issue #304 reviewer round 2 #1: a work response that clearly
+  // started the envelope (TITLE_OPEN on its own line) but dropped a
+  // close tag must route into the focused clarification turn, not
+  // fall through to the old verdict path.  Falling through would
+  // either hard-block opaquely (when the verdict comes back as
+  // SUGGESTED_SINGLE without an envelope to draw from) or quietly
+  // reuse a stale prior suggestion comment from an earlier run.
+  test("envelope with missing TITLE close tag → clarification asked, recovers on valid retry", async () => {
+    const malformed = [
+      "<<<TITLE>>>",
+      "Fix widget",
+      "", // dropped closing tag
+      "<<<BODY>>>",
+      "Body content",
+      "<<</BODY>>>",
+    ].join("\n");
+    const repaired = [
+      "<<<TITLE>>>",
+      "Fix widget",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "Body content",
+      "<<</BODY>>>",
+    ].join("\n");
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: malformed,
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: repaired }))),
+    };
+    const postSuggestionComment = vi.fn();
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+    const opts = makeOpts({
+      agent,
+      postSuggestionComment,
+      chooseSquashApplyMode,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // The clarification turn fired exactly once — not the verdict
+    // turn.  resume is the only follow-up channel in the test
+    // adapter, so this also implicitly asserts the verdict path was
+    // skipped.
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect(postSuggestionComment).toHaveBeenCalledTimes(1);
+    const postedBody = postSuggestionComment.mock.calls[0][3] as string;
+    expect(postedBody).toContain("Fix widget");
+    expect(postedBody).toContain("Body content");
+  });
+
+  test("envelope with missing BODY close tag → clarification asked", async () => {
+    const malformed = [
+      "<<<TITLE>>>",
+      "Fix widget",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "Body content",
+      // dropped closing tag
+    ].join("\n");
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: malformed,
+          }),
+        ),
+      ),
+      // Retry says SQUASHED_MULTI — agent reconsidered and chose the
+      // multi-commit branch instead of repairing the envelope.
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
+    };
+    const postSuggestionComment = vi.fn();
+    const opts = makeOpts({ agent, postSuggestionComment });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    // Clarification fires (resume called once for clarification only,
+    // not for verdict) and SQUASHED_MULTI on retry routes into the
+    // CI-poll path with no comment posted.
+    expect(result.outcome).toBe("completed");
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect(postSuggestionComment).not.toHaveBeenCalled();
+  });
+
+  // Issue #304 reviewer round 2 #2: a transient lookup failure inside
+  // the write helper must surface as a `blocked` outcome, not a
+  // duplicate POST.  The handler converts the thrown error into a
+  // user-facing blocked message.
+  test("postSuggestionComment lookup throw → blocked, no duplicate POST", async () => {
+    const envelopeText = [
+      "<<<TITLE>>>",
+      "Fix widget",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "Body content",
+      "<<</BODY>>>",
+    ].join("\n");
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelopeText,
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+    const postSuggestionComment = vi.fn().mockImplementation(() => {
+      throw new Error("rate limited during lookup");
+    });
+    const onSquashSubStep = vi.fn();
+    const opts = makeOpts({
+      agent,
+      postSuggestionComment,
+      onSquashSubStep,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("rate limited during lookup");
+    expect(result.message).toContain("duplicate");
+    // The user-choice flow was never entered.
+    const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+    expect(states).not.toContain("awaiting_user_choice");
+    expect(states[states.length - 1]).toBe(undefined);
+    // Verdict turn was not used to recover (the shortcut owned the
+    // SUGGESTED_SINGLE branch), and resume must not have been called.
+    expect(agent.resume).not.toHaveBeenCalled();
   });
 });

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -2193,23 +2193,38 @@ describe("parseSquashEnvelope", () => {
     });
   });
 
-  test("returns malformed for missing TITLE close tag", () => {
-    const text = "<<<TITLE>>>\nFix widget\n\n<<<BODY>>>\nB\n<<</BODY>>>";
-    const result = parseSquashEnvelope(text);
-    expect(result.kind).toBe("malformed");
-    if (result.kind === "malformed") {
-      expect(result.reason).toContain("</TITLE>");
-    }
+  // Strict shape detection: the envelope is only "attempted" when
+  // all four tags appear on their own lines in order.  A response
+  // that merely mentions a tag inline in prose (single-backtick
+  // quote, embedded in a sentence) must classify as `missing` so
+  // the SUGGESTED_SINGLE shortcut does not pre-empt a perfectly
+  // valid SQUASHED_MULTI / BLOCKED reply that happens to quote the
+  // tag names.  Issue #304 reviewer round 1 false-negative case.
+  test("returns missing for prose mentioning a tag inline in backticks", () => {
+    const text =
+      "I took the multi-commit path, so I did not use the `<<<TITLE>>>` / `<<<BODY>>>` envelope.";
+    expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
   });
 
-  test("returns malformed for missing BODY close tag", () => {
+  test("returns missing for prose mentioning a tag inline mid-sentence", () => {
+    const text =
+      "Multi-commit branch — see the <<<TITLE>>> envelope contract for SUGGESTED_SINGLE only.";
+    expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
+  });
+
+  test("returns missing when TITLE close tag is absent (treated as not-an-envelope)", () => {
+    // Under strict shape detection, an absent close tag is
+    // indistinguishable from "the agent did not use the envelope".
+    // The caller falls through to the verdict flow rather than
+    // hard-blocking.
+    const text = "<<<TITLE>>>\nFix widget\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
+  });
+
+  test("returns missing when BODY close tag is absent (treated as not-an-envelope)", () => {
     const text =
       "<<<TITLE>>>\nFix widget\n<<</TITLE>>>\n\n<<<BODY>>>\nFirst line.";
-    const result = parseSquashEnvelope(text);
-    expect(result.kind).toBe("malformed");
-    if (result.kind === "malformed") {
-      expect(result.reason).toContain("</BODY>");
-    }
+    expect(parseSquashEnvelope(text)).toEqual({ kind: "missing" });
   });
 
   test("returns malformed for empty title", () => {
@@ -2421,15 +2436,13 @@ describe("envelope-driven SUGGESTED_SINGLE flow", () => {
     expect(keywords).toContain("SUGGESTED_SINGLE");
   });
 
-  // Malformed envelope → blocked with an actionable message.  Cover the
-  // three categories the issue calls out: missing close tag, empty title,
-  // empty body.
+  // Malformed envelope → focused clarification round.  After the
+  // reviewer round-1 feedback, the strict shape detection narrows
+  // `malformed` to "all four tags on own lines but content empty".
+  // Both empty-title and empty-body should still survive a single
+  // clarification turn before blocking, so the agent has a chance to
+  // repair the formatting-only mistake.
   test.each([
-    {
-      name: "missing TITLE close tag",
-      envelope: "<<<TITLE>>>\nFix widget\n\n<<<BODY>>>\nB\n<<</BODY>>>",
-      expectedFragment: "</TITLE>",
-    },
     {
       name: "empty title",
       envelope: "<<<TITLE>>>\n   \n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>",
@@ -2440,7 +2453,7 @@ describe("envelope-driven SUGGESTED_SINGLE flow", () => {
       envelope: "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n\n<<</BODY>>>",
       expectedFragment: "body",
     },
-  ])("malformed envelope ($name) → blocked, no comment posted, no user choice", async ({
+  ])("malformed envelope ($name) → clarification asked, then blocked when retry is also unrecoverable", async ({
     envelope,
     expectedFragment,
   }) => {
@@ -2453,7 +2466,14 @@ describe("envelope-driven SUGGESTED_SINGLE flow", () => {
           }),
         ),
       ),
-      resume: vi.fn(),
+      // Retry is also malformed → no recovery → block.
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            responseText: "still no envelope, just prose",
+          }),
+        ),
+      ),
     };
     const postSuggestionComment = vi.fn();
     const chooseSquashApplyMode = vi.fn();
@@ -2468,17 +2488,146 @@ describe("envelope-driven SUGGESTED_SINGLE flow", () => {
     const result = await stage.handler(BASE_CTX);
 
     expect(result.outcome).toBe("blocked");
-    expect(result.message).toContain("envelope malformed");
+    expect(result.message).toContain("envelope still unrecoverable");
     expect(result.message).toContain(expectedFragment);
-    // The verdict turn must NOT have run — the malformed envelope
-    // already declares intent to take the SUGGESTED_SINGLE branch.
-    expect(agent.resume).not.toHaveBeenCalled();
+    // Clarification turn must have been sent.
+    expect(agent.resume).toHaveBeenCalledTimes(1);
     expect(postSuggestionComment).not.toHaveBeenCalled();
     expect(chooseSquashApplyMode).not.toHaveBeenCalled();
     const states = onSquashSubStep.mock.calls.map((c) => c[0]);
     expect(states).not.toContain("awaiting_user_choice");
     expect(states).not.toContain("applied_via_github");
     expect(states[states.length - 1]).toBe(undefined);
+  });
+
+  test("malformed envelope + clarification yields valid envelope → comment authored, user-choice runs", async () => {
+    const malformed =
+      "<<<TITLE>>>\n   \n<<</TITLE>>>\n\n<<<BODY>>>\nbody\n<<</BODY>>>";
+    const repaired =
+      "<<<TITLE>>>\nFix widget\n<<</TITLE>>>\n\n<<<BODY>>>\nbody\n<<</BODY>>>";
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: malformed,
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: repaired }))),
+    };
+    const postSuggestionComment = vi.fn();
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+    const opts = makeOpts({
+      agent,
+      postSuggestionComment,
+      chooseSquashApplyMode,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect(postSuggestionComment).toHaveBeenCalledTimes(1);
+    expect(chooseSquashApplyMode).toHaveBeenCalled();
+    const postedBody = postSuggestionComment.mock.calls[0][3] as string;
+    expect(postedBody).toContain("Fix widget");
+  });
+
+  test("malformed envelope + clarification yields SQUASHED_MULTI → CI poll runs, no comment posted", async () => {
+    const malformed =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n\n<<</BODY>>>";
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: malformed,
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
+    };
+    const postSuggestionComment = vi.fn();
+    const opts = makeOpts({ agent, postSuggestionComment });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(postSuggestionComment).not.toHaveBeenCalled();
+  });
+
+  test("malformed envelope + clarification yields BLOCKED → blocked", async () => {
+    const malformed =
+      "<<<TITLE>>>\n   \n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: malformed,
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValue(makeStream(makeResult({ responseText: "BLOCKED" }))),
+    };
+    const postSuggestionComment = vi.fn();
+    const opts = makeOpts({ agent, postSuggestionComment });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(postSuggestionComment).not.toHaveBeenCalled();
+  });
+
+  // Reviewer round 1 false-negative regression: a multi-commit reply
+  // that mentions the envelope tag names inline in prose (e.g. "I did
+  // not use the `<<<TITLE>>>` envelope") must NOT pre-empt the
+  // verdict turn with a malformed-envelope block.
+  test("prose mentioning envelope tags inline → falls through to verdict flow (no shortcut, no block)", async () => {
+    const proseResponse =
+      "I rewrote history into multiple commits and force-pushed. " +
+      "I did not use the `<<<TITLE>>>` / `<<<BODY>>>` envelope because this " +
+      "branch warrants SQUASHED_MULTI.";
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: proseResponse,
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValue(
+          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+        ),
+    };
+    const postSuggestionComment = vi.fn();
+    const chooseSquashApplyMode = vi.fn();
+    const opts = makeOpts({
+      agent,
+      postSuggestionComment,
+      chooseSquashApplyMode,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // Verdict turn ran.
+    expect(agent.resume).toHaveBeenCalled();
+    // No SUGGESTED_SINGLE shortcut fired.
+    expect(postSuggestionComment).not.toHaveBeenCalled();
+    expect(chooseSquashApplyMode).not.toHaveBeenCalled();
   });
 
   test("envelope absent → falls through to existing verdict flow", async () => {

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -6,8 +6,11 @@ import { PipelineEventEmitter } from "./pipeline-events.js";
 import {
   buildSquashCompletionCheckPrompt,
   buildSquashPrompt,
+  buildSquashSuggestionComment,
   createSquashStageHandler,
+  parseSquashEnvelope,
   parseSquashSuggestionBlock,
+  postOrUpdateSquashSuggestion,
   SQUASH_SUGGESTION_END_MARKER,
   SQUASH_SUGGESTION_START_MARKER,
   type SquashStageOptions,
@@ -115,13 +118,32 @@ describe("buildSquashPrompt", () => {
     expect(prompt).toContain("The widget is broken.");
   });
 
-  test("includes both squash paths and the marker block contract", () => {
+  test("includes both squash paths and the SUGGESTED_SINGLE envelope contract", () => {
     const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
     expect(prompt).toContain("If a single commit is appropriate");
     expect(prompt).toContain("If multiple commits are appropriate");
     expect(prompt).toContain("Force-push the branch");
-    expect(prompt).toContain("agentcoop:squash-suggestion:start");
-    expect(prompt).toContain("agentcoop:squash-suggestion:end");
+    expect(prompt).toContain("<<<TITLE>>>");
+    expect(prompt).toContain("<<</TITLE>>>");
+    expect(prompt).toContain("<<<BODY>>>");
+    expect(prompt).toContain("<<</BODY>>>");
+  });
+
+  // Negative assertions: the SUGGESTED_SINGLE branch no longer asks the
+  // agent to author the marker-delimited PR comment itself.  Marker
+  // placement, fence-length math, and idempotent PATCH/POST bookkeeping
+  // are now deterministic concerns owned by `buildSquashSuggestionComment`
+  // / `postOrUpdateSquashSuggestion`.  Use `not.toContain` so this test
+  // does not break on copy edits to the surrounding prose.
+  test("SUGGESTED_SINGLE prompt no longer references marker / gh comment / fence math", () => {
+    const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
+    expect(prompt).not.toContain("squash-suggestion:start");
+    expect(prompt).not.toContain("squash-suggestion:end");
+    expect(prompt).not.toContain("gh pr comment");
+    expect(prompt).not.toContain("gh api repos");
+    expect(prompt).not.toContain("--method PATCH");
+    expect(prompt).not.toContain("fence_len");
+    expect(prompt).not.toContain("longest run of backticks");
   });
 
   test("includes PR description sync instructions", () => {
@@ -2047,5 +2069,428 @@ describe("parseSquashSuggestionBlock", () => {
       "more noise",
     ].join("\n");
     expect(parseSquashSuggestionBlock(body)).toBeUndefined();
+  });
+
+  // Combined regression for the screenshot incident on
+  // aicers/aice-web-next#377: the agent-authored comment was missing
+  // both the closing body fence AND the end marker.  Either flaw on its
+  // own is already covered by an earlier case; the combined failure is
+  // the one that actually shipped, so pin it directly.
+  test("returns undefined when the body fence is unterminated AND the end marker is absent", () => {
+    const body = [
+      "noise",
+      SQUASH_SUGGESTION_START_MARKER,
+      "## Suggested squash commit",
+      "",
+      "**Title**",
+      "",
+      "```text",
+      "Fix widget rendering",
+      "```",
+      "",
+      "**Body**",
+      "",
+      "```text",
+      "First line.",
+      "",
+      "Closes #42",
+      // intentionally no closing body fence
+      // intentionally no SQUASH_SUGGESTION_END_MARKER
+      "more noise",
+    ].join("\n");
+    expect(parseSquashSuggestionBlock(body)).toBeUndefined();
+  });
+});
+
+// ---- buildSquashSuggestionComment + round-trip ------------------------------
+
+describe("buildSquashSuggestionComment ↔ parseSquashSuggestionBlock round-trip", () => {
+  // Round-trip is the single strongest guarantee that the formatter and
+  // parser stay in lock-step.  If one is changed without the other, one
+  // of these cases fails — including the malformed-comment regression
+  // class that motivated issue #304.
+  function roundTrip(suggestion: { title: string; body: string }) {
+    const built = buildSquashSuggestionComment(suggestion);
+    const parsed = parseSquashSuggestionBlock(built);
+    expect(parsed).toEqual(suggestion);
+  }
+
+  test("plain title and body", () => {
+    roundTrip({
+      title: "Fix widget rendering",
+      body: "First line.\n\nCloses #42",
+    });
+  });
+
+  test("body containing a triple-backtick fenced code sample", () => {
+    roundTrip({
+      title: "Improve docs",
+      body: "Repro:\n\n```js\nfoo();\n```\n\nCloses #1",
+    });
+  });
+
+  test("body containing a five-backtick run", () => {
+    roundTrip({
+      title: "Handle large fences",
+      body: "Look at this nesting:\n\n`````\ninner\n`````\n\nPart of #9",
+    });
+  });
+
+  test("body containing HTML comments", () => {
+    roundTrip({
+      title: "Preserve HTML comments",
+      body:
+        "<!-- review note: please check edge case -->\n\n" +
+        "Closes #42\n\n<!-- end -->",
+    });
+  });
+
+  test("title containing inline backticks (fence stays at 3)", () => {
+    roundTrip({
+      title: "Rename `foo` to `bar`",
+      body: "See #9",
+    });
+  });
+
+  test("body containing the start marker as a literal string", () => {
+    // Defensive: even if the agent's prose contains the start marker,
+    // the closing end marker still terminates the block correctly
+    // because the parser anchors on the first end-marker occurrence
+    // after the start.
+    roundTrip({
+      title: "Document the marker block",
+      body: `The marker is \`${SQUASH_SUGGESTION_START_MARKER}\`.`,
+    });
+  });
+});
+
+// ---- parseSquashEnvelope ----------------------------------------------------
+
+describe("parseSquashEnvelope", () => {
+  test("returns ok for a well-formed envelope", () => {
+    const text = [
+      "Some prose before.",
+      "",
+      "<<<TITLE>>>",
+      "Fix widget",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "First line.",
+      "",
+      "Closes #1",
+      "<<</BODY>>>",
+    ].join("\n");
+    expect(parseSquashEnvelope(text)).toEqual({
+      kind: "ok",
+      suggestion: { title: "Fix widget", body: "First line.\n\nCloses #1" },
+    });
+  });
+
+  test("returns missing when no envelope tag appears", () => {
+    expect(parseSquashEnvelope("just plain text, no envelope")).toEqual({
+      kind: "missing",
+    });
+  });
+
+  test("returns malformed for missing TITLE close tag", () => {
+    const text = "<<<TITLE>>>\nFix widget\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("</TITLE>");
+    }
+  });
+
+  test("returns malformed for missing BODY close tag", () => {
+    const text =
+      "<<<TITLE>>>\nFix widget\n<<</TITLE>>>\n\n<<<BODY>>>\nFirst line.";
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("</BODY>");
+    }
+  });
+
+  test("returns malformed for empty title", () => {
+    const text = "<<<TITLE>>>\n   \n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("title");
+    }
+  });
+
+  test("returns malformed for empty body", () => {
+    const text = "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n\n\n<<</BODY>>>";
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("body");
+    }
+  });
+
+  test("preserves internal blank lines in body and strips leading/trailing", () => {
+    const text =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n\nfirst\n\nsecond\n\n<<</BODY>>>";
+    expect(parseSquashEnvelope(text)).toEqual({
+      kind: "ok",
+      suggestion: { title: "T", body: "first\n\nsecond" },
+    });
+  });
+});
+
+// ---- postOrUpdateSquashSuggestion -------------------------------------------
+
+describe("postOrUpdateSquashSuggestion", () => {
+  test("PATCHes the existing comment when one with the start marker exists", () => {
+    const findLatest = vi
+      .fn()
+      .mockReturnValue({ id: 555, body: "stale body with marker" });
+    const patch = vi.fn();
+    const post = vi.fn();
+
+    postOrUpdateSquashSuggestion("org", "repo", 42, "new body", {
+      findLatest,
+      patch,
+      post,
+    });
+
+    expect(findLatest).toHaveBeenCalledWith(
+      "org",
+      "repo",
+      42,
+      SQUASH_SUGGESTION_START_MARKER,
+    );
+    expect(patch).toHaveBeenCalledTimes(1);
+    expect(patch).toHaveBeenCalledWith("org", "repo", 555, "new body");
+    expect(post).not.toHaveBeenCalled();
+  });
+
+  test("POSTs a new comment when no prior comment matches", () => {
+    const findLatest = vi.fn().mockReturnValue(undefined);
+    const patch = vi.fn();
+    const post = vi.fn();
+
+    postOrUpdateSquashSuggestion("org", "repo", 42, "fresh body", {
+      findLatest,
+      patch,
+      post,
+    });
+
+    expect(post).toHaveBeenCalledTimes(1);
+    expect(post).toHaveBeenCalledWith("org", "repo", 42, "fresh body");
+    expect(patch).not.toHaveBeenCalled();
+  });
+
+  test("falls back to POST when prior comment lacks an id", () => {
+    // Older fixtures (and stub adapters) may surface a body without
+    // the comment id.  Without an id we cannot PATCH, so the helper
+    // falls back to POST rather than throwing.
+    const findLatest = vi
+      .fn()
+      .mockReturnValue({ id: undefined, body: "stale" });
+    const patch = vi.fn();
+    const post = vi.fn();
+
+    postOrUpdateSquashSuggestion("org", "repo", 42, "new body", {
+      findLatest,
+      patch,
+      post,
+    });
+
+    expect(patch).not.toHaveBeenCalled();
+    expect(post).toHaveBeenCalledWith("org", "repo", 42, "new body");
+  });
+});
+
+// ---- envelope-driven SUGGESTED_SINGLE in createSquashStageHandler ----------
+
+describe("envelope-driven SUGGESTED_SINGLE flow", () => {
+  function makeEnvelopeAgent(envelope: string): AgentAdapter {
+    return {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelope,
+          }),
+        ),
+      ),
+      // Follow-up resume for the agent-squash branch.
+      resume: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-followup",
+            responseText: "Squashed and pushed.",
+          }),
+        ),
+      ),
+    };
+  }
+
+  test("agent returns envelope → code authors comment, skips verdict turn, asks user", async () => {
+    const envelopeText = [
+      "Looking at the branch...",
+      "",
+      "<<<TITLE>>>",
+      "Fix the widget",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "Refactor renderer.",
+      "",
+      "Closes #42",
+      "<<</BODY>>>",
+    ].join("\n");
+    const agent = makeEnvelopeAgent(envelopeText);
+    const postSuggestionComment = vi.fn();
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("github");
+    const onSquashSubStep = vi.fn();
+    const opts = makeOpts({
+      agent,
+      chooseSquashApplyMode,
+      postSuggestionComment,
+      onSquashSubStep,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    // Verdict turn was skipped because the envelope was present.
+    expect(agent.resume).not.toHaveBeenCalled();
+    // The code authored the comment and posted it via the injectable.
+    expect(postSuggestionComment).toHaveBeenCalledTimes(1);
+    const [postedOwner, postedRepo, postedPr, postedBody] =
+      postSuggestionComment.mock.calls[0];
+    expect(postedOwner).toBe("org");
+    expect(postedRepo).toBe("repo");
+    expect(postedPr).toBe(42);
+    // Round-trip: the parser must agree with what the formatter wrote.
+    expect(parseSquashSuggestionBlock(postedBody)).toEqual({
+      title: "Fix the widget",
+      body: "Refactor renderer.\n\nCloses #42",
+    });
+    expect(chooseSquashApplyMode).toHaveBeenCalledTimes(1);
+    const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+    expect(states).toContain("planning");
+    expect(states).toContain("awaiting_user_choice");
+    expect(states[states.length - 1]).toBe("applied_via_github");
+  });
+
+  test("agent returns envelope + user picks agent → follow-up resumes the planning session", async () => {
+    const envelopeText =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    const agent = makeEnvelopeAgent(envelopeText);
+    const postSuggestionComment = vi.fn();
+    const chooseSquashApplyMode = vi.fn().mockResolvedValue("agent");
+    const opts = makeOpts({
+      agent,
+      chooseSquashApplyMode,
+      postSuggestionComment,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(result.message).toContain("CI passed");
+    // No verdict turn — only the agent-squash follow-up resume.
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect((agent.resume as ReturnType<typeof vi.fn>).mock.calls[0][0]).toBe(
+      "sess-squash",
+    );
+    expect(postSuggestionComment).toHaveBeenCalledTimes(1);
+  });
+
+  test("envelope present + pipeline:verdict event surfaces SUGGESTED_SINGLE", async () => {
+    const envelopeText =
+      "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>";
+    const agent = makeEnvelopeAgent(envelopeText);
+    const events = new PipelineEventEmitter();
+    const handler = vi.fn();
+    events.on("pipeline:verdict", handler);
+    const opts = makeOpts({
+      agent,
+      postSuggestionComment: vi.fn(),
+      chooseSquashApplyMode: vi.fn().mockResolvedValue("github"),
+    });
+    const stage = createSquashStageHandler(opts);
+    await stage.handler({ ...BASE_CTX, events });
+
+    const keywords = handler.mock.calls.map((c) => c[0].keyword);
+    expect(keywords).toContain("SUGGESTED_SINGLE");
+  });
+
+  // Malformed envelope → blocked with an actionable message.  Cover the
+  // three categories the issue calls out: missing close tag, empty title,
+  // empty body.
+  test.each([
+    {
+      name: "missing TITLE close tag",
+      envelope: "<<<TITLE>>>\nFix widget\n\n<<<BODY>>>\nB\n<<</BODY>>>",
+      expectedFragment: "</TITLE>",
+    },
+    {
+      name: "empty title",
+      envelope: "<<<TITLE>>>\n   \n<<</TITLE>>>\n\n<<<BODY>>>\nB\n<<</BODY>>>",
+      expectedFragment: "title",
+    },
+    {
+      name: "empty body",
+      envelope: "<<<TITLE>>>\nT\n<<</TITLE>>>\n\n<<<BODY>>>\n\n<<</BODY>>>",
+      expectedFragment: "body",
+    },
+  ])("malformed envelope ($name) → blocked, no comment posted, no user choice", async ({
+    envelope,
+    expectedFragment,
+  }) => {
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: envelope,
+          }),
+        ),
+      ),
+      resume: vi.fn(),
+    };
+    const postSuggestionComment = vi.fn();
+    const chooseSquashApplyMode = vi.fn();
+    const onSquashSubStep = vi.fn();
+    const opts = makeOpts({
+      agent,
+      postSuggestionComment,
+      chooseSquashApplyMode,
+      onSquashSubStep,
+    });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("blocked");
+    expect(result.message).toContain("envelope malformed");
+    expect(result.message).toContain(expectedFragment);
+    // The verdict turn must NOT have run — the malformed envelope
+    // already declares intent to take the SUGGESTED_SINGLE branch.
+    expect(agent.resume).not.toHaveBeenCalled();
+    expect(postSuggestionComment).not.toHaveBeenCalled();
+    expect(chooseSquashApplyMode).not.toHaveBeenCalled();
+    const states = onSquashSubStep.mock.calls.map((c) => c[0]);
+    expect(states).not.toContain("awaiting_user_choice");
+    expect(states).not.toContain("applied_via_github");
+    expect(states[states.length - 1]).toBe(undefined);
+  });
+
+  test("envelope absent → falls through to existing verdict flow", async () => {
+    // Plain "Plan." response with no envelope tags should not trigger
+    // the new envelope-driven shortcut.  The verdict turn runs as
+    // before and the SQUASHED_MULTI branch proceeds to CI poll.
+    const opts = makeOpts({ postSuggestionComment: vi.fn() });
+    const stage = createSquashStageHandler(opts);
+    const result = await stage.handler(BASE_CTX);
+
+    expect(result.outcome).toBe("completed");
+    expect(opts.agent.resume).toHaveBeenCalled();
+    expect(opts.postSuggestionComment).not.toHaveBeenCalled();
   });
 });

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -2504,6 +2504,56 @@ describe("parseSquashEnvelope", () => {
       },
     });
   });
+
+  // Issue #304 reviewer round 6: LAST-match BODY_CLOSE alone still
+  // silently accepts a truncated body when the agent forgets the real
+  // structural close tag but the body itself contains an example
+  // `<<</BODY>>>` line.  In that case LAST-match would pick the
+  // in-body example and trailing content (the omitted-close-tag
+  // proof) would be ignored.  The parser additionally requires the
+  // structural BODY_CLOSE to be the last non-blank line of the
+  // response, so this case classifies as malformed and routes into
+  // the focused clarification turn.
+  test("returns malformed when body quotes <<</BODY>>> but the final close tag is missing", () => {
+    const text = [
+      "<<<TITLE>>>",
+      "Document the envelope",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "The envelope close tag is:",
+      "<<</BODY>>>",
+      "That ends the example.",
+    ].join("\n");
+    const result = parseSquashEnvelope(text);
+    expect(result.kind).toBe("malformed");
+    if (result.kind === "malformed") {
+      expect(result.reason).toContain("<<</BODY>>>");
+      expect(result.reason).toContain("last non-blank line");
+    }
+  });
+
+  // Trailing blank lines after the structural close tag are fine —
+  // only non-blank trailing content makes the structural close
+  // ambiguous.  Verifies the round 6 anchor does not over-reject.
+  test("allows trailing blank lines after the structural close tag", () => {
+    const text = [
+      "<<<TITLE>>>",
+      "T",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "B",
+      "<<</BODY>>>",
+      "",
+      "   ",
+      "",
+    ].join("\n");
+    expect(parseSquashEnvelope(text)).toEqual({
+      kind: "ok",
+      suggestion: { title: "T", body: "B" },
+    });
+  });
 });
 
 // ---- postOrUpdateSquashSuggestion -------------------------------------------

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -2413,6 +2413,97 @@ describe("parseSquashEnvelope", () => {
       suggestion: { title: "T", body: "first\n\nsecond" },
     });
   });
+
+  // Issue #304 reviewer round 5: a commit body that legitimately
+  // documents the envelope contract — plausible for issue #304 itself
+  // — must not be truncated at the first own-line `<<</BODY>>>`.  The
+  // parser anchors BODY_CLOSE to the LAST own-line occurrence after
+  // BODY_OPEN, so in-body literal close tags are absorbed as content
+  // and only the final own-line tag terminates the envelope.
+  test("body may contain a literal <<</BODY>>> line as content", () => {
+    const text = [
+      "<<<TITLE>>>",
+      "Document the envelope",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "The envelope close tag is:",
+      "<<</BODY>>>",
+      "That ends the example.",
+      "<<</BODY>>>",
+    ].join("\n");
+    expect(parseSquashEnvelope(text)).toEqual({
+      kind: "ok",
+      suggestion: {
+        title: "Document the envelope",
+        body: "The envelope close tag is:\n<<</BODY>>>\nThat ends the example.",
+      },
+    });
+  });
+
+  test("body may quote the full envelope contract verbatim", () => {
+    // The exact failure mode the round 5 reviewer flagged: a body
+    // that documents all four envelope tags inline.  With FIRST-match
+    // BODY_CLOSE this would have been truncated at the example's
+    // closing `<<</BODY>>>` line; with LAST-match it round-trips.
+    const documentedBody = [
+      "Issue #304 introduces the envelope:",
+      "",
+      "<<<TITLE>>>",
+      "...",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      "...",
+      "<<</BODY>>>",
+      "",
+      "Closes #304",
+    ].join("\n");
+    const text = [
+      "<<<TITLE>>>",
+      "Document envelope",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      documentedBody,
+      "<<</BODY>>>",
+    ].join("\n");
+    expect(parseSquashEnvelope(text)).toEqual({
+      kind: "ok",
+      suggestion: { title: "Document envelope", body: documentedBody },
+    });
+  });
+
+  test("body may contain literal envelope tags including <<</TITLE>>>", () => {
+    // The other envelope tags (start tags, TITLE close) are not
+    // structural close markers for the body; they just live as
+    // content inside the body region between BODY_OPEN and the LAST
+    // BODY_CLOSE.  Verifies the parser does not get confused by them.
+    const documentedBody = [
+      "Tags reference:",
+      "<<<TITLE>>>",
+      "<<</TITLE>>>",
+      "<<<BODY>>>",
+      "<<</BODY>>>",
+      "End of reference.",
+    ].join("\n");
+    const text = [
+      "<<<TITLE>>>",
+      "Reference all envelope tags",
+      "<<</TITLE>>>",
+      "",
+      "<<<BODY>>>",
+      documentedBody,
+      "<<</BODY>>>",
+    ].join("\n");
+    expect(parseSquashEnvelope(text)).toEqual({
+      kind: "ok",
+      suggestion: {
+        title: "Reference all envelope tags",
+        body: documentedBody,
+      },
+    });
+  });
 });
 
 // ---- postOrUpdateSquashSuggestion -------------------------------------------

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -538,63 +538,75 @@ const ENVELOPE_BODY_OPEN = "<<<BODY>>>";
 const ENVELOPE_BODY_CLOSE = "<<</BODY>>>";
 
 /**
+ * Find the first line index at or after `start` whose trimmed
+ * contents exactly match `tag`.  Returns -1 when not found.  Used
+ * for envelope tag detection — the trimmed-equality check rejects
+ * inline mentions like a backtick-quoted `<<<TITLE>>>` in prose.
+ */
+function findOwnLineTag(lines: string[], tag: string, start: number): number {
+  for (let i = start; i < lines.length; i++) {
+    if (lines[i].trim() === tag) return i;
+  }
+  return -1;
+}
+
+/**
  * Parse the agent's `<<<TITLE>>>...<<</TITLE>>> / <<<BODY>>>...<<</BODY>>>`
  * envelope from a free-form response.
  *
+ * Detection is strict by design: each of the four tags must appear
+ * as a line by itself, in the order
+ * TITLE_OPEN → TITLE_CLOSE → BODY_OPEN → BODY_CLOSE, before the
+ * response is treated as an envelope attempt at all.  This rejects
+ * stray prose mentions like "I did not use the `<<<TITLE>>>` envelope"
+ * — those classify as `missing` and the caller falls through to the
+ * verdict flow rather than hard-blocking on a multi-commit reply that
+ * happens to quote the tags.
+ *
  * Returns:
- *   - `{ kind: "missing" }` when none of the four envelope tags are
- *     present.  The caller should fall through to the verdict flow:
- *     envelope absence on its own is not a SUGGESTED_SINGLE signal.
- *   - `{ kind: "malformed", reason }` when at least one tag is present
- *     but the envelope is unparseable (missing close tag, empty title,
- *     etc.).  The caller should funnel into the blocked path with the
- *     reason surfaced for diagnostics.
+ *   - `{ kind: "missing" }` when the strict shape is not present
+ *     (tags inline in prose, any tag absent, or out-of-order).  The
+ *     caller should fall through to the verdict flow: envelope
+ *     absence on its own is not a SUGGESTED_SINGLE signal.
+ *   - `{ kind: "malformed", reason }` when the four tags are present
+ *     on their own lines and in order but the content between them
+ *     is unusable (empty title or body).  The caller should send a
+ *     focused clarification rather than blocking outright — the agent
+ *     declared intent to use the envelope, so a missed line is
+ *     usually recoverable on retry.
  *   - `{ kind: "ok", suggestion }` on a well-formed envelope.
  */
 export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
-  const titleOpen = text.indexOf(ENVELOPE_TITLE_OPEN);
-  const titleClose = text.indexOf(ENVELOPE_TITLE_CLOSE);
-  const bodyOpen = text.indexOf(ENVELOPE_BODY_OPEN);
-  const bodyClose = text.indexOf(ENVELOPE_BODY_CLOSE);
+  const lines = text.split("\n");
+  const titleOpenIdx = findOwnLineTag(lines, ENVELOPE_TITLE_OPEN, 0);
+  if (titleOpenIdx === -1) return { kind: "missing" };
+  const titleCloseIdx = findOwnLineTag(
+    lines,
+    ENVELOPE_TITLE_CLOSE,
+    titleOpenIdx + 1,
+  );
+  if (titleCloseIdx === -1) return { kind: "missing" };
+  const bodyOpenIdx = findOwnLineTag(
+    lines,
+    ENVELOPE_BODY_OPEN,
+    titleCloseIdx + 1,
+  );
+  if (bodyOpenIdx === -1) return { kind: "missing" };
+  const bodyCloseIdx = findOwnLineTag(
+    lines,
+    ENVELOPE_BODY_CLOSE,
+    bodyOpenIdx + 1,
+  );
+  if (bodyCloseIdx === -1) return { kind: "missing" };
 
-  const anyTag =
-    titleOpen !== -1 ||
-    titleClose !== -1 ||
-    bodyOpen !== -1 ||
-    bodyClose !== -1;
-  if (!anyTag) return { kind: "missing" };
-
-  if (titleOpen === -1) {
-    return { kind: "malformed", reason: "missing <<<TITLE>>> open tag" };
-  }
-  if (titleClose === -1) {
-    return { kind: "malformed", reason: "missing <<</TITLE>>> close tag" };
-  }
-  if (titleClose < titleOpen) {
-    return {
-      kind: "malformed",
-      reason: "<<</TITLE>>> appears before <<<TITLE>>>",
-    };
-  }
-  if (bodyOpen === -1) {
-    return { kind: "malformed", reason: "missing <<<BODY>>> open tag" };
-  }
-  if (bodyClose === -1) {
-    return { kind: "malformed", reason: "missing <<</BODY>>> close tag" };
-  }
-  if (bodyClose < bodyOpen) {
-    return {
-      kind: "malformed",
-      reason: "<<</BODY>>> appears before <<<BODY>>>",
-    };
-  }
-
-  const title = text
-    .slice(titleOpen + ENVELOPE_TITLE_OPEN.length, titleClose)
+  const title = lines
+    .slice(titleOpenIdx + 1, titleCloseIdx)
+    .join("\n")
     .replace(/^\n+|\n+$/g, "")
     .trim();
-  const body = text
-    .slice(bodyOpen + ENVELOPE_BODY_OPEN.length, bodyClose)
+  const body = lines
+    .slice(bodyOpenIdx + 1, bodyCloseIdx)
+    .join("\n")
     .replace(/^\n+|\n+$/g, "");
 
   if (title === "") {
@@ -604,6 +616,43 @@ export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
     return { kind: "malformed", reason: "body envelope is empty" };
   }
   return { kind: "ok", suggestion: { title, body } };
+}
+
+/**
+ * Build the focused clarification prompt sent when the work response
+ * had the envelope shape but unusable content (empty title or body).
+ *
+ * Asks the agent to either (a) re-send a valid envelope or (b) emit
+ * one of the non-SUGGESTED_SINGLE verdict keywords.  The
+ * SUGGESTED_SINGLE keyword on its own is intentionally NOT offered:
+ * without an envelope we have no content to author the comment from,
+ * so accepting it would just defer the same blocked outcome.
+ */
+export function buildSquashEnvelopeClarificationPrompt(reason: string): string {
+  return [
+    `Your previous reply contained the <<<TITLE>>> / <<<BODY>>>`,
+    `envelope tags but it could not be parsed: ${reason}.`,
+    ``,
+    `Please respond again with EITHER a valid envelope OR one of the`,
+    `non-suggestion verdict keywords below — no other commentary.`,
+    ``,
+    `Option 1 — valid envelope (each tag on its own line, non-empty`,
+    `title and body):`,
+    ``,
+    `<<<TITLE>>>`,
+    `<your title on a single line>`,
+    `<<</TITLE>>>`,
+    ``,
+    `<<<BODY>>>`,
+    `<your body, multi-line allowed>`,
+    `<<</BODY>>>`,
+    ``,
+    `Option 2 — a single keyword on its own line:`,
+    `- SQUASHED_MULTI — if you actually rewrote history into multiple`,
+    `  commits and force-pushed`,
+    `- BLOCKED — if you cannot complete either path and need user`,
+    `  intervention`,
+  ].join("\n");
 }
 
 // ---- post-or-update helper --------------------------------------------------
@@ -968,36 +1017,43 @@ export function createSquashStageHandler(
       // contract where the agent posted the comment itself and the
       // verdict turn carried "I posted it" semantics.
       //
-      // Envelope absence is NOT a SUGGESTED_SINGLE signal — the
-      // agent could be in the SQUASHED_MULTI branch, or BLOCKED, or
-      // simply ambiguous.  Only an `ok` envelope short-circuits to
-      // the user-choice flow; everything else falls through to the
-      // existing verdict / clarification chain so SQUASHED_MULTI and
-      // BLOCKED keep their behaviour.
-      const envelope = parseSquashEnvelope(squashResult.responseText);
-      if (envelope.kind === "malformed") {
-        opts.onSquashSubStep?.(undefined);
-        return {
-          outcome: "blocked",
-          message: `${squashResult.responseText}\n\n---\n\nSquash-suggestion envelope malformed: ${envelope.reason}.  The agent appears to have taken the SUGGESTED_SINGLE branch but the <<<TITLE>>> / <<<BODY>>> envelope could not be parsed.`,
-        };
-      }
-      if (envelope.kind === "ok") {
+      // The detection in `parseSquashEnvelope` is strict — it requires
+      // all four tags on their own lines, in order — so prose that
+      // merely mentions the tag names (e.g. "I did not use the
+      // `<<<TITLE>>>` envelope" in a multi-commit reply) classifies as
+      // `missing` and falls through to the existing verdict flow.
+      // SQUASHED_MULTI and BLOCKED keep their behaviour.
+      //
+      // When the shape is present but content is empty (the only
+      // remaining `malformed` case), send a focused clarification
+      // before giving up so the agent has a chance to repair a
+      // formatting-only mistake — issue #304 reviewer round 1
+      // explicitly preserves that recovery path.
+
+      /**
+       * Author the marker-delimited PR comment from a parsed envelope
+       * and dispatch to the user-choice flow.  Shared by the work-turn
+       * envelope path and the clarification-retry envelope path so the
+       * round-trip assertion, PR resolution, and verdict event stay in
+       * one place.
+       */
+      const applyOkEnvelope = async (
+        suggestion: SquashSuggestion,
+        rawResponseText: string,
+        sessionId: string | undefined,
+      ): Promise<StageResult> => {
         const prNumber = findPrNumber(ctx.owner, ctx.repo, ctx.branch);
         if (prNumber === undefined) {
           // No open PR — likely a concurrent merge or a missing PR.
-          // The merged guard would have short-circuited if the PR is
-          // merged; otherwise this is genuinely blocked because the
-          // suggestion cannot be persisted anywhere.
           const merged = guardIfPrMerged(ctx, opts);
           if (merged) return merged;
           opts.onSquashSubStep?.(undefined);
           return {
             outcome: "blocked",
-            message: `${squashResult.responseText}\n\n---\n\nSquash-suggestion envelope parsed but no open PR was found for branch ${ctx.branch}; cannot post the suggestion comment.`,
+            message: `${rawResponseText}\n\n---\n\nSquash-suggestion envelope parsed but no open PR was found for branch ${ctx.branch}; cannot post the suggestion comment.`,
           };
         }
-        const commentBody = buildSquashSuggestionComment(envelope.suggestion);
+        const commentBody = buildSquashSuggestionComment(suggestion);
         // Defense-in-depth: confirm the comment we just authored is
         // round-trip parseable before publishing it.  The formatter is
         // unit-tested for this property; the assertion guards against
@@ -1011,9 +1067,97 @@ export function createSquashStageHandler(
         verdictCtx?.events.emit("pipeline:verdict", {
           agent: verdictCtx.agent,
           keyword: "SUGGESTED_SINGLE",
-          raw: squashResult.responseText,
+          raw: rawResponseText,
         });
-        return askUserAndApply(ctx, opts, squashResult.sessionId);
+        return askUserAndApply(ctx, opts, sessionId);
+      };
+
+      const envelope = parseSquashEnvelope(squashResult.responseText);
+      if (envelope.kind === "ok") {
+        return applyOkEnvelope(
+          envelope.suggestion,
+          squashResult.responseText,
+          squashResult.sessionId,
+        );
+      }
+      if (envelope.kind === "malformed") {
+        // Shape detected but unusable — give the agent one focused
+        // chance to repair the envelope (or to redeclare a non-
+        // SUGGESTED_SINGLE verdict) before blocking.  Mirrors the
+        // existing verdict-clarification round so a recoverable agent
+        // mistake does not dump the user into "Give instruction /
+        // Halt" with no context.
+        const clarifyPrompt = buildSquashEnvelopeClarificationPrompt(
+          envelope.reason,
+        );
+        ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
+          resume: true,
+        });
+        const retry = await sendFollowUp(
+          opts.agent,
+          squashResult.sessionId,
+          clarifyPrompt,
+          ctx.worktreePath,
+          ctx.streamSinks?.a,
+          undefined,
+          ctx.usageSinks?.a,
+        );
+        if (retry.sessionId) {
+          ctx.onSessionId?.("a", retry.sessionId);
+        }
+        if (retry.status === "error") {
+          return mapAgentError(retry, "during squash envelope clarification");
+        }
+
+        const retrySessionId = retry.sessionId ?? squashResult.sessionId;
+        const retryEnvelope = parseSquashEnvelope(retry.responseText);
+        if (retryEnvelope.kind === "ok") {
+          return applyOkEnvelope(
+            retryEnvelope.suggestion,
+            retry.responseText,
+            retrySessionId,
+          );
+        }
+
+        const retryKeyword = parseVerdictKeyword(
+          retry.responseText,
+          SQUASH_CHECK_KEYWORDS,
+        ).keyword as SquashVerdict | undefined;
+
+        if (retryKeyword === "SQUASHED_MULTI") {
+          verdictCtx?.events.emit("pipeline:verdict", {
+            agent: verdictCtx.agent,
+            keyword: "SQUASHED_MULTI",
+            raw: retry.responseText,
+          });
+          return runCiPollAndFinish(ctx, opts);
+        }
+        if (retryKeyword === "BLOCKED") {
+          verdictCtx?.events.emit("pipeline:verdict", {
+            agent: verdictCtx.agent,
+            keyword: "BLOCKED",
+            raw: retry.responseText,
+          });
+          opts.onSquashSubStep?.(undefined);
+          return {
+            outcome: "blocked",
+            message: `${squashResult.responseText}\n\n---\n\n${retry.responseText}`,
+          };
+        }
+
+        // Either still malformed, missing, or returned the
+        // SUGGESTED_SINGLE keyword without a usable envelope.  None of
+        // these give us content to author the comment from, so block
+        // with the original parse reason surfaced for diagnostics.
+        const finalReason =
+          retryEnvelope.kind === "malformed"
+            ? retryEnvelope.reason
+            : envelope.reason;
+        opts.onSquashSubStep?.(undefined);
+        return {
+          outcome: "blocked",
+          message: `${squashResult.responseText}\n\n---\n\n${retry.responseText}\n\n---\n\nSquash-suggestion envelope still unrecoverable after clarification: ${finalReason}.  Expected a valid <<<TITLE>>> / <<<BODY>>> envelope or a SQUASHED_MULTI / BLOCKED keyword.`,
+        };
       }
 
       // ---- verdict --------------------------------------------------------

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -245,7 +245,11 @@ export function buildSquashPrompt(
     `     Both envelopes are required.  Do not nest fenced code blocks`,
     `     around the envelope.  agentcoop parses the text between the`,
     `     tags verbatim — leading and trailing blank lines are stripped,`,
-    `     internal blank lines are preserved.`,
+    `     internal blank lines are preserved.  The body may include a`,
+    `     literal \`<<</BODY>>>\` line as content (e.g. when documenting`,
+    `     this envelope contract); agentcoop anchors the structural`,
+    `     close to the LAST own-line \`<<</BODY>>>\`, so put your final`,
+    `     close tag on its own line as the last line of the envelope.`,
     ``,
     `   **If multiple commits are appropriate:**`,
     ...(ctx.baseSha
@@ -576,6 +580,30 @@ function findOwnLineTag(lines: string[], tag: string, start: number): number {
 }
 
 /**
+ * Find the last line index strictly before `end` (and at or after
+ * `start`) whose trimmed contents exactly match `tag`.  Returns -1
+ * when not found.
+ *
+ * Used for envelope close-tag detection so the body may legitimately
+ * contain a literal `<<</BODY>>>` line as content (e.g. a commit
+ * message that documents the envelope contract itself, plausible for
+ * issue #304 where the body discusses the marker block).  Anchoring
+ * to the LAST own-line occurrence absorbs in-body literals as content
+ * and only treats the final own-line tag as the structural close.
+ */
+function findLastOwnLineTag(
+  lines: string[],
+  tag: string,
+  start: number,
+  end: number,
+): number {
+  for (let i = end - 1; i >= start; i--) {
+    if (lines[i].trim() === tag) return i;
+  }
+  return -1;
+}
+
+/**
  * Parse the agent's `<<<TITLE>>>...<<</TITLE>>> / <<<BODY>>>...<<</BODY>>>`
  * envelope from a free-form response.
  *
@@ -589,6 +617,13 @@ function findOwnLineTag(lines: string[], tag: string, start: number): number {
  * `malformed` so the caller's focused clarification turn can fire —
  * a dropped line is exactly the recoverable formatting mistake
  * issue #304 wants the agent to be able to repair.
+ *
+ * BODY_CLOSE is anchored to the LAST own-line `<<</BODY>>>` after
+ * BODY_OPEN (vs. FIRST for the other tags) so a body documenting
+ * the envelope contract — plausible for issue #304 itself — does
+ * not get truncated at the first own-line close marker.  Title is
+ * conventionally one line per the prompt, so TITLE_CLOSE keeps the
+ * simpler FIRST rule.
  *
  * Returns:
  *   - `{ kind: "missing" }` when no `<<<TITLE>>>` tag appears on its
@@ -634,10 +669,16 @@ export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
       reason: "missing <<<BODY>>> open tag after the title envelope",
     };
   }
-  const bodyCloseIdx = findOwnLineTag(
+  // Anchor BODY_CLOSE to the LAST own-line occurrence so the body
+  // may legitimately contain a literal `<<</BODY>>>` line as content
+  // (e.g. a commit message documenting the envelope contract — see
+  // issue #304 round 5 review).  In-body literals are absorbed as
+  // content; only the final own-line tag is the structural close.
+  const bodyCloseIdx = findLastOwnLineTag(
     lines,
     ENVELOPE_BODY_CLOSE,
     bodyOpenIdx + 1,
+    lines.length,
   );
   if (bodyCloseIdx === -1) {
     return {
@@ -693,6 +734,11 @@ export function buildSquashEnvelopeClarificationPrompt(reason: string): string {
     `<<<BODY>>>`,
     `<your body, multi-line allowed>`,
     `<<</BODY>>>`,
+    ``,
+    `The body may legitimately contain a literal \`<<</BODY>>>\` line`,
+    `as content; agentcoop anchors the structural close to the LAST`,
+    `own-line \`<<</BODY>>>\`, so place your final close tag on its`,
+    `own line as the last line of the envelope.`,
     ``,
     `Option 2 — a single keyword on its own line:`,
     `- SQUASHED_MULTI — if you actually rewrote history into multiple`,

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -37,7 +37,11 @@ import {
   queryPrState as defaultQueryPrState,
   type PrLifecycleState,
 } from "./pr.js";
-import { findLatestCommentWithMarker as defaultFindLatestCommentWithMarker } from "./pr-comments.js";
+import {
+  findLatestCommentWithMarker as defaultFindLatestCommentWithMarker,
+  patchPrComment as defaultPatchPrComment,
+  postPrComment as defaultPostPrComment,
+} from "./pr-comments.js";
 import type { SquashSubStep } from "./run-state.js";
 import {
   invokeOrResume,
@@ -92,9 +96,10 @@ export interface SquashStageOptions {
   countBranchCommits?: (cwd: string, baseBranch: string) => number;
   /**
    * Look up the squash-suggestion PR comment body containing `marker`.
-   * Injected for testability.  Defaults to
-   * `pr-comments.findLatestCommentWithMarker`, which shells out to
-   * `gh api` to list PR comments.
+   * Injected for testability.  Returns just the body — the read-side
+   * never needs the comment id, so this stays string-returning even
+   * after the underlying `findLatestCommentWithMarker` was widened to
+   * `{ id, body }`.  The default adapts the widened helper.
    */
   findSuggestionCommentBody?: (
     owner: string,
@@ -102,6 +107,19 @@ export interface SquashStageOptions {
     prNumber: number,
     marker: string,
   ) => string | undefined;
+  /**
+   * Post or update the squash-suggestion PR comment idempotently.
+   * Single entry point for the write side: the implementation looks
+   * up any existing comment with the start marker and either PATCHes
+   * it or POSTs a new one.  Injected for testability — the default
+   * shells out to `gh` via {@link postOrUpdateSquashSuggestion}.
+   */
+  postSuggestionComment?: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+    body: string,
+  ) => void;
   /**
    * Resolve the PR number for the current branch.  Injected for
    * testability.  Defaults to `pr.findPrNumber`.
@@ -203,82 +221,31 @@ export function buildSquashPrompt(
     ``,
     `   **If a single commit is appropriate:**`,
     `   - Do NOT rewrite history.  Do NOT force-push.`,
+    `   - Do NOT post or edit any PR comment yourself — agentcoop will`,
+    `     author the squash-suggestion comment from your reply below.`,
     `   - Draft the commit title and body that should be used when the`,
     `     PR is squash-merged.  The title must not include issue or PR`,
     `     numbers; reference the issue in the body using \`Closes #N\``,
     `     or \`Part of #N\`.`,
-    `   - Post the suggestion as a **PR comment** (not in the PR body).`,
-    `     The comment body must contain a marker-delimited block with`,
-    `     this exact structure:`,
-    ``,
-    `     \`\`\`\`text`,
-    `     ${SQUASH_SUGGESTION_START_MARKER}`,
-    `     ## Suggested squash commit`,
-    ``,
-    `     **Title**`,
+    `   - Reply with the title and body wrapped in this exact envelope`,
+    `     (no fences, no surrounding code blocks, no extra commentary`,
+    `     between the tags):`,
     ``,
     `     \`\`\`text`,
-    `     <your title>`,
+    `     <<<TITLE>>>`,
+    `     <your title on a single line>`,
+    `     <<</TITLE>>>`,
+    ``,
+    `     <<<BODY>>>`,
+    `     <your body, multi-line allowed,`,
+    `     may include \`Closes #N\` / \`Part of #N\`>`,
+    `     <<</BODY>>>`,
     `     \`\`\``,
     ``,
-    `     **Body**`,
-    ``,
-    `     \`\`\`text`,
-    `     <your body — may include \`Closes #N\` / \`Part of #N\`>`,
-    `     \`\`\``,
-    `     ${SQUASH_SUGGESTION_END_MARKER}`,
-    `     \`\`\`\``,
-    ``,
-    `     **Choose each fence length dynamically.**  Per CommonMark, a`,
-    `     fenced code block closes only on a line containing a run of`,
-    `     the same character that is **as long or longer** than the`,
-    `     opening fence.  Commit bodies may legitimately contain code`,
-    `     samples with their own triple-backtick fences, so a fixed`,
-    `     three-backtick outer fence would close early at the first`,
-    `     \`\`\`\` line inside the content.  Compute:`,
-    ``,
-    `       fence_len = max(longest run of backticks in the content, 2) + 1`,
-    ``,
-    `     (minimum 3).  Calculate the title fence length from the`,
-    `     title string and the body fence length from the body string,`,
-    `     independently.  Use the same character (backtick) for both`,
-    `     the opening and closing line of a given block.`,
-    ``,
-    `     Worked example — if the body contains a line of triple`,
-    `     backticks anywhere (e.g. a README excerpt), open and close`,
-    `     the body with **four** backticks; a run of five backticks in`,
-    `     the content requires six on the fence; and so on.  The title`,
-    `     fence typically stays at three.`,
-    ``,
-    `     Do not add a blank line between the opening fence and the`,
-    `     first line of content, or between the last line of content`,
-    `     and the closing fence.  Do not indent the fences.`,
-    ``,
-    `     **Update idempotently.**  This prompt may run more than once`,
-    `     on the same PR.  Before posting, list existing PR comments`,
-    `     and look for a previous squash-suggestion comment — one`,
-    `     whose body contains \`${SQUASH_SUGGESTION_START_MARKER}\`.`,
-    `     If found, edit that comment via`,
-    `     \`gh api --method PATCH /repos/{owner}/{repo}/issues/comments/{id} --field body="..."\``,
-    `     so its body becomes the new suggestion.  If no prior comment`,
-    `     exists, create a fresh one with`,
-    `     \`gh pr comment <pr> --repo <owner>/<repo> --body "..."\`.`,
-    `     Locate any prior comment with:`,
-    ``,
-    `     \`\`\`text`,
-    `     gh api repos/{owner}/{repo}/issues/{pr}/comments --paginate --slurp \\`,
-    `       --jq '[.[] | .[] | select(.body | contains("${SQUASH_SUGGESTION_START_MARKER}"))] | last'`,
-    `     \`\`\``,
-    ``,
-    `     \`--paginate --slurp\` is required: \`--paginate\` alone applies`,
-    `     the \`--jq\` filter page-by-page, so on a long PR timeline`,
-    `     \`| last\` would return the last match within each page rather`,
-    `     than the latest match overall.  \`--slurp\` wraps all pages in`,
-    `     an outer array (\`[[page1...], [page2...]]\`); the \`.[] | .[]\``,
-    `     prefix flattens that before filtering.`,
-    ``,
-    `     Do not write the suggestion into the PR body.  Leave the`,
-    `     PR body untouched.`,
+    `     Both envelopes are required.  Do not nest fenced code blocks`,
+    `     around the envelope.  agentcoop parses the text between the`,
+    `     tags verbatim — leading and trailing blank lines are stripped,`,
+    `     internal blank lines are preserved.`,
     ``,
     `   **If multiple commits are appropriate:**`,
     ...(ctx.baseSha
@@ -331,8 +298,8 @@ export function buildSquashCompletionCheckPrompt(): string {
     `- SQUASHED_MULTI — if you rewrote history into multiple meaningful`,
     `  commits and force-pushed`,
     `- SUGGESTED_SINGLE — if a single commit is appropriate and you`,
-    `  posted the suggested title/body as a PR comment containing`,
-    `  the marker block (no force-push)`,
+    `  drafted the suggested title and body in the <<<TITLE>>>/`,
+    `  <<<BODY>>> envelope (no force-push)`,
     `- BLOCKED — if you could not complete either path and need user`,
     `  intervention`,
     ``,
@@ -343,17 +310,21 @@ export function buildSquashCompletionCheckPrompt(): string {
 /**
  * Follow-up prompt sent on the same session when the user picks
  * "agent squashes now" after a SUGGESTED_SINGLE verdict.  The agent
- * already drafted the message in a PR comment, so this just asks it
- * to perform the squash with the same message.
+ * already drafted the title and body (either as a `<<<TITLE>>>` /
+ * `<<<BODY>>>` envelope on the new path, or as a marker-delimited PR
+ * comment on the legacy fallback path), so this just asks it to
+ * perform the squash with the same message.
  */
 export function buildAgentSquashFollowupPrompt(): string {
   return [
     `The user chose to have you perform the squash now using the title`,
-    `and body you posted in the squash-suggestion PR comment.`,
+    `and body you drafted earlier in this conversation (either via the`,
+    `<<<TITLE>>> / <<<BODY>>> envelope or via the squash-suggestion PR`,
+    `comment).`,
     ``,
     `Squash the branch into a single commit using that exact title and`,
     `body, then force-push (\`git push --force-with-lease\`).  You may`,
-    `leave the squash-suggestion comment on the PR — it does not`,
+    `leave the squash-suggestion PR comment in place — it does not`,
     `interfere with merging.`,
   ].join("\n");
 }
@@ -479,16 +450,217 @@ function readFencedBlock(
  * label followed by a well-formed fenced block that
  * `parseSquashSuggestionBlock` can extract).
  *
- * Stage 8 must use this strict check rather than a marker-presence
- * check because Stage 9 reads the same block via
- * `parseSquashSuggestionBlock` to render the inline preview.  If
- * Stage 8 accepted a malformed block (e.g. only the start marker, or
- * a block missing the `**Title**` label / the end marker), the
- * SUGGESTED_SINGLE path could complete with `applied_via_github`
- * while leaving Stage 9 with nothing to show.
+ * Used as a defense-in-depth assertion immediately after Stage 8
+ * authored the comment itself, and as the gate when the handler
+ * resumes from `awaiting_user_choice` against a comment it did not
+ * just write.  Stage 9 reads the same block via
+ * `parseSquashSuggestionBlock` to render the inline preview, so a
+ * malformed block must not be allowed to flow into
+ * `applied_via_github`.
  */
 function hasValidSuggestionBlock(source: string | undefined): boolean {
   return parseSquashSuggestionBlock(source) !== undefined;
+}
+
+// ---- canonical comment formatter --------------------------------------------
+
+/**
+ * Longest run of backtick characters in `s`.  Used to size CommonMark
+ * fences so a body that itself contains triple-backtick code samples
+ * does not close the outer fence early.
+ */
+function longestBacktickRun(s: string): number {
+  let max = 0;
+  let current = 0;
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) === 0x60 /* ` */) {
+      current++;
+      if (current > max) max = current;
+    } else {
+      current = 0;
+    }
+  }
+  return max;
+}
+
+/**
+ * Build the canonical squash-suggestion PR comment body for
+ * `suggestion`.  The output is:
+ *
+ * - Wrapped in {@link SQUASH_SUGGESTION_START_MARKER} /
+ *   {@link SQUASH_SUGGESTION_END_MARKER}.
+ * - Title and body each appear under their `**Title**` / `**Body**`
+ *   label inside a CommonMark fenced code block.
+ * - Each fence is sized via `max(longest backtick run, 2) + 1`,
+ *   computed independently for title and body, so commit content
+ *   containing triple-backtick samples does not close the outer
+ *   block early.
+ *
+ * The result round-trips through {@link parseSquashSuggestionBlock}.
+ */
+export function buildSquashSuggestionComment(
+  suggestion: SquashSuggestion,
+): string {
+  const titleFenceLen = Math.max(longestBacktickRun(suggestion.title), 2) + 1;
+  const bodyFenceLen = Math.max(longestBacktickRun(suggestion.body), 2) + 1;
+  const titleFence = "`".repeat(titleFenceLen);
+  const bodyFence = "`".repeat(bodyFenceLen);
+  return [
+    SQUASH_SUGGESTION_START_MARKER,
+    "## Suggested squash commit",
+    "",
+    "**Title**",
+    "",
+    `${titleFence}text`,
+    suggestion.title,
+    titleFence,
+    "",
+    "**Body**",
+    "",
+    `${bodyFence}text`,
+    suggestion.body,
+    bodyFence,
+    SQUASH_SUGGESTION_END_MARKER,
+  ].join("\n");
+}
+
+// ---- envelope parser --------------------------------------------------------
+
+/** Result of parsing the `<<<TITLE>>>` / `<<<BODY>>>` agent envelope. */
+export type SquashEnvelopeResult =
+  | { kind: "missing" }
+  | { kind: "malformed"; reason: string }
+  | { kind: "ok"; suggestion: SquashSuggestion };
+
+const ENVELOPE_TITLE_OPEN = "<<<TITLE>>>";
+const ENVELOPE_TITLE_CLOSE = "<<</TITLE>>>";
+const ENVELOPE_BODY_OPEN = "<<<BODY>>>";
+const ENVELOPE_BODY_CLOSE = "<<</BODY>>>";
+
+/**
+ * Parse the agent's `<<<TITLE>>>...<<</TITLE>>> / <<<BODY>>>...<<</BODY>>>`
+ * envelope from a free-form response.
+ *
+ * Returns:
+ *   - `{ kind: "missing" }` when none of the four envelope tags are
+ *     present.  The caller should fall through to the verdict flow:
+ *     envelope absence on its own is not a SUGGESTED_SINGLE signal.
+ *   - `{ kind: "malformed", reason }` when at least one tag is present
+ *     but the envelope is unparseable (missing close tag, empty title,
+ *     etc.).  The caller should funnel into the blocked path with the
+ *     reason surfaced for diagnostics.
+ *   - `{ kind: "ok", suggestion }` on a well-formed envelope.
+ */
+export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
+  const titleOpen = text.indexOf(ENVELOPE_TITLE_OPEN);
+  const titleClose = text.indexOf(ENVELOPE_TITLE_CLOSE);
+  const bodyOpen = text.indexOf(ENVELOPE_BODY_OPEN);
+  const bodyClose = text.indexOf(ENVELOPE_BODY_CLOSE);
+
+  const anyTag =
+    titleOpen !== -1 ||
+    titleClose !== -1 ||
+    bodyOpen !== -1 ||
+    bodyClose !== -1;
+  if (!anyTag) return { kind: "missing" };
+
+  if (titleOpen === -1) {
+    return { kind: "malformed", reason: "missing <<<TITLE>>> open tag" };
+  }
+  if (titleClose === -1) {
+    return { kind: "malformed", reason: "missing <<</TITLE>>> close tag" };
+  }
+  if (titleClose < titleOpen) {
+    return {
+      kind: "malformed",
+      reason: "<<</TITLE>>> appears before <<<TITLE>>>",
+    };
+  }
+  if (bodyOpen === -1) {
+    return { kind: "malformed", reason: "missing <<<BODY>>> open tag" };
+  }
+  if (bodyClose === -1) {
+    return { kind: "malformed", reason: "missing <<</BODY>>> close tag" };
+  }
+  if (bodyClose < bodyOpen) {
+    return {
+      kind: "malformed",
+      reason: "<<</BODY>>> appears before <<<BODY>>>",
+    };
+  }
+
+  const title = text
+    .slice(titleOpen + ENVELOPE_TITLE_OPEN.length, titleClose)
+    .replace(/^\n+|\n+$/g, "")
+    .trim();
+  const body = text
+    .slice(bodyOpen + ENVELOPE_BODY_OPEN.length, bodyClose)
+    .replace(/^\n+|\n+$/g, "");
+
+  if (title === "") {
+    return { kind: "malformed", reason: "title envelope is empty" };
+  }
+  if (body === "") {
+    return { kind: "malformed", reason: "body envelope is empty" };
+  }
+  return { kind: "ok", suggestion: { title, body } };
+}
+
+// ---- post-or-update helper --------------------------------------------------
+
+/**
+ * Dependencies for {@link postOrUpdateSquashSuggestion}.  Exposed so
+ * unit tests can substitute stub gh adapters without monkey-patching
+ * the module-level imports.
+ */
+export interface PostOrUpdateSquashSuggestionDeps {
+  findLatest?: (
+    owner: string,
+    repo: string,
+    prNumber: number,
+    marker: string,
+  ) => { id: number | undefined; body: string } | undefined;
+  patch?: (owner: string, repo: string, id: number, body: string) => void;
+  post?: (owner: string, repo: string, prNumber: number, body: string) => void;
+}
+
+/**
+ * Idempotent write entry point for the squash-suggestion PR comment.
+ *
+ * Looks up any existing comment whose body contains
+ * {@link SQUASH_SUGGESTION_START_MARKER}.  When a prior comment
+ * exists and exposes its id, edit it via PATCH so the PR timeline
+ * does not accumulate duplicate suggestion comments.  Otherwise,
+ * post a fresh comment.
+ *
+ * If the prior-comment lookup returns a body without an id (older
+ * fixtures, manual stubs), this falls back to POST — the caller will
+ * end up with two comments on the PR but the most recent one wins
+ * for display purposes.  The default lookup always populates id from
+ * the GitHub API response.
+ */
+export function postOrUpdateSquashSuggestion(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  body: string,
+  deps: PostOrUpdateSquashSuggestionDeps = {},
+): void {
+  const findLatest = deps.findLatest ?? defaultFindLatestCommentWithMarker;
+  const patch = deps.patch ?? defaultPatchPrComment;
+  const post = deps.post ?? defaultPostPrComment;
+
+  const existing = findLatest(
+    owner,
+    repo,
+    prNumber,
+    SQUASH_SUGGESTION_START_MARKER,
+  );
+  if (existing && existing.id !== undefined) {
+    patch(owner, repo, existing.id, body);
+    return;
+  }
+  post(owner, repo, prNumber, body);
 }
 
 // ---- handler -----------------------------------------------------------------
@@ -619,8 +791,13 @@ export function createSquashStageHandler(
     handler: async (ctx: StageContext): Promise<StageResult> => {
       const countCommits = opts.countBranchCommits ?? defaultCountBranchCommits;
       const findSuggestionCommentBody =
-        opts.findSuggestionCommentBody ?? defaultFindLatestCommentWithMarker;
+        opts.findSuggestionCommentBody ??
+        ((owner, repo, prNumber, marker) =>
+          defaultFindLatestCommentWithMarker(owner, repo, prNumber, marker)
+            ?.body);
       const findPrNumber = opts.findPrNumber ?? defaultFindPrNumber;
+      const postSuggestionComment =
+        opts.postSuggestionComment ?? postOrUpdateSquashSuggestion;
 
       /**
        * Resolve and fetch the squash-suggestion comment body for the
@@ -778,11 +955,68 @@ export function createSquashStageHandler(
         return mapAgentError(squashResult, "during squash");
       }
 
-      // ---- verdict --------------------------------------------------------
       const verdictCtx: VerdictContext | undefined = ctx.events
         ? { events: ctx.events, agent: "a" }
         : undefined;
 
+      // ---- envelope-driven SUGGESTED_SINGLE shortcut ----------------------
+      //
+      // The agent now hands back a `<<<TITLE>>>...<<</TITLE>>>` /
+      // `<<<BODY>>>...<<</BODY>>>` envelope when it judges a single
+      // commit appropriate, and agentcoop authors the marker-delimited
+      // PR comment from those fields.  This replaces the prior
+      // contract where the agent posted the comment itself and the
+      // verdict turn carried "I posted it" semantics.
+      //
+      // Envelope absence is NOT a SUGGESTED_SINGLE signal — the
+      // agent could be in the SQUASHED_MULTI branch, or BLOCKED, or
+      // simply ambiguous.  Only an `ok` envelope short-circuits to
+      // the user-choice flow; everything else falls through to the
+      // existing verdict / clarification chain so SQUASHED_MULTI and
+      // BLOCKED keep their behaviour.
+      const envelope = parseSquashEnvelope(squashResult.responseText);
+      if (envelope.kind === "malformed") {
+        opts.onSquashSubStep?.(undefined);
+        return {
+          outcome: "blocked",
+          message: `${squashResult.responseText}\n\n---\n\nSquash-suggestion envelope malformed: ${envelope.reason}.  The agent appears to have taken the SUGGESTED_SINGLE branch but the <<<TITLE>>> / <<<BODY>>> envelope could not be parsed.`,
+        };
+      }
+      if (envelope.kind === "ok") {
+        const prNumber = findPrNumber(ctx.owner, ctx.repo, ctx.branch);
+        if (prNumber === undefined) {
+          // No open PR — likely a concurrent merge or a missing PR.
+          // The merged guard would have short-circuited if the PR is
+          // merged; otherwise this is genuinely blocked because the
+          // suggestion cannot be persisted anywhere.
+          const merged = guardIfPrMerged(ctx, opts);
+          if (merged) return merged;
+          opts.onSquashSubStep?.(undefined);
+          return {
+            outcome: "blocked",
+            message: `${squashResult.responseText}\n\n---\n\nSquash-suggestion envelope parsed but no open PR was found for branch ${ctx.branch}; cannot post the suggestion comment.`,
+          };
+        }
+        const commentBody = buildSquashSuggestionComment(envelope.suggestion);
+        // Defense-in-depth: confirm the comment we just authored is
+        // round-trip parseable before publishing it.  The formatter is
+        // unit-tested for this property; the assertion guards against
+        // a future regression sneaking a malformed block into Stage 9.
+        if (!hasValidSuggestionBlock(commentBody)) {
+          throw new Error(
+            "buildSquashSuggestionComment produced an unparseable block — formatter / parser are out of sync",
+          );
+        }
+        postSuggestionComment(ctx.owner, ctx.repo, prNumber, commentBody);
+        verdictCtx?.events.emit("pipeline:verdict", {
+          agent: verdictCtx.agent,
+          keyword: "SUGGESTED_SINGLE",
+          raw: squashResult.responseText,
+        });
+        return askUserAndApply(ctx, opts, squashResult.sessionId);
+      }
+
+      // ---- verdict --------------------------------------------------------
       const handle = await resolveVerdict(
         opts.agent,
         squashResult.sessionId,

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -337,6 +337,15 @@ export function buildAgentSquashFollowupPrompt(): string {
  * markers are missing or the block does not contain a parseable
  * title.
  *
+ * Markers are anchored to whole lines (their trimmed contents must
+ * equal the marker string).  The end marker is required to appear on
+ * its own line on or after the body's closing fence, so a literal end
+ * marker that the agent embedded inside the body fenced block does not
+ * truncate the parse: the body fence absorbs that occurrence as
+ * content, and only a free-standing end-marker line — emitted by
+ * {@link buildSquashSuggestionComment} after the body fence closes —
+ * counts as the delimiter.
+ *
  * The block uses `**Title**` and `**Body**` labels each followed by a
  * CommonMark-style fenced code block.  The fence length is chosen
  * dynamically by the agent so the block can survive commit bodies
@@ -349,16 +358,26 @@ export function parseSquashSuggestionBlock(
   source: string | undefined,
 ): SquashSuggestion | undefined {
   if (!source) return undefined;
-  const startIdx = source.indexOf(SQUASH_SUGGESTION_START_MARKER);
-  const endIdx = source.indexOf(SQUASH_SUGGESTION_END_MARKER);
-  if (startIdx === -1 || endIdx === -1 || endIdx < startIdx) return undefined;
+  const lines = source.split("\n");
 
-  const inner = source.slice(
-    startIdx + SQUASH_SUGGESTION_START_MARKER.length,
-    endIdx,
+  const startLineIdx = lines.findIndex(
+    (l) => l.trim() === SQUASH_SUGGESTION_START_MARKER,
   );
+  if (startLineIdx === -1) return undefined;
 
-  return parseFencedSuggestion(inner);
+  const parsed = parseFencedSuggestion(lines, startLineIdx + 1);
+  if (!parsed) return undefined;
+
+  // Require a free-standing end-marker line at or after the body's
+  // closing fence.  Scanning from there (rather than `indexOf` over
+  // the whole source) ignores literal end-marker text embedded inside
+  // the body fenced block, which the formatter writes verbatim.
+  for (let i = parsed.endLineIdx + 1; i < lines.length; i++) {
+    if (lines[i].trim() === SQUASH_SUGGESTION_END_MARKER) {
+      return parsed.suggestion;
+    }
+  }
+  return undefined;
 }
 
 /** Label-line regex for the fenced format (`**Title**` / `**Body**`). */
@@ -367,15 +386,18 @@ function labelLineRe(label: "Title" | "Body"): RegExp {
 }
 
 /**
- * Parse the fenced format.  Returns `undefined` when either label is
+ * Parse the fenced format from `lines` starting at index `start`.
+ * Returns the parsed suggestion plus `endLineIdx` (the line index of
+ * the body fence's closing line), or `undefined` when either label is
  * missing, when the fenced block that should follow the label is
- * malformed (missing opening fence, unterminated), or when the
- * blocks appear in the wrong order.
+ * malformed (missing opening fence, unterminated), or when the blocks
+ * appear in the wrong order.
  */
-function parseFencedSuggestion(inner: string): SquashSuggestion | undefined {
-  const lines = inner.split("\n");
-
-  const titleLabelIdx = findLabelLine(lines, 0, "Title");
+function parseFencedSuggestion(
+  lines: string[],
+  start: number,
+): { suggestion: SquashSuggestion; endLineIdx: number } | undefined {
+  const titleLabelIdx = findLabelLine(lines, start, "Title");
   if (titleLabelIdx === -1) return undefined;
 
   const titleBlock = readFencedBlock(lines, titleLabelIdx + 1);
@@ -388,8 +410,11 @@ function parseFencedSuggestion(inner: string): SquashSuggestion | undefined {
   if (!bodyBlock) return undefined;
 
   return {
-    title: titleBlock.content.replace(/^\n+|\n+$/g, "").trim(),
-    body: bodyBlock.content.replace(/^\n+|\n+$/g, ""),
+    suggestion: {
+      title: titleBlock.content.replace(/^\n+|\n+$/g, "").trim(),
+      body: bodyBlock.content.replace(/^\n+|\n+$/g, ""),
+    },
+    endLineIdx: bodyBlock.endIdx,
   };
 }
 
@@ -1079,6 +1104,18 @@ export function createSquashStageHandler(
       // meant to repair, and falling through to the verdict path
       // instead either hard-blocks opaquely or reuses a stale prior
       // suggestion comment.
+      //
+      // Issue #304 reviewer round 3: a SUGGESTED_SINGLE outcome MUST be
+      // backed by a current title/body envelope from this run.  A
+      // historical PR comment from an earlier run is not evidence that
+      // the agent intends a single-commit suggestion this time, so the
+      // post-verdict path no longer reads `findSuggestionCommentBody`
+      // to infer SUGGESTED_SINGLE — that would propagate the stale
+      // suggestion problem the issue called out into the new design.
+      // Instead, when verdict resolves to SUGGESTED_SINGLE without an
+      // envelope this run, the same focused clarification turn used for
+      // the malformed case fires (asking for either a valid envelope or
+      // SQUASHED_MULTI / BLOCKED).
 
       /**
        * Author the marker-delimited PR comment from a parsed envelope
@@ -1138,30 +1175,31 @@ export function createSquashStageHandler(
         return askUserAndApply(ctx, opts, sessionId);
       };
 
-      const envelope = parseSquashEnvelope(squashResult.responseText);
-      if (envelope.kind === "ok") {
-        return applyOkEnvelope(
-          envelope.suggestion,
-          squashResult.responseText,
-          squashResult.sessionId,
-        );
-      }
-      if (envelope.kind === "malformed") {
-        // Shape detected but unusable — give the agent one focused
-        // chance to repair the envelope (or to redeclare a non-
-        // SUGGESTED_SINGLE verdict) before blocking.  Mirrors the
-        // existing verdict-clarification round so a recoverable agent
-        // mistake does not dump the user into "Give instruction /
-        // Halt" with no context.
-        const clarifyPrompt = buildSquashEnvelopeClarificationPrompt(
-          envelope.reason,
-        );
+      /**
+       * Send the focused envelope clarification turn and route on the
+       * retry response.  Shared by the malformed-envelope path (work
+       * response had envelope intent but unusable structure) and by
+       * the post-verdict "SUGGESTED_SINGLE without envelope" path
+       * (agent declared SUGGESTED_SINGLE in the verdict turn but never
+       * provided a `<<<TITLE>>> / <<<BODY>>>` envelope in any earlier
+       * response, so we have no content to author the comment from).
+       *
+       * `messagePrefix` is everything that should appear before the
+       * retry response in any user-facing blocked message — typically
+       * the work response, optionally followed by the verdict response.
+       */
+      const runEnvelopeClarification = async (
+        messagePrefix: string,
+        prevSessionId: string | undefined,
+        reason: string,
+      ): Promise<StageResult> => {
+        const clarifyPrompt = buildSquashEnvelopeClarificationPrompt(reason);
         ctx.promptSinks?.a?.(clarifyPrompt, "verdict-followup", {
           resume: true,
         });
         const retry = await sendFollowUp(
           opts.agent,
-          squashResult.sessionId,
+          prevSessionId,
           clarifyPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
@@ -1175,7 +1213,7 @@ export function createSquashStageHandler(
           return mapAgentError(retry, "during squash envelope clarification");
         }
 
-        const retrySessionId = retry.sessionId ?? squashResult.sessionId;
+        const retrySessionId = retry.sessionId ?? prevSessionId;
         const retryEnvelope = parseSquashEnvelope(retry.responseText);
         if (retryEnvelope.kind === "ok") {
           return applyOkEnvelope(
@@ -1207,7 +1245,7 @@ export function createSquashStageHandler(
           opts.onSquashSubStep?.(undefined);
           return {
             outcome: "blocked",
-            message: `${squashResult.responseText}\n\n---\n\n${retry.responseText}`,
+            message: `${messagePrefix}\n\n---\n\n${retry.responseText}`,
           };
         }
 
@@ -1216,14 +1254,34 @@ export function createSquashStageHandler(
         // these give us content to author the comment from, so block
         // with the original parse reason surfaced for diagnostics.
         const finalReason =
-          retryEnvelope.kind === "malformed"
-            ? retryEnvelope.reason
-            : envelope.reason;
+          retryEnvelope.kind === "malformed" ? retryEnvelope.reason : reason;
         opts.onSquashSubStep?.(undefined);
         return {
           outcome: "blocked",
-          message: `${squashResult.responseText}\n\n---\n\n${retry.responseText}\n\n---\n\nSquash-suggestion envelope still unrecoverable after clarification: ${finalReason}.  Expected a valid <<<TITLE>>> / <<<BODY>>> envelope or a SQUASHED_MULTI / BLOCKED keyword.`,
+          message: `${messagePrefix}\n\n---\n\n${retry.responseText}\n\n---\n\nSquash-suggestion envelope still unrecoverable after clarification: ${finalReason}.  Expected a valid <<<TITLE>>> / <<<BODY>>> envelope or a SQUASHED_MULTI / BLOCKED keyword.`,
         };
+      };
+
+      const envelope = parseSquashEnvelope(squashResult.responseText);
+      if (envelope.kind === "ok") {
+        return applyOkEnvelope(
+          envelope.suggestion,
+          squashResult.responseText,
+          squashResult.sessionId,
+        );
+      }
+      if (envelope.kind === "malformed") {
+        // Shape detected but unusable — give the agent one focused
+        // chance to repair the envelope (or to redeclare a non-
+        // SUGGESTED_SINGLE verdict) before blocking.  Mirrors the
+        // existing verdict-clarification round so a recoverable agent
+        // mistake does not dump the user into "Give instruction /
+        // Halt" with no context.
+        return runEnvelopeClarification(
+          squashResult.responseText,
+          squashResult.sessionId,
+          envelope.reason,
+        );
       }
 
       // ---- verdict --------------------------------------------------------
@@ -1259,31 +1317,26 @@ export function createSquashStageHandler(
 
       // ---- post-clarification deterministic fallback chain -----------------
       // Order matters: a completed force-push is the hard-to-undo side
-      // effect, so detect it first.  Only then check the suggestion
-      // comment, because an earlier run may have left a stale comment
-      // on the PR that would otherwise be misclassified.  The block
-      // must be fully parseable (markers + `**Title**` label) — a malformed
-      // block is treated as missing because Stage 9 cannot render a
-      // preview from it.
+      // effect, so detect it first.  We deliberately do NOT promote a
+      // historical squash-suggestion comment on the PR to a
+      // SUGGESTED_SINGLE verdict here: issue #304 reviewer round 3
+      // called this stale-comment propagation out as a regression.  A
+      // SUGGESTED_SINGLE outcome must be backed by a current envelope
+      // from this run; without one, the only deterministic signals
+      // are commit-count collapse (SQUASHED_MULTI) or BLOCKED.
       if (verdict === undefined) {
         const postCount = countCommits(ctx.worktreePath, opts.defaultBranch);
         if (postCount < initialCount) {
           verdict = "SQUASHED_MULTI";
         } else {
-          // Check the PR lifecycle BEFORE the comment lookup:
-          // `findPrNumber` uses `gh pr list` (open PRs only), so a
-          // concurrent merge between the clarification turn and this
-          // fallback would make the lookup return `undefined` and flip
-          // the verdict to `BLOCKED` instead of taking the existing
-          // merged short-circuit.
+          // Before falling back to BLOCKED, check whether the PR was
+          // concurrently merged on GitHub.  Returning "alreadyMerged"
+          // is a more accurate outcome than BLOCKED when the merge
+          // already happened — the user did not need agentcoop to
+          // finish the squash decision.
           const merged = guardIfPrMerged(ctx, opts);
           if (merged) return merged;
-          const commentBody = readSuggestionCommentBody();
-          if (hasValidSuggestionBlock(commentBody)) {
-            verdict = "SUGGESTED_SINGLE";
-          } else {
-            verdict = "BLOCKED";
-          }
+          verdict = "BLOCKED";
         }
         // The verdict was derived deterministically rather than parsed
         // from the agent response, but telemetry consumers still need
@@ -1308,29 +1361,28 @@ export function createSquashStageHandler(
       }
 
       if (verdict === "SUGGESTED_SINGLE") {
-        // Check the PR lifecycle BEFORE reading the suggestion
-        // comment: a concurrent merge on GitHub would make the
-        // `findPrNumber` lookup (which uses `gh pr list`, open PRs
-        // only) return `undefined`, and the verdict would flip to
-        // `BLOCKED` instead of taking the existing merged
-        // short-circuit.
+        // Check the PR lifecycle BEFORE running the clarification turn:
+        // a concurrent merge on GitHub during the verdict round means
+        // there is no point asking the agent to produce an envelope
+        // for a closed branch.  `findPrNumber` uses `gh pr list` (open
+        // PRs only), so a merged PR would otherwise let the
+        // clarification fire on a dead branch.
         const merged = guardIfPrMerged(ctx, opts);
         if (merged) return merged;
-        // Verify the PR comment holds a fully parseable suggestion
-        // block before asking the user.  A bare start marker or a
-        // block missing the `**Title**` label / the end marker would
-        // let the stage complete with `applied_via_github` but leave
-        // Stage 9 unable to render the inline preview, so fail closed
-        // instead.
-        const commentBody = readSuggestionCommentBody();
-        if (!hasValidSuggestionBlock(commentBody)) {
-          opts.onSquashSubStep?.(undefined);
-          return {
-            outcome: "blocked",
-            message: `${squashResult.responseText}\n\n---\n\n${verdictResponseText}`,
-          };
-        }
-        return askUserAndApply(ctx, opts, verdictSessionId);
+        // The agent declared SUGGESTED_SINGLE in the verdict turn but
+        // never provided a `<<<TITLE>>> / <<<BODY>>>` envelope in any
+        // earlier response (envelope was `missing` at the work-turn
+        // shortcut).  Issue #304 reviewer round 3: agentcoop must NOT
+        // consume a historical PR comment as evidence here — that is
+        // exactly the stale-suggestion propagation the issue motivated.
+        // Fire the focused envelope clarification turn instead, which
+        // either recovers a usable envelope or routes into
+        // SQUASHED_MULTI / BLOCKED via the agent's keyword.
+        return runEnvelopeClarification(
+          `${squashResult.responseText}\n\n---\n\n${verdictResponseText}`,
+          verdictSessionId,
+          "the squash verdict was SUGGESTED_SINGLE but no <<<TITLE>>> / <<<BODY>>> envelope was provided in the work response",
+        );
       }
 
       // SQUASHED_MULTI — proceed with the existing CI poll path.

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -659,7 +659,7 @@ export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
   if (title === "") {
     return { kind: "malformed", reason: "title envelope is empty" };
   }
-  if (body === "") {
+  if (body.trim() === "") {
     return { kind: "malformed", reason: "body envelope is empty" };
   }
   return { kind: "ok", suggestion: { title, body } };
@@ -898,21 +898,23 @@ export function createSquashStageHandler(
       const findSuggestionCommentBody =
         opts.findSuggestionCommentBody ??
         ((owner, repo, prNumber, marker) => {
-          // Read-side: a transient lookup failure here only affects
-          // resume/fallback decisions, so silently degrading to "no
-          // matching comment" is acceptable.  The write side, by
-          // contrast, must let the error propagate so it does not
-          // turn into a duplicate POST.
-          try {
-            return defaultFindLatestCommentWithMarker(
-              owner,
-              repo,
-              prNumber,
-              marker,
-            )?.body;
-          } catch {
-            return undefined;
-          }
+          // Errors propagate to the caller; each call site decides
+          // whether to silently degrade ("no matching comment") or
+          // surface the failure.  The two read-side call sites in
+          // this handler differ on that point: the resume path from
+          // `awaiting_user_choice` blocks on lookup failure (it is
+          // stateful — silently degrading would re-invoke the agent
+          // and could change the branch decision after the user has
+          // already been presented with one), while a transient
+          // failure during a non-stateful read is harmless.  The
+          // write side, by contrast, must always let the error
+          // propagate so it does not turn into a duplicate POST.
+          return defaultFindLatestCommentWithMarker(
+            owner,
+            repo,
+            prNumber,
+            marker,
+          )?.body;
         });
       const findPrNumber = opts.findPrNumber ?? defaultFindPrNumber;
       const postSuggestionComment =
@@ -1032,7 +1034,24 @@ export function createSquashStageHandler(
         // `squash.alreadyMerged`.
         const merged = guardIfPrMerged(ctx, opts);
         if (merged) return merged;
-        const commentBody = readSuggestionCommentBody();
+        // A transient `gh api` failure on this stateful resume path
+        // must NOT silently degrade to "no matching comment": doing
+        // so falls through to a fresh planning run, which would
+        // re-invoke the agent and could re-author the suggestion or
+        // change the branch decision after the stage had already
+        // reached `awaiting_user_choice`.  Block instead, leaving
+        // `squashSubStep` at `awaiting_user_choice` so a retry once
+        // `gh` recovers re-presents the existing choice.
+        let commentBody: string | undefined;
+        try {
+          commentBody = readSuggestionCommentBody();
+        } catch (e) {
+          const detail = e instanceof Error ? e.message : String(e);
+          return {
+            outcome: "blocked",
+            message: `Could not read the squash-suggestion PR comment while resuming the user choice: ${detail}.  Resolve the underlying gh / GitHub error and retry — agentcoop refused to fall back to a fresh planning run to avoid changing a decision the user has already been asked about.`,
+          };
+        }
         if (hasValidSuggestionBlock(commentBody)) {
           return askUserAndApply(ctx, opts, undefined);
         }

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -248,8 +248,10 @@ export function buildSquashPrompt(
     `     internal blank lines are preserved.  The body may include a`,
     `     literal \`<<</BODY>>>\` line as content (e.g. when documenting`,
     `     this envelope contract); agentcoop anchors the structural`,
-    `     close to the LAST own-line \`<<</BODY>>>\`, so put your final`,
-    `     close tag on its own line as the last line of the envelope.`,
+    `     close to the LAST own-line \`<<</BODY>>>\`, AND that close tag`,
+    `     must be the last non-blank line of your response.  Do not add`,
+    `     any prose after the closing \`<<</BODY>>>\` — only blank lines`,
+    `     may follow it.`,
     ``,
     `   **If multiple commits are appropriate:**`,
     ...(ctx.baseSha
@@ -625,6 +627,13 @@ function findLastOwnLineTag(
  * conventionally one line per the prompt, so TITLE_CLOSE keeps the
  * simpler FIRST rule.
  *
+ * The structural BODY_CLOSE must additionally be the last non-blank
+ * line of the response.  Without that anchor a forgotten real close
+ * tag would still parse silently when the body contained an example
+ * `<<</BODY>>>` line: LAST-match would pick the in-body example and
+ * truncate the body.  Requiring no non-blank trailing content makes
+ * that case classify as `malformed` so the clarification turn fires.
+ *
  * Returns:
  *   - `{ kind: "missing" }` when no `<<<TITLE>>>` tag appears on its
  *     own line.  The caller falls through to the verdict flow:
@@ -686,6 +695,23 @@ export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
       reason: "missing <<</BODY>>> close tag after <<<BODY>>>",
     };
   }
+  // Round 6 reviewer: LAST-match alone still silently accepts a
+  // truncated body when the agent forgets the structural close tag
+  // but the body itself contains an example `<<</BODY>>>` line — the
+  // in-body example would be picked as the structural close.  Require
+  // the structural close tag to be the last non-blank line of the
+  // response so a missing real close tag classifies as malformed and
+  // routes into the focused clarification turn instead of being
+  // silently accepted.
+  for (let i = bodyCloseIdx + 1; i < lines.length; i++) {
+    if (lines[i].trim() !== "") {
+      return {
+        kind: "malformed",
+        reason:
+          "<<</BODY>>> close tag must be the last non-blank line of the response",
+      };
+    }
+  }
 
   const title = lines
     .slice(titleOpenIdx + 1, titleCloseIdx)
@@ -737,8 +763,9 @@ export function buildSquashEnvelopeClarificationPrompt(reason: string): string {
     ``,
     `The body may legitimately contain a literal \`<<</BODY>>>\` line`,
     `as content; agentcoop anchors the structural close to the LAST`,
-    `own-line \`<<</BODY>>>\`, so place your final close tag on its`,
-    `own line as the last line of the envelope.`,
+    `own-line \`<<</BODY>>>\`, AND that close tag must be the last`,
+    `non-blank line of your response.  Do not add prose after the`,
+    `closing \`<<</BODY>>>\` — only blank lines may follow it.`,
     ``,
     `Option 2 — a single keyword on its own line:`,
     `- SQUASHED_MULTI — if you actually rewrote history into multiple`,

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -554,50 +554,72 @@ function findOwnLineTag(lines: string[], tag: string, start: number): number {
  * Parse the agent's `<<<TITLE>>>...<<</TITLE>>> / <<<BODY>>>...<<</BODY>>>`
  * envelope from a free-form response.
  *
- * Detection is strict by design: each of the four tags must appear
- * as a line by itself, in the order
- * TITLE_OPEN → TITLE_CLOSE → BODY_OPEN → BODY_CLOSE, before the
- * response is treated as an envelope attempt at all.  This rejects
- * stray prose mentions like "I did not use the `<<<TITLE>>>` envelope"
- * — those classify as `missing` and the caller falls through to the
- * verdict flow rather than hard-blocking on a multi-commit reply that
- * happens to quote the tags.
+ * Detection treats a `<<<TITLE>>>` open tag *on its own line* as a
+ * clear declaration of envelope intent: stray prose like "I did not
+ * use the `<<<TITLE>>>` envelope" mentions the tag inline (mid-line,
+ * backtick-quoted, or both) and never produces a tag on its own
+ * line, so it classifies as `missing` and falls through to the
+ * verdict flow.  Once envelope intent is declared, a missing close
+ * tag, missing body section, or empty content classifies as
+ * `malformed` so the caller's focused clarification turn can fire —
+ * a dropped line is exactly the recoverable formatting mistake
+ * issue #304 wants the agent to be able to repair.
  *
  * Returns:
- *   - `{ kind: "missing" }` when the strict shape is not present
- *     (tags inline in prose, any tag absent, or out-of-order).  The
- *     caller should fall through to the verdict flow: envelope
- *     absence on its own is not a SUGGESTED_SINGLE signal.
- *   - `{ kind: "malformed", reason }` when the four tags are present
- *     on their own lines and in order but the content between them
- *     is unusable (empty title or body).  The caller should send a
- *     focused clarification rather than blocking outright — the agent
- *     declared intent to use the envelope, so a missed line is
- *     usually recoverable on retry.
+ *   - `{ kind: "missing" }` when no `<<<TITLE>>>` tag appears on its
+ *     own line.  The caller falls through to the verdict flow:
+ *     envelope absence on its own is not a SUGGESTED_SINGLE signal,
+ *     and prose that merely names the tags is not envelope intent.
+ *   - `{ kind: "malformed", reason }` when envelope intent is
+ *     declared (TITLE_OPEN on its own line) but the structure is
+ *     broken — a close tag missing, body section absent, body open
+ *     before the title closes, or empty title/body content.  The
+ *     caller should send a focused clarification rather than
+ *     blocking outright.
  *   - `{ kind: "ok", suggestion }` on a well-formed envelope.
  */
 export function parseSquashEnvelope(text: string): SquashEnvelopeResult {
   const lines = text.split("\n");
   const titleOpenIdx = findOwnLineTag(lines, ENVELOPE_TITLE_OPEN, 0);
   if (titleOpenIdx === -1) return { kind: "missing" };
+  // From here on the agent has declared envelope intent (an open tag
+  // on its own line is not something prose mentions produce).  Any
+  // subsequent structural break is a recoverable formatting mistake,
+  // not "no envelope at all", so it must classify as `malformed` to
+  // route into the clarification turn.
   const titleCloseIdx = findOwnLineTag(
     lines,
     ENVELOPE_TITLE_CLOSE,
     titleOpenIdx + 1,
   );
-  if (titleCloseIdx === -1) return { kind: "missing" };
+  if (titleCloseIdx === -1) {
+    return {
+      kind: "malformed",
+      reason: "missing <<</TITLE>>> close tag after <<<TITLE>>>",
+    };
+  }
   const bodyOpenIdx = findOwnLineTag(
     lines,
     ENVELOPE_BODY_OPEN,
     titleCloseIdx + 1,
   );
-  if (bodyOpenIdx === -1) return { kind: "missing" };
+  if (bodyOpenIdx === -1) {
+    return {
+      kind: "malformed",
+      reason: "missing <<<BODY>>> open tag after the title envelope",
+    };
+  }
   const bodyCloseIdx = findOwnLineTag(
     lines,
     ENVELOPE_BODY_CLOSE,
     bodyOpenIdx + 1,
   );
-  if (bodyCloseIdx === -1) return { kind: "missing" };
+  if (bodyCloseIdx === -1) {
+    return {
+      kind: "malformed",
+      reason: "missing <<</BODY>>> close tag after <<<BODY>>>",
+    };
+  }
 
   const title = lines
     .slice(titleOpenIdx + 1, titleCloseIdx)
@@ -681,6 +703,15 @@ export interface PostOrUpdateSquashSuggestionDeps {
  * exists and exposes its id, edit it via PATCH so the PR timeline
  * does not accumulate duplicate suggestion comments.  Otherwise,
  * post a fresh comment.
+ *
+ * Errors from the lookup propagate to the caller — they are NOT
+ * swallowed into "no prior comment".  Issue #304 reviewer round 2
+ * called out the original swallow behaviour: a transient auth /
+ * network / rate-limit failure during lookup would otherwise be
+ * indistinguishable from "no matching comment", and the helper would
+ * happily POST a fresh comment, creating duplicates on the PR
+ * timeline on every blip.  The handler converts the error into a
+ * `blocked` outcome instead.
  *
  * If the prior-comment lookup returns a body without an id (older
  * fixtures, manual stubs), this falls back to POST — the caller will
@@ -841,9 +872,23 @@ export function createSquashStageHandler(
       const countCommits = opts.countBranchCommits ?? defaultCountBranchCommits;
       const findSuggestionCommentBody =
         opts.findSuggestionCommentBody ??
-        ((owner, repo, prNumber, marker) =>
-          defaultFindLatestCommentWithMarker(owner, repo, prNumber, marker)
-            ?.body);
+        ((owner, repo, prNumber, marker) => {
+          // Read-side: a transient lookup failure here only affects
+          // resume/fallback decisions, so silently degrading to "no
+          // matching comment" is acceptable.  The write side, by
+          // contrast, must let the error propagate so it does not
+          // turn into a duplicate POST.
+          try {
+            return defaultFindLatestCommentWithMarker(
+              owner,
+              repo,
+              prNumber,
+              marker,
+            )?.body;
+          } catch {
+            return undefined;
+          }
+        });
       const findPrNumber = opts.findPrNumber ?? defaultFindPrNumber;
       const postSuggestionComment =
         opts.postSuggestionComment ?? postOrUpdateSquashSuggestion;
@@ -1017,18 +1062,23 @@ export function createSquashStageHandler(
       // contract where the agent posted the comment itself and the
       // verdict turn carried "I posted it" semantics.
       //
-      // The detection in `parseSquashEnvelope` is strict — it requires
-      // all four tags on their own lines, in order — so prose that
-      // merely mentions the tag names (e.g. "I did not use the
-      // `<<<TITLE>>>` envelope" in a multi-commit reply) classifies as
-      // `missing` and falls through to the existing verdict flow.
-      // SQUASHED_MULTI and BLOCKED keep their behaviour.
+      // The detection in `parseSquashEnvelope` keys off a `<<<TITLE>>>`
+      // open tag on its own line — prose that merely mentions the tag
+      // names (e.g. backtick-quoted "I did not use the `<<<TITLE>>>`
+      // envelope" in a multi-commit reply) never produces a tag on a
+      // line by itself, so it classifies as `missing` and falls through
+      // to the verdict flow.  SQUASHED_MULTI and BLOCKED keep their
+      // behaviour.
       //
-      // When the shape is present but content is empty (the only
-      // remaining `malformed` case), send a focused clarification
-      // before giving up so the agent has a chance to repair a
-      // formatting-only mistake — issue #304 reviewer round 1
-      // explicitly preserves that recovery path.
+      // Once envelope intent is declared, any structural break (a
+      // missing close tag, an absent body section, or empty content)
+      // classifies as `malformed` and routes into the focused
+      // clarification turn rather than the verdict flow.  This is what
+      // issue #304 reviewer round 2 called out: a dropped close tag is
+      // exactly the recoverable mistake the clarification round was
+      // meant to repair, and falling through to the verdict path
+      // instead either hard-blocks opaquely or reuses a stale prior
+      // suggestion comment.
 
       /**
        * Author the marker-delimited PR comment from a parsed envelope
@@ -1063,7 +1113,23 @@ export function createSquashStageHandler(
             "buildSquashSuggestionComment produced an unparseable block — formatter / parser are out of sync",
           );
         }
-        postSuggestionComment(ctx.owner, ctx.repo, prNumber, commentBody);
+        // The write helper looks up the prior suggestion comment to
+        // decide between PATCH and POST.  A transient `gh` failure
+        // during that lookup MUST surface as an error here rather than
+        // being silently treated as "no prior comment" — otherwise the
+        // PR would accumulate duplicate suggestion comments on every
+        // network blip.  Convert any thrown error into a `blocked`
+        // outcome with the failure surfaced for the user.
+        try {
+          postSuggestionComment(ctx.owner, ctx.repo, prNumber, commentBody);
+        } catch (err) {
+          opts.onSquashSubStep?.(undefined);
+          const detail = err instanceof Error ? err.message : String(err);
+          return {
+            outcome: "blocked",
+            message: `${rawResponseText}\n\n---\n\nSquash-suggestion comment lookup or post failed: ${detail}.  Resolve the underlying gh / GitHub error and retry — agentcoop refused to POST a fresh comment to avoid creating a duplicate suggestion.`,
+          };
+        }
         verdictCtx?.events.emit("pipeline:verdict", {
           agent: verdictCtx.agent,
           keyword: "SUGGESTED_SINGLE",


### PR DESCRIPTION
## Summary

Stage 8's SUGGESTED_SINGLE branch used to delegate authoring of the marker-delimited squash-suggestion PR comment to the agent — marker placement, CommonMark fence sizing, and idempotent PATCH/POST bookkeeping all had to be reproduced on every turn. A single missed line would silently flip the stage to `blocked` after the verdict cleanly returned `SUGGESTED_SINGLE`, as observed on aicers/aice-web-next#377 (missing closing body fence and end marker, repaired by hand).

This PR splits responsibilities so the agent only produces the natural-language title and body inside a small `<<<TITLE>>> / <<<BODY>>>` envelope, and agentcoop deterministically renders the marker block and PATCH/POSTs it idempotently.

Key changes:

- `buildSquashSuggestionComment(suggestion)` renders the canonical marker block, sizing title/body fences independently as `max(longest backtick run, 2) + 1` (min 3).
- `parseSquashSuggestionBlock` anchors both markers to whole lines and requires the end-marker line at or after the body's closing fence.  This prevents a literal end marker embedded inside the body fenced block from truncating the parse — the body fence absorbs that occurrence as content, and only a free-standing end-marker line counts as the delimiter.  Round-trip tests cover bodies that mention either marker as a literal.
- `parseSquashEnvelope(text)` extracts the agent's reply, distinguishing three outcomes:
  - **`missing`** — no `<<<TITLE>>>` tag on its own line.  Prose that mentions the tag names mid-sentence or in backticks (e.g. a multi-commit reply explaining why the envelope was not used) classifies here and falls through to the verdict flow.
  - **`malformed`** — envelope intent declared (TITLE_OPEN on its own line) but the structure is broken: a missing close tag, an absent body section, an empty title, or an empty / whitespace-only body.  Routes into the focused clarification turn so a recoverable formatting mistake — including the dropped close tag that motivated this issue — gets one more attempt before blocking.
  - **`ok`** — well-formed envelope with non-empty content.
- `postOrUpdateSquashSuggestion(...)` is the single write entry point: PATCH the prior comment by id when one with the start marker exists, otherwise POST. Backed by injectable `findLatest`/`patch`/`post` deps for unit-testability.  Errors from the lookup propagate to the caller — they are NOT swallowed into 'no prior comment'.  A transient auth / network / rate-limit failure during lookup would otherwise be indistinguishable from 'no matching comment' and would turn an idempotent PATCH into a duplicate POST.  The handler converts the thrown error into a `blocked` outcome instead.
- `findLatestCommentWithMarker` now returns `{ id, body }` so PATCH callers don't need a second lookup; the two read-only callers destructure `.body`.  Errors from the underlying `gh api` call propagate to the caller.  `getSquashMergeHint` in `index.ts` wraps with `try`/`catch` to silently degrade — the hint is purely cosmetic.  The squash handler's read-side `findSuggestionCommentBody` adapter no longer silently degrades: errors propagate to the caller, and the `awaiting_user_choice` resume path now blocks on a lookup failure (leaving `squashSubStep` at `awaiting_user_choice`) instead of falling through to a fresh planning run that could re-invoke the agent and re-author the suggestion or change the branch decision after the user had already been asked about one.
- New `patchPrComment` helper in `src/pr-comments.ts` sends the body via stdin as a JSON request payload so multi-line content with fences / Markdown-active characters survives verbatim.
- The SUGGESTED_SINGLE work prompt is simplified — no more marker, fence-length math, or `gh` invocation instructions for the agent. The SQUASHED_MULTI branch is unchanged.
- `createSquashStageHandler` runs the envelope-driven shortcut **before** the verdict turn:
  - Well-formed envelope → code authors the comment, asserts it round-trips through the parser, posts it (lookup failure → `blocked` rather than duplicate POST), emits a `pipeline:verdict` `SUGGESTED_SINGLE` event, and proceeds to the user-choice flow (verdict turn skipped).
  - Malformed envelope (intent declared, structure broken) → send one focused **clarification turn** asking for either a valid envelope or a `SQUASHED_MULTI` / `BLOCKED` keyword. Re-parse: ok envelope → author + post; SQUASHED_MULTI → CI poll; BLOCKED → blocked; anything else (still malformed, missing, or bare SUGGESTED_SINGLE) → blocked with both responses surfaced. This preserves the recoverable-mistake path the verdict-clarification round already provides.
  - Envelope absent → fall through to the existing verdict / clarification / deterministic-fallback chain (SQUASHED_MULTI and BLOCKED keep their behaviour; envelope absence is not a SUGGESTED_SINGLE signal).
- **No stale-comment promotion to SUGGESTED_SINGLE.**  A SUGGESTED_SINGLE outcome must be backed by a current envelope from this run.  When the verdict resolves to SUGGESTED_SINGLE without an envelope, the same focused envelope clarification turn fires (asking for either a valid envelope or SQUASHED_MULTI / BLOCKED) — agentcoop does not consume a historical squash-suggestion comment as evidence, which would re-introduce the stale-suggestion propagation problem issue #304 was meant to fix.  The deterministic fallback chain similarly drops the "valid marker block on PR → SUGGESTED_SINGLE" rule; without an envelope from this run, the only deterministic signals are commit-count collapse (SQUASHED_MULTI) or BLOCKED.  The fallback chain's PR-merged guard is preserved so a concurrent merge surfaces as `alreadyMerged` rather than `BLOCKED`.
- `hasValidSuggestionBlock` is demoted to defense-in-depth: an assertion on the just-authored path and the gate when resuming from `awaiting_user_choice` against a comment we did not just write.
- `docs/pipeline.md` and `CHANGELOG.md` updated to match.

Per the issue, option 1 ('keep the verdict turn, infer the branch from the work response') was chosen — the second option (collapsing work + verdict into one turn) is left out of scope.

Closes #304

## Test plan

- [x] \`pnpm tsc --noEmit\` passes
- [x] \`pnpm biome check\` passes
- [x] \`pnpm vitest run\` — full suite green (2056 tests)
- [x] Round-trip \`buildSquashSuggestionComment\` ↔ \`parseSquashSuggestionBlock\` for: plain body, triple-backtick body, five-backtick body, HTML comments in body, inline backticks in title, body containing the start marker as a literal string, body containing the **end marker** as a literal string on its own line, body containing **both** markers as literal strings
- [x] \`parseSquashEnvelope\` classification: ok; missing (no tags / inline backtick-quoted prose / inline mid-sentence prose); malformed for missing TITLE close tag / missing BODY close tag / missing BODY section / empty title / empty body / **whitespace-only body**
- [x] \`postOrUpdateSquashSuggestion\`: PATCHes when prior comment has an id, POSTs when no prior comment, falls back to POST when prior comment lacks an id, propagates errors from \`findLatest\` and does NOT call \`post\` on lookup failure
- [x] \`findLatestCommentWithMarker\`: propagates errors from the underlying \`gh\` call (no longer swallowed)
- [x] Combined regression test: \`parseSquashSuggestionBlock\` rejects a block missing **both** the closing body fence and the end marker (the screenshot incident)
- [x] Negative prompt assertions: SUGGESTED_SINGLE prompt no longer mentions \`squash-suggestion:start\` / \`squash-suggestion:end\` / \`gh pr comment\` / \`gh api repos\` / \`--method PATCH\` / \`fence_len\` / 'longest run of backticks'
- [x] Stage-handler end-to-end: envelope present → comment authored, verdict turn skipped, user-choice runs; envelope present + user picks agent → follow-up resumes the planning session; envelope present → \`pipeline:verdict\` \`SUGGESTED_SINGLE\` event emitted; malformed envelope (empty title or body) → clarification turn sent, then ok envelope on retry → comment authored / SQUASHED_MULTI on retry → CI poll / BLOCKED on retry → blocked / still unrecoverable on retry → blocked; **missing TITLE close tag** → clarification asked, recovers on valid retry; **missing BODY close tag** → clarification asked, SQUASHED_MULTI retry routes into CI poll; envelope absent → falls through to existing verdict flow; multi-commit reply mentioning tag names inline → falls through (no shortcut, no block); **postSuggestionComment lookup throw** → blocked with no duplicate POST
- [x] **Stale-comment fix:** verdict SUGGESTED_SINGLE without envelope + stale historical PR comment → clarification fires (stale comment NOT consumed); clarification retry yielding a valid envelope → comment authored from FRESH content (not stale); deterministic fallback chain with stale marker block + count unchanged → BLOCKED (not SUGGESTED_SINGLE); \`pipeline:verdict\` emits BLOCKED (not SUGGESTED_SINGLE) when only a stale block is present
- [x] **awaiting_user_choice resume:** lookup failure → blocked with detail surfaced, no fresh planning run, no \`chooseSquashApplyMode\` call, sub-step preserved at \`awaiting_user_choice\`