### PR TITLE
Add per-launch auth-mode prompt and TokenBar badge (#320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- AgentCoop now prompts on every launch to choose between the
+  child CLI's API-key environment variable and its stored OAuth
+  login, separately for Claude and Codex.  The prompt is shown
+  only when an auth-bearing env var is actually detected
+  (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` for Claude,
+  `OPENAI_API_KEY` / `CODEX_API_KEY` for Codex), the previous
+  choice is preselected, and the result is persisted under
+  `authPolicy` in `~/.agentcoop/config.json`.  When `oauth` is
+  selected, the corresponding env vars are stripped from the
+  spawned child's environment so the CLI falls back to its
+  subscription credentials, and AgentCoop verifies that those
+  credentials exist before continuing (file check on Linux for
+  Claude, CLI-based `codex login status` probe — invoked with
+  the API-key vars stripped — for Codex).  The active mode is
+  surfaced as a coloured `[API]` / `[OAuth]` badge in the
+  TokenBar from session start, before any token usage has
+  arrived.  The persisted agent configuration is unchanged; the
+  per-run mode is runtime-only state.  Closes #320.
+
 ### Changed
 
 - CI fix, findings-review, and dismiss-alerts prompts no longer inline

--- a/src/auth-policy.test.ts
+++ b/src/auth-policy.test.ts
@@ -283,4 +283,80 @@ describe("precheckCodexOAuth", () => {
     expect(result.ok).toBe(false);
     expect(result.reason).toContain("codex CLI not found");
   });
+
+  describe("file fallback when probe unsupported", () => {
+    beforeEach(() => {
+      mkdirSync(tmpHome, { recursive: true });
+    });
+    afterEach(() => {
+      rmSync(tmpHome, { recursive: true, force: true });
+    });
+
+    test('falls back to ~/.codex/auth.json when probe reports "unrecognized subcommand"', () => {
+      const dir = join(tmpHome, ".codex");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "auth.json"), "{}");
+      const probe = vi.fn().mockReturnValue({
+        status: 2,
+        stdout: "",
+        stderr: "error: unrecognized subcommand 'login'",
+      });
+      const result = precheckCodexOAuth({}, probe);
+      expect(result.ok).toBe(true);
+    });
+
+    test("falls back to file check on usage-style help output", () => {
+      const dir = join(tmpHome, ".codex");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "auth.json"), "{}");
+      const probe = vi.fn().mockReturnValue({
+        status: 64,
+        stdout: "Usage: codex [options] <command>\n",
+        stderr: "",
+      });
+      const result = precheckCodexOAuth({}, probe);
+      expect(result.ok).toBe(true);
+    });
+
+    test("falls back and aborts when both probe is unsupported and file is missing", () => {
+      const probe = vi.fn().mockReturnValue({
+        status: 2,
+        stdout: "",
+        stderr: "unknown command 'login'",
+      });
+      const result = precheckCodexOAuth({}, probe);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toContain("auth.json");
+      expect(result.reason).toContain("codex login");
+    });
+
+    test("honors CODEX_HOME override in file fallback", () => {
+      const dir = join(tmpHome, "custom-codex");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "auth.json"), "{}");
+      const probe = vi.fn().mockReturnValue({
+        status: 2,
+        stdout: "",
+        stderr: "error: unrecognized subcommand",
+      });
+      const result = precheckCodexOAuth({ CODEX_HOME: dir }, probe);
+      expect(result.ok).toBe(true);
+    });
+
+    test('does NOT fall back when probe explicitly reports "not logged in"', () => {
+      // Even if the auth file happens to exist, an explicit
+      // not-logged-in signal from the probe wins.
+      const dir = join(tmpHome, ".codex");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, "auth.json"), "{}");
+      const probe = vi.fn().mockReturnValue({
+        status: 1,
+        stdout: "",
+        stderr: "not logged in",
+      });
+      const result = precheckCodexOAuth({}, probe);
+      expect(result.ok).toBe(false);
+      expect(result.reason).toContain("codex login");
+    });
+  });
 });

--- a/src/auth-policy.test.ts
+++ b/src/auth-policy.test.ts
@@ -1,0 +1,286 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const tmpHome = join(import.meta.dirname, "..", ".tmp-auth-policy-home");
+
+vi.mock("node:os", async () => {
+  const actual = await vi.importActual<typeof import("node:os")>("node:os");
+  return {
+    ...actual,
+    homedir: () => tmpHome,
+  };
+});
+
+const {
+  buildChildEnv,
+  detectedAuthEnvVars,
+  precheckClaudeOAuth,
+  precheckCodexOAuth,
+  resolveAuthPolicyForRun,
+  CLAUDE_AUTH_ENV_VARS,
+  CODEX_AUTH_ENV_VARS,
+} = await import("./auth-policy.js");
+
+describe("buildChildEnv", () => {
+  test("env mode returns env unchanged", () => {
+    const base = {
+      ANTHROPIC_API_KEY: "sk-ant-1",
+      OPENAI_API_KEY: "sk-1",
+      PATH: "/usr/bin",
+    } as NodeJS.ProcessEnv;
+    const out = buildChildEnv("claude", "env", base);
+    expect(out.ANTHROPIC_API_KEY).toBe("sk-ant-1");
+    expect(out.OPENAI_API_KEY).toBe("sk-1");
+  });
+
+  test("oauth strips claude vars but leaves others", () => {
+    const base = {
+      ANTHROPIC_API_KEY: "sk-ant-1",
+      ANTHROPIC_AUTH_TOKEN: "tok",
+      OPENAI_API_KEY: "sk-1",
+      PATH: "/usr/bin",
+    } as NodeJS.ProcessEnv;
+    const out = buildChildEnv("claude", "oauth", base);
+    expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(out.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(out.OPENAI_API_KEY).toBe("sk-1");
+    expect(out.PATH).toBe("/usr/bin");
+  });
+
+  test("oauth strips codex vars but leaves others", () => {
+    const base = {
+      ANTHROPIC_API_KEY: "sk-ant-1",
+      OPENAI_API_KEY: "sk-1",
+      CODEX_API_KEY: "ck-1",
+    } as NodeJS.ProcessEnv;
+    const out = buildChildEnv("codex", "oauth", base);
+    expect(out.OPENAI_API_KEY).toBeUndefined();
+    expect(out.CODEX_API_KEY).toBeUndefined();
+    expect(out.ANTHROPIC_API_KEY).toBe("sk-ant-1");
+  });
+
+  test("oauth treats both env vars as auth-bearing for each cli", () => {
+    expect(CLAUDE_AUTH_ENV_VARS).toEqual([
+      "ANTHROPIC_API_KEY",
+      "ANTHROPIC_AUTH_TOKEN",
+    ]);
+    expect(CODEX_AUTH_ENV_VARS).toEqual(["OPENAI_API_KEY", "CODEX_API_KEY"]);
+  });
+});
+
+describe("detectedAuthEnvVars", () => {
+  test("ignores empty-string values", () => {
+    const env = { ANTHROPIC_API_KEY: "", ANTHROPIC_AUTH_TOKEN: "tok" };
+    expect(detectedAuthEnvVars("claude", env)).toEqual([
+      "ANTHROPIC_AUTH_TOKEN",
+    ]);
+  });
+});
+
+describe("resolveAuthPolicyForRun", () => {
+  test("forces oauth and skips prompt when no env vars are set", async () => {
+    const promptAuthMode = vi.fn();
+    const result = await resolveAuthPolicyForRun({
+      cliSet: ["claude"],
+      env: {},
+      prompter: { promptAuthMode },
+    });
+    expect(promptAuthMode).not.toHaveBeenCalled();
+    expect(result.effective).toEqual({ claude: "oauth" });
+    expect(result.toPersist).toBeUndefined();
+    expect(result.changed).toBe(false);
+  });
+
+  test("prompts when an env var is set, persists answer", async () => {
+    const promptAuthMode = vi.fn().mockResolvedValue("oauth");
+    const result = await resolveAuthPolicyForRun({
+      cliSet: ["claude"],
+      env: { ANTHROPIC_API_KEY: "sk-ant-1" },
+      prompter: { promptAuthMode },
+    });
+    expect(promptAuthMode).toHaveBeenCalledWith({
+      cli: "claude",
+      detectedEnvVars: ["ANTHROPIC_API_KEY"],
+      defaultMode: "env",
+    });
+    expect(result.effective).toEqual({ claude: "oauth" });
+    expect(result.toPersist).toEqual({ claude: "oauth" });
+    expect(result.changed).toBe(true);
+  });
+
+  test("preselects saved choice when prompting", async () => {
+    const promptAuthMode = vi.fn().mockResolvedValue("oauth");
+    await resolveAuthPolicyForRun({
+      cliSet: ["claude"],
+      env: { ANTHROPIC_AUTH_TOKEN: "tok" },
+      savedPolicy: { claude: "oauth" },
+      prompter: { promptAuthMode },
+    });
+    expect(promptAuthMode).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultMode: "oauth" }),
+    );
+  });
+
+  test("does not overwrite a saved policy for a CLI not in the run", async () => {
+    const promptAuthMode = vi.fn().mockResolvedValue("env");
+    const result = await resolveAuthPolicyForRun({
+      cliSet: ["claude"],
+      env: { ANTHROPIC_API_KEY: "sk-ant-1" },
+      savedPolicy: { codex: "oauth" },
+      prompter: { promptAuthMode },
+    });
+    // codex (not in cliSet) is preserved.
+    expect(result.toPersist).toEqual({ claude: "env", codex: "oauth" });
+    // codex is not in the effective set because it is not in cliSet.
+    expect(result.effective).toEqual({ claude: "env" });
+  });
+
+  test("does not persist when the prompt is skipped (env-var-less CLI)", async () => {
+    // A run with codex only and no env var set; saved claude policy
+    // must be preserved; codex must not be written.
+    const promptAuthMode = vi.fn();
+    const result = await resolveAuthPolicyForRun({
+      cliSet: ["codex"],
+      env: {},
+      savedPolicy: { claude: "env" },
+      prompter: { promptAuthMode },
+    });
+    expect(promptAuthMode).not.toHaveBeenCalled();
+    expect(result.toPersist).toEqual({ claude: "env" });
+    expect(result.changed).toBe(false);
+    expect(result.effective).toEqual({ codex: "oauth" });
+  });
+
+  test("changed=false when answer matches saved", async () => {
+    const promptAuthMode = vi.fn().mockResolvedValue("env");
+    const result = await resolveAuthPolicyForRun({
+      cliSet: ["claude"],
+      env: { ANTHROPIC_API_KEY: "sk-1" },
+      savedPolicy: { claude: "env" },
+      prompter: { promptAuthMode },
+    });
+    expect(result.changed).toBe(false);
+  });
+
+  test("prompts once per unique CLI even when both agents share the CLI", async () => {
+    const promptAuthMode = vi.fn().mockResolvedValue("env");
+    await resolveAuthPolicyForRun({
+      cliSet: ["claude"],
+      env: { ANTHROPIC_API_KEY: "sk-1" },
+      prompter: { promptAuthMode },
+    });
+    expect(promptAuthMode).toHaveBeenCalledTimes(1);
+  });
+
+  test("prompts for both CLIs when both have env vars set", async () => {
+    const promptAuthMode = vi
+      .fn()
+      .mockResolvedValueOnce("env")
+      .mockResolvedValueOnce("oauth");
+    const result = await resolveAuthPolicyForRun({
+      cliSet: ["claude", "codex"],
+      env: { ANTHROPIC_API_KEY: "sk-1", CODEX_API_KEY: "ck-1" },
+      prompter: { promptAuthMode },
+    });
+    expect(promptAuthMode).toHaveBeenCalledTimes(2);
+    expect(result.toPersist).toEqual({ claude: "env", codex: "oauth" });
+    expect(result.effective).toEqual({ claude: "env", codex: "oauth" });
+  });
+});
+
+describe("precheckClaudeOAuth", () => {
+  beforeEach(() => {
+    mkdirSync(tmpHome, { recursive: true });
+  });
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  test("on macOS, skip pre-check (Keychain backed)", () => {
+    const result = precheckClaudeOAuth({}, "darwin");
+    expect(result.ok).toBe(true);
+  });
+
+  test("on Linux, fails when ~/.claude/.credentials.json missing", () => {
+    const result = precheckClaudeOAuth({}, "linux");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain(".credentials.json");
+    expect(result.reason).toContain("claude login");
+  });
+
+  test("on Linux, succeeds when credentials file present", () => {
+    const dir = join(tmpHome, ".claude");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".credentials.json"), "{}");
+    const result = precheckClaudeOAuth({}, "linux");
+    expect(result.ok).toBe(true);
+  });
+
+  test("on Linux, honors CLAUDE_CONFIG_DIR override", () => {
+    const dir = join(tmpHome, "custom-claude");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, ".credentials.json"), "{}");
+    const result = precheckClaudeOAuth({ CLAUDE_CONFIG_DIR: dir }, "linux");
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("precheckCodexOAuth", () => {
+  test("invokes the probe with codex env vars stripped", () => {
+    const probe = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: "Logged in as foo@example.com",
+      stderr: "",
+    });
+    const result = precheckCodexOAuth(
+      {
+        OPENAI_API_KEY: "sk-stale",
+        CODEX_API_KEY: "ck-stale",
+        PATH: "/usr/bin",
+      },
+      probe,
+    );
+    expect(result.ok).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+    const env = probe.mock.calls[0][0] as NodeJS.ProcessEnv;
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CODEX_API_KEY).toBeUndefined();
+    expect(env.PATH).toBe("/usr/bin");
+  });
+
+  test("treats non-zero exit as missing credentials", () => {
+    const probe = vi.fn().mockReturnValue({
+      status: 1,
+      stdout: "",
+      stderr: "not logged in",
+    });
+    const result = precheckCodexOAuth({}, probe);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("codex login");
+  });
+
+  test('treats "not logged in" stdout/stderr as missing credentials even on exit 0', () => {
+    const probe = vi.fn().mockReturnValue({
+      status: 0,
+      stdout: "Not logged in",
+      stderr: "",
+    });
+    const result = precheckCodexOAuth({}, probe);
+    expect(result.ok).toBe(false);
+  });
+
+  test("ENOENT (codex CLI missing) reports actionable message", () => {
+    const err = new Error("spawn codex ENOENT") as NodeJS.ErrnoException;
+    err.code = "ENOENT";
+    const probe = vi.fn().mockReturnValue({
+      status: null,
+      stdout: "",
+      stderr: "",
+      error: err,
+    });
+    const result = precheckCodexOAuth({}, probe);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("codex CLI not found");
+  });
+});

--- a/src/auth-policy.ts
+++ b/src/auth-policy.ts
@@ -217,12 +217,41 @@ export const defaultCodexProbe: CodexProbeRunner = (env) => {
   };
 };
 
+const NOT_LOGGED_IN_RE = /not logged in|not signed in|no credentials/i;
+
+/**
+ * Heuristic for "the `login status` subcommand is not understood by
+ * this Codex build" — distinct from "the subcommand ran and reported
+ * not-logged-in".  Triggers a fallback to the file check.
+ */
+const UNSUPPORTED_PROBE_RE =
+  /unrecognized (sub)?command|unknown (sub)?command|no such (sub)?command|invalid (sub)?command|unexpected argument|^\s*usage:/im;
+
+/**
+ * File-existence fallback for the Codex login-status probe.  Used only
+ * when the CLI-based probe is unavailable (subcommand missing /
+ * unsupported), so we do not mistakenly abort on Codex builds that
+ * have stored credentials but lack `login status`.
+ */
+export function codexAuthFileExists(baseEnv: NodeJS.ProcessEnv = process.env): {
+  exists: boolean;
+  path: string;
+} {
+  const dir = baseEnv.CODEX_HOME ?? join(homedir(), ".codex");
+  const credPath = join(dir, "auth.json");
+  return { exists: existsSync(credPath), path: credPath };
+}
+
 /**
  * Verify that Codex has stored login credentials.
  *
  * The probe MUST run with `OPENAI_API_KEY` and `CODEX_API_KEY`
  * stripped from the env, so a stale API key in the parent shell does
  * not produce a false-positive "logged in" response.
+ *
+ * If the probe itself is unavailable (e.g. a Codex build without the
+ * `login status` subcommand), fall back to checking
+ * `$CODEX_HOME/auth.json` (defaulting to `~/.codex/auth.json`).
  *
  * The probe is injectable for tests.
  */
@@ -247,13 +276,13 @@ export function precheckCodexOAuth(
         "codex CLI not found on PATH. Install Codex and run `codex login`.",
     };
   }
+
+  const combined = `${res.stdout}\n${res.stderr}`;
+  const notLoggedIn = NOT_LOGGED_IN_RE.test(combined);
+  const unsupported = UNSUPPORTED_PROBE_RE.test(combined);
+
   if (res.status === 0) {
-    const combined = `${res.stdout}\n${res.stderr}`.toLowerCase();
-    if (
-      combined.includes("not logged in") ||
-      combined.includes("not signed in") ||
-      combined.includes("no credentials")
-    ) {
+    if (notLoggedIn) {
       return {
         ok: false,
         reason:
@@ -261,6 +290,27 @@ export function precheckCodexOAuth(
       };
     }
     return { ok: true };
+  }
+
+  // Non-zero exit.  If the probe explicitly reports not-logged-in,
+  // trust it.  If it looks like the subcommand is not supported (or
+  // produced no recognizable output at all), fall back to the file
+  // check rather than aborting on a Codex build that simply lacks
+  // `login status`.
+  if (notLoggedIn) {
+    return {
+      ok: false,
+      reason:
+        "Codex OAuth credentials not found. Please run `codex login` first, then re-launch agentcoop.",
+    };
+  }
+  if (unsupported || combined.trim() === "") {
+    const fb = codexAuthFileExists(baseEnv);
+    if (fb.exists) return { ok: true };
+    return {
+      ok: false,
+      reason: `Codex OAuth credentials not found at ${fb.path}. Please run \`codex login\` first, then re-launch agentcoop.`,
+    };
   }
   return {
     ok: false,

--- a/src/auth-policy.ts
+++ b/src/auth-policy.ts
@@ -1,0 +1,286 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Authentication mode for an agent CLI child process.
+ *
+ * - `env` keeps the relevant API-key environment variables in the
+ *   child's environment, so the CLI uses the user's API key.
+ * - `oauth` strips those variables from the child's environment,
+ *   forcing the CLI to fall back to its stored login credentials.
+ */
+export type AuthMode = "env" | "oauth";
+
+export type CliKind = "claude" | "codex";
+
+export interface AuthPolicy {
+  claude?: AuthMode;
+  codex?: AuthMode;
+}
+
+/**
+ * Auth-bearing environment variables for each CLI.  When ANY of these
+ * is set in the parent shell, AgentCoop must prompt the user to choose
+ * between API-key mode and OAuth.  When `oauth` is selected, ALL of
+ * these are stripped from the spawned child's env.
+ */
+export const CLAUDE_AUTH_ENV_VARS = [
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+] as const;
+
+export const CODEX_AUTH_ENV_VARS = ["OPENAI_API_KEY", "CODEX_API_KEY"] as const;
+
+export function authEnvVarsFor(cli: CliKind): readonly string[] {
+  return cli === "claude" ? CLAUDE_AUTH_ENV_VARS : CODEX_AUTH_ENV_VARS;
+}
+
+/** Names of auth-bearing env vars that are present in `env`. */
+export function detectedAuthEnvVars(
+  cli: CliKind,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  return authEnvVarsFor(cli).filter((name) => {
+    const v = env[name];
+    return typeof v === "string" && v.length > 0;
+  });
+}
+
+/**
+ * Build the env object passed to a child process based on the auth
+ * policy for that CLI.  When `oauth`, copies `baseEnv` and removes the
+ * auth-bearing keys; otherwise returns a shallow copy of `baseEnv`.
+ *
+ * `baseEnv` is injectable so tests do not need to monkey-patch
+ * `process.env`.
+ */
+export function buildChildEnv(
+  cli: CliKind,
+  mode: AuthMode,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  if (mode === "oauth") {
+    for (const name of authEnvVarsFor(cli)) {
+      delete env[name];
+    }
+  }
+  return env;
+}
+
+export interface AuthPrompter {
+  /**
+   * Show an env-vs-oauth choice for the given CLI.
+   *
+   * The implementation must label the `env` option with whichever of
+   * the auth-bearing env vars are actually detected (so the user can
+   * see which keys are about to be passed through or stripped).
+   */
+  promptAuthMode(opts: {
+    cli: CliKind;
+    detectedEnvVars: readonly string[];
+    defaultMode: AuthMode;
+  }): Promise<AuthMode>;
+}
+
+export interface ResolveAuthPolicyInput {
+  /** CLIs that will actually be spawned this run (deduplicated). */
+  cliSet: readonly CliKind[];
+  /** Previously persisted policy, if any. */
+  savedPolicy?: AuthPolicy | undefined;
+  /** Source of env vars (defaults to `process.env`). */
+  env?: NodeJS.ProcessEnv;
+  /** Async prompter; only invoked when an auth-bearing env var is set. */
+  prompter: AuthPrompter;
+}
+
+export interface ResolvedAuthPolicy {
+  /** Effective per-CLI mode for the current run (always present per CLI in `cliSet`). */
+  effective: { claude?: AuthMode; codex?: AuthMode };
+  /**
+   * The merged policy to persist to `~/.agentcoop/config.json`.
+   *
+   * Preserves saved values for CLIs not in `cliSet` and only writes a
+   * subfield when the user actually answered a prompt.  When the
+   * prompt is skipped (no auth env vars present), the saved value for
+   * that CLI is left untouched — i.e. NOT overwritten with `oauth`.
+   */
+  toPersist: AuthPolicy | undefined;
+  /** True when `toPersist` differs from `savedPolicy`. */
+  changed: boolean;
+}
+
+/**
+ * Pure decision helper: derive the per-run auth policy from the saved
+ * config, the parent env, and a prompter.
+ *
+ * Behavior per CLI in `cliSet`:
+ * - If none of that CLI's auth-bearing env vars are set, force `oauth`
+ *   for the run and do NOT persist (so a saved value for the CLI is
+ *   preserved across runs).
+ * - Otherwise prompt with the saved choice (or `env`) preselected, and
+ *   persist the answer.
+ */
+export async function resolveAuthPolicyForRun(
+  input: ResolveAuthPolicyInput,
+): Promise<ResolvedAuthPolicy> {
+  const env = input.env ?? process.env;
+  const saved = input.savedPolicy ?? {};
+  const effective: { claude?: AuthMode; codex?: AuthMode } = {};
+  const persisted: AuthPolicy = { ...saved };
+  let changed = false;
+
+  for (const cli of input.cliSet) {
+    const detected = detectedAuthEnvVars(cli, env);
+    if (detected.length === 0) {
+      effective[cli] = "oauth";
+      continue;
+    }
+
+    const defaultMode: AuthMode = saved[cli] ?? "env";
+    const chosen = await input.prompter.promptAuthMode({
+      cli,
+      detectedEnvVars: detected,
+      defaultMode,
+    });
+
+    effective[cli] = chosen;
+    if (persisted[cli] !== chosen) {
+      persisted[cli] = chosen;
+      changed = true;
+    }
+  }
+
+  const hasAny =
+    persisted.claude !== undefined || persisted.codex !== undefined;
+  return {
+    effective,
+    toPersist: hasAny ? persisted : undefined,
+    changed,
+  };
+}
+
+export interface OAuthPrecheckResult {
+  ok: boolean;
+  /** When `ok` is false, a short explanation suitable for printing. */
+  reason?: string;
+}
+
+/**
+ * Verify that login credentials exist for `claude` on the current OS.
+ *
+ * Linux: file under `$CLAUDE_CONFIG_DIR/.credentials.json` or
+ *   `~/.claude/.credentials.json`.
+ * macOS: credentials live in the system Keychain — skip the check and
+ *   let the spawned `claude` process surface its own error if needed.
+ */
+export function precheckClaudeOAuth(
+  env: NodeJS.ProcessEnv = process.env,
+  os: NodeJS.Platform = platform(),
+): OAuthPrecheckResult {
+  if (os === "darwin") {
+    return { ok: true };
+  }
+  const dir = env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+  const credPath = join(dir, ".credentials.json");
+  if (existsSync(credPath)) return { ok: true };
+  return {
+    ok: false,
+    reason: `Claude OAuth credentials not found at ${credPath}. Please run \`claude login\` first, then re-launch agentcoop.`,
+  };
+}
+
+export type CodexProbeRunner = (env: NodeJS.ProcessEnv) => {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  error?: NodeJS.ErrnoException;
+};
+
+/**
+ * Default Codex login-status probe: invokes `codex login status` with
+ * the supplied env (caller is responsible for stripping auth env vars).
+ */
+export const defaultCodexProbe: CodexProbeRunner = (env) => {
+  const result = spawnSync("codex", ["login", "status"], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf-8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+    error: result.error as NodeJS.ErrnoException | undefined,
+  };
+};
+
+/**
+ * Verify that Codex has stored login credentials.
+ *
+ * The probe MUST run with `OPENAI_API_KEY` and `CODEX_API_KEY`
+ * stripped from the env, so a stale API key in the parent shell does
+ * not produce a false-positive "logged in" response.
+ *
+ * The probe is injectable for tests.
+ */
+export function precheckCodexOAuth(
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  probe: CodexProbeRunner = defaultCodexProbe,
+): OAuthPrecheckResult {
+  const env = buildChildEnv("codex", "oauth", baseEnv);
+  let res: ReturnType<CodexProbeRunner>;
+  try {
+    res = probe(env);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `Codex login-status probe failed: ${(err as Error).message}`,
+    };
+  }
+  if (res.error?.code === "ENOENT") {
+    return {
+      ok: false,
+      reason:
+        "codex CLI not found on PATH. Install Codex and run `codex login`.",
+    };
+  }
+  if (res.status === 0) {
+    const combined = `${res.stdout}\n${res.stderr}`.toLowerCase();
+    if (
+      combined.includes("not logged in") ||
+      combined.includes("not signed in") ||
+      combined.includes("no credentials")
+    ) {
+      return {
+        ok: false,
+        reason:
+          "Codex OAuth credentials not found. Please run `codex login` first, then re-launch agentcoop.",
+      };
+    }
+    return { ok: true };
+  }
+  return {
+    ok: false,
+    reason:
+      "Codex OAuth credentials not found. Please run `codex login` first, then re-launch agentcoop.",
+  };
+}
+
+export function runOAuthPrechecks(
+  effective: { claude?: AuthMode; codex?: AuthMode },
+  baseEnv: NodeJS.ProcessEnv = process.env,
+  os: NodeJS.Platform = platform(),
+  codexProbe: CodexProbeRunner = defaultCodexProbe,
+): OAuthPrecheckResult[] {
+  const results: OAuthPrecheckResult[] = [];
+  if (effective.claude === "oauth") {
+    results.push(precheckClaudeOAuth(baseEnv, os));
+  }
+  if (effective.codex === "oauth") {
+    results.push(precheckCodexOAuth(baseEnv, codexProbe));
+  }
+  return results;
+}

