### PR TITLE
Reduce token usage in stage prompts (#310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   repo from cwd.  Agent B reviewer prompts run from a detached
   worktree where `gh pr view` cannot infer the current branch, so
   they invoke `gh pr view {branch} --repo {owner}/{repo}` explicitly
-  instead of relying on auto-detection.  Saves roughly 3,000–4,000 tokens per pipeline run on
-  a typical issue with one self-check, one CI fix, and two review
-  rounds, with no change to verdict parsing semantics.
+  instead of relying on auto-detection.  Saves roughly 3,000–4,000
+  tokens per pipeline run on a typical issue with one self-check, one
+  CI fix, and two review rounds, with no change to verdict parsing
+  semantics.
 - Agent B review turns now run from a detached reviewer worktree that is
   refreshed from `origin/{authorBranch}` before reviewer activity,
   while Agent A continues to modify the author worktree.  Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- Pipeline stage prompts now use a compact resume-form when sending to
+  an agent on a live session, falling back to the full fresh-form only
+  when the resume helper has to fall back to a fresh `invoke` (session
+  expired / unknown error).  Each stage's `buildXxxPrompt` produces both
+  forms; `invokeOrResume` accepts an optional `fallbackPrompt` (and
+  `promptSink` / `promptKind` / `promptMeta` for diagnostics, bundled
+  into a single options object) so call sites that supply both forms
+  log the prompt actually sent.  The compact resume prompt drops the
+  repository header and full issue body (the agent already has them
+  from the prior stage's session) and keeps only stage-specific
+  instructions plus a one-line `issue #N` reference.  Verdict and
+  clarification prompts (`buildCompletionCheckPrompt`,
+  `buildPrCompletionCheckPrompt`, `buildFixOrDoneVerdictPrompt`,
+  `buildTestPlanVerdictPrompt`, `buildReviewVerdictPrompt`,
+  `buildUnresolvedVerdictPrompt`, `buildPrFinalizationVerdictPrompt`,
+  `buildSquashCompletionCheckPrompt`, and `buildClarificationPrompt`)
+  are collapsed to two-line "Reply with exactly one keyword …" forms;
+  the strict verdict parser is unchanged.  The redundant `Worktree:`
+  line is removed from every stage prompt — the agent's cwd is already
+  the worktree.  `Owner:` / `Repo:` / `Branch:` are retained where they
+  are interpolated into command examples or API URLs (e.g. the CodeQL
+  dismiss block in Stage 5) and dropped where `gh` auto-detects the
+  repo from cwd.  Saves roughly 3,000–4,000 tokens per pipeline run on
+  a typical issue with one self-check, one CI fix, and two review
+  rounds, with no change to verdict parsing semantics.
 - Agent B review turns now run from a detached reviewer worktree that is
   refreshed from `origin/{authorBranch}` before reviewer activity,
   while Agent A continues to modify the author worktree.  Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,16 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   current Agent A session id from `StageContext`, sends the compact
   `buildCiFindingsResumePrompt` / `buildCiFixResumePrompt` on the live
   session, and falls back to the fresh-form prompts only when the
-  helper has to fresh-invoke.  Saves roughly 3,000–4,000 tokens per
-  pipeline run on a typical issue with one self-check, one CI fix, and
-  two review rounds, with no change to verdict parsing semantics.
+  helper has to fresh-invoke.  `pollCiAndFix` accepts an optional
+  `initialAgentASessionId` so callers can hand it the freshest Agent A
+  session id from the same handler invocation; Stage 7 (post-author-fix
+  CI poll) and Stage 8 (`runCiPollAndFinish` from the verdict /
+  clarification / agent-squash follow-up paths) thread the live session
+  id through, since `ctx.savedAgentASessionId` is a stage-entry snapshot
+  and would otherwise force the first CI findings/fix turn back onto a
+  fresh `invoke`.  Saves roughly 3,000–4,000 tokens per pipeline run
+  on a typical issue with one self-check, one CI fix, and two review
+  rounds, with no change to verdict parsing semantics.
 - Agent B review turns now run from a detached reviewer worktree that is
   refreshed from `origin/{authorBranch}` before reviewer activity,
   while Agent A continues to modify the author worktree.  Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,15 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   repo from cwd.  Agent B reviewer prompts run from a detached
   worktree where `gh pr view` cannot infer the current branch, so
   they invoke `gh pr view {branch} --repo {owner}/{repo}` explicitly
-  instead of relying on auto-detection.  Saves roughly 3,000–4,000
-  tokens per pipeline run on a typical issue with one self-check, one
-  CI fix, and two review rounds, with no change to verdict parsing
-  semantics.
+  instead of relying on auto-detection.  The shared `pollCiAndFix`
+  helper used by Stage 7 (post-review CI fix) and Stage 8 (post-squash
+  CI fix) was also threaded through `invokeOrResume`: it now reads the
+  current Agent A session id from `StageContext`, sends the compact
+  `buildCiFindingsResumePrompt` / `buildCiFixResumePrompt` on the live
+  session, and falls back to the fresh-form prompts only when the
+  helper has to fresh-invoke.  Saves roughly 3,000–4,000 tokens per
+  pipeline run on a typical issue with one self-check, one CI fix, and
+  two review rounds, with no change to verdict parsing semantics.
 - Agent B review turns now run from a detached reviewer worktree that is
   refreshed from `origin/{authorBranch}` before reviewer activity,
   while Agent A continues to modify the author worktree.  Cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   the worktree.  `Owner:` / `Repo:` / `Branch:` are retained where they
   are interpolated into command examples or API URLs (e.g. the CodeQL
   dismiss block in Stage 5) and dropped where `gh` auto-detects the
-  repo from cwd.  Saves roughly 3,000–4,000 tokens per pipeline run on
+  repo from cwd.  Agent B reviewer prompts run from a detached
+  worktree where `gh pr view` cannot infer the current branch, so
+  they invoke `gh pr view {branch} --repo {owner}/{repo}` explicitly
+  instead of relying on auto-detection.  Saves roughly 3,000–4,000 tokens per pipeline run on
   a typical issue with one self-check, one CI fix, and two review
   rounds, with no change to verdict parsing semantics.
 - Agent B review turns now run from a detached reviewer worktree that is

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -76,6 +76,17 @@ resume falls back to a fresh invoke, the helper sends
 `fallbackPrompt` instead and emits a second prompt-sink event so
 diagnostic streams reflect the prompt actually sent.
 
+The shared `pollCiAndFix` helper (used by Stage 5, the post-review
+CI fix in Stage 7, and the post-squash CI fix in Stage 8) is also
+threaded through `invokeOrResume`. It reads the current Agent A
+session id from `StageContext`, sends the compact
+`buildCiFindingsResumePrompt` / `buildCiFixResumePrompt` on the
+live session, and falls back to the fresh
+`buildCiFindingsPrompt` / `buildCiFixPrompt` only when the helper
+has to fresh-invoke. Across multiple iterations of the fix loop,
+the helper tracks the latest session id locally so each turn
+resumes the most recent session.
+
 The `Worktree:` line is no longer included in any stage prompt:
 the agent's working directory is already set to the worktree, so
 the line was informational noise. `Owner` / `Repo` / `Branch` are

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -874,7 +874,8 @@ You are reviewing a pull request for the following GitHub issue.
 
 ## Instructions
 
-1. Find the pull request for this branch (use `gh pr view`).
+1. Find the pull request for this branch (use
+   `gh pr view {branch} --repo {owner}/{repo}`).
 2. Review the diff against the issue.
    Your job is an
    independent judgment on whether this is the right change

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -48,13 +48,38 @@ user interaction.
 
 ## Prompt design principles
 
-### Self-contained context
+### Self-contained context (with resume-form compaction)
 
-Every prompt includes the full repository coordinates (owner,
-repo, branch, worktree path) and the complete issue body. Agents
-never need to search for context — it is handed to them. This
-avoids wasted tokens on exploration and reduces the chance of the
-agent working against the wrong branch or issue.
+Every stage's first work prompt includes the full repository
+coordinates (owner, repo, branch) and the complete issue body when
+the agent does not yet have a live session — agents never need to
+search for context. To avoid retransmitting the same header and
+issue body on every stage transition, the orchestrator keeps each
+agent's CLI session alive across stages and sends a compact
+**resume-form** prompt when a saved session id is available:
+
+- **Fresh form** — the full prompt with repo header, issue body,
+  and stage instructions. Sent on the very first stage entry
+  (cold start) and as a fallback when the resume helper has to
+  fall back to a fresh `invoke` because the saved session expired.
+- **Resume form** — drops the issue body and repo header, keeping
+  only stage-specific instructions and a one-line `issue #N`
+  reference. Sent whenever a saved session id is available.
+
+`invokeOrResume` accepts an optional `fallbackPrompt` parameter
+(via an options object) so the call site can supply both forms.
+When the resume succeeds, the compact prompt is sent; if the
+resume falls back to a fresh invoke, the helper sends
+`fallbackPrompt` instead and emits a second prompt-sink event so
+diagnostic streams reflect the prompt actually sent.
+
+The `Worktree:` line is no longer included in any stage prompt:
+the agent's working directory is already set to the worktree, so
+the line was informational noise. `Owner` / `Repo` / `Branch` are
+retained only where they are interpolated into command examples
+or API URLs (e.g. the CodeQL dismiss block in Stage 5); elsewhere
+the agent uses `gh` against the current repo and `gh` auto-detects
+the repo from the cwd's git remote.
 
 ### Two-step verdict pattern
 
@@ -75,16 +100,12 @@ or out-of-scope keywords.  When the parser rejects a response, a
 single clarification retry is attempted listing only the valid
 keywords for that substep.
 
-The canonical verdict prompt template:
+The canonical verdict prompt template (compact, two lines):
 
 ```text
-<Context sentence about what just happened.>
-Respond with exactly one of the following keywords:
-
-- KEYWORD_A — <when to use>
-- KEYWORD_B — <when to use>
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+KEYWORD_A if <when to use>,
+KEYWORD_B if <when to use>.
 ```
 
 #### Keyword contracts per substep
@@ -219,25 +240,18 @@ two contexts:
   review stage).  `StageResult.validVerdicts` carries the
   keyword set from the stage handler to the pipeline engine.
 
-When `validVerdicts` is provided, the clarification prompt:
+When `validVerdicts` is provided, the clarification prompt is a
+single line listing only the in-scope keywords:
 
 ```text
-Your previous response did not contain a clear verdict keyword.
-Respond with exactly one of the following keywords: KEYWORD_A, KEYWORD_B
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary): KEYWORD_A, KEYWORD_B.
 ```
 
 When no `validVerdicts` are set (legacy fallback), all six keywords
 are listed:
 
 ```text
-Your previous response did not end with a clear status keyword.
-Please reply with exactly one of the following keywords to indicate
-the current status: COMPLETED, FIXED, DONE, APPROVED, NOT_APPROVED,
-or BLOCKED.
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary): COMPLETED, FIXED, DONE, APPROVED, NOT_APPROVED, BLOCKED.
 ```
 
 ## Stage reference
@@ -290,7 +304,6 @@ You are implementing a solution for the following GitHub issue.
 - Owner: {owner}
 - Repo: {repo}
 - Branch: {branch}
-- Worktree: {worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -298,8 +311,8 @@ You are implementing a solution for the following GitHub issue.
 
 ## Instructions
 
-Implement the changes required to resolve this issue.  Work inside the
-worktree directory listed above — it is freshly based on the latest
+Implement the changes required to resolve this issue.  The current
+working directory is a worktree freshly based on the latest
 remote default branch, so you are working on top of the most recent
 upstream state.  Make sure the code compiles and any existing tests
 still pass.
@@ -319,13 +332,9 @@ above.
 **Completion check:**
 
 ```text
-You have finished your implementation attempt.  Please evaluate the
-result and respond with exactly one of the following keywords:
-
-- COMPLETED — if the implementation is finished and working
-- BLOCKED — if you cannot proceed and need user intervention
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+COMPLETED if the implementation is finished and working,
+BLOCKED if you cannot proceed and need user intervention.
 ```
 
 **Outcome handling:**
@@ -352,7 +361,6 @@ You are reviewing the implementation for the following GitHub issue.
 - Owner: {owner}
 - Repo: {repo}
 - Branch: {branch}
-- Worktree: {worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -416,13 +424,9 @@ Based on your self-check above, decide what to do next.
 **Fix-or-done verdict follow-up:**
 
 ```text
-You have finished the self-check pass.
-Respond with exactly one of the following keywords:
-
-- FIXED — if you found and fixed issues
-- DONE — if everything looks good and no changes were needed
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+FIXED if you found and fixed issues,
+DONE if everything looks good and no changes were needed.
 ```
 
 **Loop behavior:** `FIXED` → repeat self-check. `DONE` → run
@@ -494,12 +498,6 @@ or if any step fails, the pipeline continues.
 ```text
 You are creating a pull request for the following GitHub issue.
 
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {worktree_path}
-
 ## Issue #{number}: {title}
 
 {issue_body}
@@ -526,13 +524,9 @@ You are creating a pull request for the following GitHub issue.
 **Completion check:**
 
 ```text
-You have finished your PR creation attempt.  Please evaluate the
-result and respond with exactly one of the following keywords:
-
-- COMPLETED — if the pull request was created successfully
-- BLOCKED — if you could not create the PR and need user intervention
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+COMPLETED if the pull request was created successfully,
+BLOCKED if you could not create the PR and need user intervention.
 ```
 
 **Ambiguous response handling:** If the completion check response
@@ -572,12 +566,6 @@ When CI passes with no findings, the stage completes immediately.
 
 ```text
 You are fixing CI failures for the following GitHub issue.
-
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -636,12 +624,6 @@ presented to Agent A for review.
 ````text
 CI passed but check runs reported findings (annotations).
 Review the findings below and decide whether any should be addressed.
-
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -794,12 +776,6 @@ check off completed tasks in the issue.
 ```text
 You are verifying the test plan for the following GitHub issue.
 
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {worktree_path}
-
 ## Issue #{number}: {title}
 
 {issue_body}
@@ -862,13 +838,9 @@ If everything is verified and passing, you are done.
 **Test plan verdict follow-up:**
 
 ```text
-You have finished the test plan verification pass.
-Respond with exactly one of the following keywords:
-
-- FIXED — if you found and fixed issues
-- DONE — if everything is verified and passing with no changes needed
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+FIXED if you found and fixed issues,
+DONE if everything is verified and passing with no changes needed.
 ```
 
 **Loop behavior:** `FIXED` → repeat the verification loop.
@@ -895,12 +867,6 @@ from the author worktree.
 
 ```text
 You are reviewing a pull request for the following GitHub issue.
-
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {reviewer_worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -950,13 +916,9 @@ You are reviewing a pull request for the following GitHub issue.
 **Reviewer verdict follow-up** (sent after the review comment):
 
 ```text
-You have posted your review comment.
-Respond with exactly one of the following keywords:
-
-- APPROVED — if the changes are ready to merge
-- NOT_APPROVED — if changes are needed
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+APPROVED if the changes are ready to merge,
+NOT_APPROVED if changes are needed.
 ```
 
 **Verdict comment:** After recording the verdict, the
@@ -1033,12 +995,6 @@ Sent when Agent B returns `NOT_APPROVED`:
 ```text
 You are addressing review feedback for the following GitHub issue.
 
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {author_worktree_path}
-
 ## Issue #{number}: {title}
 
 {issue_body}
@@ -1091,13 +1047,9 @@ You are addressing review feedback for the following GitHub issue.
 **Author completion check:**
 
 ```text
-You have finished addressing the review feedback.  Please evaluate
-the result and respond with exactly one of the following keywords:
-
-- COMPLETED — if all feedback was addressed and changes were pushed
-- BLOCKED — if you cannot proceed and need user intervention
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+COMPLETED if all feedback was addressed and changes were pushed,
+BLOCKED if you cannot proceed and need user intervention.
 ```
 
 After Agent A pushes, the orchestrator runs an internal CI
@@ -1124,12 +1076,9 @@ unresolved items from this review cycle.
 **Verdict follow-up:**
 
 ```text
-Respond with exactly one of the following keywords:
-
-- NONE — if there are no unresolved items
-- COMPLETED — if you posted the unresolved items comment
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+NONE if there are no unresolved items,
+COMPLETED if you posted the unresolved items comment.
 ```
 
 If the verdict is ambiguous or contains an out-of-scope keyword,
@@ -1147,12 +1096,6 @@ the PR body:
 The review is complete and the PR has been approved.  Before
 merging, verify that the PR body accurately reflects the final
 state of the implementation.
-
-## Repository
-- Owner: {owner}
-- Repo: {repo}
-- Branch: {branch}
-- Worktree: {author_worktree_path}
 
 ## Issue #{number}: {title}
 
@@ -1176,12 +1119,8 @@ state of the implementation.
 **PR finalization verdict follow-up:**
 
 ```text
-You have finished verifying the PR body.
-Respond with exactly one of the following keywords:
-
-- PR_FINALIZED — if the PR body is now accurate
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+PR_FINALIZED if the PR body is now accurate.
 ```
 
 Agent A must respond with `PR_FINALIZED` for the stage to
@@ -1321,18 +1260,14 @@ The work prompt asks the agent to:
 **Completion check:**
 
 ```text
-You have finished your squash decision.  Respond with exactly one
-of the following keywords:
-
-- SQUASHED_MULTI — if you rewrote history into multiple meaningful
-  commits and force-pushed
-- SUGGESTED_SINGLE — if a single commit is appropriate and you
-  drafted the suggested title and body in the
-  `<<<TITLE>>>` / `<<<BODY>>>` envelope (no force-push)
-- BLOCKED — if you could not complete either path and need user
-  intervention
-
-Do not include any other commentary — just the keyword.
+Reply with exactly one keyword (no commentary):
+SQUASHED_MULTI if you rewrote history into multiple meaningful
+commits and force-pushed,
+SUGGESTED_SINGLE if a single commit is appropriate and you drafted
+the suggested title and body in the <<<TITLE>>>/<<<BODY>>> envelope
+(no force-push),
+BLOCKED if you could not complete either path and need user
+intervention.
 ```
 
 The handler calls `parseVerdictKeyword` directly with these three
@@ -1727,7 +1662,6 @@ You are rebasing a feature branch onto the latest main.
 - Owner: {owner}
 - Repo: {repo}
 - Branch: {branch}
-- Worktree: {worktree_path}
 
 ## Instructions
 

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -50,21 +50,24 @@ user interaction.
 
 ### Self-contained context (with resume-form compaction)
 
-Every stage's first work prompt includes the full repository
-coordinates (owner, repo, branch) and the complete issue body when
-the agent does not yet have a live session — agents never need to
-search for context. To avoid retransmitting the same header and
-issue body on every stage transition, the orchestrator keeps each
-agent's CLI session alive across stages and sends a compact
-**resume-form** prompt when a saved session id is available:
+Every stage's first work prompt includes the complete issue body
+plus whatever repository details that stage actually needs, so the
+agent never has to search for context. To avoid retransmitting the
+same header and issue body on every stage transition, the
+orchestrator keeps each agent's CLI session alive across stages
+and sends a compact **resume-form** prompt when a saved session id
+is available:
 
-- **Fresh form** — the full prompt with repo header, issue body,
-  and stage instructions. Sent on the very first stage entry
-  (cold start) and as a fallback when the resume helper has to
-  fall back to a fresh `invoke` because the saved session expired.
-- **Resume form** — drops the issue body and repo header, keeping
-  only stage-specific instructions and a one-line `issue #N`
-  reference. Sent whenever a saved session id is available.
+- **Fresh form** — the full prompt with the issue body, the
+  stage's required repository details (see the `Owner` / `Repo` /
+  `Branch` rule below), and stage instructions. Sent on the very
+  first stage entry (cold start) and as a fallback when the resume
+  helper has to fall back to a fresh `invoke` because the saved
+  session expired.
+- **Resume form** — drops the issue body and any repo header,
+  keeping only stage-specific instructions and a one-line
+  `issue #N` reference. Sent whenever a saved session id is
+  available.
 
 `invokeOrResume` accepts an optional `fallbackPrompt` parameter
 (via an options object) so the call site can supply both forms.

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -9,7 +9,7 @@ the [README](../README.md).
 
 - [Pipeline overview](#pipeline-overview)
 - [Prompt design principles](#prompt-design-principles)
-  - [Self-contained context](#self-contained-context)
+  - [Self-contained context](#self-contained-context-with-resume-form-compaction)
   - [Two-step verdict pattern](#two-step-verdict-pattern)
   - [No confirmation requests](#no-confirmation-requests)
   - [Service-aware instructions](#service-aware-instructions)

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -79,13 +79,17 @@ diagnostic streams reflect the prompt actually sent.
 The shared `pollCiAndFix` helper (used by Stage 5, the post-review
 CI fix in Stage 7, and the post-squash CI fix in Stage 8) is also
 threaded through `invokeOrResume`. It reads the current Agent A
-session id from `StageContext`, sends the compact
-`buildCiFindingsResumePrompt` / `buildCiFixResumePrompt` on the
-live session, and falls back to the fresh
-`buildCiFindingsPrompt` / `buildCiFixPrompt` only when the helper
-has to fresh-invoke. Across multiple iterations of the fix loop,
-the helper tracks the latest session id locally so each turn
-resumes the most recent session.
+session id from `StageContext` (or, when the caller has just
+obtained a newer session id in the same handler invocation, from
+the optional `initialAgentASessionId` option — Stage 7 hands in
+the author-fix/completion-check session id, Stage 8 hands in the
+verdict / clarification / agent-squash follow-up session id),
+sends the compact `buildCiFindingsResumePrompt` /
+`buildCiFixResumePrompt` on the live session, and falls back to
+the fresh `buildCiFindingsPrompt` / `buildCiFixPrompt` only when
+the helper has to fresh-invoke. Across multiple iterations of the
+fix loop, the helper tracks the latest session id locally so each
+turn resumes the most recent session.
 
 The `Worktree:` line is no longer included in any stage prompt:
 the agent's working directory is already set to the worktree, so

--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -65,9 +65,35 @@ const BASE_CTX: StageContext = {
 };
 
 function makeAgent(invokeResult?: AgentResult): AgentAdapter {
+  const result = invokeResult ?? makeResult();
   return {
-    invoke: vi.fn().mockReturnValue(makeStream(invokeResult ?? makeResult())),
-    resume: vi.fn(),
+    invoke: vi.fn().mockReturnValue(makeStream(result)),
+    // `pollCiAndFix` now reuses the saved Agent A session id across
+    // iterations, so `resume` must return a stream too — otherwise
+    // the second-and-later turns of multi-iteration tests fail.
+    resume: vi.fn().mockReturnValue(makeStream(result)),
+  };
+}
+
+/**
+ * Build an agent whose `invoke` and `resume` share a single ordered
+ * queue of results.  `pollCiAndFix` calls `invoke` for the very first
+ * Agent A turn and `resume` for every subsequent turn, so multi-turn
+ * tests need both methods to draw from the same sequence.  Returns an
+ * adapter plus a `totalCalls()` helper that sums calls across both
+ * methods.
+ */
+function makeSequencedAgent(results: AgentResult[]): {
+  agent: AgentAdapter;
+  totalCalls: () => number;
+} {
+  let call = 0;
+  const next = () => makeStream(results[call++]);
+  const invoke = vi.fn().mockImplementation(next);
+  const resume = vi.fn().mockImplementation(next);
+  return {
+    agent: { invoke, resume },
+    totalCalls: () => invoke.mock.calls.length + resume.mock.calls.length,
   };
 }
 
@@ -193,16 +219,11 @@ describe("pollCiAndFix", () => {
       );
     const collectFailureLogs = vi.fn().mockReturnValue("err");
 
-    const invokeResults = [
-      makeStream(makeResult({ responseText: "Fix 1." })),
-      makeStream(makeResult({ responseText: "Fix 2." })),
-      makeStream(makeResult({ responseText: "Fix 3." })),
-    ];
-    let call = 0;
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => invokeResults[call++]),
-      resume: vi.fn(),
-    };
+    const { agent, totalCalls } = makeSequencedAgent([
+      makeResult({ responseText: "Fix 1." }),
+      makeResult({ responseText: "Fix 2." }),
+      makeResult({ responseText: "Fix 3." }),
+    ]);
 
     const result = await pollCiAndFix(
       makeOpts({ agent, getCiStatus, collectFailureLogs, maxFixAttempts: 3 }),
@@ -210,7 +231,7 @@ describe("pollCiAndFix", () => {
 
     expect(result.passed).toBe(false);
     expect(result.message).toContain("still failing after 3 fix attempt");
-    expect(agent.invoke).toHaveBeenCalledTimes(3);
+    expect(totalCalls()).toBe(3);
   });
 
   // -- agent error during fix -------------------------------------------------
@@ -398,22 +419,17 @@ describe("pollCiAndFix", () => {
 
     const collectFailureLogs = vi.fn().mockReturnValue("err");
 
-    const invokeResults = [
-      makeStream(makeResult({ responseText: "Fix 1." })),
-      makeStream(makeResult({ responseText: "Fix 2." })),
-    ];
-    let call = 0;
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => invokeResults[call++]),
-      resume: vi.fn(),
-    };
+    const { agent, totalCalls } = makeSequencedAgent([
+      makeResult({ responseText: "Fix 1." }),
+      makeResult({ responseText: "Fix 2." }),
+    ]);
 
     const result = await pollCiAndFix(
       makeOpts({ agent, getCiStatus, collectFailureLogs }),
     );
 
     expect(result.passed).toBe(true);
-    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    expect(totalCalls()).toBe(2);
   });
 
   // -- confirmRetry opt-in prompt --------------------------------------------
@@ -623,24 +639,15 @@ describe("pollCiAndFix", () => {
       .mockReturnValue(makeCiStatus("pass", [makeCiRun()], findings));
     const getHeadSha = vi.fn().mockReturnValue("same-sha");
 
-    let invokeCall = 0;
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => {
-        invokeCall++;
-        if (invokeCall === 1) {
-          return makeStream(
-            makeResult({
-              status: "error",
-              errorType: "execution_error",
-              stderrText: "crash",
-              responseText: "",
-            }),
-          );
-        }
-        return makeStream(makeResult({ responseText: "Acknowledged." }));
+    const { agent, totalCalls } = makeSequencedAgent([
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "crash",
+        responseText: "",
       }),
-      resume: vi.fn(),
-    };
+      makeResult({ responseText: "Acknowledged." }),
+    ]);
 
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const confirmRetry = vi.fn().mockResolvedValue(true);
@@ -662,9 +669,9 @@ describe("pollCiAndFix", () => {
     expect(confirmRetry).toHaveBeenCalledOnce();
     expect(confirmRetry.mock.calls[0][0].reason).toBe("agent_error");
     expect(confirmRetry.mock.calls[0][0].detail).toContain("crash");
-    // Two invokes: the failed first attempt + the retry.  This proves
-    // the findingsReviews counter was decremented on retry.
-    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    // Two agent calls: the failed first attempt + the retry.  This
+    // proves the findingsReviews counter was decremented on retry.
+    expect(totalCalls()).toBe(2);
     expect(result.passed).toBe(true);
 
     errorSpy.mockRestore();
@@ -724,24 +731,15 @@ describe("pollCiAndFix", () => {
       .mockReturnValueOnce(makeCiStatus("pass"));
     const collectFailureLogs = vi.fn().mockReturnValue("err");
 
-    let invokeCall = 0;
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => {
-        invokeCall++;
-        if (invokeCall === 1) {
-          return makeStream(
-            makeResult({
-              status: "error",
-              errorType: "execution_error",
-              stderrText: "boom",
-              responseText: "",
-            }),
-          );
-        }
-        return makeStream(makeResult({ responseText: "Fixed." }));
+    const { agent, totalCalls } = makeSequencedAgent([
+      makeResult({
+        status: "error",
+        errorType: "execution_error",
+        stderrText: "boom",
+        responseText: "",
       }),
-      resume: vi.fn(),
-    };
+      makeResult({ responseText: "Fixed." }),
+    ]);
 
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const confirmRetry = vi.fn().mockResolvedValue(true);
@@ -761,7 +759,7 @@ describe("pollCiAndFix", () => {
 
     expect(confirmRetry).toHaveBeenCalledOnce();
     expect(confirmRetry.mock.calls[0][0].reason).toBe("agent_error");
-    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    expect(totalCalls()).toBe(2);
     expect(result.passed).toBe(true);
 
     errorSpy.mockRestore();
@@ -1252,15 +1250,10 @@ describe("pollCiAndFix", () => {
     const shas = ["sha-1", "sha-1", "sha-2", "sha-2", "sha-3"];
     const getHeadSha = vi.fn().mockImplementation(() => shas[shaCall++]);
 
-    const invokeResults = [
-      makeStream(makeResult({ responseText: "Reviewed findings." })),
-      makeStream(makeResult({ responseText: "Fixed CI." })),
-    ];
-    let invokeCall = 0;
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
-      resume: vi.fn(),
-    };
+    const { agent, totalCalls } = makeSequencedAgent([
+      makeResult({ responseText: "Reviewed findings." }),
+      makeResult({ responseText: "Fixed CI." }),
+    ]);
 
     const result = await pollCiAndFix(
       makeOpts({
@@ -1276,7 +1269,7 @@ describe("pollCiAndFix", () => {
     // With the old coupled counter, this would have exhausted the budget.
     expect(result.passed).toBe(true);
     expect(result.message).toContain("CI checks passed");
-    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    expect(totalCalls()).toBe(2);
   });
 
   test("caps findings-review re-polls at maxFixAttempts", async () => {
@@ -1305,16 +1298,11 @@ describe("pollCiAndFix", () => {
       return sha;
     });
 
-    const invokeResults = [
-      makeStream(makeResult()),
-      makeStream(makeResult()),
-      makeStream(makeResult()),
-    ];
-    let invokeCall = 0;
-    const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
-      resume: vi.fn(),
-    };
+    const { agent, totalCalls } = makeSequencedAgent([
+      makeResult(),
+      makeResult(),
+      makeResult(),
+    ]);
 
     const result = await pollCiAndFix(
       makeOpts({
@@ -1330,7 +1318,7 @@ describe("pollCiAndFix", () => {
     expect(result.passed).toBe(true);
     expect(result.message).toContain("Findings were reviewed");
     // maxFixAttempts=2 → max(1,2)=2 findings reviews allowed.
-    expect(agent.invoke).toHaveBeenCalledTimes(2);
+    expect(totalCalls()).toBe(2);
   });
 
   test("findings prompt includes structured finding details", async () => {

--- a/src/ci-poll.test.ts
+++ b/src/ci-poll.test.ts
@@ -209,6 +209,82 @@ describe("pollCiAndFix", () => {
     expect(invokedPrompt).toContain("Error: test failed at line 42");
   });
 
+  // -- initialAgentASessionId seeds the loop's session tracker --------------
+
+  test("initialAgentASessionId resumes the live session for the first CI fix turn", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    const agent = makeAgent();
+    await pollCiAndFix(
+      makeOpts({
+        agent,
+        getCiStatus,
+        collectFailureLogs,
+        initialAgentASessionId: "sess-live",
+      }),
+    );
+
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    expect(agent.invoke).not.toHaveBeenCalled();
+    const [resumedSessionId, resumedPrompt] = (
+      agent.resume as ReturnType<typeof vi.fn>
+    ).mock.calls[0];
+    expect(resumedSessionId).toBe("sess-live");
+    expect(resumedPrompt).not.toContain("## Repository");
+    expect(resumedPrompt).not.toContain("The widget is broken.");
+  });
+
+  test("initialAgentASessionId is preferred over ctx.savedAgentASessionId", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    const agent = makeAgent();
+    await pollCiAndFix(
+      makeOpts({
+        ctx: { ...BASE_CTX, savedAgentASessionId: "sess-stale" },
+        agent,
+        getCiStatus,
+        collectFailureLogs,
+        initialAgentASessionId: "sess-live",
+      }),
+    );
+
+    expect(agent.resume).toHaveBeenCalledTimes(1);
+    const [resumedSessionId] = (agent.resume as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(resumedSessionId).toBe("sess-live");
+  });
+
+  test("falls back to fresh invoke when neither initialAgentASessionId nor ctx.savedAgentASessionId is set", async () => {
+    const getCiStatus = vi
+      .fn()
+      .mockReturnValueOnce(
+        makeCiStatus("fail", [makeCiRun({ conclusion: "failure" })]),
+      )
+      .mockReturnValueOnce(makeCiStatus("pass"));
+    const collectFailureLogs = vi.fn().mockReturnValue("err");
+
+    const agent = makeAgent();
+    await pollCiAndFix(makeOpts({ agent, getCiStatus, collectFailureLogs }));
+
+    expect(agent.invoke).toHaveBeenCalledTimes(1);
+    expect(agent.resume).not.toHaveBeenCalled();
+    const invokedPrompt = (agent.invoke as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(invokedPrompt).toContain("CI Failure Logs");
+  });
+
   // -- CI fails, all fix attempts exhausted -----------------------------------
 
   test("returns error after maxFixAttempts exhausted", async () => {

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -24,10 +24,15 @@ import {
 import { t } from "./i18n/index.js";
 import type { StageContext } from "./pipeline.js";
 import type { PipelineEventEmitter } from "./pipeline-events.js";
-import { buildCiFindingsPrompt, buildCiFixPrompt } from "./stage-cicheck.js";
+import {
+  buildCiFindingsPrompt,
+  buildCiFindingsResumePrompt,
+  buildCiFixPrompt,
+  buildCiFixResumePrompt,
+} from "./stage-cicheck.js";
 import {
   buildErrorDetail,
-  drainToSink,
+  invokeOrResume,
   logAgentFailure,
 } from "./stage-util.js";
 import { getHeadSha as defaultGetHeadSha } from "./worktree.js";
@@ -225,6 +230,14 @@ export async function pollCiAndFix(
   let fixAttempts = 0;
   let findingsReviews = 0;
 
+  // Track the current Agent A session id locally so each iteration
+  // resumes the most recent session.  Initialised from the stage
+  // context, then updated after every agent invocation.  When
+  // present, the compact resume-form prompt is sent on the live
+  // session and the fresh-form prompt is used as the fallback if
+  // the session has expired.
+  let currentSessionId = ctx.savedAgentASessionId;
+
   while (true) {
     // Read HEAD SHA from the worktree so we only consider CI runs
     // triggered by the most recent push (initial or fix).
@@ -304,25 +317,40 @@ export async function pollCiAndFix(
           ? correlateFindings(ciStatus.findings, alerts)
           : undefined;
 
-      const findingsPrompt = buildCiFindingsPrompt(
+      const freshFindingsPrompt = buildCiFindingsPrompt(
         ctx,
         { issueTitle, issueBody },
         ciStatus.findings,
         ciStatus.findingsIncomplete,
         correlated,
       );
+      const resumeFindingsPrompt = buildCiFindingsResumePrompt(
+        ctx,
+        ciStatus.findings,
+        ciStatus.findingsIncomplete,
+        correlated,
+      );
+      const findingsUseResume = currentSessionId !== undefined;
+      const findingsPrompt = findingsUseResume
+        ? resumeFindingsPrompt
+        : freshFindingsPrompt;
       ctx.promptSinks?.a?.(findingsPrompt, "ci-fix");
-      const reviewStream = agent.invoke(findingsPrompt, {
-        cwd: ctx.worktreePath,
-        onUsage: ctx.usageSinks?.a,
-      });
-      const drained = ctx.streamSinks?.a
-        ? drainToSink(reviewStream, ctx.streamSinks.a)
-        : undefined;
-      const reviewResult = await reviewStream.result;
-      if (drained) await drained;
+      const reviewResult = await invokeOrResume(
+        agent,
+        currentSessionId,
+        findingsPrompt,
+        ctx.worktreePath,
+        ctx.streamSinks?.a,
+        {
+          fallbackPrompt: findingsUseResume ? freshFindingsPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "ci-fix",
+        },
+      );
 
       if (reviewResult.sessionId) {
+        currentSessionId = reviewResult.sessionId;
         ctx.onSessionId?.("a", reviewResult.sessionId);
       }
 
@@ -399,23 +427,31 @@ export async function pollCiAndFix(
         ? logSections.join("\n\n")
         : "No detailed failure logs available.";
 
-    const fixPrompt = buildCiFixPrompt(
+    const freshFixPrompt = buildCiFixPrompt(
       ctx,
       { agent, issueTitle, issueBody },
       failureLogs,
     );
+    const resumeFixPrompt = buildCiFixResumePrompt(ctx, failureLogs);
+    const fixUseResume = currentSessionId !== undefined;
+    const fixPrompt = fixUseResume ? resumeFixPrompt : freshFixPrompt;
     ctx.promptSinks?.a?.(fixPrompt, "ci-fix");
-    const fixStream = agent.invoke(fixPrompt, {
-      cwd: ctx.worktreePath,
-      onUsage: ctx.usageSinks?.a,
-    });
-    const drained = ctx.streamSinks?.a
-      ? drainToSink(fixStream, ctx.streamSinks.a)
-      : undefined;
-    const fixResult = await fixStream.result;
-    if (drained) await drained;
+    const fixResult = await invokeOrResume(
+      agent,
+      currentSessionId,
+      fixPrompt,
+      ctx.worktreePath,
+      ctx.streamSinks?.a,
+      {
+        fallbackPrompt: fixUseResume ? freshFixPrompt : undefined,
+        usageSink: ctx.usageSinks?.a,
+        promptSink: ctx.promptSinks?.a,
+        promptKind: "ci-fix",
+      },
+    );
 
     if (fixResult.sessionId) {
+      currentSessionId = fixResult.sessionId;
       ctx.onSessionId?.("a", fixResult.sessionId);
     }
 

--- a/src/ci-poll.ts
+++ b/src/ci-poll.ts
@@ -85,6 +85,26 @@ export interface CiPollOptions {
   /** Pipeline event emitter for diagnostic events. */
   events?: PipelineEventEmitter;
   /**
+   * Latest known Agent A session id at the moment the caller hands
+   * off to `pollCiAndFix`.  When set, it overrides
+   * `ctx.savedAgentASessionId` for seeding the CI loop's own session
+   * tracker so the very first CI findings/fix turn resumes the
+   * caller's most recent conversation rather than the stage-entry
+   * snapshot.
+   *
+   * Why a separate option instead of relying on `ctx.savedAgentASessionId`:
+   * `StageContext` is a one-shot snapshot taken at handler entry, but
+   * Stage 7 (`author_fix` → `ci_poll`) and Stage 8 (squash work →
+   * verdict → user choice → CI poll) routinely produce a newer Agent
+   * A session id within the same handler invocation.  `ctx.onSessionId`
+   * persists those externally but does not mutate the snapshot, so
+   * without this option the first CI prompt would still fall back to
+   * fresh-form even though the live session is known.  Subsequent
+   * loop iterations are covered by the helper's local
+   * `currentSessionId` which is updated after every agent turn.
+   */
+  initialAgentASessionId?: string;
+  /**
    * Optional callback invoked when CI cannot proceed via the normal
    * fix loop — exhausted fix budget, pending timeout, or an agent
    * error during findings review or fix.  When set, the caller is
@@ -231,12 +251,15 @@ export async function pollCiAndFix(
   let findingsReviews = 0;
 
   // Track the current Agent A session id locally so each iteration
-  // resumes the most recent session.  Initialised from the stage
-  // context, then updated after every agent invocation.  When
-  // present, the compact resume-form prompt is sent on the live
-  // session and the fresh-form prompt is used as the fallback if
-  // the session has expired.
-  let currentSessionId = ctx.savedAgentASessionId;
+  // resumes the most recent session.  Prefer the caller's
+  // `initialAgentASessionId` (the live session id from the same
+  // handler invocation) over `ctx.savedAgentASessionId` (the
+  // stage-entry snapshot), then update after every agent invocation.
+  // When present, the compact resume-form prompt is sent on the live
+  // session and the fresh-form prompt is used as the fallback if the
+  // session has expired.
+  let currentSessionId =
+    options.initialAgentASessionId ?? ctx.savedAgentASessionId;
 
   while (true) {
     // Read HEAD SHA from the worktree so we only consider CI runs

--- a/src/rebase.ts
+++ b/src/rebase.ts
@@ -59,7 +59,6 @@ export function buildRebasePrompt(
     `- Owner: ${ctx.owner}`,
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-cicheck.test.ts
+++ b/src/stage-cicheck.test.ts
@@ -90,12 +90,12 @@ function makeOpts(
 // ---- buildCiFixPrompt ------------------------------------------------------
 
 describe("buildCiFixPrompt", () => {
-  test("includes repo context", () => {
+  test("omits redundant repo headers", () => {
     const prompt = buildCiFixPrompt(BASE_CTX, makeOpts(), "error log");
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
-    expect(prompt).toContain("Branch: issue-42");
-    expect(prompt).toContain("Worktree: /tmp/wt");
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Repo: repo");
+    expect(prompt).not.toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("includes issue details", () => {
@@ -855,11 +855,12 @@ describe("buildCiFindingsPrompt", () => {
     },
   ];
 
-  test("includes repo context", () => {
+  test("omits redundant repo headers", () => {
     const prompt = buildCiFindingsPrompt(BASE_CTX, makeOpts(), sampleFindings);
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
-    expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Repo: repo");
+    expect(prompt).not.toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("includes issue details", () => {

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -90,12 +90,6 @@ export function buildCiFixPrompt(
   const lines = [
     `You are fixing CI failures for the following GitHub issue.`,
     ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
-    ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
     opts.issueBody,
@@ -120,6 +114,39 @@ export function buildCiFixPrompt(
     lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
   }
 
+  return lines.join("\n");
+}
+
+/**
+ * Compact resume-form CI fix prompt — repository / issue context is
+ * already in the live agent session, so only the failure logs and
+ * instructions are re-sent.
+ */
+export function buildCiFixResumePrompt(
+  ctx: StageContext,
+  failureLogs: string,
+): string {
+  const lines = [
+    `Fix the CI failures for issue #${ctx.issueNumber}.`,
+    ``,
+    `## CI Failure Logs`,
+    ``,
+    failureLogs || "No detailed failure logs available.",
+    ``,
+    `## Instructions`,
+    ``,
+    `Diagnose and fix the CI failures shown above.  After making your`,
+    `changes:`,
+    ``,
+    buildDocConsistencyInstructions(),
+    ``,
+    `${buildPrSyncInstructions(ctx.issueNumber)}`,
+    ``,
+    `Then commit and push the branch so a new CI run is triggered.`,
+  ];
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
   return lines.join("\n");
 }
 
@@ -246,15 +273,66 @@ export function buildCiFindingsPrompt(
     `CI passed but check runs reported findings (annotations).`,
     `Review the findings below and decide whether any should be addressed.`,
     ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
-    ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
     opts.issueBody,
+    ``,
+    `## CI Findings`,
+    ``,
+    correlated ? formatFindings(correlated) : formatFindings(findings),
+  ];
+
+  if (findingsIncomplete) {
+    lines.push(
+      ``,
+      `**Note:** Some check run annotations could not be fetched.`,
+      `The findings above may be incomplete.  Check the PR's Checks`,
+      `tab for the full list of annotations.`,
+    );
+  }
+
+  if (correlated) {
+    lines.push(buildTriageInstructions(ctx, correlated));
+  }
+
+  lines.push(
+    ``,
+    `## Instructions`,
+    ``,
+    `For each finding, decide whether it should be fixed or can be`,
+    `safely ignored.  If you fix any findings:`,
+    ``,
+    buildDocConsistencyInstructions(),
+    ``,
+    `${buildPrSyncInstructions(ctx.issueNumber)}`,
+    ``,
+    `Then commit and push the branch so a new CI run is triggered.`,
+    `If all findings are acceptable as-is, explain your reasoning.`,
+  );
+
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Compact resume-form findings prompt — drops the issue body which
+ * the agent's live session already has from prior stages.  Findings
+ * data and the (conditional) CodeQL triage block are preserved
+ * because they are dynamic per-run content.
+ */
+export function buildCiFindingsResumePrompt(
+  ctx: StageContext,
+  findings: CiFinding[],
+  findingsIncomplete?: boolean,
+  correlated?: CorrelatedFinding[],
+): string {
+  const lines = [
+    `CI passed but check runs reported findings (annotations) for issue`,
+    `#${ctx.issueNumber}.  Review the findings below and decide whether`,
+    `any should be addressed.`,
     ``,
     `## CI Findings`,
     ``,
@@ -386,13 +464,23 @@ export function createCiCheckStageHandler(
             ? correlateFindings(ciStatus.findings, alerts)
             : undefined;
 
-        const findingsPrompt = buildCiFindingsPrompt(
+        const freshFindingsPrompt = buildCiFindingsPrompt(
           ctx,
           opts,
           ciStatus.findings,
           ciStatus.findingsIncomplete,
           correlated,
         );
+        const resumeFindingsPrompt = buildCiFindingsResumePrompt(
+          ctx,
+          ciStatus.findings,
+          ciStatus.findingsIncomplete,
+          correlated,
+        );
+        const findingsUseResume = ctx.savedAgentASessionId !== undefined;
+        const findingsPrompt = findingsUseResume
+          ? resumeFindingsPrompt
+          : freshFindingsPrompt;
         ctx.promptSinks?.a?.(findingsPrompt, "ci-fix");
         const reviewResult = await invokeOrResume(
           opts.agent,
@@ -400,8 +488,12 @@ export function createCiCheckStageHandler(
           findingsPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
-          undefined,
-          ctx.usageSinks?.a,
+          {
+            fallbackPrompt: findingsUseResume ? freshFindingsPrompt : undefined,
+            usageSink: ctx.usageSinks?.a,
+            promptSink: ctx.promptSinks?.a,
+            promptKind: "ci-fix",
+          },
         );
 
         if (reviewResult.sessionId) {
@@ -447,7 +539,10 @@ export function createCiCheckStageHandler(
           ? logSections.join("\n\n")
           : "No detailed failure logs available.";
 
-      const prompt = buildCiFixPrompt(ctx, opts, failureLogs);
+      const freshFixPrompt = buildCiFixPrompt(ctx, opts, failureLogs);
+      const resumeFixPrompt = buildCiFixResumePrompt(ctx, failureLogs);
+      const fixUseResume = ctx.savedAgentASessionId !== undefined;
+      const prompt = fixUseResume ? resumeFixPrompt : freshFixPrompt;
       ctx.promptSinks?.a?.(prompt, "ci-fix");
       const fixResult = await invokeOrResume(
         opts.agent,
@@ -455,8 +550,12 @@ export function createCiCheckStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
+        {
+          fallbackPrompt: fixUseResume ? freshFixPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "ci-fix",
+        },
       );
 
       if (fixResult.sessionId) {

--- a/src/stage-createpr.test.ts
+++ b/src/stage-createpr.test.ts
@@ -67,12 +67,14 @@ function makeOpts(
 // ---- buildCreatePrPrompt ---------------------------------------------------
 
 describe("buildCreatePrPrompt", () => {
-  test("includes repo context", () => {
+  test("omits redundant repo headers", () => {
+    // Owner / Repo / Branch / Worktree are redundant — `gh` infers
+    // the repo from cwd, and cwd is already the worktree.
     const prompt = buildCreatePrPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
-    expect(prompt).toContain("Branch: issue-42");
-    expect(prompt).toContain("Worktree: /tmp/wt");
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Repo: repo");
+    expect(prompt).not.toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("includes issue details", () => {
@@ -124,13 +126,13 @@ describe("buildPrCompletionCheckPrompt", () => {
 
   test("asks for exactly one keyword", () => {
     const prompt = buildPrCompletionCheckPrompt();
-    expect(prompt).toContain("exactly one");
+    expect(prompt).toContain("exactly one keyword");
   });
 
   test("asks for just the keyword with no other commentary", () => {
     const prompt = buildPrCompletionCheckPrompt();
     expect(prompt).toContain("BLOCKED");
-    expect(prompt).toContain("Do not include any other commentary");
+    expect(prompt).toContain("no commentary");
   });
 });
 

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -52,12 +52,6 @@ export function buildCreatePrPrompt(
   const lines = [
     `You are creating a pull request for the following GitHub issue.`,
     ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
-    ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
     opts.issueBody,
@@ -88,17 +82,43 @@ export function buildCreatePrPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Compact resume-form prompt for stage 4 — sent when the agent
+ * already has the issue context from a prior stage's session.
+ */
+export function buildCreatePrResumePrompt(ctx: StageContext): string {
+  const lines = [
+    `Create a pull request for issue #${ctx.issueNumber}.`,
+    ``,
+    `1. Commit any remaining uncommitted changes on the branch.`,
+    `2. Push the branch to the remote.`,
+    `3. Create a pull request using \`gh pr create\` targeting the default`,
+    `   branch.  The PR title should reference the issue number`,
+    `   (e.g. "Fix widget rendering (#${ctx.issueNumber})").`,
+    `4. In the PR body, include:`,
+    `   - A brief summary of the changes`,
+    `   - If this PR fully resolves the issue, include "Closes #${ctx.issueNumber}"`,
+    `     in the description. If it only partially addresses it,`,
+    `     use "Part of #${ctx.issueNumber}" instead and add a`,
+    `     "## Not addressed" section listing which issue requirements`,
+    `     were not implemented and why.`,
+    `   - A "## Test plan" section with a checkbox checklist of items to`,
+    `     verify (derived from the issue requirements)`,
+    `5. Do NOT merge the PR — just create it.`,
+  ];
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+  return lines.join("\n");
+}
+
 export const PR_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
 
 export function buildPrCompletionCheckPrompt(): string {
   return [
-    `You have finished your PR creation attempt.  Please evaluate the`,
-    `result and respond with exactly one of the following keywords:`,
-    ``,
-    `- COMPLETED — if the pull request was created successfully`,
-    `- BLOCKED — if you could not create the PR and need user intervention`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `COMPLETED if the pull request was created successfully,`,
+    `BLOCKED if you could not create the PR and need user intervention.`,
   ].join("\n");
 }
 
@@ -112,7 +132,10 @@ export function createCreatePrStageHandler(
     requiresArtifact: true,
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the PR creation prompt (resume if saved session).
-      const prompt = buildCreatePrPrompt(ctx, opts);
+      const freshPrompt = buildCreatePrPrompt(ctx, opts);
+      const resumePrompt = buildCreatePrResumePrompt(ctx);
+      const useResume = ctx.savedAgentASessionId !== undefined;
+      const prompt = useResume ? resumePrompt : freshPrompt;
       ctx.promptSinks?.a?.(prompt, "work");
       const prResult = await invokeOrResume(
         opts.agent,
@@ -120,8 +143,12 @@ export function createCreatePrStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
+        {
+          fallbackPrompt: useResume ? freshPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "work",
+        },
       );
 
       if (prResult.sessionId) {

--- a/src/stage-e2e.test.ts
+++ b/src/stage-e2e.test.ts
@@ -1327,7 +1327,7 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
         );
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-        if (prompt.includes("PR creation attempt")) {
+        if (prompt.includes("COMPLETED if the pull request was created")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
         // Test plan self-check
@@ -1375,11 +1375,11 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
         );
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-        if (prompt.includes("PR creation attempt")) {
+        if (prompt.includes("COMPLETED if the pull request was created")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
         // Test plan verdict follow-up (3-step: work + verdict)
-        if (prompt.includes("finished the test plan verification pass")) {
+        if (prompt.includes("DONE if everything is verified")) {
           tpVerdictCalls++;
           if (tpVerdictCalls === 1) {
             return makeStream(makeResult({ responseText: "FIXED" }));
@@ -1431,7 +1431,7 @@ describe("Multi-stage E2E: Stage 4 → Stage 5 → Stage 6", () => {
         );
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-        if (prompt.includes("PR creation attempt")) {
+        if (prompt.includes("COMPLETED if the pull request was created")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
         // Always FIXED — never done
@@ -1499,7 +1499,7 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
         );
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-        if (prompt.includes("evaluate the")) {
+        if (prompt.includes("COMPLETED if the implementation")) {
           implResumeCalls++;
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
@@ -1548,7 +1548,7 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
         );
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-        if (prompt.includes("evaluate the")) {
+        if (prompt.includes("COMPLETED if the implementation")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
         // 3-step self-check: odd = work, even = verdict.
@@ -1594,7 +1594,7 @@ describe("Multi-stage E2E: Stage 2 → Stage 3", () => {
           makeStream(makeResult({ sessionId: "s1", responseText: "ok" })),
         ),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
-        if (prompt.includes("evaluate the")) {
+        if (prompt.includes("COMPLETED if the implementation")) {
           return makeStream(makeResult({ responseText: "COMPLETED" }));
         }
         return makeStream(makeResult({ responseText: "DONE" }));
@@ -1947,7 +1947,7 @@ describe("Stage 7 (Review) through pipeline", () => {
       ),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
         // Verdict follow-up → NOT_APPROVED
-        if (prompt.includes("posted your review")) {
+        if (prompt.includes("APPROVED if the changes are ready")) {
           return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
         }
         // Unresolved summary + verdict
@@ -2010,7 +2010,7 @@ describe("Stage 7 (Review) through pipeline", () => {
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
         // Verdict follow-up
-        if (prompt.includes("posted your review")) {
+        if (prompt.includes("APPROVED if the changes are ready")) {
           if (bInvokeCalls <= 3) {
             return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
           }
@@ -2080,7 +2080,7 @@ describe("Stage 7 (Review) through pipeline", () => {
       }),
       resume: vi.fn().mockImplementation((_sid: string, prompt: string) => {
         // Review verdict follow-up
-        if (prompt.includes("posted your review")) {
+        if (prompt.includes("APPROVED if the changes are ready")) {
           return makeStream(makeResult({ responseText: "NOT_APPROVED" }));
         }
         // Unresolved summary work step (contains "review cycle")
@@ -2166,7 +2166,7 @@ describe("Stage 7 (Review) through pipeline", () => {
         // Verdict follow-up — return a session ID that advances
         // beyond the invoke session, so we can verify the
         // unresolved summary resumes the verdict session.
-        if (prompt.includes("posted your review")) {
+        if (prompt.includes("APPROVED if the changes are ready")) {
           if (bInvokeCalls <= 2) {
             return makeStream(
               makeResult({

--- a/src/stage-implement.test.ts
+++ b/src/stage-implement.test.ts
@@ -72,7 +72,8 @@ describe("buildImplementPrompt", () => {
     expect(prompt).toContain("Owner: org");
     expect(prompt).toContain("Repo: repo");
     expect(prompt).toContain("Branch: issue-42");
-    expect(prompt).toContain("Worktree: /tmp/wt");
+    // Worktree line is dropped — the agent's cwd is the worktree.
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("includes issue details", () => {
@@ -103,6 +104,27 @@ describe("buildImplementPrompt", () => {
     const prompt = buildImplementPrompt(BASE_CTX, makeOpts());
     expect(prompt).toContain("freshly based on the latest");
     expect(prompt).toContain("remote default branch");
+  });
+});
+
+// ---- buildImplementResumePrompt --------------------------------------------
+
+import { buildImplementResumePrompt } from "./stage-implement.js";
+
+describe("buildImplementResumePrompt", () => {
+  test("references issue number without including the full body", () => {
+    const prompt = buildImplementResumePrompt(BASE_CTX);
+    expect(prompt).toContain("issue #42");
+    // Issue body is intentionally omitted on the resume form.
+    expect(prompt).not.toContain("The widget is broken.");
+    expect(prompt).not.toContain("## Repository");
+  });
+
+  test("includes user instruction when present", () => {
+    const ctx = { ...BASE_CTX, userInstruction: "Try a different approach" };
+    const prompt = buildImplementResumePrompt(ctx);
+    expect(prompt).toContain("Additional feedback");
+    expect(prompt).toContain("Try a different approach");
   });
 });
 

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -37,7 +37,6 @@ export function buildImplementPrompt(
     `- Owner: ${ctx.owner}`,
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
     ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
@@ -45,8 +44,8 @@ export function buildImplementPrompt(
     ``,
     `## Instructions`,
     ``,
-    `Implement the changes required to resolve this issue.  Work inside the`,
-    `worktree directory listed above — it is freshly based on the latest`,
+    `Implement the changes required to resolve this issue.  The current`,
+    `working directory is a worktree freshly based on the latest`,
     `remote default branch, so you are working on top of the most recent`,
     `upstream state.  Make sure the code compiles and any existing tests`,
     `still pass.`,
@@ -65,17 +64,35 @@ export function buildImplementPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Compact resume-form prompt for stage 2 — sent when the agent
+ * already has the repository / issue context from a prior stage's
+ * session.  The fresh-form prompt is sent only when the resume falls
+ * back to a fresh invoke.
+ */
+export function buildImplementResumePrompt(ctx: StageContext): string {
+  const lines = [
+    `Implement the changes required to resolve issue #${ctx.issueNumber}.`,
+    `Make sure the code compiles and any existing tests still pass.`,
+    ``,
+    `If the project uses external services (databases, message brokers,`,
+    `dev servers, etc.), start them using whatever tools the project`,
+    `provides and run the full test suite against them.  If a port`,
+    `conflict occurs, change the port rather than skipping the service.`,
+  ];
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+  return lines.join("\n");
+}
+
 export const IMPLEMENT_CHECK_KEYWORDS = ["COMPLETED", "BLOCKED"] as const;
 
 export function buildCompletionCheckPrompt(): string {
   return [
-    `You have finished your implementation attempt.  Please evaluate the`,
-    `result and respond with exactly one of the following keywords:`,
-    ``,
-    `- COMPLETED — if the implementation is finished and working`,
-    `- BLOCKED — if you cannot proceed and need user intervention`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `COMPLETED if the implementation is finished and working,`,
+    `BLOCKED if you cannot proceed and need user intervention.`,
   ].join("\n");
 }
 
@@ -88,7 +105,13 @@ export function createImplementStageHandler(
     primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send the implementation prompt (resume if saved session).
-      const prompt = buildImplementPrompt(ctx, opts);
+      // When a saved session exists, send the compact resume-form
+      // prompt and supply the full fresh-form as fallback so an
+      // expired session still gets full context.
+      const freshPrompt = buildImplementPrompt(ctx, opts);
+      const resumePrompt = buildImplementResumePrompt(ctx);
+      const useResume = ctx.savedAgentASessionId !== undefined;
+      const prompt = useResume ? resumePrompt : freshPrompt;
       ctx.promptSinks?.a?.(prompt, "work");
       const implResult = await invokeOrResume(
         opts.agent,
@@ -96,8 +119,12 @@ export function createImplementStageHandler(
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
+        {
+          fallbackPrompt: useResume ? freshPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "work",
+        },
       );
 
       if (implResult.sessionId) {

--- a/src/stage-review.test.ts
+++ b/src/stage-review.test.ts
@@ -130,16 +130,14 @@ function makeOpts(
 // ---- prompt builders ---------------------------------------------------------
 
 describe("buildReviewPrompt", () => {
-  test("includes repo and issue context", () => {
+  test("issue context is preserved while redundant headers are dropped", () => {
     const prompt = buildReviewPrompt(BASE_CTX, makeOpts(), 1);
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
     expect(prompt).toContain("Issue #42: Fix the widget");
-  });
-
-  test("uses reviewer worktree path in reviewer prompt", () => {
-    const prompt = buildReviewPrompt(BASE_CTX, makeOpts(), 1);
-    expect(prompt).toContain("Worktree: /tmp/wt-review");
+    // Owner / Repo / Branch / Worktree are redundant — gh infers
+    // the repo from cwd, and cwd is the reviewer worktree.
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Repo: repo");
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("includes round number", () => {
@@ -301,30 +299,33 @@ describe("buildUnresolvedSummaryPrompt", () => {
 });
 
 describe("buildResumeUnresolvedSummaryPrompt", () => {
-  test("includes repo context and instructs B to read its review", () => {
+  test("instructs B to read its review by issue number", () => {
     const prompt = buildResumeUnresolvedSummaryPrompt(BASE_CTX, 2);
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
-    expect(prompt).toContain("Branch: issue-42");
-    expect(prompt).toContain("Worktree: /tmp/wt-review");
+    // Worktree / Owner / Repo / Branch are dropped — cwd is the
+    // reviewer worktree and gh auto-detects the repo.
+    expect(prompt).not.toContain("Worktree:");
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).toContain("issue #42");
     expect(prompt).toContain("[Reviewer Round 2]");
     expect(prompt).toContain("[Reviewer Unresolved Round 2]");
   });
 });
 
 describe("buildResumeVerdictPrompt", () => {
-  test("includes reviewer worktree path", () => {
+  test("references the issue and round without the worktree path", () => {
     const prompt = buildResumeVerdictPrompt(BASE_CTX, 2);
-    expect(prompt).toContain("Worktree: /tmp/wt-review");
+    expect(prompt).not.toContain("Worktree:");
+    expect(prompt).toContain("issue #42");
+    expect(prompt).toContain("[Reviewer Round 2]");
   });
 });
 
 describe("buildPrFinalizationPrompt", () => {
-  test("includes repo and issue context", () => {
+  test("includes issue context and omits redundant headers", () => {
     const prompt = buildPrFinalizationPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
     expect(prompt).toContain("Issue #42: Fix the widget");
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("mentions Closes, Part of, and Not addressed", () => {
@@ -1685,12 +1686,12 @@ describe("createReviewStageHandler", () => {
     await stage.handler(BASE_CTX);
 
     // B.invoke should have been called (not resume) since there's
-    // no session, and the prompt should contain repo context.
+    // no session, and the prompt should reference the issue and
+    // ask B to read its review from the PR.
     const invokeCall = (agentB.invoke as ReturnType<typeof vi.fn>).mock
       .calls[0];
     const prompt: string = invokeCall[0];
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
+    expect(prompt).toContain("issue #42");
     expect(prompt).toContain("[Reviewer Round 1]");
   });
 
@@ -3160,7 +3161,7 @@ describe("saved Agent B session reuse on resume", () => {
 
     expect(agentB.invoke).toHaveBeenCalledWith(
       expect.stringContaining(
-        "You previously posted a review on a pull request",
+        "You previously posted a review on the pull request for issue #42",
       ),
       expect.objectContaining({ cwd: "/tmp/wt-review" }),
     );
@@ -3211,7 +3212,7 @@ describe("saved Agent B session reuse on resume", () => {
 
     expect(agentB.invoke).toHaveBeenCalledWith(
       expect.stringContaining(
-        "You previously reviewed a pull request and the review was approved.",
+        "You previously reviewed a pull request for issue #42",
       ),
       expect.objectContaining({ cwd: "/tmp/wt-review" }),
     );

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -1037,6 +1037,13 @@ export function createReviewStageHandler(
       }
 
       // ---- NOT_APPROVED path: author fix + CI poll -----------------
+      // Track the latest Agent A session id produced inside this
+      // handler invocation so the subsequent CI poll can resume the
+      // live conversation rather than the stage-entry snapshot.  When
+      // resuming directly into `ci_poll` (author_fix block skipped),
+      // this stays undefined and `pollCiAndFix` falls back to
+      // `ctx.savedAgentASessionId`.
+      let latestAuthorFixSessionId: string | undefined;
       if (currentStep === "author_fix") {
         opts.onReviewProgress?.("author_fix", "NOT_APPROVED");
 
@@ -1150,17 +1157,27 @@ export function createReviewStageHandler(
           return checkMapped;
         }
 
+        latestAuthorFixSessionId = checkResult.sessionId ?? fixResult.sessionId;
         opts.onReviewProgress?.("ci_poll", "NOT_APPROVED");
         currentStep = "ci_poll";
       }
 
       // ---- CI poll (NOT_APPROVED path) -----------------------------
       if (currentStep === "ci_poll") {
+        // The author-fix and completion-check turns above may have
+        // produced a newer Agent A session id than the stage-entry
+        // snapshot in `ctx.savedAgentASessionId`.  Hand the freshest
+        // known id to `pollCiAndFix` so the first CI findings/fix
+        // turn resumes the live conversation rather than fresh-
+        // invoking.
+        const initialAgentASessionId =
+          latestAuthorFixSessionId ?? ctx.savedAgentASessionId;
         const ciResult = await pollCiAndFix({
           ctx,
           agent: opts.agentA,
           issueTitle: opts.issueTitle,
           issueBody: opts.issueBody,
+          initialAgentASessionId,
           getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
           collectFailureLogs:
             opts.collectFailureLogs ?? defaultCollectFailureLogs,

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -193,7 +193,8 @@ export function buildReviewPrompt(
     ``,
     `## Instructions`,
     ``,
-    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `1. Find the pull request for this branch (use`,
+    `   \`gh pr view ${ctx.branch} --repo ${ctx.owner}/${ctx.repo}\`).`,
   ];
 
   if (round > 1) {
@@ -249,7 +250,8 @@ export function buildReviewResumePrompt(
   const lines = [
     `Review the pull request for issue #${ctx.issueNumber} (round ${round}).`,
     ``,
-    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `1. Find the pull request for this branch (use`,
+    `   \`gh pr view ${ctx.branch} --repo ${ctx.owner}/${ctx.repo}\`).`,
   ];
 
   if (round > 1) {
@@ -441,7 +443,8 @@ export function buildResumeUnresolvedSummaryPrompt(
     `and the review was approved.  The process was interrupted before you`,
     `could summarise unresolved items.`,
     ``,
-    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `1. Find the pull request for this branch (use`,
+    `   \`gh pr view ${ctx.branch} --repo ${ctx.owner}/${ctx.repo}\`).`,
     `2. Read your \`[Reviewer Round ${round}]\` review comment to`,
     `   understand which items you raised.`,
     `3. Check the code on the branch to see which items were addressed`,
@@ -524,7 +527,8 @@ export function buildResumeVerdictPrompt(
     `prefixed with \`**[Reviewer Round ${round}]**\`.  The process was`,
     `interrupted before your verdict was recorded.`,
     ``,
-    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `1. Find the pull request for this branch (use`,
+    `   \`gh pr view ${ctx.branch} --repo ${ctx.owner}/${ctx.repo}\`).`,
     `2. Read your \`[Reviewer Round ${round}]\` review comment.`,
     `3. Reply with exactly one keyword (no commentary):`,
     `   APPROVED if the changes are ready to merge,`,

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -178,16 +178,14 @@ export function buildReviewPrompt(
   round: number,
   reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath,
 ): string {
+  // reviewerWorktreePath is preserved as a parameter for callers that
+  // want to log or override the path, but is no longer interpolated
+  // into the prompt — the agent's cwd is already the reviewer worktree.
+  void reviewerWorktreePath;
   const anglesBlock = buildReviewAnglesBlock();
 
   const lines = [
     `You are reviewing a pull request for the following GitHub issue.`,
-    ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${reviewerWorktreePath}`,
     ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
@@ -238,17 +236,68 @@ export function buildReviewPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Compact resume-form review prompt.  Re-uses the angles guidance
+ * because per-round evaluation depth is what changes; only the issue
+ * body is dropped.
+ */
+export function buildReviewResumePrompt(
+  ctx: StageContext,
+  round: number,
+): string {
+  const anglesBlock = buildReviewAnglesBlock();
+  const lines = [
+    `Review the pull request for issue #${ctx.issueNumber} (round ${round}).`,
+    ``,
+    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+  ];
+
+  if (round > 1) {
+    lines.push(
+      `2. Read the author's response in the PR comment prefixed with`,
+      `   \`[Author Round ${round - 1}]\` to understand what was changed.`,
+      `   For each item you raised in \`[Reviewer Round ${round - 1}]\`,`,
+      `   check the outcome:`,
+      `   - If the author says it was fixed, verify that the fix is`,
+      `     actually present in the updated diff.`,
+      `   - If the author pushed back with reasoning, evaluate that`,
+      `     reasoning honestly. If it is sound, treat the item as`,
+      `     resolved and do NOT re-raise it. If it is weak, unclear,`,
+      `     or does not address the concern, keep the item open.`,
+      `   - Only carry forward items that remain genuinely unresolved.`,
+      `3. Review the updated diff against the issue.`,
+      anglesBlock,
+      `4. Post your follow-up review as a PR comment prefixed with`,
+      `   \`**[Reviewer Round ${round}]**\`. Include any still-unresolved`,
+      `   prior items and any new findings from this round. Be`,
+      `   specific. Cite file paths and line numbers when they help;`,
+      `   for broader concerns, explain the concern at the`,
+      `   appropriate level.`,
+    );
+  } else {
+    lines.push(
+      `2. Review the diff against the issue.`,
+      anglesBlock,
+      `3. Post your review as a PR comment prefixed with`,
+      `   \`**[Reviewer Round ${round}]**\`. Be specific. Cite file paths and`,
+      `   line numbers when they help; for broader concerns, explain`,
+      `   the concern at the appropriate level.`,
+    );
+  }
+
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+  return lines.join("\n");
+}
+
 export const REVIEW_VERDICT_KEYWORDS = ["APPROVED", "NOT_APPROVED"] as const;
 
 export function buildReviewVerdictPrompt(): string {
   return [
-    `You have posted your review comment.`,
-    `Respond with exactly one of the following keywords:`,
-    ``,
-    `- APPROVED — if the changes are ready to merge`,
-    `- NOT_APPROVED — if changes are needed`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `APPROVED if the changes are ready to merge,`,
+    `NOT_APPROVED if changes are needed.`,
   ].join("\n");
 }
 
@@ -258,12 +307,9 @@ export const UNRESOLVED_KEYWORDS = ["NONE", "COMPLETED"] as const;
 
 export function buildUnresolvedVerdictPrompt(): string {
   return [
-    `Respond with exactly one of the following keywords:`,
-    ``,
-    `- NONE — if there are no unresolved items`,
-    `- COMPLETED — if you posted the unresolved items comment`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `NONE if there are no unresolved items,`,
+    `COMPLETED if you posted the unresolved items comment.`,
   ].join("\n");
 }
 
@@ -271,12 +317,8 @@ export const PR_FINALIZATION_KEYWORDS = ["PR_FINALIZED"] as const;
 
 export function buildPrFinalizationVerdictPrompt(): string {
   return [
-    `You have finished verifying the PR body.`,
-    `Respond with exactly one of the following keywords:`,
-    ``,
-    `- PR_FINALIZED — if the PR body is now accurate`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `PR_FINALIZED if the PR body is now accurate.`,
   ].join("\n");
 }
 
@@ -287,12 +329,6 @@ export function buildAuthorFixPrompt(
 ): string {
   const lines = [
     `You are addressing review feedback for the following GitHub issue.`,
-    ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
     ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
@@ -327,15 +363,48 @@ export function buildAuthorFixPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Compact resume-form author-fix prompt.  Drops the issue body (the
+ * agent already has it from the prior stage's session).
+ */
+export function buildAuthorFixResumePrompt(
+  ctx: StageContext,
+  round: number,
+): string {
+  const lines = [
+    `Address the round ${round} review feedback for issue #${ctx.issueNumber}.`,
+    ``,
+    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `2. Read the review comments prefixed with \`[Reviewer Round ${round}]\``,
+    `   (only comments from your own account).`,
+    `3. Evaluate each review item against the issue requirements and`,
+    `   the codebase context before acting on it:`,
+    `   - **Accept and fix** items that are valid.`,
+    `   - **Push back with reasoning** on items that are incorrect,`,
+    `     out of scope, would introduce regressions, or conflict`,
+    `     with project conventions — do not apply them blindly.`,
+    `   - **Partially address** items where only part of the`,
+    `     suggestion is appropriate, and explain what you kept`,
+    `     and why.`,
+    `4. Post a response as a PR comment prefixed with`,
+    `   \`**[Author Round ${round}]**\`. For each review item,`,
+    `   clearly state its disposition:`,
+    `   - **Fixed** — what you changed.`,
+    `   - **Pushed back** — why the suggestion should not be applied.`,
+    `   - **Partially addressed** — what you changed and what you`,
+    `     left, with reasoning.`,
+    `5. ${buildDocConsistencyInstructions("   ").trimStart()}`,
+    `6. ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `7. Commit and push your changes so a new CI run is triggered.`,
+  ];
+  return lines.join("\n");
+}
+
 export function buildAuthorCompletionCheckPrompt(): string {
   return [
-    `You have finished addressing the review feedback.  Please evaluate`,
-    `the result and respond with exactly one of the following keywords:`,
-    ``,
-    `- COMPLETED — if all feedback was addressed and changes were pushed`,
-    `- BLOCKED — if you cannot proceed and need user intervention`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `COMPLETED if all feedback was addressed and changes were pushed,`,
+    `BLOCKED if you cannot proceed and need user intervention.`,
   ].join("\n");
 }
 
@@ -353,23 +422,24 @@ export function buildUnresolvedSummaryPrompt(round: number): string {
 
 /**
  * Prompt for resuming the unresolved-summary step when Agent B has no
- * saved session.  Gives B repository context and tells it to read its
- * own review from the PR before deciding what is unresolved.
+ * saved session.  This is the **fresh-form** prompt invoked when there
+ * is no live reviewer session to follow up on; the agent's cwd is
+ * already set to the reviewer worktree, so the worktree path is no
+ * longer interpolated explicitly.
  */
 export function buildResumeUnresolvedSummaryPrompt(
   ctx: StageContext,
   round: number,
   reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath,
 ): string {
+  // reviewerWorktreePath is preserved as a parameter for callers that
+  // want to log or override the path, but is no longer interpolated
+  // into the prompt.
+  void reviewerWorktreePath;
   return [
-    `You previously reviewed a pull request and the review was approved.`,
-    `The process was interrupted before you could summarise unresolved items.`,
-    ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${reviewerWorktreePath}`,
+    `You previously reviewed a pull request for issue #${ctx.issueNumber}`,
+    `and the review was approved.  The process was interrupted before you`,
+    `could summarise unresolved items.`,
     ``,
     `1. Find the pull request for this branch (use \`gh pr view\`).`,
     `2. Read your \`[Reviewer Round ${round}]\` review comment to`,
@@ -392,12 +462,6 @@ export function buildPrFinalizationPrompt(
     `merging, verify that the PR body accurately reflects the final`,
     `state of the implementation.`,
     ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
-    ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
     opts.issueBody,
@@ -419,35 +483,52 @@ export function buildPrFinalizationPrompt(
 }
 
 /**
+ * Compact resume-form PR finalization prompt — drops the issue body.
+ */
+export function buildPrFinalizationResumePrompt(ctx: StageContext): string {
+  return [
+    `The review is complete and the PR has been approved.  Before merging,`,
+    `verify the PR body for issue #${ctx.issueNumber} accurately reflects`,
+    `the final state of the implementation.`,
+    ``,
+    `1. Read the current PR body using`,
+    `   \`gh pr view --json body --jq .body\`.`,
+    `2. Compare the issue requirements against the code on the branch`,
+    `   to determine whether every requirement has been addressed.`,
+    `3. If the PR fully resolves the issue, ensure the body contains`,
+    `   "Closes #${ctx.issueNumber}".  If it only partially addresses it,`,
+    `   ensure it says "Part of #${ctx.issueNumber}" and includes a`,
+    `   "## Not addressed" section listing which issue requirements`,
+    `   were not implemented and why.`,
+    `4. If the reference or "## Not addressed" section needs to change,`,
+    `   update the PR body using \`gh pr edit --body "..."\`.`,
+  ].join("\n");
+}
+
+/**
  * Prompt for resuming when the reviewer comment was already posted but
  * the process died before recording the verdict.  Agent B reads its
- * own review and provides just the verdict keyword.
+ * own review and provides just the verdict keyword.  This is a
+ * **fresh-form** prompt invoked when there is no live reviewer
+ * session; the agent's cwd is already set to the reviewer worktree,
+ * so the worktree path is no longer interpolated explicitly.
  */
 export function buildResumeVerdictPrompt(
   ctx: StageContext,
   round: number,
   reviewerWorktreePath = ctx.reviewerWorktreePath ?? ctx.worktreePath,
 ): string {
+  void reviewerWorktreePath;
   return [
-    `You previously posted a review on a pull request, prefixed with`,
-    `\`**[Reviewer Round ${round}]**\`.  The process was interrupted`,
-    `before your verdict was recorded.`,
-    ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${reviewerWorktreePath}`,
+    `You previously posted a review on the pull request for issue #${ctx.issueNumber},`,
+    `prefixed with \`**[Reviewer Round ${round}]**\`.  The process was`,
+    `interrupted before your verdict was recorded.`,
     ``,
     `1. Find the pull request for this branch (use \`gh pr view\`).`,
     `2. Read your \`[Reviewer Round ${round}]\` review comment.`,
-    `3. Based on your review, respond with exactly one of the`,
-    `   following keywords:`,
-    ``,
-    `   - APPROVED — if the changes are ready to merge`,
-    `   - NOT_APPROVED — if changes are needed`,
-    ``,
-    `   Do not include any other commentary — just the keyword.`,
+    `3. Reply with exactly one keyword (no commentary):`,
+    `   APPROVED if the changes are ready to merge,`,
+    `   NOT_APPROVED if changes are needed.`,
   ].join("\n");
 }
 
@@ -475,6 +556,11 @@ export function createReviewStageHandler(
       const invokeReviewer = async (
         sessionId: string | undefined,
         prompt: string,
+        extras?: {
+          fallbackPrompt?: string;
+          promptKind?: import("./pipeline-events.js").AgentPromptKind;
+          promptMeta?: { round?: number; resume?: boolean };
+        },
       ): Promise<AgentResult> => {
         prepareReviewerWorktree(ctx);
         try {
@@ -484,8 +570,13 @@ export function createReviewStageHandler(
             prompt,
             reviewerWorktreePath,
             ctx.streamSinks?.b,
-            undefined,
-            ctx.usageSinks?.b,
+            {
+              fallbackPrompt: extras?.fallbackPrompt,
+              usageSink: ctx.usageSinks?.b,
+              promptSink: ctx.promptSinks?.b,
+              promptKind: extras?.promptKind,
+              promptMeta: extras?.promptMeta,
+            },
           );
         } finally {
           maybeCleanReviewerWorktree();
@@ -553,16 +644,26 @@ export function createReviewStageHandler(
       // ---- review --------------------------------------------------
       if (currentStep === "review") {
         opts.onReviewProgress?.("review");
-        const reviewPrompt = buildReviewPrompt(
+        const freshReviewPrompt = buildReviewPrompt(
           ctx,
           opts,
           round,
           reviewerWorktreePath,
         );
+        const resumeReviewPrompt = buildReviewResumePrompt(ctx, round);
+        const reviewUseResume = ctx.savedAgentBSessionId !== undefined;
+        const reviewPrompt = reviewUseResume
+          ? resumeReviewPrompt
+          : freshReviewPrompt;
         ctx.promptSinks?.b?.(reviewPrompt, "review", { round });
         const reviewResult = await invokeReviewer(
           ctx.savedAgentBSessionId,
           reviewPrompt,
+          {
+            fallbackPrompt: reviewUseResume ? freshReviewPrompt : undefined,
+            promptKind: "review",
+            promptMeta: { round },
+          },
         );
 
         if (reviewResult.sessionId) {
@@ -781,7 +882,12 @@ export function createReviewStageHandler(
 
         // PR finalization: Agent A verifies issue reference and
         // "Not addressed" section before the pipeline advances.
-        const finalizePrompt = buildPrFinalizationPrompt(ctx, opts);
+        const freshFinalizePrompt = buildPrFinalizationPrompt(ctx, opts);
+        const resumeFinalizePrompt = buildPrFinalizationResumePrompt(ctx);
+        const finalizeUseResume = ctx.savedAgentASessionId !== undefined;
+        const finalizePrompt = finalizeUseResume
+          ? resumeFinalizePrompt
+          : freshFinalizePrompt;
         ctx.promptSinks?.a?.(finalizePrompt, "work");
         const finalizeResult = await invokeOrResume(
           opts.agentA,
@@ -789,8 +895,12 @@ export function createReviewStageHandler(
           finalizePrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
-          undefined,
-          ctx.usageSinks?.a,
+          {
+            fallbackPrompt: finalizeUseResume ? freshFinalizePrompt : undefined,
+            usageSink: ctx.usageSinks?.a,
+            promptSink: ctx.promptSinks?.a,
+            promptKind: "work",
+          },
         );
 
         if (finalizeResult.sessionId) {
@@ -926,7 +1036,10 @@ export function createReviewStageHandler(
       if (currentStep === "author_fix") {
         opts.onReviewProgress?.("author_fix", "NOT_APPROVED");
 
-        const fixPrompt = buildAuthorFixPrompt(ctx, opts, round);
+        const freshFixPrompt = buildAuthorFixPrompt(ctx, opts, round);
+        const resumeFixPrompt = buildAuthorFixResumePrompt(ctx, round);
+        const fixUseResume = ctx.savedAgentASessionId !== undefined;
+        const fixPrompt = fixUseResume ? resumeFixPrompt : freshFixPrompt;
         ctx.promptSinks?.a?.(fixPrompt, "work");
         const fixResult = await invokeOrResume(
           opts.agentA,
@@ -934,8 +1047,12 @@ export function createReviewStageHandler(
           fixPrompt,
           ctx.worktreePath,
           ctx.streamSinks?.a,
-          undefined,
-          ctx.usageSinks?.a,
+          {
+            fallbackPrompt: fixUseResume ? freshFixPrompt : undefined,
+            usageSink: ctx.usageSinks?.a,
+            promptSink: ctx.promptSinks?.a,
+            promptKind: "work",
+          },
         );
 
         if (fixResult.sessionId) {

--- a/src/stage-selfcheck.test.ts
+++ b/src/stage-selfcheck.test.ts
@@ -125,6 +125,7 @@ describe("buildSelfCheckPrompt", () => {
     expect(prompt).toContain("Owner: org");
     expect(prompt).toContain("Repo: repo");
     expect(prompt).toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Worktree:");
     expect(prompt).toContain("Issue #42: Fix the widget");
     expect(prompt).toContain("The widget is broken.");
   });

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -60,7 +60,6 @@ export function buildSelfCheckPrompt(
     `- Owner: ${ctx.owner}`,
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
     ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
@@ -106,6 +105,53 @@ export function buildSelfCheckPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Compact resume-form prompt for stage 3 — sent when the agent
+ * already has the repository / issue context from a prior stage's
+ * session.  Re-states the 8 review items because the self-check
+ * substep itself is what changes between iterations; only the repo
+ * header and full issue body are dropped.
+ */
+export function buildSelfCheckResumePrompt(ctx: StageContext): string {
+  const lines = [
+    `Run a self-check pass on issue #${ctx.issueNumber}.`,
+    ``,
+    `Review the current implementation against all 8 items below.  For each`,
+    `item, briefly note whether it passes or needs attention.`,
+    ``,
+    `1. **Correctness** — Does the implementation fully address the issue?`,
+    `2. **Tests** — Are there thorough tests covering happy paths,`,
+    `   edge cases, and error scenarios, including E2E tests where`,
+    `   applicable?  If any meaningful scenario is untested, write`,
+    `   the missing tests.  Then run the full test suite and verify all tests pass.`,
+    `   If tests require services (databases, message brokers, dev`,
+    `   servers, etc.), start them using whatever tools the project`,
+    `   provides (Docker Compose, \`pnpm dev\`, setup scripts, etc.).`,
+    `   If a port conflict occurs, change the port rather than skipping`,
+    `   the service.`,
+    `3. **Error handling** — Are errors handled gracefully?`,
+    `4. **External services** — Are API calls, network requests, or external`,
+    `   service integrations correct and resilient?  Start all required`,
+    `   services and run integration tests against them rather than skipping`,
+    `   tests that need external services.`,
+    `5. **Documentation consistency** — Are all forms of project`,
+    `   documentation consistent with the code changes?`,
+    ``,
+    buildDocConsistencyInstructions("   "),
+    `6. **Security** — Are there any security concerns (injection, auth,`,
+    `   secrets exposure)?`,
+    `7. **Performance** — Are there obvious performance issues or regressions?`,
+    `8. **Code quality** — Is the new or modified code clean and`,
+    `   maintainable?  If you spot opportunities to simplify, improve,`,
+    `   or refactor the code *within the scope of this change*, apply`,
+    `   them.  Do not refactor unrelated existing code.`,
+  ];
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+  return lines.join("\n");
+}
+
 export function buildFixOrDonePrompt(): string {
   return [
     `Based on your self-check above, decide what to do next.`,
@@ -119,13 +165,9 @@ export const FIX_OR_DONE_KEYWORDS = ["FIXED", "DONE"] as const;
 
 export function buildFixOrDoneVerdictPrompt(): string {
   return [
-    `You have finished the self-check pass.`,
-    `Respond with exactly one of the following keywords:`,
-    ``,
-    `- FIXED — if you found and fixed issues`,
-    `- DONE — if everything looks good and no changes were needed`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `FIXED if you found and fixed issues,`,
+    `DONE if everything looks good and no changes were needed.`,
   ].join("\n");
 }
 
@@ -138,7 +180,10 @@ export function createSelfCheckStageHandler(
     primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send self-check prompt (resume if saved session).
-      const checkPrompt = buildSelfCheckPrompt(ctx, opts);
+      const freshPrompt = buildSelfCheckPrompt(ctx, opts);
+      const resumePrompt = buildSelfCheckResumePrompt(ctx);
+      const useResume = ctx.savedAgentASessionId !== undefined;
+      const checkPrompt = useResume ? resumePrompt : freshPrompt;
       ctx.promptSinks?.a?.(checkPrompt, "work");
       const checkResult = await invokeOrResume(
         opts.agent,
@@ -146,8 +191,12 @@ export function createSelfCheckStageHandler(
         checkPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
+        {
+          fallbackPrompt: useResume ? freshPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "work",
+        },
       );
 
       if (checkResult.sessionId) {

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -711,13 +711,13 @@ describe("createSquashStageHandler", () => {
       );
     const collectFailureLogs = vi.fn().mockReturnValue("err");
 
-    const invokeResults = [
-      makeStream(
-        makeResult({
-          sessionId: "sess-squash",
-          responseText: "Squashed.",
-        }),
-      ),
+    // The squash work prompt persists `sess-squash`; the verdict
+    // follow-up resumes that session and returns SQUASHED_MULTI, then
+    // the CI fix turn resumes the same session via `pollCiAndFix` and
+    // crashes.  Sequence the resume mock so the second resume call
+    // (the CI fix) is the agent error.
+    const resumeResults = [
+      makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
       makeStream(
         makeResult({
           status: "error",
@@ -727,14 +727,17 @@ describe("createSquashStageHandler", () => {
         }),
       ),
     ];
-    let invokeCall = 0;
+    let resumeCall = 0;
     const agent: AgentAdapter = {
-      invoke: vi.fn().mockImplementation(() => invokeResults[invokeCall++]),
-      resume: vi
-        .fn()
-        .mockReturnValue(
-          makeStream(makeResult({ responseText: "SQUASHED_MULTI" })),
+      invoke: vi.fn().mockReturnValue(
+        makeStream(
+          makeResult({
+            sessionId: "sess-squash",
+            responseText: "Squashed.",
+          }),
         ),
+      ),
+      resume: vi.fn().mockImplementation(() => resumeResults[resumeCall++]),
     };
 
     const opts = makeOpts({ agent, getCiStatus, collectFailureLogs });

--- a/src/stage-squash.test.ts
+++ b/src/stage-squash.test.ts
@@ -109,11 +109,14 @@ function makeOpts(
 // ---- buildSquashPrompt -------------------------------------------------------
 
 describe("buildSquashPrompt", () => {
-  test("includes repo and issue context", () => {
+  test("includes issue context and omits redundant repo headers", () => {
     const prompt = buildSquashPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
-    expect(prompt).toContain("Branch: issue-42");
+    // Owner / Repo / Branch / Worktree are dropped — gh infers the
+    // repo from cwd and the cwd is already the worktree.
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Repo: repo");
+    expect(prompt).not.toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Worktree:");
     expect(prompt).toContain("Issue #42: Fix the widget");
     expect(prompt).toContain("The widget is broken.");
   });

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -194,12 +194,6 @@ export function buildSquashPrompt(
   const lines = [
     `You are squashing commits for the following GitHub issue.`,
     ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
-    ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
     opts.issueBody,
@@ -283,6 +277,95 @@ export function buildSquashPrompt(
 }
 
 /**
+ * Compact resume-form squash prompt — drops the issue body which the
+ * agent already has from prior stages.  The detailed envelope contract
+ * and branch-on-decision instructions remain because they are
+ * squash-specific guidance the agent has not yet seen this stage.
+ */
+export function buildSquashResumePrompt(
+  ctx: StageContext,
+  opts: SquashStageOptions,
+): string {
+  const lines = [
+    `Squash commits for issue #${ctx.issueNumber}.`,
+    ``,
+    `1. ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `2. Decide whether the work on this branch is best presented as`,
+    `   **one** commit or as **several** meaningful commits.  Inspect the`,
+    `   existing commits' scope, file overlap, and intent.`,
+    ``,
+    `   - **One commit is appropriate** when all changes belong to a`,
+    `     single logical change (typical small fix or feature).`,
+    `   - **Multiple commits are appropriate** when the branch contains`,
+    `     genuinely independent changes that benefit from separate`,
+    `     history (e.g. a refactor preceding a feature).`,
+    ``,
+    `3. Branch on your decision:`,
+    ``,
+    `   **If a single commit is appropriate:**`,
+    `   - Do NOT rewrite history.  Do NOT force-push.`,
+    `   - Do NOT post or edit any PR comment yourself — agentcoop will`,
+    `     author the squash-suggestion comment from your reply below.`,
+    `   - Draft the commit title and body that should be used when the`,
+    `     PR is squash-merged.  The title must not include issue or PR`,
+    `     numbers; reference the issue in the body using \`Closes #N\``,
+    `     or \`Part of #N\`.`,
+    `   - Reply with the title and body wrapped in this exact envelope`,
+    `     (no fences, no surrounding code blocks, no extra commentary`,
+    `     between the tags):`,
+    ``,
+    `     \`\`\`text`,
+    `     <<<TITLE>>>`,
+    `     <your title on a single line>`,
+    `     <<</TITLE>>>`,
+    ``,
+    `     <<<BODY>>>`,
+    `     <your body, multi-line allowed,`,
+    `     may include \`Closes #N\` / \`Part of #N\`>`,
+    `     <<</BODY>>>`,
+    `     \`\`\``,
+    ``,
+    `     Both envelopes are required.  Do not nest fenced code blocks`,
+    `     around the envelope.  agentcoop parses the text between the`,
+    `     tags verbatim — leading and trailing blank lines are stripped,`,
+    `     internal blank lines are preserved.  The body may include a`,
+    `     literal \`<<</BODY>>>\` line as content (e.g. when documenting`,
+    `     this envelope contract); agentcoop anchors the structural`,
+    `     close to the LAST own-line \`<<</BODY>>>\`, AND that close tag`,
+    `     must be the last non-blank line of your response.  Do not add`,
+    `     any prose after the closing \`<<</BODY>>>\` — only blank lines`,
+    `     may follow it.`,
+    ``,
+    `   **If multiple commits are appropriate:**`,
+    ...(ctx.baseSha
+      ? [
+          `   - Review the commits after the base commit \`${ctx.baseSha}\``,
+          `     and consolidate them into a few meaningful commits.  Only`,
+          `     commits introduced on this branch should be touched — do not`,
+          `     include commits from the base branch.  Use`,
+          `     \`git reset --soft ${ctx.baseSha}\` followed by \`git commit\`,`,
+          `     or an interactive rebase — whichever is simpler.`,
+        ]
+      : [
+          `   - Review all commits on this branch and consolidate them into`,
+          `     a few meaningful commits.  Use an interactive rebase or`,
+          `     reset-based approach — whichever is simpler.`,
+        ]),
+    `   - Write clear, concise commit messages that summarise the changes.`,
+    `     Do not include issue or PR numbers in the commit title.`,
+    `     Instead, reference the issue in the commit body using`,
+    `     \`Closes #N\` or \`Part of #N\`.`,
+    `   - Force-push the branch (\`git push --force-with-lease\`).`,
+  ];
+  // Suppress unused parameter warning — opts may be needed in future.
+  void opts;
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+  return lines.join("\n");
+}
+
+/**
  * Three-way verdict keywords for the squash stage.  Kept out of the
  * shared `KEYWORD_MAP` / `StepStatus` enum because they are
  * squash-specific; the handler branches on the raw keyword from
@@ -298,18 +381,14 @@ export type SquashVerdict = (typeof SQUASH_CHECK_KEYWORDS)[number];
 
 export function buildSquashCompletionCheckPrompt(): string {
   return [
-    `You have finished your squash decision.  Respond with exactly one`,
-    `of the following keywords:`,
-    ``,
-    `- SQUASHED_MULTI — if you rewrote history into multiple meaningful`,
-    `  commits and force-pushed`,
-    `- SUGGESTED_SINGLE — if a single commit is appropriate and you`,
-    `  drafted the suggested title and body in the <<<TITLE>>>/`,
-    `  <<<BODY>>> envelope (no force-push)`,
-    `- BLOCKED — if you could not complete either path and need user`,
-    `  intervention`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `SQUASHED_MULTI if you rewrote history into multiple meaningful`,
+    `commits and force-pushed,`,
+    `SUGGESTED_SINGLE if a single commit is appropriate and you drafted`,
+    `the suggested title and body in the <<<TITLE>>>/<<<BODY>>> envelope`,
+    `(no force-push),`,
+    `BLOCKED if you could not complete either path and need user`,
+    `intervention.`,
   ].join("\n");
 }
 
@@ -1146,16 +1225,24 @@ export function createSquashStageHandler(
       // ---- planning: send the squash work prompt --------------------------
       opts.onSquashSubStep?.("planning");
 
-      const prompt = buildSquashPrompt(ctx, opts);
+      const freshSquashPrompt = buildSquashPrompt(ctx, opts);
+      const resumeSquashPrompt = buildSquashResumePrompt(ctx, opts);
+      const savedSquashSessionId = resolveSavedSessionId();
+      const squashUseResume = savedSquashSessionId !== undefined;
+      const prompt = squashUseResume ? resumeSquashPrompt : freshSquashPrompt;
       ctx.promptSinks?.a?.(prompt, "work");
       const squashResult = await invokeOrResume(
         opts.agent,
-        resolveSavedSessionId(),
+        savedSquashSessionId,
         prompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
+        {
+          fallbackPrompt: squashUseResume ? freshSquashPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "work",
+        },
       );
 
       if (squashResult.sessionId) {

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -1118,7 +1118,7 @@ export function createSquashStageHandler(
       }
 
       if (saved === "ci_poll") {
-        return runCiPollAndFinish(ctx, opts);
+        return runCiPollAndFinish(ctx, opts, resolveSavedSessionId());
       }
 
       if (saved === "squashing") {
@@ -1142,7 +1142,7 @@ export function createSquashStageHandler(
         // prompt so the agent continues the same conversation.
         const resumeCount = countCommits(ctx.worktreePath, opts.defaultBranch);
         if (resumeCount <= 1) {
-          return runCiPollAndFinish(ctx, opts);
+          return runCiPollAndFinish(ctx, opts, resolveSavedSessionId());
         }
 
         const sessionId = resolveSavedSessionId();
@@ -1170,7 +1170,7 @@ export function createSquashStageHandler(
             );
           }
 
-          return runCiPollAndFinish(ctx, opts);
+          return runCiPollAndFinish(ctx, opts, followup.sessionId ?? sessionId);
         }
         // No session available — fall through to a fresh planning run
         // as a last resort.  This should be rare: the session id is
@@ -1413,7 +1413,7 @@ export function createSquashStageHandler(
             keyword: "SQUASHED_MULTI",
             raw: retry.responseText,
           });
-          return runCiPollAndFinish(ctx, opts);
+          return runCiPollAndFinish(ctx, opts, retrySessionId);
         }
         if (retryKeyword === "BLOCKED") {
           verdictCtx?.events.emit("pipeline:verdict", {
@@ -1565,7 +1565,13 @@ export function createSquashStageHandler(
       }
 
       // SQUASHED_MULTI — proceed with the existing CI poll path.
-      return runCiPollAndFinish(ctx, opts);
+      // Hand the freshest known Agent A session id to the CI poll so
+      // the first findings/fix turn resumes the live conversation.
+      return runCiPollAndFinish(
+        ctx,
+        opts,
+        verdictSessionId ?? squashResult.sessionId,
+      );
     },
   };
 }
@@ -1651,15 +1657,25 @@ async function askUserAndApply(
     return mapAgentError(followup, "during agent squash follow-up");
   }
 
-  return runCiPollAndFinish(ctx, opts);
+  return runCiPollAndFinish(ctx, opts, followup.sessionId ?? sessionId);
 }
 
 /**
  * Poll CI after a force-push and return the final stage result.
+ *
+ * `initialAgentASessionId` is the latest known Agent A session id at
+ * the call site — typically a verdict / clarification / follow-up
+ * session that was just persisted in the same handler invocation.
+ * `pollCiAndFix` uses it to seed its internal session tracker so the
+ * first CI findings/fix turn resumes that live conversation rather
+ * than the stage-entry snapshot in `ctx.savedAgentASessionId`.  When
+ * not supplied, the helper falls back to the live persisted id (via
+ * `getSavedAgentSessionId`) and finally to `ctx.savedAgentASessionId`.
  */
 async function runCiPollAndFinish(
   ctx: StageContext,
   opts: SquashStageOptions,
+  initialAgentASessionId?: string,
 ): Promise<StageResult> {
   opts.onSquashSubStep?.("ci_poll");
 
@@ -1668,6 +1684,10 @@ async function runCiPollAndFinish(
     agent: opts.agent,
     issueTitle: opts.issueTitle,
     issueBody: opts.issueBody,
+    initialAgentASessionId:
+      initialAgentASessionId ??
+      opts.getSavedAgentSessionId?.() ??
+      ctx.savedAgentASessionId,
     getCiStatus: opts.getCiStatus ?? defaultGetCiStatus,
     collectFailureLogs: opts.collectFailureLogs ?? defaultCollectFailureLogs,
     getHeadSha: opts.getHeadSha,

--- a/src/stage-testplan.test.ts
+++ b/src/stage-testplan.test.ts
@@ -81,12 +81,12 @@ function makeOpts(
 // ---- buildTestPlanVerifyPrompt ---------------------------------------------
 
 describe("buildTestPlanVerifyPrompt", () => {
-  test("includes repo context", () => {
+  test("omits redundant repo headers", () => {
     const prompt = buildTestPlanVerifyPrompt(BASE_CTX, makeOpts());
-    expect(prompt).toContain("Owner: org");
-    expect(prompt).toContain("Repo: repo");
-    expect(prompt).toContain("Branch: issue-42");
-    expect(prompt).toContain("Worktree: /tmp/wt");
+    expect(prompt).not.toContain("Owner: org");
+    expect(prompt).not.toContain("Repo: repo");
+    expect(prompt).not.toContain("Branch: issue-42");
+    expect(prompt).not.toContain("Worktree:");
   });
 
   test("includes issue details", () => {

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -39,12 +39,6 @@ export function buildTestPlanVerifyPrompt(
   const lines = [
     `You are verifying the test plan for the following GitHub issue.`,
     ``,
-    `## Repository`,
-    `- Owner: ${ctx.owner}`,
-    `- Repo: ${ctx.repo}`,
-    `- Branch: ${ctx.branch}`,
-    `- Worktree: ${ctx.worktreePath}`,
-    ``,
     `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
     ``,
     opts.issueBody,
@@ -90,6 +84,51 @@ export function buildTestPlanVerifyPrompt(
   return lines.join("\n");
 }
 
+/**
+ * Compact resume-form prompt — drops the issue body since the agent
+ * already has it from the prior stage's session.
+ */
+export function buildTestPlanVerifyResumePrompt(ctx: StageContext): string {
+  const lines = [
+    `Verify the test plan for issue #${ctx.issueNumber}.`,
+    ``,
+    `1. Find the pull request for this branch (use \`gh pr view\`).`,
+    `2. Go through each item in the PR's "Test plan" checklist.  For`,
+    `   each item, actually run or verify the described test or behavior.`,
+    `   - Start all required services (dev servers, databases, external`,
+    `     services, etc.) using whatever tools the project provides`,
+    `     (Docker Compose, \`pnpm dev\`, setup scripts, etc.).  If a port`,
+    `     conflict occurs, change the port rather than skipping the`,
+    `     service.`,
+    `   - If a browser is needed for testing, launch one (e.g., headless`,
+    `     Chrome via Playwright).`,
+    `   - For manual test items, do not defer them to the user.  Act as`,
+    `     the end user: launch the application, navigate the UI, verify`,
+    `     behavior, and check off each item yourself.  Use browser`,
+    `     automation (Playwright, headless Chrome) or direct CLI/API`,
+    `     interaction to replicate what a human user would do.`,
+    `   - Only flag a test item for the user if it is truly impossible`,
+    `     to verify programmatically (e.g., subjective visual design`,
+    `     judgment).`,
+    `   - When documentation or the PR requires screenshots, do not use`,
+    `     placeholders.  Actually start the application, open a browser,`,
+    `     and capture real screenshots.`,
+    `3. Check off each verified item in the PR using \`gh\` commands.`,
+    `4. Also go through the task checklist in the GitHub issue.  Check`,
+    `   off each completed task using \`gh\` commands.  Then check the`,
+    `   issue's parent issue (and grandparent, recursively) and check`,
+    `   off any tasks that are now completed.`,
+    `5. If you made any code changes:`,
+    `   ${buildPrSyncInstructions(ctx.issueNumber)}`,
+    `   Then commit and push them so a new CI run is triggered.`,
+    `6. Make sure CI is still passing after any changes.`,
+  ];
+  if (ctx.userInstruction) {
+    lines.push(``, `## Additional feedback`, ``, ctx.userInstruction);
+  }
+  return lines.join("\n");
+}
+
 export function buildTestPlanSelfCheckPrompt(): string {
   return [
     `Based on your verification above, evaluate the current state.`,
@@ -109,13 +148,9 @@ export const TEST_PLAN_VERDICT_KEYWORDS = ["FIXED", "DONE"] as const;
 
 export function buildTestPlanVerdictPrompt(): string {
   return [
-    `You have finished the test plan verification pass.`,
-    `Respond with exactly one of the following keywords:`,
-    ``,
-    `- FIXED — if you found and fixed issues`,
-    `- DONE — if everything is verified and passing with no changes needed`,
-    ``,
-    `Do not include any other commentary — just the keyword.`,
+    `Reply with exactly one keyword (no commentary):`,
+    `FIXED if you found and fixed issues,`,
+    `DONE if everything is verified and passing with no changes needed.`,
   ].join("\n");
 }
 
@@ -128,7 +163,10 @@ export function createTestPlanStageHandler(
     primaryAgent: "a",
     handler: async (ctx: StageContext): Promise<StageResult> => {
       // Step 1: Send verification prompt (resume if saved session).
-      const verifyPrompt = buildTestPlanVerifyPrompt(ctx, opts);
+      const freshPrompt = buildTestPlanVerifyPrompt(ctx, opts);
+      const resumePrompt = buildTestPlanVerifyResumePrompt(ctx);
+      const useResume = ctx.savedAgentASessionId !== undefined;
+      const verifyPrompt = useResume ? resumePrompt : freshPrompt;
       ctx.promptSinks?.a?.(verifyPrompt, "work");
       const verifyResult = await invokeOrResume(
         opts.agent,
@@ -136,8 +174,12 @@ export function createTestPlanStageHandler(
         verifyPrompt,
         ctx.worktreePath,
         ctx.streamSinks?.a,
-        undefined,
-        ctx.usageSinks?.a,
+        {
+          fallbackPrompt: useResume ? freshPrompt : undefined,
+          usageSink: ctx.usageSinks?.a,
+          promptSink: ctx.promptSinks?.a,
+          promptKind: "work",
+        },
       );
 
       if (verifyResult.sessionId) {

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -765,6 +765,109 @@ describe("invokeOrResume", () => {
     expect(agent.invoke).not.toHaveBeenCalled();
   });
 
+  test("uses fallbackPrompt for fresh invoke when resume falls through", async () => {
+    // Saved session triggers a resume; a soft error like "session
+    // expired / unknown" makes the helper fall back to a fresh
+    // invoke.  When `fallbackPrompt` is supplied, the fresh invoke
+    // must use it (the compact resume-form prompt is only safe on a
+    // live session — fresh agents need full context).
+    const errorResult = makeResult({
+      status: "error",
+      errorType: "unknown",
+      stderrText: "session expired",
+    });
+    const freshResult = makeResult({ sessionId: "fresh-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(freshResult)),
+      resume: vi.fn().mockReturnValue(makeStream(errorResult)),
+    };
+    const promptSink = vi.fn();
+
+    const out = await invokeOrResume(
+      agent,
+      "old-sess",
+      "compact resume prompt",
+      "/cwd",
+      undefined,
+      {
+        fallbackPrompt: "full fresh prompt",
+        promptSink,
+        promptKind: "work",
+      },
+    );
+
+    expect(out).toBe(freshResult);
+    // Resume tried with the compact prompt, fresh invoke used the
+    // full fallback prompt.
+    expect(agent.resume).toHaveBeenCalledWith(
+      "old-sess",
+      "compact resume prompt",
+      { cwd: "/cwd", onUsage: undefined },
+    );
+    expect(agent.invoke).toHaveBeenCalledWith("full fresh prompt", {
+      cwd: "/cwd",
+      onUsage: undefined,
+    });
+    // Prompt sink received a follow-up event reflecting the fresh
+    // prompt actually sent.
+    expect(promptSink).toHaveBeenCalledWith(
+      "full fresh prompt",
+      "work",
+      undefined,
+    );
+  });
+
+  test("does not emit fallback prompt-sink event when fallback is unused", async () => {
+    // When the resume succeeds, the fallback path is never taken so
+    // the helper must not emit a duplicate prompt-sink event.
+    const result = makeResult({ sessionId: "resumed-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn(),
+      resume: vi.fn().mockReturnValue(makeStream(result)),
+    };
+    const promptSink = vi.fn();
+
+    await invokeOrResume(
+      agent,
+      "saved-sess",
+      "compact resume prompt",
+      "/cwd",
+      undefined,
+      {
+        fallbackPrompt: "full fresh prompt",
+        promptSink,
+        promptKind: "work",
+      },
+    );
+
+    expect(agent.invoke).not.toHaveBeenCalled();
+    expect(promptSink).not.toHaveBeenCalled();
+  });
+
+  test("legacy positional usageSink still works", async () => {
+    const result = makeResult({ sessionId: "fresh-sess" });
+    const agent: AgentAdapter = {
+      invoke: vi.fn().mockReturnValue(makeStream(result)),
+      resume: vi.fn(),
+    };
+    const usageSink = vi.fn();
+
+    await invokeOrResume(
+      agent,
+      undefined,
+      "p",
+      "/cwd",
+      undefined,
+      3,
+      usageSink,
+    );
+
+    expect(agent.invoke).toHaveBeenCalledWith("p", {
+      cwd: "/cwd",
+      onUsage: usageSink,
+    });
+  });
+
   test("returns error immediately on config_parsing (non-recoverable)", async () => {
     const configError = makeResult({
       status: "error",

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -268,12 +268,41 @@ async function retryOnTimeout(
 }
 
 /**
+ * Optional extras for {@link invokeOrResume}.  Bundled into a single
+ * options object so the helper can grow without piling on positional
+ * trailing arguments.  `fallbackPrompt` is only used when the saved
+ * session resume fails and the helper falls back to a fresh `invoke`;
+ * this lets stages send a compact "resume form" prompt on the live
+ * session and the full "fresh form" only when the session has expired.
+ *
+ * `promptSink` / `promptKind` / `promptMeta` mirror the parameters of
+ * {@link PromptSink}.  When `fallbackPrompt` is used, the helper emits
+ * a second prompt-sink event with the actual fresh prompt so diagnostic
+ * consumers reflect what was sent rather than the compact resume prompt
+ * the call site logged before invoking the helper.
+ */
+export interface InvokeOrResumeExtras {
+  fallbackPrompt?: string;
+  maxAutoResumes?: number;
+  usageSink?: UsageSink;
+  promptSink?: PromptSink;
+  promptKind?: AgentPromptKind;
+  promptMeta?: PromptSinkMeta;
+}
+
+/**
  * Invoke-or-resume with automatic retry on inactivity timeout.
  *
  * When the agent process is killed due to stdout inactivity, this
  * function automatically resumes the session (up to `maxAutoResumes`
  * times).  After that, the timeout error is returned to the caller so
  * the pipeline can prompt the user.
+ *
+ * The trailing optional `extras` argument bundles `fallbackPrompt` and
+ * the previously-trailing options (`maxAutoResumes`, `usageSink`).  For
+ * source compatibility, callers can still pass the legacy positional
+ * `maxAutoResumes` (number) and `usageSink` (function) as trailing
+ * arguments.
  */
 export async function invokeOrResume(
   agent: AgentAdapter,
@@ -281,16 +310,33 @@ export async function invokeOrResume(
   prompt: string,
   cwd: string,
   sink?: StreamSink,
-  maxAutoResumes = 3,
+  maxAutoResumesOrExtras?: number | InvokeOrResumeExtras,
   usageSink?: UsageSink,
 ): Promise<AgentResult> {
+  const extras: InvokeOrResumeExtras =
+    typeof maxAutoResumesOrExtras === "object" && maxAutoResumesOrExtras
+      ? maxAutoResumesOrExtras
+      : {
+          maxAutoResumes:
+            typeof maxAutoResumesOrExtras === "number"
+              ? maxAutoResumesOrExtras
+              : undefined,
+          usageSink,
+        };
+  const maxAutoResumes = extras.maxAutoResumes ?? 3;
+  const effectiveUsageSink = extras.usageSink ?? usageSink;
+
   const result = await invokeOrResumeOnce(
     agent,
     savedSessionId,
     prompt,
     cwd,
     sink,
-    usageSink,
+    effectiveUsageSink,
+    extras.fallbackPrompt,
+    extras.promptSink,
+    extras.promptKind,
+    extras.promptMeta,
   );
   return retryOnTimeout(
     agent,
@@ -299,7 +345,7 @@ export async function invokeOrResume(
     undefined,
     sink,
     maxAutoResumes,
-    usageSink,
+    effectiveUsageSink,
   );
 }
 
@@ -313,6 +359,10 @@ async function invokeOrResumeOnce(
   cwd: string,
   sink?: StreamSink,
   usageSink?: UsageSink,
+  fallbackPrompt?: string,
+  promptSink?: PromptSink,
+  promptKind?: AgentPromptKind,
+  promptMeta?: PromptSinkMeta,
 ): Promise<AgentResult> {
   const opts = { cwd, onUsage: usageSink };
   if (savedSessionId) {
@@ -336,7 +386,21 @@ async function invokeOrResumeOnce(
     }
     // Session expired or unknown error — fall back to fresh invoke.
   }
-  const stream = agent.invoke(prompt, opts);
+  // When a fallback prompt is provided (e.g. the call site sent a
+  // compact resume-form prompt that assumed a live session), use it
+  // for the fresh invoke so the agent receives full context.  Emit a
+  // second prompt-sink event reflecting the prompt actually sent.
+  const effectivePrompt =
+    savedSessionId && fallbackPrompt !== undefined ? fallbackPrompt : prompt;
+  if (
+    savedSessionId &&
+    fallbackPrompt !== undefined &&
+    promptSink &&
+    promptKind
+  ) {
+    promptSink(fallbackPrompt, promptKind, promptMeta);
+  }
+  const stream = agent.invoke(effectivePrompt, opts);
   const drained = sink ? drainToSink(stream, sink) : undefined;
   const result = await stream.result;
   if (drained) await drained;

--- a/src/step-parser.test.ts
+++ b/src/step-parser.test.ts
@@ -176,9 +176,10 @@ describe("buildClarificationPrompt", () => {
     expect(prompt).toContain("BLOCKED");
   });
 
-  test("scoped prompt uses 'verdict keyword' phrasing", () => {
+  test("scoped prompt asks for one keyword with no commentary", () => {
     const prompt = buildClarificationPrompt("ambiguous", ["APPROVED"]);
-    expect(prompt).toContain("verdict keyword");
+    expect(prompt).toContain("exactly one keyword");
+    expect(prompt).toContain("APPROVED");
   });
 });
 

--- a/src/step-parser.ts
+++ b/src/step-parser.ts
@@ -153,22 +153,8 @@ export function buildClarificationPrompt(
   _originalResponse: string,
   validKeywords?: readonly string[],
 ): string {
-  if (validKeywords && validKeywords.length > 0) {
-    const keywordList = validKeywords.join(", ");
-    return [
-      "Your previous response did not contain a clear verdict keyword.",
-      `Respond with exactly one of the following keywords: ${keywordList}`,
-      "",
-      "Do not include any other commentary — just the keyword.",
-    ].join("\n");
-  }
-
-  return [
-    "Your previous response did not end with a clear status keyword.",
-    "Please reply with exactly one of the following keywords to indicate",
-    "the current status: COMPLETED, FIXED, DONE, APPROVED, NOT_APPROVED,",
-    "or BLOCKED.",
-    "",
-    "Do not include any other commentary — just the keyword.",
-  ].join("\n");
+  const keywords = validKeywords?.length
+    ? validKeywords.join(", ")
+    : "COMPLETED, FIXED, DONE, APPROVED, NOT_APPROVED, BLOCKED";
+  return `Reply with exactly one keyword (no commentary): ${keywords}.`;
 }


### PR DESCRIPTION
## Summary

- Add resume/fresh prompt split: `invokeOrResume` takes an options object with `fallbackPrompt`, `promptSink`, `promptKind`, and `promptMeta`. Stages send a compact resume prompt (no repo header / issue body) on a live session and fall back to the full fresh prompt only when the helper has to do a fresh `invoke` on session expiry. When no saved session id exists, the fresh form is sent as the primary prompt. Prompt-sink diagnostics now record the prompt actually sent.
- Wire the resume/fresh split through every stage's `buildXxxPrompt`, including the direct invoke/resume sites in `stage-review.ts` (verdict step without a review session, `handleUnresolvedSummary`).
- Thread the shared `pollCiAndFix` helper through `invokeOrResume`. The post-review (Stage 7) and post-squash (Stage 8) CI fix loops now read the current Agent A session id and send `buildCiFindingsResumePrompt` / `buildCiFixResumePrompt` on the live session, falling back to the fresh-form prompts only when the helper has to fresh-invoke. The helper tracks the latest session id locally across loop iterations so each turn resumes the most recent session, and prompt-sink diagnostics inside the loop now reflect fallback behaviour like every other stage.
- `pollCiAndFix` accepts an optional `initialAgentASessionId` so callers can hand it the freshest Agent A session id from the same handler invocation. Stage 7 (post-author-fix / completion-check) and Stage 8 (`runCiPollAndFinish` from the verdict / clarification / agent-squash follow-up paths) thread the live session id through, since `ctx.savedAgentASessionId` is a stage-entry snapshot and would otherwise force the first CI findings/fix turn back onto a fresh `invoke`.
- Compress all verdict prompts (`buildCompletionCheckPrompt`, `buildPrCompletionCheckPrompt`, `buildFixOrDoneVerdictPrompt`, `buildTestPlanVerdictPrompt`, `buildReviewVerdictPrompt`, `buildUnresolvedVerdictPrompt`, `buildPrFinalizationVerdictPrompt`, `buildSquashCompletionCheckPrompt`) and `buildClarificationPrompt` to a two-line "Reply with exactly one keyword" form. Tests updated to match. The strict verdict parser is unchanged.
- Drop the redundant `Worktree:` line from every stage prompt and rewrite "the worktree listed above"-style prose to match. Keep `Owner:` / `Repo:` / `Branch:` only where they are interpolated into command examples or API URLs (notably the CodeQL dismiss block in Stage 5). Agent B reviewer prompts run from a detached worktree where `gh pr view` cannot infer the current branch, so they invoke `gh pr view {branch} --repo {owner}/{repo}` explicitly.
- Update `docs/pipeline.md` to describe the resume-vs-fresh split (including the `pollCiAndFix` wiring and `initialAgentASessionId` plumbing) and the new compact verdict wording, and add a `CHANGELOG.md` entry.

Estimated savings: ~3,000–4,000 tokens per typical pipeline run (one self-check, one CI fix, two review rounds), with negligible accuracy risk because the fresh-form fallback preserves full context on any session expiry. `README.md` did not reference the changed material and was left alone.

Closes #310

## Test plan

- [x] `pnpm vitest run` passes
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes
- [x] `invokeOrResume` accepts the new options object and existing call sites still compile
- [x] When `invokeOrResume` falls back to `fallbackPrompt`, prompt-sink diagnostics emit the prompt actually sent
- [x] Each stage's first work prompt sends the resume form when a saved session id exists, and the fresh form when it does not
- [x] Direct invoke/resume sites in `stage-review.ts` (verdict-without-session, unresolved-summary) use the compact resume form correctly
- [x] `pollCiAndFix` resumes the saved Agent A session for the Stage 7 / 8 CI findings and fix prompts, with fresh-form fallback on session expiry
- [x] `pollCiAndFix` accepts `initialAgentASessionId`; Stage 7 and Stage 8 hand in the freshest live session id so the first CI fix turn after author-fix / verdict / agent-squash follow-up resumes the live conversation
- [x] Verdict and clarification prompts are short and the verdict parser still classifies COMPLETED / BLOCKED / etc. unchanged
- [x] `Worktree:` line no longer appears in any stage prompt; prose referencing it is updated
- [x] `Owner` / `Repo` / `Branch` retained wherever a command example or API URL needs them; removed elsewhere
- [x] Agent B reviewer prompts call `gh pr view` with explicit `{branch}` and `--repo {owner}/{repo}` so they work from the detached reviewer worktree
- [x] `docs/pipeline.md` reflects the resume/fresh split and compact verdict wording
- [x] `CHANGELOG.md` entry describes the token-reduction work