### PR TITLE
Isolate reviewer runs in detached worktree (#306)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -311,6 +311,35 @@ describe("squash-apply policy join point", () => {
 });
 
 // ---------------------------------------------------------------------------
+// reviewer worktree orchestration join points (issue #306)
+// ---------------------------------------------------------------------------
+describe("reviewer worktree orchestration", () => {
+  const indexSource = readFileSync(resolve(root, "src/index.ts"), "utf-8");
+
+  test("passes reviewerWorktreePath into stage context for fresh and resumed runs", () => {
+    const matches =
+      indexSource.match(/reviewerWorktreePath:\s*reviewerWtPath/g) ?? [];
+    expect(matches).toEqual([
+      "reviewerWorktreePath: reviewerWtPath",
+      "reviewerWorktreePath: reviewerWtPath",
+    ]);
+  });
+
+  test("cleanup paths remove both author and reviewer worktrees", () => {
+    const cleanupMatches = indexSource.match(
+      /removeWorktree\(owner,\s*repo,\s*issueNumber,\s*wt\.branch\);\s*removeReviewerWorktree\(owner,\s*repo,\s*issueNumber\);/g,
+    );
+    expect(cleanupMatches).toHaveLength(2);
+  });
+
+  test("cancellation cleanup removes the reviewer worktree", () => {
+    expect(indexSource).toMatch(
+      /removeReviewerWorktree\(opts\.owner,\s*opts\.repo,\s*opts\.issueNumber\);/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // CLI E2E smoke test
 // ---------------------------------------------------------------------------
 describe("CLI E2E", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,10 +89,14 @@ import {
 } from "./version-check.js";
 import {
   bootstrapRepo,
+  cleanReviewerWorktreeChanges,
   createWorktree,
   detectDefaultBranch,
   hasUncommittedChanges,
+  prepareReviewerWorktree,
+  removeReviewerWorktree,
   removeWorktree,
+  reviewerWorktreePath,
   worktreePath,
 } from "./worktree.js";
 
@@ -237,6 +241,7 @@ async function runCancellationCleanup(opts: {
   if (deleteWt) {
     console.log(m["cleanup.deletingWorktree"]);
     removeWorktree(opts.owner, opts.repo, opts.issueNumber, opts.branch);
+    removeReviewerWorktree(opts.owner, opts.repo, opts.issueNumber);
     result.deletedWorktree = true;
   }
 
@@ -548,6 +553,7 @@ try {
     conflictChoice: startFresh ? "clean" : "reuse",
   });
   bootstrapLog.log(m["boot.worktreeReady"](wt.path, wt.branch));
+  const reviewerWtPath = reviewerWorktreePath(owner, repo, issueNumber);
 
   if (wt.hadUncommittedChanges) {
     bootstrapLog.warn(m["boot.uncommittedPreserved"]);
@@ -729,6 +735,19 @@ try {
           saveRunState(runState);
           emitter.emit("review:posted", { round });
         },
+        prepareReviewerWorktree: (ctx) => {
+          const path = prepareReviewerWorktree({
+            owner: ctx.owner,
+            repo: ctx.repo,
+            issueNumber: ctx.issueNumber,
+            authorBranch: ctx.branch,
+          });
+          if (runState.reviewerWorktreePath !== path) {
+            runState.reviewerWorktreePath = path;
+            saveRunState(runState);
+          }
+        },
+        cleanReviewerWorktreeChanges,
       }),
     pipelineSettings,
   );
@@ -741,6 +760,7 @@ try {
     issueNumber,
     branch: wt.branch,
     worktreePath: wt.path,
+    reviewerWorktreePath: reviewerWtPath,
     baseSha: wt.baseSha,
     prNumber: undefined,
     currentStage: 2,
@@ -866,7 +886,10 @@ try {
         },
       });
     },
-    cleanup: () => removeWorktree(owner, repo, issueNumber, wt.branch),
+    cleanup: () => {
+      removeWorktree(owner, repo, issueNumber, wt.branch);
+      removeReviewerWorktree(owner, repo, issueNumber);
+    },
     stopServices: () => {
       if (hasDockerComposeRunning(wt.path)) {
         stopDockerCompose(wt.path);
@@ -923,6 +946,7 @@ try {
       if (signal?.aborted) return;
       if (deleteWt) {
         removeWorktree(owner, repo, issueNumber, wt.branch);
+        removeReviewerWorktree(owner, repo, issueNumber);
       }
 
       // Delete remote branch (only if pushed).
@@ -980,6 +1004,7 @@ try {
       issueTitle,
       branch: wt.branch,
       worktreePath: wt.path,
+      reviewerWorktreePath: reviewerWtPath,
       baseSha: savedState?.baseSha ?? wt.baseSha,
     },
     startFromStage,

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -111,6 +111,7 @@ export interface StageContext {
   issueTitle?: string;
   branch: string;
   worktreePath: string;
+  reviewerWorktreePath?: string;
   /**
    * Full SHA of the base commit (tip of origin/{defaultBranch} when the
    * worktree was created).  Used by the squash stage to limit the

--- a/src/run-state.test.ts
+++ b/src/run-state.test.ts
@@ -100,6 +100,15 @@ describe("saveRunState / loadRunState round-trip", () => {
     expect(loaded?.prNumber).toBeUndefined();
   });
 
+  test("preserves reviewerWorktreePath", () => {
+    const state = makeRunState({
+      reviewerWorktreePath: "/tmp/wt/issue-42-review",
+    });
+    saveRunState(state);
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded?.reviewerWorktreePath).toBe("/tmp/wt/issue-42-review");
+  });
+
   test("preserves agent sessionIds", () => {
     const state = makeRunState({
       agentA: {
@@ -184,6 +193,18 @@ describe("loadRunState — missing / malformed", () => {
     const loaded = loadRunState("org", "repo", 42);
     expect(loaded).toBeDefined();
     expect(loaded?.prNumber).toBeUndefined();
+  });
+
+  test("normalises null reviewerWorktreePath to undefined", () => {
+    const raw = { ...makeRunState(), reviewerWorktreePath: null };
+    const path = runStatePath("org", "repo", 42);
+    mkdirSync(join(tmpHome, ".agentcoop", "runs", "org", "repo"), {
+      recursive: true,
+    });
+    writeFileSync(path, JSON.stringify(raw));
+    const loaded = loadRunState("org", "repo", 42);
+    expect(loaded).toBeDefined();
+    expect(loaded?.reviewerWorktreePath).toBeUndefined();
   });
 
   test("normalises null sessionId to undefined", () => {

--- a/src/run-state.ts
+++ b/src/run-state.ts
@@ -83,6 +83,7 @@ export interface RunState {
   issueNumber: number;
   branch: string;
   worktreePath: string;
+  reviewerWorktreePath?: string;
   /** Full SHA of origin/{defaultBranch} at worktree creation time. */
   baseSha: string | undefined;
   prNumber: number | undefined;
@@ -164,6 +165,7 @@ function isValidRunState(
     typeof r.issueNumber === "number" &&
     typeof r.branch === "string" &&
     typeof r.worktreePath === "string" &&
+    isOptionalString(r.reviewerWorktreePath) &&
     isOptionalString(r.baseSha) &&
     (r.prNumber === undefined ||
       r.prNumber === null ||
@@ -261,6 +263,8 @@ export function loadRunState(
     ...raw,
     version: (r.version as number) ?? 1,
     baseSha: (r.baseSha as string | undefined) ?? undefined,
+    reviewerWorktreePath:
+      (r.reviewerWorktreePath as string | undefined) ?? undefined,
     prNumber: raw.prNumber ?? undefined,
     selfCheckCount: (r.selfCheckCount as number | undefined) ?? 0,
     reviewCount: (r.reviewCount as number | undefined) ?? 0,

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -8,6 +8,7 @@ import {
   buildPrFinalizationPrompt,
   buildPrFinalizationVerdictPrompt,
   buildResumeUnresolvedSummaryPrompt,
+  buildResumeVerdictPrompt,
   buildReviewPrompt,
   buildReviewVerdictPrompt,
   buildUnresolvedSummaryPrompt,
@@ -61,6 +62,7 @@ const BASE_CTX: StageContext = {
   issueNumber: 42,
   branch: "issue-42",
   worktreePath: "/tmp/wt",
+  reviewerWorktreePath: "/tmp/wt-review",
   iteration: 0,
   lastAutoIteration: false,
   userInstruction: undefined,
@@ -119,6 +121,8 @@ function makeOpts(
     pollTimeoutMs: 1000,
     emptyRunsGracePeriodMs: 0,
     postPrComment: vi.fn(),
+    prepareReviewerWorktree: vi.fn(),
+    cleanReviewerWorktreeChanges: vi.fn().mockReturnValue(false),
     ...overrides,
   };
 }
@@ -131,6 +135,11 @@ describe("buildReviewPrompt", () => {
     expect(prompt).toContain("Owner: org");
     expect(prompt).toContain("Repo: repo");
     expect(prompt).toContain("Issue #42: Fix the widget");
+  });
+
+  test("uses reviewer worktree path in reviewer prompt", () => {
+    const prompt = buildReviewPrompt(BASE_CTX, makeOpts(), 1);
+    expect(prompt).toContain("Worktree: /tmp/wt-review");
   });
 
   test("includes round number", () => {
@@ -297,8 +306,16 @@ describe("buildResumeUnresolvedSummaryPrompt", () => {
     expect(prompt).toContain("Owner: org");
     expect(prompt).toContain("Repo: repo");
     expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).toContain("Worktree: /tmp/wt-review");
     expect(prompt).toContain("[Reviewer Round 2]");
     expect(prompt).toContain("[Reviewer Unresolved Round 2]");
+  });
+});
+
+describe("buildResumeVerdictPrompt", () => {
+  test("includes reviewer worktree path", () => {
+    const prompt = buildResumeVerdictPrompt(BASE_CTX, 2);
+    expect(prompt).toContain("Worktree: /tmp/wt-review");
   });
 });
 
@@ -1690,6 +1707,84 @@ describe("createReviewStageHandler", () => {
     );
   });
 
+  test("uses reviewer cwd for Agent B and author cwd for Agent A", async () => {
+    const opts = makeOpts();
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(opts.agentB.invoke).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ cwd: "/tmp/wt-review" }),
+    );
+    expect(opts.agentA.invoke).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ cwd: "/tmp/wt" }),
+    );
+  });
+
+  test("keeps author-fix substeps on the author worktree after NOT_APPROVED", async () => {
+    const opts = makeOpts({
+      agentB: {
+        invoke: vi.fn().mockReturnValue(
+          makeStream(
+            makeResult({
+              sessionId: "sess-b",
+              responseText: "Needs changes.",
+            }),
+          ),
+        ),
+        resume: vi
+          .fn()
+          .mockReturnValue(
+            makeStream(makeResult({ responseText: "NOT_APPROVED" })),
+          ),
+      },
+    });
+    const stage = createReviewStageHandler(opts);
+
+    await stage.handler(BASE_CTX);
+
+    expect(opts.agentB.invoke).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ cwd: "/tmp/wt-review" }),
+    );
+    expect(opts.agentA.invoke).toHaveBeenCalledWith(
+      expect.stringContaining("[Reviewer Round 1]"),
+      expect.objectContaining({ cwd: "/tmp/wt" }),
+    );
+    expect(opts.agentA.resume).toHaveBeenCalledWith(
+      "sess-a",
+      buildAuthorCompletionCheckPrompt(),
+      expect.objectContaining({ cwd: "/tmp/wt" }),
+    );
+  });
+
+  test("prepares reviewer worktree before reviewer calls", async () => {
+    const opts = makeOpts();
+    const stage = createReviewStageHandler(opts);
+    await stage.handler(BASE_CTX);
+
+    expect(opts.prepareReviewerWorktree).toHaveBeenCalled();
+  });
+
+  test("cleans unexpected reviewer changes after reviewer calls", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const opts = makeOpts({
+      cleanReviewerWorktreeChanges: vi.fn().mockReturnValue(true),
+    });
+    const stage = createReviewStageHandler(opts);
+
+    await stage.handler(BASE_CTX);
+
+    expect(opts.cleanReviewerWorktreeChanges).toHaveBeenCalledWith(
+      "/tmp/wt-review",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Warning: cleaned unexpected local changes in reviewer worktree /tmp/wt-review",
+    );
+    warn.mockRestore();
+  });
+
   test("returns error when PR finalization agent call fails", async () => {
     const agentA: AgentAdapter = {
       invoke: vi.fn().mockReturnValue(
@@ -3029,5 +3124,103 @@ describe("saved Agent B session reuse on resume", () => {
     const firstResumeCall = (agentB.resume as ReturnType<typeof vi.fn>).mock
       .calls[0];
     expect(firstResumeCall[0]).toBe("saved-b-sess");
+  });
+
+  test("resume at verdict without a saved session invokes Agent B in the reviewer worktree", async () => {
+    const prepareReviewerWorktree = vi.fn();
+    const cleanReviewerWorktreeChanges = vi.fn().mockReturnValue(false);
+    const agentB: AgentAdapter = {
+      invoke: vi.fn().mockReturnValueOnce(
+        makeStream(
+          makeResult({
+            sessionId: "sess-b-verdict",
+            responseText: "APPROVED",
+          }),
+        ),
+      ),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(makeResult({ responseText: "No unresolved items." })),
+        )
+        .mockReturnValueOnce(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+    const opts = makeOpts({
+      agentB,
+      prepareReviewerWorktree,
+      cleanReviewerWorktreeChanges,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+
+    await stage.handler({ ...BASE_CTX, savedAgentBSessionId: undefined });
+
+    expect(agentB.invoke).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "You previously posted a review on a pull request",
+      ),
+      expect.objectContaining({ cwd: "/tmp/wt-review" }),
+    );
+    expect(agentB.resume).toHaveBeenCalledWith(
+      "sess-b-verdict",
+      expect.any(String),
+      expect.objectContaining({ cwd: "/tmp/wt-review" }),
+    );
+    expect(prepareReviewerWorktree).toHaveBeenCalled();
+    expect(cleanReviewerWorktreeChanges).toHaveBeenCalledWith("/tmp/wt-review");
+  });
+
+  test("resume at unresolved_summary without a saved session invokes Agent B in the reviewer worktree", async () => {
+    const prepareReviewerWorktree = vi.fn();
+    const cleanReviewerWorktreeChanges = vi.fn().mockReturnValue(false);
+    const agentB: AgentAdapter = {
+      invoke: vi
+        .fn()
+        .mockReturnValueOnce(
+          makeStream(
+            makeResult({
+              sessionId: "sess-b-unresolved",
+              responseText: "Nothing unresolved.",
+            }),
+          ),
+        )
+        .mockReturnValueOnce(makeStream(makeResult({ responseText: "NONE" }))),
+      resume: vi
+        .fn()
+        .mockReturnValueOnce(makeStream(makeResult({ responseText: "NONE" }))),
+    };
+    const opts = makeOpts({
+      agentB,
+      prepareReviewerWorktree,
+      cleanReviewerWorktreeChanges,
+      getPrNumber: () => 99,
+      fetchPrComments: () => [
+        { body: "**[Reviewer Round 1]** Review.", user: { login: "bot" } },
+        {
+          body: "[Review Verdict Round 1: APPROVED]",
+          user: { login: "bot" },
+        },
+      ],
+    });
+    const stage = createReviewStageHandler(opts);
+
+    await stage.handler({ ...BASE_CTX, savedAgentBSessionId: undefined });
+
+    expect(agentB.invoke).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "You previously reviewed a pull request and the review was approved.",
+      ),
+      expect.objectContaining({ cwd: "/tmp/wt-review" }),
+    );
+    expect(agentB.resume).toHaveBeenCalledWith(
+      "sess-b-unresolved",
+      expect.any(String),
+      expect.objectContaining({ cwd: "/tmp/wt-review" }),
+    );
+    expect(prepareReviewerWorktree).toHaveBeenCalled();
+    expect(cleanReviewerWorktreeChanges).toHaveBeenCalledWith("/tmp/wt-review");
   });
 });

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -117,6 +117,17 @@ export interface ReviewStageOptions {
    * genuinely posted (not on every stage-7 exit).
    */
   onReviewPosted?: (round: number) => void;
+  /**
+   * Refresh the detached reviewer worktree before reviewer activity.
+   * Defaults to no-op for tests that do not care about worktree setup.
+   */
+  prepareReviewerWorktree?: (ctx: StageContext) => void;
+  /**
+   * Clean unexpected reviewer changes after reviewer activity.
+   *
+   * @returns true when changes were found and cleaned.
+   */
+  cleanReviewerWorktreeChanges?: (reviewerWorktreePath: string) => boolean;
 }
 
 // ---- prompt builders ---------------------------------------------------------
@@ -165,6 +176,7 @@ export function buildReviewPrompt(
   ctx: StageContext,
   opts: ReviewStageOptions,
   round: number,
+  reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath,
 ): string {
   const anglesBlock = buildReviewAnglesBlock();
 
@@ -175,7 +187,7 @@ export function buildReviewPrompt(
     `- Owner: ${ctx.owner}`,
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
+    `- Worktree: ${reviewerWorktreePath}`,
     ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
@@ -347,6 +359,7 @@ export function buildUnresolvedSummaryPrompt(round: number): string {
 export function buildResumeUnresolvedSummaryPrompt(
   ctx: StageContext,
   round: number,
+  reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath,
 ): string {
   return [
     `You previously reviewed a pull request and the review was approved.`,
@@ -356,6 +369,7 @@ export function buildResumeUnresolvedSummaryPrompt(
     `- Owner: ${ctx.owner}`,
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
+    `- Worktree: ${reviewerWorktreePath}`,
     ``,
     `1. Find the pull request for this branch (use \`gh pr view\`).`,
     `2. Read your \`[Reviewer Round ${round}]\` review comment to`,
@@ -412,6 +426,7 @@ export function buildPrFinalizationPrompt(
 export function buildResumeVerdictPrompt(
   ctx: StageContext,
   round: number,
+  reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath,
 ): string {
   return [
     `You previously posted a review on a pull request, prefixed with`,
@@ -422,6 +437,7 @@ export function buildResumeVerdictPrompt(
     `- Owner: ${ctx.owner}`,
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
+    `- Worktree: ${reviewerWorktreePath}`,
     ``,
     `1. Find the pull request for this branch (use \`gh pr view\`).`,
     `2. Read your \`[Reviewer Round ${round}]\` review comment.`,
@@ -445,6 +461,55 @@ export function createReviewStageHandler(
     number: 7,
     primaryAgent: "b",
     handler: async (ctx: StageContext): Promise<StageResult> => {
+      const reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath;
+      const prepareReviewerWorktree =
+        opts.prepareReviewerWorktree ?? (() => undefined);
+      const cleanReviewerWorktreeChanges =
+        opts.cleanReviewerWorktreeChanges ?? (() => false);
+      const maybeCleanReviewerWorktree = () => {
+        if (!cleanReviewerWorktreeChanges(reviewerWorktreePath)) return;
+        console.warn(
+          `Warning: cleaned unexpected local changes in reviewer worktree ${reviewerWorktreePath}`,
+        );
+      };
+      const invokeReviewer = async (
+        sessionId: string | undefined,
+        prompt: string,
+      ): Promise<AgentResult> => {
+        prepareReviewerWorktree(ctx);
+        try {
+          return await invokeOrResume(
+            opts.agentB,
+            sessionId,
+            prompt,
+            reviewerWorktreePath,
+            ctx.streamSinks?.b,
+            undefined,
+            ctx.usageSinks?.b,
+          );
+        } finally {
+          maybeCleanReviewerWorktree();
+        }
+      };
+      const followUpReviewer = async (
+        sessionId: string,
+        prompt: string,
+      ): Promise<AgentResult> => {
+        prepareReviewerWorktree(ctx);
+        try {
+          return await sendFollowUp(
+            opts.agentB,
+            sessionId,
+            prompt,
+            reviewerWorktreePath,
+            ctx.streamSinks?.b,
+            undefined,
+            ctx.usageSinks?.b,
+          );
+        } finally {
+          maybeCleanReviewerWorktree();
+        }
+      };
       const round = ctx.iteration + 1; // 1-based for display
 
       // Fetch PR comments for sub-step derivation and validation.
@@ -488,16 +553,16 @@ export function createReviewStageHandler(
       // ---- review --------------------------------------------------
       if (currentStep === "review") {
         opts.onReviewProgress?.("review");
-        const reviewPrompt = buildReviewPrompt(ctx, opts, round);
+        const reviewPrompt = buildReviewPrompt(
+          ctx,
+          opts,
+          round,
+          reviewerWorktreePath,
+        );
         ctx.promptSinks?.b?.(reviewPrompt, "review", { round });
-        const reviewResult = await invokeOrResume(
-          opts.agentB,
+        const reviewResult = await invokeReviewer(
           ctx.savedAgentBSessionId,
           reviewPrompt,
-          ctx.worktreePath,
-          ctx.streamSinks?.b,
-          undefined,
-          ctx.usageSinks?.b,
         );
 
         if (reviewResult.sessionId) {
@@ -534,14 +599,9 @@ export function createReviewStageHandler(
           ctx.promptSinks?.b?.(verdictPrompt, "verdict-followup", {
             resume: true,
           });
-          verdictResult = await sendFollowUp(
-            opts.agentB,
+          verdictResult = await followUpReviewer(
             agentBSessionId,
             verdictPrompt,
-            ctx.worktreePath,
-            ctx.streamSinks?.b,
-            undefined,
-            ctx.usageSinks?.b,
           );
         } else {
           // No review session — review was already posted on the PR.
@@ -559,17 +619,13 @@ export function createReviewStageHandler(
           }
           // Invoke Agent B fresh to read its own review and provide
           // the verdict keyword.
-          const resumePrompt = buildResumeVerdictPrompt(ctx, round);
-          ctx.promptSinks?.b?.(resumePrompt, "verdict-followup");
-          verdictResult = await invokeOrResume(
-            opts.agentB,
-            undefined,
-            resumePrompt,
-            ctx.worktreePath,
-            ctx.streamSinks?.b,
-            undefined,
-            ctx.usageSinks?.b,
+          const resumePrompt = buildResumeVerdictPrompt(
+            ctx,
+            round,
+            reviewerWorktreePath,
           );
+          ctx.promptSinks?.b?.(resumePrompt, "verdict-followup");
+          verdictResult = await invokeReviewer(undefined, resumePrompt);
           if (verdictResult.sessionId) {
             ctx.onSessionId?.("b", verdictResult.sessionId);
           }
@@ -602,27 +658,14 @@ export function createReviewStageHandler(
           const clarifySessionId = verdictResult.sessionId ?? agentBSessionId;
           let retryResult: AgentResult;
           if (clarifySessionId) {
-            retryResult = await sendFollowUp(
-              opts.agentB,
+            retryResult = await followUpReviewer(
               clarifySessionId,
               clarifyPrompt,
-              ctx.worktreePath,
-              ctx.streamSinks?.b,
-              undefined,
-              ctx.usageSinks?.b,
             );
           } else {
             // No session from either the fresh verdict invoke or a
             // prior review step — invoke fresh again for clarification.
-            retryResult = await invokeOrResume(
-              opts.agentB,
-              undefined,
-              clarifyPrompt,
-              ctx.worktreePath,
-              ctx.streamSinks?.b,
-              undefined,
-              ctx.usageSinks?.b,
-            );
+            retryResult = await invokeReviewer(undefined, clarifyPrompt);
           }
 
           if (retryResult.status === "error") {
@@ -726,7 +769,7 @@ export function createReviewStageHandler(
           opts,
           agentBSessionId,
           round,
-          ctx.worktreePath,
+          reviewerWorktreePath,
           ctx,
           ctx.streamSinks?.b,
           ctx.promptSinks?.b,
@@ -1021,7 +1064,7 @@ export function createReviewStageHandler(
             opts,
             agentBSessionId,
             round,
-            ctx.worktreePath,
+            reviewerWorktreePath,
             ctx,
             ctx.streamSinks?.b,
             ctx.promptSinks?.b,
@@ -1062,41 +1105,56 @@ async function handleUnresolvedSummary(
   opts: ReviewStageOptions,
   sessionId: string | undefined,
   round: number,
-  cwd: string,
+  reviewerWorktreePath: string,
   ctx: StageContext,
   sink?: StreamSink,
   promptSink?: PromptSink,
   usageSink?: UsageSink,
 ): Promise<UnresolvedSummaryResult> {
+  const prepareReviewerWorktree =
+    opts.prepareReviewerWorktree ?? (() => undefined);
+  const cleanReviewerWorktreeChanges =
+    opts.cleanReviewerWorktreeChanges ?? (() => false);
+  const maybeCleanReviewerWorktree = () => {
+    if (!cleanReviewerWorktreeChanges(reviewerWorktreePath)) return;
+    console.warn(
+      `Warning: cleaned unexpected local changes in reviewer worktree ${reviewerWorktreePath}`,
+    );
+  };
   // When resuming without a session, use the richer resume prompt
   // that gives Agent B repository context and tells it to read its
   // own review from the PR.  With a live session the agent already
   // has full context from the review step.
   const summaryPrompt = sessionId
     ? buildUnresolvedSummaryPrompt(round)
-    : buildResumeUnresolvedSummaryPrompt(ctx, round);
+    : buildResumeUnresolvedSummaryPrompt(ctx, round, reviewerWorktreePath);
   promptSink?.(summaryPrompt, "summary");
 
   // If we have a session, resume; otherwise invoke fresh.
   let result: AgentResult;
-  if (sessionId) {
-    result = await sendFollowUp(
-      opts.agentB,
-      sessionId,
-      summaryPrompt,
-      cwd,
-      sink,
-      undefined,
-      usageSink,
-    );
-  } else {
-    const stream = opts.agentB.invoke(summaryPrompt, {
-      cwd,
-      onUsage: usageSink,
-    });
-    const drained = sink ? drainToSink(stream, sink) : undefined;
-    result = await stream.result;
-    if (drained) await drained;
+  prepareReviewerWorktree(ctx);
+  try {
+    if (sessionId) {
+      result = await sendFollowUp(
+        opts.agentB,
+        sessionId,
+        summaryPrompt,
+        reviewerWorktreePath,
+        sink,
+        undefined,
+        usageSink,
+      );
+    } else {
+      const stream = opts.agentB.invoke(summaryPrompt, {
+        cwd: reviewerWorktreePath,
+        onUsage: usageSink,
+      });
+      const drained = sink ? drainToSink(stream, sink) : undefined;
+      result = await stream.result;
+      if (drained) await drained;
+    }
+  } finally {
+    maybeCleanReviewerWorktree();
   }
 
   if (result.status === "error") {
@@ -1114,24 +1172,29 @@ async function handleUnresolvedSummary(
   let verdictResult: AgentResult;
   const verdictSessionId = result.sessionId ?? sessionId;
 
-  if (verdictSessionId) {
-    verdictResult = await sendFollowUp(
-      opts.agentB,
-      verdictSessionId,
-      verdictPrompt,
-      cwd,
-      sink,
-      undefined,
-      usageSink,
-    );
-  } else {
-    const stream = opts.agentB.invoke(verdictPrompt, {
-      cwd,
-      onUsage: usageSink,
-    });
-    const drained = sink ? drainToSink(stream, sink) : undefined;
-    verdictResult = await stream.result;
-    if (drained) await drained;
+  prepareReviewerWorktree(ctx);
+  try {
+    if (verdictSessionId) {
+      verdictResult = await sendFollowUp(
+        opts.agentB,
+        verdictSessionId,
+        verdictPrompt,
+        reviewerWorktreePath,
+        sink,
+        undefined,
+        usageSink,
+      );
+    } else {
+      const stream = opts.agentB.invoke(verdictPrompt, {
+        cwd: reviewerWorktreePath,
+        onUsage: usageSink,
+      });
+      const drained = sink ? drainToSink(stream, sink) : undefined;
+      verdictResult = await stream.result;
+      if (drained) await drained;
+    }
+  } finally {
+    maybeCleanReviewerWorktree();
   }
 
   if (verdictResult.status === "error") {
@@ -1165,24 +1228,29 @@ async function handleUnresolvedSummary(
     const verdictSessionId2 = verdictResult.sessionId ?? sessionId;
     let retryResult: AgentResult;
 
-    if (verdictSessionId2) {
-      retryResult = await sendFollowUp(
-        opts.agentB,
-        verdictSessionId2,
-        clarifyPrompt,
-        cwd,
-        sink,
-        undefined,
-        usageSink,
-      );
-    } else {
-      const stream = opts.agentB.invoke(clarifyPrompt, {
-        cwd,
-        onUsage: usageSink,
-      });
-      const drained = sink ? drainToSink(stream, sink) : undefined;
-      retryResult = await stream.result;
-      if (drained) await drained;
+    prepareReviewerWorktree(ctx);
+    try {
+      if (verdictSessionId2) {
+        retryResult = await sendFollowUp(
+          opts.agentB,
+          verdictSessionId2,
+          clarifyPrompt,
+          reviewerWorktreePath,
+          sink,
+          undefined,
+          usageSink,
+        );
+      } else {
+        const stream = opts.agentB.invoke(clarifyPrompt, {
+          cwd: reviewerWorktreePath,
+          onUsage: usageSink,
+        });
+        const drained = sink ? drainToSink(stream, sink) : undefined;
+        retryResult = await stream.result;
+        if (drained) await drained;
+      }
+    } finally {
+      maybeCleanReviewerWorktree();
     }
 
     if (retryResult.status === "error") {

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -22,14 +22,18 @@ vi.mock("./lock.js", () => ({
 
 const {
   worktreePath,
+  reviewerWorktreePath,
   repoPath,
   detectDefaultBranch,
   bootstrapRepo,
   hasUncommittedChanges,
+  cleanReviewerWorktreeChanges,
   getHeadSha,
+  prepareReviewerWorktree,
   resolveBaseSha,
   resolveMergeBase,
   createWorktree,
+  removeReviewerWorktree,
   removeWorktree,
 } = await import("./worktree.js");
 
@@ -56,6 +60,21 @@ describe("worktreePath", () => {
   test("handles different issue numbers", () => {
     expect(worktreePath("org", "repo", 42)).toBe(
       join(home, ".agentcoop", "worktrees", "org", "repo", "issue-42"),
+    );
+  });
+});
+
+describe("reviewerWorktreePath", () => {
+  test("returns deterministic reviewer path", () => {
+    expect(reviewerWorktreePath("aicers", "agentcoop", 5)).toBe(
+      join(
+        home,
+        ".agentcoop",
+        "worktrees",
+        "aicers",
+        "agentcoop",
+        "issue-5-review",
+      ),
     );
   });
 });
@@ -550,6 +569,187 @@ describe("removeWorktree", () => {
       "git",
       ["branch", "-D", "issue-5"],
       expect.objectContaining({ cwd: bare }),
+    );
+  });
+});
+
+describe("prepareReviewerWorktree", () => {
+  const baseOpts = {
+    owner: "org",
+    repo: "repo",
+    issueNumber: 5,
+    authorBranch: "alice/issue-5",
+  };
+
+  test("creates detached reviewer worktree when missing", () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const result = prepareReviewerWorktree(baseOpts);
+
+    expect(result).toBe(reviewerWorktreePath("org", "repo", 5));
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["fetch", "origin", "alice/issue-5"],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      [
+        "worktree",
+        "add",
+        "--detach",
+        reviewerWorktreePath("org", "repo", 5),
+        "origin/alice/issue-5",
+      ],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+  });
+
+  test("refreshes existing valid reviewer worktree to latest origin branch", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "rev-parse") return "true\n";
+      return "" as never;
+    }) as typeof execFileSync);
+
+    prepareReviewerWorktree(baseOpts);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["switch", "--detach", "origin/alice/issue-5"],
+      expect.objectContaining({ cwd: reviewerWorktreePath("org", "repo", 5) }),
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["reset", "--hard", "origin/alice/issue-5"],
+      expect.objectContaining({ cwd: reviewerWorktreePath("org", "repo", 5) }),
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["clean", "-fd"],
+      expect.objectContaining({ cwd: reviewerWorktreePath("org", "repo", 5) }),
+    );
+  });
+
+  test("recreates reviewer worktree when refresh fails", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "rev-parse") return "true\n";
+      if (cmd === "git" && args[0] === "switch") {
+        throw new Error("refresh failed");
+      }
+      return "" as never;
+    }) as typeof execFileSync);
+
+    prepareReviewerWorktree(baseOpts);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "remove", "--force", reviewerWorktreePath("org", "repo", 5)],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+    expect(mockRmSync).toHaveBeenCalledWith(
+      reviewerWorktreePath("org", "repo", 5),
+      { recursive: true, force: true },
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      [
+        "worktree",
+        "add",
+        "--detach",
+        reviewerWorktreePath("org", "repo", 5),
+        "origin/alice/issue-5",
+      ],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+  });
+
+  test("recreates reviewer worktree when existing path is invalid", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "rev-parse") {
+        throw new Error("not a git worktree");
+      }
+      return "" as never;
+    }) as typeof execFileSync);
+
+    prepareReviewerWorktree(baseOpts);
+
+    expect(mockRmSync).toHaveBeenCalledWith(
+      reviewerWorktreePath("org", "repo", 5),
+      { recursive: true, force: true },
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      [
+        "worktree",
+        "add",
+        "--detach",
+        reviewerWorktreePath("org", "repo", 5),
+        "origin/alice/issue-5",
+      ],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+  });
+});
+
+describe("cleanReviewerWorktreeChanges", () => {
+  test("returns false when reviewer worktree is already clean", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync.mockReturnValue("");
+
+    expect(cleanReviewerWorktreeChanges("/tmp/reviewer")).toBe(false);
+  });
+
+  test("cleans tracked and untracked reviewer changes", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync
+      .mockReturnValueOnce(" M src/index.ts\n?? tmp.txt\n")
+      .mockReturnValue("" as never);
+
+    expect(cleanReviewerWorktreeChanges("/tmp/reviewer")).toBe(true);
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["reset", "--hard", "HEAD"],
+      expect.objectContaining({ cwd: "/tmp/reviewer" }),
+    );
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["clean", "-fd"],
+      expect.objectContaining({ cwd: "/tmp/reviewer" }),
+    );
+  });
+
+  test("returns true even when best-effort cleanup commands fail", () => {
+    mockExistsSync.mockReturnValue(true);
+    mockExecFileSync
+      .mockReturnValueOnce(" M src/index.ts\n")
+      .mockImplementation(() => {
+        throw new Error("cleanup failed");
+      });
+
+    expect(cleanReviewerWorktreeChanges("/tmp/reviewer")).toBe(true);
+  });
+});
+
+describe("removeReviewerWorktree", () => {
+  test("removes detached reviewer worktree without branch deletion", () => {
+    removeReviewerWorktree("org", "repo", 5);
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      "git",
+      ["worktree", "remove", "--force", reviewerWorktreePath("org", "repo", 5)],
+      expect.objectContaining({ cwd: repoPath("org", "repo") }),
+    );
+    expect(mockRmSync).toHaveBeenCalledWith(
+      reviewerWorktreePath("org", "repo", 5),
+      { recursive: true, force: true },
+    );
+    expect(mockExecFileSync).not.toHaveBeenCalledWith(
+      "git",
+      ["branch", "-D", expect.any(String)],
+      expect.anything(),
     );
   });
 });

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -51,6 +51,25 @@ export function worktreePath(
 }
 
 /**
+ * Return the deterministic detached reviewer worktree path:
+ * `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}-review`
+ */
+export function reviewerWorktreePath(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): string {
+  return join(
+    homedir(),
+    ".agentcoop",
+    "worktrees",
+    owner,
+    repo,
+    `issue-${issueNumber}-review`,
+  );
+}
+
+/**
  * Return the path to the bare clone used as the main repository:
  * `~/.agentcoop/repos/{owner}/{repo}.git`
  */
@@ -278,6 +297,37 @@ function forceRemoveWorktreeAndBranch(
 }
 
 /**
+ * Force-remove a detached reviewer worktree entry.
+ * Errors are silently ignored (the worktree may not exist).
+ */
+function forceRemoveDetachedWorktree(bare: string, wtPath: string): void {
+  try {
+    execFileSync("git", ["worktree", "remove", "--force", wtPath], {
+      ...EXEC_OPTS,
+      cwd: bare,
+    });
+  } catch {
+    // Already removed or never existed.
+  }
+
+  rmSync(wtPath, { recursive: true, force: true });
+  execFileSync("git", ["worktree", "prune"], { ...EXEC_OPTS, cwd: bare });
+}
+
+function isValidGitWorktree(wtPath: string): boolean {
+  if (!existsSync(wtPath)) return false;
+  try {
+    const output = execFileSync("git", ["rev-parse", "--is-inside-work-tree"], {
+      ...EXEC_OPTS,
+      cwd: wtPath,
+    }) as string;
+    return output.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Create a worktree for the given issue, branching from `baseBranch`.
  *
  * When the target path already exists the caller must provide a
@@ -371,6 +421,86 @@ export function createWorktree(options: {
 }
 
 /**
+ * Create or refresh the detached reviewer worktree on the latest
+ * `origin/{authorBranch}`.
+ */
+export function prepareReviewerWorktree(options: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  authorBranch: string;
+}): string {
+  const { owner, repo, issueNumber, authorBranch } = options;
+  const bare = repoPath(owner, repo);
+  const wtPath = reviewerWorktreePath(owner, repo, issueNumber);
+  const lockPath = repoLockPath(owner, repo);
+
+  withLock(lockPath, () => {
+    execFileSync("git", ["fetch", "origin", authorBranch], {
+      ...EXEC_OPTS,
+      cwd: bare,
+    });
+
+    const refresh = () => {
+      execFileSync("git", ["switch", "--detach", `origin/${authorBranch}`], {
+        ...EXEC_OPTS,
+        cwd: wtPath,
+      });
+      execFileSync("git", ["reset", "--hard", `origin/${authorBranch}`], {
+        ...EXEC_OPTS,
+        cwd: wtPath,
+      });
+      execFileSync("git", ["clean", "-fd"], {
+        ...EXEC_OPTS,
+        cwd: wtPath,
+      });
+    };
+
+    if (isValidGitWorktree(wtPath)) {
+      try {
+        refresh();
+        return;
+      } catch {
+        forceRemoveDetachedWorktree(bare, wtPath);
+      }
+    } else if (existsSync(wtPath)) {
+      forceRemoveDetachedWorktree(bare, wtPath);
+    }
+
+    execFileSync(
+      "git",
+      ["worktree", "add", "--detach", wtPath, `origin/${authorBranch}`],
+      { ...EXEC_OPTS, cwd: bare },
+    );
+  });
+
+  return wtPath;
+}
+
+/**
+ * Reset and clean unexpected reviewer changes.
+ *
+ * @returns true when changes were found and cleaned.
+ */
+export function cleanReviewerWorktreeChanges(wtPath: string): boolean {
+  if (!hasUncommittedChanges(wtPath)) return false;
+
+  try {
+    execFileSync("git", ["reset", "--hard", "HEAD"], {
+      ...EXEC_OPTS,
+      cwd: wtPath,
+    });
+    execFileSync("git", ["clean", "-fd"], {
+      ...EXEC_OPTS,
+      cwd: wtPath,
+    });
+  } catch {
+    // Best-effort cleanup only; reviewer dirtiness should not fail the run.
+  }
+  return true;
+}
+
+/**
  * Remove a worktree and its branch.  Used during final cleanup (stage 9).
  *
  * @param branch - The branch to delete.  Defaults to `issue-{issueNumber}`
@@ -387,4 +517,17 @@ export function removeWorktree(
   const wtPath = worktreePath(owner, repo, issueNumber);
   const resolvedBranch = branch ?? `issue-${issueNumber}`;
   forceRemoveWorktreeAndBranch(bare, wtPath, resolvedBranch);
+}
+
+/**
+ * Remove the detached reviewer worktree. Used during cleanup.
+ */
+export function removeReviewerWorktree(
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): void {
+  const bare = repoPath(owner, repo);
+  const wtPath = reviewerWorktreePath(owner, repo, issueNumber);
+  forceRemoveDetachedWorktree(bare, wtPath);
 }


### PR DESCRIPTION
## Summary
- add a dedicated detached reviewer worktree at `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}-review`
- refresh reviewer runs from `origin/{authorBranch}` before each reviewer step and keep author calls on the existing author worktree
- clean unexpected reviewer-side local changes after reviewer calls and remove both worktrees during cleanup
- persist reviewer worktree state for resume flows and extend tests for fresh runs, resume paths, refresh behavior, and cleanup

Closes #306

## Test plan
- [x] Run a fresh issue flow and verify reviewer prompts show the reviewer worktree path
- [x] Verify reviewer agent calls run in the detached reviewer worktree while author calls still run in the author worktree
- [x] Verify the reviewer worktree refreshes to the latest pushed `origin/{authorBranch}` state before each review round
- [x] Verify reviewer-created tracked or untracked changes are detected, cleaned automatically, and warned about
- [x] Verify resume flows preserve and reuse reviewer worktree state correctly
- [x] Verify cleanup removes both the author worktree and the detached reviewer worktree
- [x] Verify local validation remains green with `pnpm check` and `pnpm test`