--- a/src/claude-adapter.ts
+++ b/src/claude-adapter.ts
@@ -6,6 +6,8 @@ import type {
   TokenUsage,
 } from "./agent.js";
 import { JsonlLineTransformer } from "./agent.js";
+import type { AuthMode } from "./auth-policy.js";
+import { buildChildEnv } from "./auth-policy.js";
 import { spawnAgent } from "./spawn-agent.js";
 
 // ---------------------------------------------------------------------------
@@ -204,6 +206,13 @@ export interface ClaudeAdapterOptions {
   effortLevel?: ClaudeEffortLevel;
   contextWindow?: string;
   inactivityTimeoutMs?: number;
+  /**
+   * Authentication mode for the spawned `claude` process.  When
+   * `oauth`, `ANTHROPIC_API_KEY` and `ANTHROPIC_AUTH_TOKEN` are
+   * stripped from the child's env so Claude Code uses its stored
+   * subscription credentials.  Defaults to `env`.
+   */
+  authMode?: AuthMode;
 }
 
 export function buildClaudeArgs(
@@ -290,6 +299,8 @@ export function createClaudeAdapter(
   const effortLevel = opts.effortLevel;
   const contextWindow = opts.contextWindow;
   const inactivityTimeoutMs = opts.inactivityTimeoutMs;
+  const authMode: AuthMode = opts.authMode ?? "env";
+  const env = buildChildEnv("claude", authMode);
 
   return {
     invoke(prompt, options?: InvokeOptions) {
@@ -307,6 +318,7 @@ export function createClaudeAdapter(
         chunkTransformer: transformer,
         inactivityTimeoutMs,
         stdin: prompt,
+        env,
       });
     },
     resume(sessionId, prompt, options?: InvokeOptions) {
@@ -320,6 +332,7 @@ export function createClaudeAdapter(
         chunkTransformer: transformer,
         inactivityTimeoutMs,
         stdin: prompt,
+        env,
       });
     },
   };

