### PR TITLE
Extract issue header builder and add long-issue guard (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,18 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- The fresh-form issue header (`## Issue #N: <title>` + blank + body)
+  is now produced by a single `buildIssueHeader` helper in
+  `src/stage-util.ts` and shared across all 11 fresh-form prompt
+  builders (implement, testplan, selfcheck, review/author-fix/PR
+  finalization, ci-fix/ci-findings, createpr, squash, issue-sync).
+  The helper also adds a long-issue guard: when an issue body
+  exceeds `ISSUE_BODY_INLINE_LIMIT` (~4 KB) it replaces the inlined
+  body with a short instruction telling the agent to fetch the body
+  itself via `gh issue view <N> --repo <owner>/<repo> --json body
+  --jq .body`, so unusually long issue bodies (e.g. tens of KB of
+  pasted logs) no longer bloat every fresh-form prompt. Behavior is
+  unchanged for issues under the threshold. Closes #318.
 - CI fix, findings-review, and dismiss-alerts prompts no longer inline
   raw `gh run view --log-failed` output, serialised annotation lists,
   or code scanning alert payloads.  The pipeline now emits a small,

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -63,7 +63,12 @@ is available:
   `Branch` rule below), and stage instructions. Sent on the very
   first stage entry (cold start) and as a fallback when the resume
   helper has to fall back to a fresh `invoke` because the saved
-  session expired.
+  session expired. The shared `buildIssueHeader` helper inlines the
+  issue body verbatim up to a conservative size limit
+  (`ISSUE_BODY_INLINE_LIMIT`, ~4 KB); past that, it emits a short
+  delegation block that asks the agent to fetch the body itself
+  via `gh issue view <N> --json body --jq .body`, so an unusually
+  long issue body never bloats every fresh-form prompt.
 - **Resume form** — drops the issue body and any repo header,
   keeping only stage-specific instructions and a one-line
   `issue #N` reference. Sent whenever a saved session id is

--- a/src/issue-sync.ts
+++ b/src/issue-sync.ts
@@ -13,6 +13,7 @@
 
 import { t } from "./i18n/index.js";
 import type { StageContext } from "./pipeline.js";
+import { buildIssueHeader } from "./stage-util.js";
 
 // ---- public types --------------------------------------------------------
 
