### PR TITLE
Document reviewer worktree behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Agent B review turns now run from a detached reviewer worktree that is
+  refreshed from `origin/{authorBranch}` before reviewer activity,
+  while Agent A continues to modify the author worktree.  Cleanup
+  removes both worktrees.
 - Stage 8 (Squash) no longer asks the agent to author the
   marker-delimited squash-suggestion PR comment.  The agent now
   drafts the title and body inside a `<<<TITLE>>>` / `<<<BODY>>>`

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ inside the TUI; Stage 1 is orchestrator-managed and runs beforehand.
 
 - **Stage 1 — Bootstrap:** Orchestrator-managed, runs before the TUI
   mounts. Bootstraps the repository (clone or fetch), detects the
-  default branch via `gh repo view`, creates the git worktree for
-  this issue, and on resume promotes the starting stage past
+  default branch via `gh repo view`, creates the author git worktree
+  for this issue, and on resume promotes the starting stage past
   `Create PR` if a PR already exists so `gh pr create` is not
   replayed.
 - **Stage 2 — Implement:** Agent A implements the issue in a git worktree
@@ -164,8 +164,9 @@ keep trying (timeout resumes polling; agent-error retries the same
 step; exhaustion resets the fix counter) before cleanup runs, so
 none of those branches can silently end the session.
 Once the user confirms the PR has been merged, the orchestrator