--- a/src/codex-adapter.ts
+++ b/src/codex-adapter.ts
@@ -7,6 +7,8 @@ import type {
   TokenUsage,
 } from "./agent.js";
 import { JsonlLineTransformer } from "./agent.js";
+import type { AuthMode } from "./auth-policy.js";
+import { buildChildEnv } from "./auth-policy.js";
 import { spawnAgent } from "./spawn-agent.js";
 
 // ---------------------------------------------------------------------------
@@ -499,6 +501,13 @@ export interface CodexAdapterOptions {
   model?: string;
   reasoningEffort?: CodexReasoningEffort;
   inactivityTimeoutMs?: number;
+  /**
+   * Authentication mode for the spawned `codex` process.  When
+   * `oauth`, `OPENAI_API_KEY` and `CODEX_API_KEY` are stripped from
+   * the child's env so Codex uses its stored login credentials.
+   * Defaults to `env`.
+   */
+  authMode?: AuthMode;
 }
 
 export function buildCodexInvokeArgs(opts: {
@@ -769,6 +778,8 @@ export function createCodexAdapter(
     opts.reasoningEffort ?? "high",
   );
   const inactivityTimeoutMs = opts.inactivityTimeoutMs;
+  const authMode: AuthMode = opts.authMode ?? "env";
+  const env = buildChildEnv("codex", authMode);
 
   return {
     invoke(prompt, options?: InvokeOptions) {
@@ -785,6 +796,7 @@ export function createCodexAdapter(
         chunkTransformer: makeTransformer(),
         inactivityTimeoutMs,
         stdin: prompt,
+        env,
       });
       if (reasoningEffort !== "xhigh") return stream;
       return withXhighFallback(stream, () =>
@@ -799,6 +811,7 @@ export function createCodexAdapter(
           chunkTransformer: makeTransformer(),
           inactivityTimeoutMs,
           stdin: prompt,
+          env,
         }),
       );
     },
@@ -824,6 +837,7 @@ export function createCodexAdapter(
           chunkTransformer: makeTransformer(),
           inactivityTimeoutMs,
           stdin: prompt,
+          env,
         });
       }
 
