### PR TITLE
Route gh calls through ghExec helper (#314)

### DIFF
--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -204,7 +204,7 @@ describe("fetchCiRuns", () => {
         "--limit",
         "100",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -233,7 +233,7 @@ describe("fetchCiRuns", () => {
         "--commit",
         "abc123",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -315,7 +315,7 @@ describe("fetchCiRuns", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["api", "repos/org/repo/commits/deadbeef/check-runs?per_page=100"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -329,7 +329,7 @@ describe("fetchCiRuns", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["api", "repos/org/repo/commits/my-branch/check-runs?per_page=100"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -343,7 +343,7 @@ describe("fetchCiRuns", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["api", "repos/org/repo/commits/user%2Fissue-42/check-runs?per_page=100"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -516,7 +516,7 @@ describe("collectFailureLogs", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["run", "view", "12345", "--repo", "org/repo", "--log-failed"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -577,7 +577,7 @@ describe("collectFailureLogs", () => {
         "--slurp",
         "repos/org/repo/check-runs/500/annotations?per_page=100",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -733,7 +733,7 @@ describe("collectFailureLogs", () => {
         "--slurp",
         "repos/org/repo/check-runs/900/annotations?per_page=100",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 });
@@ -953,7 +953,7 @@ describe("fetchCodeScanningAlerts", () => {
         "--slurp",
         "repos/org/repo/code-scanning/alerts?ref=my-branch&state=open&per_page=100",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -1133,7 +1133,7 @@ describe("dismissCodeScanningAlert", () => {
         "-f",
         "dismissed_comment=Test-only code",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -5,7 +5,7 @@
  * pass for a given branch/commit.  Reusable by stages 5, 7, and 8.
  */
 
-import { execFileSync } from "node:child_process";
+import { ghExec } from "./gh-exec.js";
 
 // ---- public types --------------------------------------------------------
 
@@ -179,16 +179,12 @@ function fetchCheckRunAnnotations(
   repo: string,
   checkRunId: number,
 ): CheckRunAnnotation[] {
-  const raw = execFileSync(
-    "gh",
-    [
-      "api",
-      "--paginate",
-      "--slurp",
-      `repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=100`,
-    ],
-    { encoding: "utf-8" },
-  );
+  const raw = ghExec([
+    "api",
+    "--paginate",
+    "--slurp",
+    `repos/${owner}/${repo}/check-runs/${checkRunId}/annotations?per_page=100`,
+  ]);
   const pages: CheckRunAnnotation[][] = JSON.parse(raw);
   return pages.flat();
 }
@@ -255,14 +251,10 @@ function fetchCheckRunsFromApi(
   repo: string,
   ref: string,
 ): CiRun[] {
-  const output = execFileSync(
-    "gh",
-    [
-      "api",
-      `repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}/check-runs?per_page=100`,
-    ],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "api",
+    `repos/${owner}/${repo}/commits/${encodeURIComponent(ref)}/check-runs?per_page=100`,
+  ]);
 
   const parsed = JSON.parse(output);
   const entries: CheckRunApiEntry[] = parsed.check_runs ?? [];
@@ -303,11 +295,10 @@ function collectCheckRunLogs(owner: string, repo: string, run: CiRun): string {
   if (output === undefined) {
     let detail: CheckRunApiEntry | undefined;
     try {
-      const raw = execFileSync(
-        "gh",
-        ["api", `repos/${owner}/${repo}/check-runs/${checkRunId}`],
-        { encoding: "utf-8" },
-      );
+      const raw = ghExec([
+        "api",
+        `repos/${owner}/${repo}/check-runs/${checkRunId}`,
+      ]);
       detail = JSON.parse(raw);
     } catch {
       return "Unable to retrieve check run details.";
@@ -376,7 +367,7 @@ export function fetchCiRuns(
   if (commitSha) {
     args.push("--commit", commitSha);
   }
-  const output = execFileSync("gh", args, { encoding: "utf-8" });
+  const output = ghExec(args);
   let workflowRuns: CiRun[];
   try {
     workflowRuns = (JSON.parse(output) as Omit<CiRun, "source">[]).map((r) => ({
@@ -431,18 +422,14 @@ export function collectFailureLogs(
   if (run.source === "check") {
     return collectCheckRunLogs(owner, repo, run);
   }
-  const output = execFileSync(
-    "gh",
-    [
-      "run",
-      "view",
-      String(run.databaseId),
-      "--repo",
-      `${owner}/${repo}`,
-      "--log-failed",
-    ],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "run",
+    "view",
+    String(run.databaseId),
+    "--repo",
+    `${owner}/${repo}`,
+    "--log-failed",
+  ]);
   return typeof output === "string" ? output : "";
 }
 
@@ -494,16 +481,12 @@ export function fetchCodeScanningAlerts(
   ref: string,
 ): CodeScanningAlert[] {
   try {
-    const raw = execFileSync(
-      "gh",
-      [
-        "api",
-        "--paginate",
-        "--slurp",
-        `repos/${owner}/${repo}/code-scanning/alerts?ref=${encodeURIComponent(ref)}&state=open&per_page=100`,
-      ],
-      { encoding: "utf-8" },
-    );
+    const raw = ghExec([
+      "api",
+      "--paginate",
+      "--slurp",
+      `repos/${owner}/${repo}/code-scanning/alerts?ref=${encodeURIComponent(ref)}&state=open&per_page=100`,
+    ]);
     const pages: CodeScanningAlert[][] = JSON.parse(raw);
     return pages.flat();
   } catch {
@@ -582,20 +565,16 @@ export function dismissCodeScanningAlert(
   alertNumber: number,
   reason: string,
 ): void {
-  execFileSync(
-    "gh",
-    [
-      "api",
-      "-X",
-      "PATCH",
-      `repos/${owner}/${repo}/code-scanning/alerts/${alertNumber}`,
-      "-f",
-      "state=dismissed",
-      "-f",
-      "dismissed_reason=false positive",
-      "-f",
-      `dismissed_comment=${reason}`,
-    ],
-    { encoding: "utf-8" },
-  );
+  ghExec([
+    "api",
+    "-X",
+    "PATCH",
+    `repos/${owner}/${repo}/code-scanning/alerts/${alertNumber}`,
+    "-f",
+    "state=dismissed",
+    "-f",
+    "dismissed_reason=false positive",
+    "-f",
+    `dismissed_comment=${reason}`,
+  ]);
 }

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -8,6 +8,7 @@
 import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { ghExec } from "./gh-exec.js";
 
 const EXEC_OPTS: ExecFileSyncOptions = { encoding: "utf-8", stdio: "pipe" };
 
@@ -73,11 +74,11 @@ export function remoteBranchExists(
   branch: string,
 ): boolean {
   try {
-    execFileSync(
-      "gh",
-      ["api", `repos/${owner}/${repo}/git/ref/heads/${branch}`, "--silent"],
-      EXEC_OPTS,
-    );
+    ghExec([
+      "api",
+      `repos/${owner}/${repo}/git/ref/heads/${branch}`,
+      "--silent",
+    ]);
     return true;
   } catch {
     return false;
@@ -92,11 +93,12 @@ export function deleteRemoteBranch(
   repo: string,
   branch: string,
 ): void {
-  execFileSync(
-    "gh",
-    ["api", "-X", "DELETE", `repos/${owner}/${repo}/git/refs/heads/${branch}`],
-    EXEC_OPTS,
-  );
+  ghExec([
+    "api",
+    "-X",
+    "DELETE",
+    `repos/${owner}/${repo}/git/refs/heads/${branch}`,
+  ]);
 }
 
 // ---- pull request ---------------------------------------------------------
@@ -105,9 +107,5 @@ export function deleteRemoteBranch(
  * Close an open PR on GitHub without merging.
  */
 export function closePr(owner: string, repo: string, prNumber: number): void {
-  execFileSync(
-    "gh",
-    ["pr", "close", String(prNumber), "--repo", `${owner}/${repo}`],
-    EXEC_OPTS,
-  );
+  ghExec(["pr", "close", String(prNumber), "--repo", `${owner}/${repo}`]);
 }

--- a/src/fetch-pr-comments.test.ts
+++ b/src/fetch-pr-comments.test.ts
@@ -22,7 +22,7 @@ describe("fetchPrComments", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["api", "repos/org/repo/issues/5/comments", "--paginate", "--slurp"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 

--- a/src/gh-exec.test.ts
+++ b/src/gh-exec.test.ts
@@ -1,0 +1,85 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+
+import { ghExec } from "./gh-exec.js";
+
+// A fake `gh` binary on PATH that writes the requested number of
+// bytes to stdout.  Lets us exercise the `maxBuffer` boundary without
+// hitting the real GitHub API.
+let tmpDir: string;
+let originalPath: string | undefined;
+
+beforeAll(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "agentcoop-gh-exec-"));
+  const ghPath = join(tmpDir, "gh");
+  writeFileSync(ghPath, '#!/bin/sh\nyes a | head -c "$1"\n');
+  chmodSync(ghPath, 0o755);
+  originalPath = process.env.PATH;
+  process.env.PATH = `${tmpDir}:${originalPath ?? ""}`;
+});
+
+afterAll(() => {
+  if (originalPath === undefined) {
+    delete process.env.PATH;
+  } else {
+    process.env.PATH = originalPath;
+  }
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("ghExec", () => {
+  test("succeeds when output exceeds the legacy 1 MiB execFileSync default", () => {
+    // 2 MiB — would have tripped the old 1 MiB default.
+    const size = 2 * 1024 * 1024;
+    const out = ghExec([String(size)]);
+    expect(out.length).toBe(size);
+  });
+
+  test("fails with args in message when output exceeds the 64 MiB cap", () => {
+    const size = 70 * 1024 * 1024;
+    let captured: NodeJS.ErrnoException | undefined;
+    try {
+      ghExec([String(size), "marker-arg"]);
+    } catch (err) {
+      captured = err as NodeJS.ErrnoException;
+    }
+    expect(captured).toBeDefined();
+    // The rethrow prepends the args so the next incident points
+    // straight at the offending call site.
+    expect(captured?.message).toContain(String(size));
+    expect(captured?.message).toContain("marker-arg");
+  });
+
+  test('no production source under src/ calls execFileSync("gh", ...) directly', () => {
+    // Acceptance criterion: every `gh` invocation must go through the
+    // helper so the maxBuffer cap cannot be silently re-defaulted.
+    const srcDir = dirname(fileURLToPath(import.meta.url));
+    const offenders: string[] = [];
+    const forbidden = /execFileSync\s*\(\s*["']gh["']/;
+    for (const entry of readdirSync(srcDir, {
+      withFileTypes: true,
+      recursive: true,
+    })) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".ts")) continue;
+      // Skip tests and the helper itself (the only sanctioned caller).
+      if (entry.name.endsWith(".test.ts") || entry.name.endsWith(".test.tsx")) {
+        continue;
+      }
+      if (entry.name === "gh-exec.ts") continue;
+      const full = join(entry.parentPath, entry.name);
+      if (forbidden.test(readFileSync(full, "utf-8"))) offenders.push(full);
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/gh-exec.ts
+++ b/src/gh-exec.ts
@@ -1,0 +1,61 @@
+/**
+ * Centralized `gh` CLI invocation.
+ *
+ * `execFileSync` defaults `maxBuffer` to 1 MiB; `gh` calls that fetch
+ * CI logs, PR comments, or check annotations easily exceed that, and
+ * the resulting `ENOBUFS` is deterministic — retrying does not help.
+ * Routing every `gh` call through this helper guarantees a generous
+ * cap (64 MiB, applied to stdout AND stderr) and ensures `encoding`
+ * and `stdio` cannot be weakened by callers.
+ */
+
+import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
+
+/**
+ * Maximum bytes captured from `gh`'s stdout/stderr per call.
+ *
+ * The cap is intentionally generous so that long CI failure logs and
+ * heavy PR/comment listings do not trip ENOBUFS.  Bump if a real
+ * payload approaches the limit; do not lower without checking the
+ * call sites in `ci.ts`, `pr-comments.ts`, etc.
+ */
+const GH_MAX_BUFFER = 64 * 1024 * 1024;
+
+/**
+ * Options accepted by {@link ghExec}.  `encoding`, `maxBuffer`, and
+ * `stdio` are owned by the helper so callers cannot weaken the
+ * guarantees that the return value is a string and that capture is
+ * large enough for `gh` payloads.
+ */
+export type GhExecOptions = Omit<
+  ExecFileSyncOptions,
+  "encoding" | "maxBuffer" | "stdio"
+>;
+
+/**
+ * Invoke `gh` with the given args, returning stdout as a string.
+ *
+ * The `maxBuffer` cap applies to stdout AND stderr — commands that
+ * stream long progress to stderr (e.g. `gh run watch`) must stay
+ * within the same budget.
+ *
+ * On failure the original error is rethrown with the offending args
+ * prepended to its message so the next ENOBUFS (or other spawn
+ * failure) points straight at the call site.
+ */
+export function ghExec(args: string[], options: GhExecOptions = {}): string {
+  try {
+    return execFileSync("gh", args, {
+      ...options,
+      encoding: "utf-8",
+      maxBuffer: GH_MAX_BUFFER,
+      // Capture stderr so a noisy progress stream cannot leak to the
+      // user's terminal, and so the maxBuffer cap applies to it too.
+      stdio: "pipe",
+    });
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    e.message = `gh ${args.join(" ")}: ${e.message}`;
+    throw e;
+  }
+}

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -27,7 +27,7 @@ describe("getGitHubUsername", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["api", "user", "--jq", ".login"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
     expect(result).toBe("octocat");
   });
@@ -67,7 +67,7 @@ describe("listRepositories", () => {
         "100",
         "--no-archived",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
     expect(result).toEqual(repos);
   });
@@ -121,7 +121,7 @@ describe("getIssue", () => {
         "--json",
         "number,title,body,state,labels",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
     expect(result).toEqual({
       number: 42,

--- a/src/github.ts
+++ b/src/github.ts
@@ -1,13 +1,11 @@
-import { execFileSync } from "node:child_process";
+import { ghExec } from "./gh-exec.js";
 
 /**
  * Returns the login of the currently authenticated GitHub user.
  */
 export function getGitHubUsername(): string {
   try {
-    return execFileSync("gh", ["api", "user", "--jq", ".login"], {
-      encoding: "utf-8",
-    }).trim();
+    return ghExec(["api", "user", "--jq", ".login"]).trim();
   } catch {
     throw new Error(
       "Failed to determine GitHub username. Ensure `gh` is installed and authenticated (`gh auth login`).",
@@ -29,37 +27,29 @@ export interface Issue {
 }
 
 export function listRepositories(owner: string): Repository[] {
-  const output = execFileSync(
-    "gh",
-    [
-      "repo",
-      "list",
-      owner,
-      "--json",
-      "name,description",
-      "--limit",
-      "100",
-      "--no-archived",
-    ],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "repo",
+    "list",
+    owner,
+    "--json",
+    "name,description",
+    "--limit",
+    "100",
+    "--no-archived",
+  ]);
   return JSON.parse(output);
 }
 
 export function getIssue(owner: string, repo: string, number: number): Issue {
-  const output = execFileSync(
-    "gh",
-    [
-      "issue",
-      "view",
-      String(number),
-      "--repo",
-      `${owner}/${repo}`,
-      "--json",
-      "number,title,body,state,labels",
-    ],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "issue",
+    "view",
+    String(number),
+    "--repo",
+    `${owner}/${repo}`,
+    "--json",
+    "number,title,body,state,labels",
+  ]);
   const raw = JSON.parse(output);
   return {
     number: raw.number,

--- a/src/pr-comments.ts
+++ b/src/pr-comments.ts
@@ -6,8 +6,7 @@
  * to reconcile local RunState with the PR-derived state on resume.
  */
 
-import { execFileSync } from "node:child_process";
-
+import { ghExec } from "./gh-exec.js";
 import type { ReviewSubStep, RunState } from "./run-state.js";
 
 // ---- types ---------------------------------------------------------------
@@ -71,16 +70,12 @@ export function fetchPrComments(
   repo: string,
   prNumber: number,
 ): PrComment[] {
-  const output = execFileSync(
-    "gh",
-    [
-      "api",
-      `repos/${owner}/${repo}/issues/${prNumber}/comments`,
-      "--paginate",
-      "--slurp",
-    ],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "api",
+    `repos/${owner}/${repo}/issues/${prNumber}/comments`,
+    "--paginate",
+    "--slurp",
+  ]);
   // --slurp wraps all pages in an outer array: [[page1...], [page2...]].
   // Flatten to a single array of comments.
   const pages: PrComment[][] = JSON.parse(output);
@@ -96,19 +91,15 @@ export function postPrComment(
   prNumber: number,
   body: string,
 ): void {
-  execFileSync(
-    "gh",
-    [
-      "pr",
-      "comment",
-      String(prNumber),
-      "--repo",
-      `${owner}/${repo}`,
-      "--body",
-      body,
-    ],
-    { encoding: "utf-8" },
-  );
+  ghExec([
+    "pr",
+    "comment",
+    String(prNumber),
+    "--repo",
+    `${owner}/${repo}`,
+    "--body",
+    body,
+  ]);
 }
 
 /**
@@ -125,8 +116,7 @@ export function patchPrComment(
   commentId: number,
   body: string,
 ): void {
-  execFileSync(
-    "gh",
+  ghExec(
     [
       "api",
       "--method",
@@ -135,7 +125,7 @@ export function patchPrComment(
       "--input",
       "-",
     ],
-    { encoding: "utf-8", input: JSON.stringify({ body }) },
+    { input: JSON.stringify({ body }) },
   );
 }
 

--- a/src/pr.test.ts
+++ b/src/pr.test.ts
@@ -45,7 +45,7 @@ describe("findPrNumber", () => {
         "--limit",
         "1",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -101,7 +101,7 @@ describe("getPrBody", () => {
         "--jq",
         ".body",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 
@@ -171,7 +171,7 @@ describe("queryMergeableState", () => {
         "--json",
         "mergeable",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 });
@@ -226,7 +226,7 @@ describe("queryPrState", () => {
         "--json",
         "state",
       ],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 });

--- a/src/pr.ts
+++ b/src/pr.ts
@@ -4,7 +4,7 @@
  * Wraps `gh` CLI commands to query PR metadata.
  */
 
-import { execFileSync } from "node:child_process";
+import { ghExec } from "./gh-exec.js";
 
 /**
  * Find the PR number associated with `branch` in `owner/repo`.
@@ -16,22 +16,18 @@ export function findPrNumber(
   repo: string,
   branch: string,
 ): number | undefined {
-  const output = execFileSync(
-    "gh",
-    [
-      "pr",
-      "list",
-      "--repo",
-      `${owner}/${repo}`,
-      "--head",
-      branch,
-      "--json",
-      "number",
-      "--limit",
-      "1",
-    ],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "pr",
+    "list",
+    "--repo",
+    `${owner}/${repo}`,
+    "--head",
+    branch,
+    "--json",
+    "number",
+    "--limit",
+    "1",
+  ]);
 
   let prs: { number: number }[];
   try {
@@ -56,21 +52,17 @@ export function getPrBody(
   branch: string,
 ): string | undefined {
   try {
-    return execFileSync(
-      "gh",
-      [
-        "pr",
-        "view",
-        "--repo",
-        `${owner}/${repo}`,
-        branch,
-        "--json",
-        "body",
-        "--jq",
-        ".body",
-      ],
-      { encoding: "utf-8" },
-    ).trim();
+    return ghExec([
+      "pr",
+      "view",
+      "--repo",
+      `${owner}/${repo}`,
+      branch,
+      "--json",
+      "body",
+      "--jq",
+      ".body",
+    ]).trim();
   } catch {
     return undefined;
   }
@@ -119,19 +111,15 @@ export function queryMergeableState(
   branch: string,
 ): MergeableState {
   try {
-    const output = execFileSync(
-      "gh",
-      [
-        "pr",
-        "view",
-        "--repo",
-        `${owner}/${repo}`,
-        branch,
-        "--json",
-        "mergeable",
-      ],
-      { encoding: "utf-8" },
-    );
+    const output = ghExec([
+      "pr",
+      "view",
+      "--repo",
+      `${owner}/${repo}`,
+      branch,
+      "--json",
+      "mergeable",
+    ]);
     const parsed = JSON.parse(output) as { mergeable: string };
     const state = parsed.mergeable;
     if (
@@ -169,11 +157,15 @@ export function queryPrState(
   branch: string,
 ): PrLifecycleState {
   try {
-    const output = execFileSync(
-      "gh",
-      ["pr", "view", "--repo", `${owner}/${repo}`, branch, "--json", "state"],
-      { encoding: "utf-8" },
-    );
+    const output = ghExec([
+      "pr",
+      "view",
+      "--repo",
+      `${owner}/${repo}`,
+      branch,
+      "--json",
+      "state",
+    ]);
     const parsed = JSON.parse(output) as { state: string };
     const state = parsed.state;
     if (state === "OPEN" || state === "CLOSED" || state === "MERGED") {

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -102,7 +102,7 @@ describe("detectDefaultBranch", () => {
     expect(mockExecFileSync).toHaveBeenCalledWith(
       "gh",
       ["repo", "view", "org/repo", "--json", "defaultBranchRef"],
-      { encoding: "utf-8" },
+      expect.objectContaining({ encoding: "utf-8" }),
     );
   });
 

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -11,6 +11,7 @@ import { type ExecFileSyncOptions, execFileSync } from "node:child_process";
 import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { ghExec } from "./gh-exec.js";
 import { t } from "./i18n/index.js";
 import { repoLockPath, withLock } from "./lock.js";
 
@@ -83,11 +84,13 @@ export function repoPath(owner: string, repo: string): string {
  * Detect the default branch for `owner/repo` via `gh repo view`.
  */
 export function detectDefaultBranch(owner: string, repo: string): string {
-  const output = execFileSync(
-    "gh",
-    ["repo", "view", `${owner}/${repo}`, "--json", "defaultBranchRef"],
-    { encoding: "utf-8" },
-  );
+  const output = ghExec([
+    "repo",
+    "view",
+    `${owner}/${repo}`,
+    "--json",
+    "defaultBranchRef",
+  ]);
   const data = JSON.parse(output);
   return data.defaultBranchRef?.name ?? "main";
 }


### PR DESCRIPTION
## Summary

Centralize every `gh` CLI invocation through a new `ghExec` helper in `src/gh-exec.ts` so calls no longer inherit Node's 1 MiB `execFileSync` default `maxBuffer`. The helper raises the cap to 64 MiB, applies it to both stdout and stderr, and locks `encoding`/`maxBuffer`/`stdio` at the type level so callers cannot weaken the guarantees. On any spawn failure (including ENOBUFS) the helper rethrows with the offending args prepended to the error message so the next incident points straight at the offending call site.

All previous `execFileSync("gh", ...)` sites under `src/` (`ci.ts`, `pr-comments.ts`, `pr.ts`, `github.ts`, `cleanup.ts`, `worktree.ts`) now route through `ghExec`. A unit test runs a fake `gh` on PATH to verify >1 MiB succeeds, >64 MiB fails with args in the message, and a grep-style test fails CI if any future production source reintroduces a direct `execFileSync("gh", ...)` call.

Closes #314

## Test plan

- [x] `ghExec` helper exists with `encoding`, `maxBuffer`, `stdio` removed from its option type
- [x] No production source under `src/` invokes `execFileSync("gh", ...)` directly (enforced by a test)
- [x] Unit test: fake `gh` output of 2 MiB succeeds (would have tripped the old 1 MiB default)
- [x] Unit test: fake `gh` output of 70 MiB fails with the args present in the error message
- [x] `pnpm vitest run` passes (2093 tests)
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check src/` passes
- [x] `pnpm build` passes