@@ -39,9 +40,7 @@ export function buildIssueSyncPrompt(
     `You have completed the self-check.  Now compare the actual`,
     `implementation against the original issue description below.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-cicheck.ts
+++ b/src/stage-cicheck.ts
@@ -32,6 +32,7 @@ import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   buildDocConsistencyInstructions,
+  buildIssueHeader,
   invokeOrResume,
   mapAgentError,
 } from "./stage-util.js";
@@ -251,9 +252,7 @@ export function buildCiFixPrompt(
   const lines = [
     `You are fixing CI failures for the following GitHub issue.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## CI Inspection Context`,
     ``,
@@ -330,9 +329,7 @@ export function buildCiFindingsPrompt(
     `CI passed but check runs reported annotations.  Inspect them`,
     `yourself and decide whether any should be addressed.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## CI Inspection Context`,
     ``,

--- a/src/stage-createpr.ts
+++ b/src/stage-createpr.ts
@@ -25,6 +25,7 @@ import { t } from "./i18n/index.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import { findPrNumber as defaultFindPrNumber } from "./pr.js";
 import {
+  buildIssueHeader,
   invokeOrResume,
   mapAgentError,
   mapResponseToResult,
@@ -52,9 +53,7 @@ export function buildCreatePrPrompt(
   const lines = [
     `You are creating a pull request for the following GitHub issue.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-implement.ts
+++ b/src/stage-implement.ts
@@ -12,6 +12,7 @@ import type { AgentAdapter } from "./agent.js";
 import { t } from "./i18n/index.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  buildIssueHeader,
   invokeOrResume,
   mapAgentError,
   mapResponseToResult,
@@ -38,9 +39,7 @@ export function buildImplementPrompt(
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-review.ts
+++ b/src/stage-review.ts
@@ -43,6 +43,7 @@ import {
 import type { ReviewSubStep } from "./run-state.js";
 import {
   buildDocConsistencyInstructions,
+  buildIssueHeader,
   drainToSink,
   invokeOrResume,
   mapAgentError,
@@ -184,9 +185,7 @@ export function buildReviewPrompt(
   const lines = [
     `You are reviewing a pull request for the following GitHub issue.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,
@@ -329,9 +328,7 @@ export function buildAuthorFixPrompt(
   const lines = [
     `You are addressing review feedback for the following GitHub issue.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,
@@ -462,9 +459,7 @@ export function buildPrFinalizationPrompt(
     `merging, verify that the PR body accurately reflects the final`,
     `state of the implementation.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-selfcheck.ts
+++ b/src/stage-selfcheck.ts
@@ -25,6 +25,7 @@ import {
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
   buildDocConsistencyInstructions,
+  buildIssueHeader,
   invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
@@ -61,9 +62,7 @@ export function buildSelfCheckPrompt(
     `- Repo: ${ctx.repo}`,
     `- Branch: ${ctx.branch}`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Self-check`,
     ``,

--- a/src/stage-squash.ts
+++ b/src/stage-squash.ts
@@ -41,6 +41,7 @@ import {
 } from "./pr-comments.js";
 import type { SquashSubStep } from "./run-state.js";
 import {
+  buildIssueHeader,
   invokeOrResume,
   mapAgentError,
   sendFollowUp,
@@ -191,9 +192,7 @@ export function buildSquashPrompt(
   const lines = [
     `You are squashing commits for the following GitHub issue.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-testplan.ts
+++ b/src/stage-testplan.ts
@@ -18,6 +18,7 @@ import { t } from "./i18n/index.js";
 import { buildPrSyncInstructions } from "./issue-sync.js";
 import type { StageContext, StageDefinition, StageResult } from "./pipeline.js";
 import {
+  buildIssueHeader,
   invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
@@ -39,9 +40,7 @@ export function buildTestPlanVerifyPrompt(
   const lines = [
     `You are verifying the test plan for the following GitHub issue.`,
     ``,
-    `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`,
-    ``,
-    opts.issueBody,
+    ...buildIssueHeader(ctx, opts),
     ``,
     `## Instructions`,
     ``,

--- a/src/stage-util.test.ts
+++ b/src/stage-util.test.ts
@@ -3,6 +3,8 @@ import type { AgentAdapter, AgentResult, AgentStream } from "./agent.js";
 import { PipelineEventEmitter } from "./pipeline-events.js";
 import {
   buildDocConsistencyInstructions,
+  buildIssueHeader,
+  ISSUE_BODY_INLINE_LIMIT,
   invokeOrResume,
   mapAgentError,
   mapFixOrDoneResponse,
@@ -1510,5 +1512,58 @@ describe("buildDocConsistencyInstructions", () => {
   test("indent parameter preserves blank line between paragraphs", () => {
     const indented = buildDocConsistencyInstructions("   ");
     expect(indented).toContain("\n\n");
+  });
+});
+
+describe("buildIssueHeader", () => {
+  const ctx = { owner: "octo", repo: "demo", issueNumber: 42 };
+
+  test("inlines the body when under the threshold", () => {
+    const lines = buildIssueHeader(ctx, {
+      issueTitle: "Fix widget rendering",
+      issueBody: "The widget renders incorrectly when X happens.",
+    });
+    expect(lines).toEqual([
+      "## Issue #42: Fix widget rendering",
+      "",
+      "The widget renders incorrectly when X happens.",
+    ]);
+  });
+
+  test("inlines bodies exactly at the threshold", () => {
+    const body = "x".repeat(ISSUE_BODY_INLINE_LIMIT);
+    const lines = buildIssueHeader(ctx, {
+      issueTitle: "Edge",
+      issueBody: body,
+    });
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).toBe(body);
+  });
+
+  test("delegates to gh issue view when the body is over the threshold", () => {
+    const body = "x".repeat(ISSUE_BODY_INLINE_LIMIT + 1);
+    const lines = buildIssueHeader(ctx, {
+      issueTitle: "Long",
+      issueBody: body,
+    });
+    const joined = lines.join("\n");
+    expect(joined).not.toContain(body);
+    expect(joined).toContain("## Issue #42: Long");
+    expect(joined).toContain(
+      "gh issue view 42 --repo octo/demo --json body --jq .body",
+    );
+    expect(joined).toContain(String(body.length));
+    expect(joined).toMatch(/parent issue/i);
+  });
+
+  test("delegation block uses the owner/repo from the context", () => {
+    const body = "x".repeat(ISSUE_BODY_INLINE_LIMIT + 100);
+    const lines = buildIssueHeader(
+      { owner: "acme", repo: "service", issueNumber: 7 },
+      { issueTitle: "Big", issueBody: body },
+    );
+    expect(lines.join("\n")).toContain(
+      "gh issue view 7 --repo acme/service --json body --jq .body",
+    );
   });
 });

--- a/src/stage-util.ts
+++ b/src/stage-util.ts
@@ -10,7 +10,7 @@ import type {
   TokenUsage,
 } from "./agent.js";
 import { t } from "./i18n/index.js";
-import type { StageOutcome, StageResult } from "./pipeline.js";
+import type { StageContext, StageOutcome, StageResult } from "./pipeline.js";
 import type {
   AgentPromptKind,
   PipelineEventEmitter,
@@ -605,4 +605,60 @@ export function mapFixOrDoneResponse(
     );
   }
   return mapParsedStepToResult(parsed, responseText, undefined, validKeywords);
+}
+
+/**
+ * Maximum issue body size, in characters, that is inlined into a
+ * fresh-form prompt verbatim.  Bodies larger than this are replaced
+ * with a short instruction telling the agent to fetch the body via
+ * `gh issue view`, so we don't blow up the prompt with tens of KB of
+ * pasted logs.  ~4 KB ≈ ~1500 tokens, conservative enough to cover
+ * the vast majority of real-world issue bodies.
+ */
+export const ISSUE_BODY_INLINE_LIMIT = 4096;
+
+/** Subset of {@link StageContext} used when building the issue header. */
+export type IssueHeaderContext = Pick<
+  StageContext,
+  "owner" | "repo" | "issueNumber"
+>;
+
+export interface IssueHeaderOptions {
+  issueTitle: string;
+  issueBody: string;
+}
+
+/**
+ * Build the GitHub issue header block shared by every fresh-form
+ * stage prompt.
+ *
+ * For bodies up to {@link ISSUE_BODY_INLINE_LIMIT} characters this
+ * returns the familiar three-line block (heading, blank, body).  For
+ * larger bodies it returns a delegation block that tells the agent to
+ * fetch the body itself via `gh issue view`, avoiding tens of KB of
+ * pasted logs in every fresh-form prompt.
+ *
+ * Returns an array of lines so call sites can spread it directly into
+ * their existing `lines` arrays.
+ */
+export function buildIssueHeader(
+  ctx: IssueHeaderContext,
+  opts: IssueHeaderOptions,
+): string[] {
+  const heading = `## Issue #${ctx.issueNumber}: ${opts.issueTitle}`;
+  if (opts.issueBody.length > ISSUE_BODY_INLINE_LIMIT) {
+    const repoSlug = `${ctx.owner}/${ctx.repo}`;
+    return [
+      heading,
+      ``,
+      `The issue body is too long to inline here (${opts.issueBody.length}`,
+      `characters).  Fetch it yourself before proceeding:`,
+      ``,
+      `\`gh issue view ${ctx.issueNumber} --repo ${repoSlug} --json body --jq .body\``,
+      ``,
+      `If the issue references a parent issue, fetch that too with the`,
+      `same command and the parent's number.`,
+    ];
+  }
+  return [heading, ``, opts.issueBody];
 }


### PR DESCRIPTION
## Summary

The fresh-form `## Issue #N: <title>` + blank + body block was duplicated across 11 fresh-form prompt builders. This PR centralises it in a new `buildIssueHeader` helper in `src/stage-util.ts` so future header-format or policy changes touch one place instead of eleven.

It also adds a long-issue guard inside the helper: when an issue body exceeds `ISSUE_BODY_INLINE_LIMIT` (~4 KB / ~1500 tokens), the helper emits a short delegation block telling the agent to fetch the body itself via `gh issue view <N> --repo <owner>/<repo> --json body --jq .body`, so unusually long issue bodies (e.g. tens of KB of pasted logs) no longer bloat every fresh-form prompt. Behavior is unchanged for issues under the threshold.

All 11 inline header patterns are replaced — implement, testplan, selfcheck, review/author-fix/PR finalization, ci-fix/ci-findings, createpr, squash, and issue-sync.

Closes #318

## Test plan

- [x] `buildIssueHeader` unit tests cover the inline path (under threshold and exactly at threshold)
- [x] `buildIssueHeader` unit tests cover the delegation path (over threshold) and verify the `gh issue view` instruction uses the context's owner/repo/issueNumber
- [x] `pnpm vitest run` passes (2134/2134)
- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes
- [x] All 11 fresh-form call sites verified to use `buildIssueHeader`
- [x] Resume-form prompts left unchanged (out of scope per issue non-goals)