@@ -847,6 +861,7 @@ export function createCodexAdapter(
             ),
           inactivityTimeoutMs,
           stdin: prompt,
+          env,
         });
       }
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -14,8 +14,13 @@ vi.mock("node:os", () => ({
   homedir: () => tmpHome,
 }));
 
-const { configPath, loadConfig, patchVersionCheckState, saveConfig } =
-  await import("./config.js");
+const {
+  configPath,
+  loadConfig,
+  patchAuthPolicy,
+  patchVersionCheckState,
+  saveConfig,
+} = await import("./config.js");
 
 describe("configPath", () => {
   test("returns path under ~/.agentcoop/", () => {
@@ -868,6 +873,79 @@ describe("patchVersionCheckState", () => {
       lastKnownVersions: { claude: "1.3.0" },
     });
     expect(readFileSync(configPath(), "utf-8").endsWith("\n")).toBe(true);
+  });
+
+  test("authPolicy round-trips through saveConfig/loadConfig", () => {
+    const config = loadConfig();
+    config.authPolicy = { claude: "oauth", codex: "env" };
+    saveConfig(config);
+    const reloaded = loadConfig();
+    expect(reloaded.authPolicy).toEqual({ claude: "oauth", codex: "env" });
+  });
+
+  test("authPolicy with only one CLI subfield is preserved", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        authPolicy: { codex: "oauth" },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.authPolicy).toEqual({ codex: "oauth" });
+    expect(config.authPolicy?.claude).toBeUndefined();
+  });
+
+  test("authPolicy ignores unknown values", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        authPolicy: { claude: "garbage", codex: "oauth" },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.authPolicy).toEqual({ codex: "oauth" });
+  });
+
+  test("authPolicy returns undefined when both subfields invalid", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        authPolicy: { claude: 1, codex: null },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.authPolicy).toBeUndefined();
+  });
+
+  test("patchAuthPolicy merges per-CLI without clearing the other CLI's saved value", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: [],
+        authPolicy: { claude: "env", codex: "oauth" },
+      }),
+    );
+    patchAuthPolicy({ claude: "oauth" });
+    const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
+    // codex must survive when only claude was patched.
+    expect(raw.authPolicy).toEqual({ claude: "oauth", codex: "oauth" });
+  });
+
+  test("patchAuthPolicy preserves unknown top-level keys", () => {
+    writeFileSync(
+      configPath(),
+      JSON.stringify({
+        owners: ["aicers"],
+        unknownKey: { hello: "world" },
+      }),
+    );
+    patchAuthPolicy({ claude: "env" });
+    const raw = JSON.parse(readFileSync(configPath(), "utf-8"));
+    expect(raw.unknownKey).toEqual({ hello: "world" });
+    expect(raw.authPolicy).toEqual({ claude: "env" });
   });
 
   test("preserves unknown nested CLI entries inside lastKnownVersions", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import type { AuthPolicy } from "./auth-policy.js";
 
 export interface PipelineSettings {
   selfCheckAutoIterations: number;
@@ -66,6 +67,14 @@ export interface Config {
    * throttle network calls to roughly once per 24h.
    */
   lastVersionCheckAt?: number;
+  /**
+   * Per-CLI authentication mode.  `env` passes the relevant API-key
+   * env var through to the spawned CLI; `oauth` strips it so the CLI
+   * uses its stored login credentials.  Both subfields are optional;
+   * missing subfields preserve any previously saved value when the
+   * other CLI alone was prompted.
+   */
+  authPolicy?: AuthPolicy;
 }
 
 const DEFAULT_CONFIG: Config = {
@@ -128,6 +137,20 @@ function loadLastKnownVersions(
   const result: NonNullable<Config["lastKnownVersions"]> = {};
   if (typeof r.claude === "string") result.claude = r.claude;
   if (typeof r.codex === "string") result.codex = r.codex;
+  if (result.claude === undefined && result.codex === undefined) {
+    return undefined;
+  }
+  return result;
+}
+
+function loadAuthPolicy(raw: unknown): AuthPolicy | undefined {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return undefined;
+  }
+  const r = raw as Record<string, unknown>;
+  const result: AuthPolicy = {};
+  if (r.claude === "env" || r.claude === "oauth") result.claude = r.claude;
+  if (r.codex === "env" || r.codex === "oauth") result.codex = r.codex;
   if (result.claude === undefined && result.codex === undefined) {
     return undefined;
   }
@@ -241,6 +264,7 @@ export function loadConfig(): Config {
       Number.isFinite(raw.lastVersionCheckAt)
         ? raw.lastVersionCheckAt
         : undefined,
+    authPolicy: loadAuthPolicy(raw.authPolicy),
   };
 }
 
@@ -315,6 +339,47 @@ export function saveConfig(config: Config): void {
  * added.  This helper reads the raw JSON, merges the supplied fields,
  * and writes the file back, preserving unknown keys.
  */
+/**
+ * Patch only the auth-policy field in `~/.agentcoop/config.json`
+ * without round-tripping through the normalized `Config` shape.
+ *
+ * Mirrors {@link patchVersionCheckState}: writing through `saveConfig`
+ * would drop unknown top-level keys.  This helper merges the supplied
+ * subfields into the existing nested object, so a session that only
+ * answered the prompt for one CLI does NOT clear the saved value for
+ * the other.
+ */
+export function patchAuthPolicy(updates: AuthPolicy): void {
+  const path = configPath();
+  let raw: Record<string, unknown> = {};
+  if (existsSync(path)) {
+    try {
+      const parsed = JSON.parse(readFileSync(path, "utf-8"));
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        !Array.isArray(parsed)
+      ) {
+        raw = parsed as Record<string, unknown>;
+      }
+    } catch {
+      // Unreadable or invalid JSON — fall through and write a fresh file.
+    }
+  }
+  const existing =
+    typeof raw.authPolicy === "object" &&
+    raw.authPolicy !== null &&
+    !Array.isArray(raw.authPolicy)
+      ? (raw.authPolicy as Record<string, unknown>)
+      : {};
+  const merged: Record<string, unknown> = { ...existing };
+  if (updates.claude !== undefined) merged.claude = updates.claude;
+  if (updates.codex !== undefined) merged.codex = updates.codex;
+  raw.authPolicy = merged;
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(raw, null, 2)}\n`);
+}
+
 export function patchVersionCheckState(updates: {
   lastKnownVersions?: NonNullable<Config["lastKnownVersions"]>;
   lastVersionCheckAt?: number;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -51,6 +51,17 @@ export const en: Messages = {
   "startup.squashApplyPolicyPrompt":
     "When a single-commit squash is suggested, apply it automatically " +
     "via the agent? (No = ask each time)",
+  "auth.promptClaude": "Claude authentication for this run:",
+  "auth.promptCodex": "Codex authentication for this run:",
+  "auth.optionEnvClaude": (envVarsList) =>
+    `Use credentials from environment (${envVarsList})`,
+  "auth.optionEnvCodex": (envVarsList) =>
+    `Use credentials from environment (${envVarsList})`,
+  "auth.optionOauthClaude": "Use logged-in subscription (claude login)",
+  "auth.optionOauthCodex": "Use logged-in subscription (codex login)",
+  "auth.precheckFailed": (detail) => detail,
+  "auth.badgeApi": "API",
+  "auth.badgeOauth": "OAuth",
 
   // ---- custom model entry --------------------------------------------------
 

--- a/src/i18n/ko.ts
+++ b/src/i18n/ko.ts
@@ -67,6 +67,17 @@ export const ko: Messages = {
   "startup.squashApplyPolicyPrompt":
     "단일 커밋 스쿼시가 제안될 때, 에이전트가 자동으로 적용할까요? " +
     "(아니오 = 매번 묻기)",
+  "auth.promptClaude": "이번 실행의 Claude 인증 방식:",
+  "auth.promptCodex": "이번 실행의 Codex 인증 방식:",
+  "auth.optionEnvClaude": (envVarsList) =>
+    `환경 변수의 자격 증명 사용 (${envVarsList})`,
+  "auth.optionEnvCodex": (envVarsList) =>
+    `환경 변수의 자격 증명 사용 (${envVarsList})`,
+  "auth.optionOauthClaude": "로그인된 구독 사용 (claude login)",
+  "auth.optionOauthCodex": "로그인된 구독 사용 (codex login)",
+  "auth.precheckFailed": (detail) => detail,
+  "auth.badgeApi": "API",
+  "auth.badgeOauth": "OAuth",
 
   // ---- custom model entry --------------------------------------------------
 

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -52,6 +52,15 @@ export interface Messages {
   "startup.proceedWithIssue": string;
   "startup.issueNotConfirmed": string;
   "startup.squashApplyPolicyPrompt": string;
+  "auth.promptClaude": string;
+  "auth.promptCodex": string;
+  "auth.optionEnvClaude": (envVarsList: string) => string;
+  "auth.optionEnvCodex": (envVarsList: string) => string;
+  "auth.optionOauthClaude": string;
+  "auth.optionOauthCodex": string;
+  "auth.precheckFailed": (detail: string) => string;
+  "auth.badgeApi": string;
+  "auth.badgeOauth": string;
 
   // ---- custom model entry (startup.ts) -------------------------------------
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@
 import { confirm, input, select } from "@inquirer/prompts";
 
 import type { AgentAdapter, AgentStream } from "./agent.js";
+import type { AuthMode, AuthPrompter, CliKind } from "./auth-policy.js";
+import { resolveAuthPolicyForRun, runOAuthPrechecks } from "./auth-policy.js";
 import { type BootstrapLog, createBootstrapLog } from "./bootstrap-log.js";
 import { pollCiAndFix } from "./ci-poll.js";
 import { createClaudeAdapter } from "./claude-adapter.js";
@@ -24,6 +26,7 @@ import {
   assembleReviewStage,
   assembleSquashStage,
   loadConfig,
+  patchAuthPolicy,
   patchVersionCheckState,
 } from "./config.js";
 import {
@@ -129,6 +132,7 @@ interface RunParams {
 function createAdapter(
   agentConfig: AgentConfig,
   inactivityTimeoutMs?: number,
+  authMode?: AuthMode,
 ): AgentAdapter {
   if (agentConfig.cli === "claude") {
     return createClaudeAdapter({
@@ -142,6 +146,7 @@ function createAdapter(
         | undefined,
       contextWindow: agentConfig.contextWindow,
       inactivityTimeoutMs,
+      authMode,
     });
   }
   return createCodexAdapter({
@@ -153,6 +158,7 @@ function createAdapter(
       | "xhigh"
       | undefined,
     inactivityTimeoutMs,
+    authMode,
   });
 }
 
@@ -458,6 +464,64 @@ try {
   // semantics of "not persisted" and the default-true rationale.
   params.squashApplyPolicy = await promptSquashApplyPolicy();
 
+  // Resolve the per-CLI auth policy at the same shared join point.
+  // The choice is surfaced on every launch (fresh + resume) so the
+  // user can see — and override — which credentials each agent CLI
+  // will use this run.  See issue #320.
+  const authMessages = t();
+  const authPrompter: AuthPrompter = {
+    promptAuthMode: async ({ cli, detectedEnvVars, defaultMode }) => {
+      const envVarsList = detectedEnvVars.map((n) => `$${n}`).join(", ");
+      const message =
+        cli === "claude"
+          ? authMessages["auth.promptClaude"]
+          : authMessages["auth.promptCodex"];
+      const envLabel =
+        cli === "claude"
+          ? authMessages["auth.optionEnvClaude"](envVarsList)
+          : authMessages["auth.optionEnvCodex"](envVarsList);
+      const oauthLabel =
+        cli === "claude"
+          ? authMessages["auth.optionOauthClaude"]
+          : authMessages["auth.optionOauthCodex"];
+      return select<AuthMode>({
+        message,
+        choices: [
+          { name: envLabel, value: "env" as const },
+          { name: oauthLabel, value: "oauth" as const },
+        ],
+        default: defaultMode,
+      });
+    },
+  };
+  const authPolicyConfig = loadConfig();
+  const cliSet: CliKind[] = [];
+  for (const c of [params.agentAConfig.cli, params.agentBConfig.cli]) {
+    if (!cliSet.includes(c)) cliSet.push(c);
+  }
+  const resolvedAuth = await resolveAuthPolicyForRun({
+    cliSet,
+    savedPolicy: authPolicyConfig.authPolicy,
+    prompter: authPrompter,
+  });
+  if (resolvedAuth.changed && resolvedAuth.toPersist !== undefined) {
+    patchAuthPolicy(resolvedAuth.toPersist);
+  }
+  // Verify OAuth credentials before continuing so a missing login is
+  // surfaced up-front rather than as a cryptic CLI failure mid-run.
+  for (const result of runOAuthPrechecks(resolvedAuth.effective)) {
+    if (!result.ok) {
+      console.error(
+        authMessages["auth.precheckFailed"](result.reason ?? "unknown"),
+      );
+      process.exit(1);
+    }
+  }
+  const authModeA: AuthMode =
+    resolvedAuth.effective[params.agentAConfig.cli] ?? "oauth";
+  const authModeB: AuthMode =
+    resolvedAuth.effective[params.agentBConfig.cli] ?? "oauth";
+
   // Check CLI versions against the appropriate distribution channel
   // and prompt the user to update when a newer version is available.
   // Runs after the CLIs actually used this run are known (fresh /
@@ -618,11 +682,11 @@ try {
   const inactivityTimeoutMs =
     pipelineSettings.inactivityTimeoutMinutes * 60_000;
   const agentA = trackProcesses(
-    createAdapter(agentAConfig, inactivityTimeoutMs),
+    createAdapter(agentAConfig, inactivityTimeoutMs, authModeA),
     activeStreams,
   );
   const agentB = trackProcesses(
-    createAdapter(agentBConfig, inactivityTimeoutMs),
+    createAdapter(agentBConfig, inactivityTimeoutMs, authModeB),
     activeStreams,
   );
 
@@ -1082,6 +1146,8 @@ try {
       cliTypeB: agentBConfig.cli,
       cliVersionA: agentAVersion,
       cliVersionB: agentBVersion,
+      authModeA,
+      authModeB,
       notifications,
       initialSelfCheckCount: runState.selfCheckCount,
       initialReviewCount: runState.reviewCount,

--- a/src/spawn-agent.test.ts
+++ b/src/spawn-agent.test.ts
@@ -943,6 +943,166 @@ describe("inactivityTimeoutMs", () => {
 });
 
 // ---------------------------------------------------------------------------
+// env threading
+// ---------------------------------------------------------------------------
+describe("spawnAgent env option", () => {
+  test("forwards env to spawn() when provided", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+      env: { FOO: "bar", PATH: "/usr/bin" },
+    });
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(opts.env).toEqual({ FOO: "bar", PATH: "/usr/bin" });
+  });
+
+  test("omits env from spawn() options when not provided (preserves default behavior)", () => {
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    spawnAgent({
+      command: "cmd",
+      args: [],
+      parseResult: () => ({
+        sessionId: undefined,
+        responseText: "",
+        status: "success",
+        errorType: undefined,
+        stderrText: "",
+      }),
+    });
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as Record<string, unknown>;
+    expect("env" in opts).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// adapter env threading (auth-policy)
+// ---------------------------------------------------------------------------
+describe("adapter env threading", () => {
+  const origAnthropicKey = process.env.ANTHROPIC_API_KEY;
+  const origAnthropicTok = process.env.ANTHROPIC_AUTH_TOKEN;
+  const origOpenaiKey = process.env.OPENAI_API_KEY;
+  const origCodexKey = process.env.CODEX_API_KEY;
+
+  afterEach(() => {
+    if (origAnthropicKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+    else process.env.ANTHROPIC_API_KEY = origAnthropicKey;
+    if (origAnthropicTok === undefined) delete process.env.ANTHROPIC_AUTH_TOKEN;
+    else process.env.ANTHROPIC_AUTH_TOKEN = origAnthropicTok;
+    if (origOpenaiKey === undefined) delete process.env.OPENAI_API_KEY;
+    else process.env.OPENAI_API_KEY = origOpenaiKey;
+    if (origCodexKey === undefined) delete process.env.CODEX_API_KEY;
+    else process.env.CODEX_API_KEY = origCodexKey;
+  });
+
+  test("Claude adapter in oauth mode strips ANTHROPIC_API_KEY and ANTHROPIC_AUTH_TOKEN", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-stale";
+    process.env.ANTHROPIC_AUTH_TOKEN = "tok-stale";
+    process.env.OPENAI_API_KEY = "sk-keep";
+
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter({ authMode: "oauth" });
+    adapter.invoke("hello");
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(opts.env).toBeDefined();
+    expect(opts.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(opts.env?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+    expect(opts.env?.OPENAI_API_KEY).toBe("sk-keep");
+  });
+
+  test("Claude adapter in env mode preserves API key", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-keep";
+
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter({ authMode: "env" });
+    adapter.invoke("hello");
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(opts.env?.ANTHROPIC_API_KEY).toBe("sk-ant-keep");
+  });
+
+  test("Claude adapter resume in oauth mode strips both Anthropic vars", () => {
+    process.env.ANTHROPIC_API_KEY = "sk-ant-stale";
+    process.env.ANTHROPIC_AUTH_TOKEN = "tok-stale";
+
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createClaudeAdapter({ authMode: "oauth" });
+    adapter.resume("sess", "continue");
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(opts.env?.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(opts.env?.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
+  });
+
+  test("Codex adapter in oauth mode strips OPENAI_API_KEY and CODEX_API_KEY", () => {
+    process.env.OPENAI_API_KEY = "sk-stale";
+    process.env.CODEX_API_KEY = "ck-stale";
+    process.env.ANTHROPIC_API_KEY = "sk-ant-keep";
+
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ authMode: "oauth" });
+    adapter.invoke("hello");
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(opts.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(opts.env?.CODEX_API_KEY).toBeUndefined();
+    expect(opts.env?.ANTHROPIC_API_KEY).toBe("sk-ant-keep");
+  });
+
+  test("Codex adapter resume in oauth mode strips both Codex vars", () => {
+    process.env.OPENAI_API_KEY = "sk-stale";
+    process.env.CODEX_API_KEY = "ck-stale";
+
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ authMode: "oauth" });
+    adapter.resume("sess", "continue");
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(opts.env?.OPENAI_API_KEY).toBeUndefined();
+    expect(opts.env?.CODEX_API_KEY).toBeUndefined();
+  });
+
+  test("Codex adapter in env mode preserves API keys", () => {
+    process.env.OPENAI_API_KEY = "sk-keep";
+    process.env.CODEX_API_KEY = "ck-keep";
+
+    const child = createMockChild();
+    mockSpawn.mockReturnValue(child);
+
+    const adapter = createCodexAdapter({ authMode: "env" });
+    adapter.invoke("hello");
+
+    const opts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+    expect(opts.env?.OPENAI_API_KEY).toBe("sk-keep");
+    expect(opts.env?.CODEX_API_KEY).toBe("ck-keep");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // E2E: Claude adapter full flow
 // ---------------------------------------------------------------------------
 describe("Claude adapter invoke/resume (E2E with mock spawn)", () => {

--- a/src/spawn-agent.ts
+++ b/src/spawn-agent.ts
@@ -29,6 +29,13 @@ export interface SpawnAgentOptions<TResult extends AgentResult = AgentResult> {
    * line where they can hit the OS `ARG_MAX` limit.
    */
   stdin?: string;
+  /**
+   * Environment variables for the child process.  Defaults to
+   * `process.env` (Node's default behavior).  Caller-supplied envs are
+   * passed through verbatim — see `buildChildEnv()` in `auth-policy.ts`
+   * for the policy that strips API-key vars when OAuth mode is active.
+   */
+  env?: NodeJS.ProcessEnv;
 }
 
 export function spawnAgent<TResult extends AgentResult = AgentResult>(
@@ -39,6 +46,7 @@ export function spawnAgent<TResult extends AgentResult = AgentResult>(
     child = spawn(opts.command, opts.args, {
       cwd: opts.cwd,
       stdio: ["pipe", "pipe", "pipe"],
+      ...(opts.env !== undefined ? { env: opts.env } : {}),
     });
   } catch (err) {
     // spawn() can throw synchronously for errors like E2BIG (argument

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -1,5 +1,6 @@
 import { Box, useInput, useStdout } from "ink";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { AuthMode } from "../auth-policy.js";
 import type { BootstrapLogEntry } from "../bootstrap-log.js";
 import type { NotificationSettings } from "../config.js";
 import { t } from "../i18n/index.js";
@@ -294,6 +295,10 @@ export interface AppProps {
   cliVersionA?: string;
   /** Installed CLI version for Agent B, detected at pipeline start. */
   cliVersionB?: string;
+  /** Authentication mode for Agent A (env = API key, oauth = subscription). */
+  authModeA?: AuthMode;
+  /** Authentication mode for Agent B (env = API key, oauth = subscription). */
+  authModeB?: AuthMode;
   /** Notification settings (bell / desktop). */
   notifications?: NotificationSettings;
   /**
@@ -334,6 +339,8 @@ export function App({
   cliTypeB,
   cliVersionA,
   cliVersionB,
+  authModeA,
+  authModeB,
   notifications,
   onCancel,
   startedAt,
@@ -357,6 +364,11 @@ export function App({
     "row",
   );
   const [hasTokenData, setHasTokenData] = useState(false);
+  // The TokenBar should render the auth badge from session start, even
+  // before any token usage has been reported.  Treat the presence of
+  // either auth mode as content for the visibility flag computation.
+  const hasTokenBarContent =
+    hasTokenData || authModeA !== undefined || authModeB !== undefined;
   const [prNumber, setPrNumber] = useState<number | undefined>(initialPrNumber);
 
   useEffect(() => {
@@ -425,7 +437,7 @@ export function App({
     return computeVisibilityFlags(
       terminalHeight,
       inputHeight,
-      hasTokenData,
+      hasTokenBarContent,
       preferredLayout,
       {
         terminalWidth: layoutWidth,
@@ -435,7 +447,7 @@ export function App({
   }, [
     terminalHeight,
     inputHeight,
-    hasTokenData,
+    hasTokenBarContent,
     preferredLayout,
     layoutWidth,
     paneHeaderTexts,
@@ -591,6 +603,8 @@ export function App({
         layout={effectiveLayout}
         cliTypeA={cliTypeA}
         cliTypeB={cliTypeB}
+        authModeA={authModeA}
+        authModeB={authModeB}
       />
       <StatusBar
         emitter={emitter}

--- a/src/ui/TokenBar.tsx
+++ b/src/ui/TokenBar.tsx
@@ -1,6 +1,7 @@
 import { Box, Text } from "ink";
 import { useEffect, useState } from "react";
 import type { TokenUsage } from "../agent.js";
+import type { AuthMode } from "../auth-policy.js";
 import { t } from "../i18n/index.js";
 import type {
   AgentUsageEvent,
@@ -55,6 +56,10 @@ interface TokenBarProps {
   cliTypeA?: string;
   /** CLI identifier for Agent B (e.g. "claude" or "codex"). */
   cliTypeB?: string;
+  /** Authentication mode for Agent A (env = API key, oauth = subscription). */
+  authModeA?: AuthMode;
+  /** Authentication mode for Agent B (env = API key, oauth = subscription). */
+  authModeB?: AuthMode;
 }
 
 export function TokenBar({
@@ -64,6 +69,8 @@ export function TokenBar({
   layout = "row",
   cliTypeA,
   cliTypeB,
+  authModeA,
+  authModeB,
 }: TokenBarProps) {
   const [usageA, setUsageA] = useState<TokenUsage>({
     inputTokens: 0,
@@ -100,8 +107,9 @@ export function TokenBar({
     usageB.inputTokens > 0 ||
     usageB.outputTokens > 0 ||
     usageB.cachedInputTokens > 0;
+  const hasBadge = authModeA !== undefined || authModeB !== undefined;
 
-  if (!visible || !hasData) return null;
+  if (!visible || (!hasData && !hasBadge)) return null;
 
   const labelA = cliTypeA
     ? `${m["agent.labelShortA"]} (${cliDisplayName(cliTypeA)})`
@@ -126,16 +134,45 @@ export function TokenBar({
     );
   }
 
-  const textA = formatUsage(labelA, usageA);
-  const textB = formatUsage(labelB, usageB);
+  function usageHasData(usage: TokenUsage): boolean {
+    return (
+      usage.inputTokens > 0 ||
+      usage.outputTokens > 0 ||
+      usage.cachedInputTokens > 0
+    );
+  }
+
+  const textA = usageHasData(usageA)
+    ? formatUsage(labelA, usageA)
+    : `${labelA}:`;
+  const textB = usageHasData(usageB)
+    ? formatUsage(labelB, usageB)
+    : `${labelB}:`;
+
+  // The badge is rendered in a separate <Text> so it can keep its own
+  // color independent of the rest of the line.
+  const reservedForBadge =
+    contentWidth !== undefined
+      ? Math.max(
+          0,
+          Math.max(
+            authModeA ? authBadgeWidth(authModeA) : 0,
+            authModeB ? authBadgeWidth(authModeB) : 0,
+          ),
+        )
+      : 0;
+  const usageContentWidth =
+    contentWidth !== undefined
+      ? Math.max(1, contentWidth - reservedForBadge)
+      : undefined;
 
   const displayA =
-    contentWidth !== undefined
-      ? truncateWithEllipsis(textA, contentWidth)
+    usageContentWidth !== undefined
+      ? truncateWithEllipsis(textA, usageContentWidth)
       : textA;
   const displayB =
-    contentWidth !== undefined
-      ? truncateWithEllipsis(textB, contentWidth)
+    usageContentWidth !== undefined
+      ? truncateWithEllipsis(textB, usageContentWidth)
       : textB;
 
   const boxHeight = contentWidth !== undefined ? 3 : undefined;
@@ -153,7 +190,11 @@ export function TokenBar({
         height={boxHeight}
         overflow="hidden"
       >
-        <Text>{displayA}</Text>
+        <Text>
+          {displayA}
+          {authModeA ? " " : ""}
+          {authModeA ? renderBadge(authModeA) : null}
+        </Text>
       </Box>
       <Box
         {...mainAxisSizing}
@@ -163,8 +204,34 @@ export function TokenBar({
         height={boxHeight}
         overflow="hidden"
       >
-        <Text>{displayB}</Text>
+        <Text>
+          {displayB}
+          {authModeB ? " " : ""}
+          {authModeB ? renderBadge(authModeB) : null}
+        </Text>
       </Box>
     </Box>
+  );
+}
+
+/**
+ * Render the auth-mode badge.  `[API]` is yellow to flag the
+ * billed-by-token mode; `[OAuth]` is green to flag the subscription
+ * mode.  The badge is wrapped in a nested `<Text>` so it inherits the
+ * outer line layout while keeping its own color.
+ */
+function renderBadge(mode: AuthMode) {
+  const m = t();
+  if (mode === "env") {
+    return <Text color="yellow">{`[${m["auth.badgeApi"]}]`}</Text>;
+  }
+  return <Text color="green">{`[${m["auth.badgeOauth"]}]`}</Text>;
+}
+
+export function authBadgeWidth(mode: AuthMode): number {
+  const m = t();
+  // Brackets + label + leading space.
+  return (
+    (mode === "env" ? m["auth.badgeApi"] : m["auth.badgeOauth"]).length + 3
   );
 }

--- a/src/ui/components.test.tsx
+++ b/src/ui/components.test.tsx
@@ -2534,6 +2534,41 @@ describe("TokenBar", () => {
     expect(frame).toContain("Agent A (author)");
     expect(frame).toContain("5.0K in");
   });
+
+  test("renders auth badge from session start, before any usage data", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} authModeA="env" authModeB="oauth" />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[API]");
+    expect(frame).toContain("[OAuth]");
+  });
+
+  test("auth badge stays visible after usage events arrive", async () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(
+      <TokenBar emitter={emitter} authModeA="env" authModeB="oauth" />,
+    );
+    emitter.emit("agent:usage", {
+      agent: "a",
+      usage: { inputTokens: 1000, outputTokens: 500, cachedInputTokens: 0 },
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("[API]");
+    expect(frame).toContain("[OAuth]");
+    expect(frame).toContain("1.0K in");
+  });
+
+  test("renders nothing when neither auth badge nor usage data is present", () => {
+    const emitter = new PipelineEventEmitter();
+    const { lastFrame } = render(<TokenBar emitter={emitter} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).not.toContain("[API]");
+    expect(frame).not.toContain("[OAuth]");
+    expect(frame).not.toContain("Agent A");
+  });
 });
 
 describe("TokenBar width adaptation", () => {


### PR DESCRIPTION
## Summary

- Prompt on every launch to choose between the child CLI's API-key environment variable and its stored OAuth login, separately for Claude and Codex. The prompt fires only when an auth-bearing env var is actually detected (`ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` for Claude, `OPENAI_API_KEY` / `CODEX_API_KEY` for Codex), shows the previously saved choice preselected, and persists the answer under `authPolicy` in `~/.agentcoop/config.json` (per-CLI fields are independent — answering for one CLI does not overwrite a saved value for the other).
- Strip the appropriate API-key env vars from the spawned child's env when OAuth is selected, via a shared `buildChildEnv()` helper used by both adapters and the Codex pre-check probe. Pre-check OAuth credentials before continuing: filesystem check on Linux for Claude (skipped on macOS, where credentials live in the Keychain), and a `codex login status` probe for Codex — invoked with `OPENAI_API_KEY`/`CODEX_API_KEY` stripped so a stale parent env cannot produce a false positive. When the Codex probe is unavailable/unsupported (e.g. a build that lacks the `login status` subcommand), fall back to a file check at `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) so we do not abort on Codex builds that have stored credentials but lack the probe.
- Plumb the resolved per-run auth mode through `createAdapter()` and into the Claude/Codex adapters; surface it in the TUI as a coloured `[API]` (yellow) / `[OAuth]` (green) badge on each agent's TokenBar line. The TokenBar now renders the badge from session start, before any token usage has been recorded. The persisted `SavedAgentConfig` is unchanged; the per-run `authMode` is runtime-only state.
- Decision logic lives in a pure `resolveAuthPolicyForRun({ savedPolicy, env, cliSet, prompter })` helper that is unit-testable with injected env / saved-config / prompter, called from the shared join point that both the fresh-startup and resume paths converge on.

Closes #320

## Test plan

- [x] \`~/.agentcoop/config.json\` round-trips the new \`authPolicy\` field; a session that only prompts for one CLI does not overwrite a previously saved value for the other CLI.
- [x] The auth-mode prompt runs on both fresh-startup and resume paths after \`params\` is finalized, and asks once per unique CLI (not once per agent slot).
- [x] Prompt wording is CLI-specific and reflects the actually-detected env vars (Claude labels mention \`\$ANTHROPIC_API_KEY\` and/or \`\$ANTHROPIC_AUTH_TOKEN\`; Codex labels mention \`\$OPENAI_API_KEY\` and/or \`\$CODEX_API_KEY\`).
- [x] The Claude prompt is triggered when **either** \`ANTHROPIC_API_KEY\` or \`ANTHROPIC_AUTH_TOKEN\` is set; Codex prompt is triggered when **either** \`OPENAI_API_KEY\` or \`CODEX_API_KEY\` is set.
- [x] Running with no auth-bearing env var set for a given CLI does not show the prompt for that CLI.
- [x] On Linux, selecting \`oauth\` for Claude when \`~/.claude/.credentials.json\` (or \`\$CLAUDE_CONFIG_DIR/.credentials.json\`) is missing aborts with a clear instruction.
- [x] On macOS, selecting \`oauth\` for Claude proceeds without a filesystem pre-check.
- [x] Selecting \`oauth\` for Codex on either OS uses the \`codex login status\` probe to detect missing credentials and aborts with a clear instruction when not logged in.
- [x] When the Codex probe is unavailable/unsupported (subcommand not recognized, usage-style help output), the pre-check falls back to a file check at \`\$CODEX_HOME/auth.json\` (default \`~/.codex/auth.json\`) and only aborts when the file is also missing.
- [x] The Codex login-status probe is invoked with \`OPENAI_API_KEY\` and \`CODEX_API_KEY\` stripped from the child env, so a stale API key in the parent shell cannot cause a false-positive pre-check.
- [x] When \`oauth\` is active for Claude, the spawned child does not see \`ANTHROPIC_API_KEY\` or \`ANTHROPIC_AUTH_TOKEN\`. When \`oauth\` is active for Codex, the spawned child does not see \`OPENAI_API_KEY\` or \`CODEX_API_KEY\`. Verified via unit tests that mock \`spawn\` and inspect the \`env\` argument.
- [x] The \`[API]\` / \`[OAuth]\` badge is visible in the TUI from the moment the session starts, before any token usage has been recorded.
- [x] \`pnpm vitest run\`, \`pnpm tsc --noEmit\`, and \`pnpm biome check\` all pass.