-stops any running services (e.g., Docker Compose), deletes the git
-worktree and its branch, and ends the agent sessions.  See
+stops any running services (e.g., Docker Compose), deletes the author
+git worktree, its branch, and the detached reviewer worktree, and
+ends the agent sessions.  See
 [Done stage details](docs/pipeline.md#stage-9-done) for the full
 flow.
 
@@ -246,16 +247,25 @@ issue's work from the original repository.
 On first run for a repository, AgentCoop creates a bare clone at
 `~/.agentcoop/repos/{owner}/{repo}.git`. On subsequent runs it
 fetches to keep the bare clone up to date. From this bare clone,
-each issue gets its own git worktree at
+each issue gets an author git worktree at
 `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`, branched
 from the latest remote default branch.
+
+During the review stage, Agent B uses a separate detached reviewer
+worktree at
+`~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}-review`. The
+reviewer worktree is refreshed from `origin/{authorBranch}` before
+reviewer activity, so Agent B reviews the pushed PR branch without
+sharing Agent A's editable checkout.
 
 This design has two advantages:
 
 - **No pollution.** The user's working copy is never touched. All
-  agent work happens in an isolated worktree outside the repository,
+  agent work happens in isolated worktrees outside the repository,
   so there is no risk of interfering with the user's uncommitted
-  changes, IDE state, or other branches.
+  changes, IDE state, or other branches. Reviewer-side changes are
+  cleaned from the detached reviewer worktree and cannot contaminate
+  the author worktree.
 - **Parallel safety.** Multiple issues can be worked on
   simultaneously because each gets its own worktree and branch. The
   bare clone serves as a shared, lockfile-protected reference that

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -245,8 +245,8 @@ Do not include any other commentary — just the keyword.
 ### Stage 1: Bootstrap
 
 **Agent:** none (orchestrator-managed)\
-**Purpose:** Prepare the repository, default branch, and worktree so
-later stages can run against a known-good local checkout.
+**Purpose:** Prepare the repository, default branch, and author
+worktree so later stages can run against a known-good local checkout.
 
 Stage 1 runs synchronously before the ink TUI mounts.  It performs:
 
@@ -257,10 +257,15 @@ Stage 1 runs synchronously before the ink TUI mounts.  It performs:
 - **Default branch detection:** Query via
   `gh repo view {owner}/{repo} --json defaultBranchRef` instead of
   assuming `main`.
-- **Worktree creation:** Create a git worktree from the latest remote
-  default branch at
+- **Author worktree creation:** Create a git worktree from the latest
+  remote default branch at
   `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}`, outside the
   repository to avoid pollution.
+- **Reviewer worktree path:** Record the deterministic detached
+  reviewer worktree path at
+  `~/.agentcoop/worktrees/{owner}/{repo}/issue-{number}-review`.
+  The reviewer worktree is created or refreshed later, immediately
+  before Agent B reviewer activity.
 - **Resume pre-flight:** On resume, if `startFromStage === 4` and a PR
   already exists, promote the starting stage to 5 (CI check) so the
   side-effectful `gh pr create` is not replayed.
@@ -880,6 +885,12 @@ addressing feedback. Multi-round until approval.
 Since both agents operate under the same GitHub account, comments
 are distinguished by prefix and round number.
 
+Agent A and Agent B use separate worktrees during review. Agent B
+reviewer turns run from the detached reviewer worktree, refreshed
+from `origin/{branch}` before reviewer activity. Agent A author
+substeps, including PR finalization and review fixes, continue to run
+from the author worktree.
+
 #### Review prompt — Agent B (round 1)
 
 ```text
@@ -889,7 +900,7 @@ You are reviewing a pull request for the following GitHub issue.
 - Owner: {owner}
 - Repo: {repo}
 - Branch: {branch}
-- Worktree: {worktree_path}
+- Worktree: {reviewer_worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -1026,7 +1037,7 @@ You are addressing review feedback for the following GitHub issue.
 - Owner: {owner}
 - Repo: {repo}
 - Branch: {branch}
-- Worktree: {worktree_path}
+- Worktree: {author_worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -1141,7 +1152,7 @@ state of the implementation.
 - Owner: {owner}
 - Repo: {repo}
 - Branch: {branch}
-- Worktree: {worktree_path}
+- Worktree: {author_worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -1217,6 +1228,10 @@ actual PR comment history and corrects:
   authoritative for post-approval progress.
 - **`lastVerdict`** — always corrected to the verdict derived from
   the comment history, even when sub-step reconciliation is skipped.
+- **`reviewerWorktreePath`** — persisted with run state so resumed
+  review stages continue to know the detached reviewer checkout path.
+  The worktree itself is still refreshed from `origin/{branch}`
+  before reviewer activity.
 - **Agent session invalidation** — if any field diverged from the
   persisted value, all agent sessions are invalidated so they
   start fresh with corrected state.
@@ -1645,8 +1660,9 @@ Cleanup
 
 3. **Merge confirmation** — the user chooses:
    - **Merged** — the user has merged the PR externally. Stop
-     running services (e.g., Docker Compose), clean up the git
-     worktree and branch, and report completion.
+     running services (e.g., Docker Compose), clean up the author
+     worktree and branch plus the detached reviewer worktree, and
+     report completion.
    - **Check conflicts** — run the mergeable check again without
      leaving this screen. This lets the user verify the state
      right before merging. If `MERGEABLE` comes back, the inner
@@ -1661,8 +1677,8 @@ Cleanup
      merge confirmation is re-presented.
    - **Exit** — stop the pipeline without merging. The
      orchestrator offers cleanup options: stop running services,
-     delete the worktree, delete the remote branch, and close
-     the PR. Each action is individually selectable.
+     delete the author and reviewer worktrees, delete the remote
+     branch, and close the PR. Each action is individually selectable.
 
    **Prompt viewport cap.** Stage 9's prompts must always leave the
    choice / text-input line visible.  Ink renders in-place without


### PR DESCRIPTION
## Summary
- add an Unreleased changelog entry for detached reviewer worktrees
- update the README to distinguish the author worktree from the detached reviewer worktree and cleanup behavior
- update the pipeline guide for Stage 1, Stage 7 reviewer/author worktree paths, resume state, and cleanup

Closes #308

## Test plan
- [x] `git diff --check`
- [x] `pnpm check` (passed; Biome reported an informational schema-version mismatch from `biome.json`)
- [x] `pnpm test`