### PR TITLE
Bump pinned pnpm to 10.33.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.33.4",
   "engines": {
     "node": ">=24.0.0 <25.0.0"
   },


### PR DESCRIPTION
## Summary

- Bump the `packageManager` pin in `package.json` from `pnpm@10.12.1` (2025-06-08) to `pnpm@10.33.4` (2026-05-06).

The pin had drifted ~11 months and 21 minor versions behind the latest 10.x release because the `packageManager` field is corepack-only metadata and is not tracked by Dependabot's `npm` ecosystem. Refreshing within the same major (10.x) is a low-risk maintenance bump — no breaking changes, lockfile v9.0 remains compatible, and CI's corepack flow consumes the new pin without modification. Migrating to pnpm 11 is intentionally out of scope (it was released only 11 days ago and is still receiving daily patches).

## Test plan

- [x] `pnpm install --frozen-lockfile` (lockfile in sync)
- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test` (47 files, 2134 tests passing)
- [x] `pnpm build`
- [x] `pnpm --version` reports `10.33.4` inside the project

Closes #327