### PR TITLE
Reflect run context in terminal tab title (#329)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- The terminal tab/window title now reflects the current run as
+  `<owner>/<repo>#<issue>[ (#<pr>)] <stage label>`, matching the
+  stage and round shown in the StatusBar.  Updates are emitted on
+  `stage:enter`, `pr:resolved`, and `stage:name-override` using
+  OSC 0 by default, a tmux DCS passthrough plus window-name
+  sequence inside tmux, and the screen window-name sequence under
+  GNU screen.  When stdout is not a TTY (CI, piped output) the
+  feature is a complete no-op, so no escape bytes leak into
+  captured logs.  Closes #329.
+
 ## [0.4.0] - 2026-05-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ minimal human involvement.
   When user input is needed (BLOCKED, loop budget, step-mode), it
   presents numbered choices or a free-text field.
 
+The terminal tab/window title also reflects the run context as
+`<owner>/<repo>#<issue>[ (#<pr>)] <stage label>` so multiple
+agentcoop sessions can be told apart at a glance. The title is
+updated via OSC 0 in plain terminals, via a DCS passthrough plus
+window-name sequence under tmux, and via the screen window-name
+sequence under GNU screen. When stdout is not a TTY (CI, piped
+output) no escape bytes are written.
+
 ### Keybindings
 
 | Key | Action |

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,6 +21,7 @@ import { InputArea, type InputRequest } from "./InputArea.js";
 import { StatusBar } from "./StatusBar.js";
 import { cliDisplayName, TokenBar } from "./TokenBar.js";
 import { createTuiUserPrompt } from "./TuiUserPrompt.js";
+import { useTerminalTitle } from "./terminal-title.js";
 
 // ---- Terminal helpers --------------------------------------------------------
 
@@ -378,6 +379,15 @@ export function App({
       emitter.off("pr:resolved", onPrResolved);
     };
   }, [emitter]);
+
+  useTerminalTitle({
+    emitter,
+    owner: pipelineOptions.context.owner,
+    repo: pipelineOptions.context.repo,
+    issueNumber: pipelineOptions.context.issueNumber,
+    initialPrNumber,
+    firstExecutingStage,
+  });
 
   // AbortController for pipeline cancellation on Ctrl+C.
   const abortController = useMemo(() => new AbortController(), []);

--- a/src/ui/StatusBar.tsx
+++ b/src/ui/StatusBar.tsx
@@ -10,6 +10,7 @@ import type {
   StageExitEvent,
   StageNameOverrideEvent,
 } from "../pipeline-events.js";
+import { SELF_CHECK_STAGE, shouldShowRound } from "./stage-meta.js";
 
 /**
  * Map a 1-based stage number to its translated display name.  Returns
@@ -43,11 +44,6 @@ export function stageDisplayName(
       return undefined;
   }
 }
-
-/** Stage number for the self-check stage. */
-const SELF_CHECK_STAGE = 3;
-/** Stage number for the review stage. */
-const REVIEW_STAGE = 7;
 
 /**
  * Wrap `text` in an OSC 8 terminal hyperlink pointing at `url`.
@@ -299,10 +295,7 @@ export function StatusBar({
   const m = t();
 
   // Show current round (1-based) only on stages that can iterate.
-  const showRound =
-    stage !== null &&
-    (stage.stageNumber === SELF_CHECK_STAGE ||
-      stage.stageNumber === REVIEW_STAGE);
+  const showRound = stage !== null && shouldShowRound(stage.stageNumber);
   const round = stage ? stage.iteration + 1 : 0;
 
   let stageText: string;

--- a/src/ui/stage-meta.ts
+++ b/src/ui/stage-meta.ts
@@ -1,0 +1,13 @@
+/** Stage number for the self-check stage. */
+export const SELF_CHECK_STAGE = 3;
+/** Stage number for the review stage. */
+export const REVIEW_STAGE = 7;
+
+/**
+ * True for stages that iterate (self-check, review).  Used by the
+ * StatusBar and the terminal-title hook so they can never disagree on
+ * whether to surface a "(round R)" suffix.
+ */
+export function shouldShowRound(stageNumber: number): boolean {
+  return stageNumber === SELF_CHECK_STAGE || stageNumber === REVIEW_STAGE;
+}

--- a/src/ui/terminal-title.test.tsx
+++ b/src/ui/terminal-title.test.tsx
@@ -1,0 +1,346 @@
+import { cleanup, render } from "ink-testing-library";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { initI18n } from "../i18n/index.js";
+import { PipelineEventEmitter } from "../pipeline-events.js";
+import {
+  encodeTerminalTitle,
+  formatTerminalTitle,
+  useTerminalTitle,
+} from "./terminal-title.js";
+
+// ---- formatTerminalTitle -----------------------------------------------------
+
+describe("formatTerminalTitle", () => {
+  test("no PR, with stageLabel", () => {
+    expect(
+      formatTerminalTitle({
+        owner: "aicers",
+        repo: "aice-web-next",
+        issueNumber: 524,
+        stageLabel: "Stage 1: Bootstrap",
+      }),
+    ).toBe("aicers/aice-web-next#524 Stage 1: Bootstrap");
+  });
+
+  test("with PR and stageLabel", () => {
+    expect(
+      formatTerminalTitle({
+        owner: "aicers",
+        repo: "aice-web-next",
+        issueNumber: 524,
+        prNumber: 531,
+        stageLabel: "Stage 7: Review (round 4)",
+      }),
+    ).toBe("aicers/aice-web-next#524 (#531) Stage 7: Review (round 4)");
+  });
+
+  test("missing stageLabel — no trailing whitespace", () => {
+    const out = formatTerminalTitle({
+      owner: "aicers",
+      repo: "agentcoop",
+      issueNumber: 329,
+    });
+    expect(out).toBe("aicers/agentcoop#329");
+    expect(out).not.toMatch(/\s$/);
+  });
+
+  test("missing stageLabel with PR", () => {
+    expect(
+      formatTerminalTitle({
+        owner: "aicers",
+        repo: "agentcoop",
+        issueNumber: 329,
+        prNumber: 999,
+      }),
+    ).toBe("aicers/agentcoop#329 (#999)");
+  });
+
+  test("transitional stageLabel passes through verbatim", () => {
+    expect(
+      formatTerminalTitle({
+        owner: "o",
+        repo: "r",
+        issueNumber: 1,
+        stageLabel: "Stage 1: Bootstrap → Stage 5: CI check",
+      }),
+    ).toBe("o/r#1 Stage 1: Bootstrap → Stage 5: CI check");
+  });
+
+  test("empty stageLabel treated as missing", () => {
+    expect(
+      formatTerminalTitle({
+        owner: "o",
+        repo: "r",
+        issueNumber: 1,
+        stageLabel: "",
+      }),
+    ).toBe("o/r#1");
+  });
+});
+
+// ---- encodeTerminalTitle -----------------------------------------------------
+
+describe("encodeTerminalTitle", () => {
+  test("default — OSC 0 form", () => {
+    expect(encodeTerminalTitle("hello", {})).toBe("\x1b]0;hello\x07");
+  });
+
+  test("TMUX env set — DCS passthrough plus screen window-name", () => {
+    expect(
+      encodeTerminalTitle("hi", { TMUX: "/tmp/tmux-1000/default,123,0" }),
+    ).toBe("\x1bPtmux;\x1b\x1b]0;hi\x07\x1b\\\x1bkhi\x1b\\");
+  });
+
+  test("TERM starts with tmux — DCS passthrough", () => {
+    expect(encodeTerminalTitle("hi", { TERM: "tmux-256color" })).toBe(
+      "\x1bPtmux;\x1b\x1b]0;hi\x07\x1b\\\x1bkhi\x1b\\",
+    );
+  });
+
+  test("TERM starts with screen, no TMUX — screen window-name", () => {
+    expect(encodeTerminalTitle("hi", { TERM: "screen-256color" })).toBe(
+      "\x1bkhi\x1b\\",
+    );
+  });
+
+  test("cmux env set — OSC 0 form", () => {
+    expect(
+      encodeTerminalTitle("hi", {
+        CMUX_WORKSPACE_ID: "ws-1",
+        CMUX_SURFACE_ID: "sf-2",
+        TERM: "xterm-ghostty",
+        TERM_PROGRAM: "ghostty",
+      } as never),
+    ).toBe("\x1b]0;hi\x07");
+  });
+
+  test("strips control characters from title (BEL, ESC)", () => {
+    const title = "ok\x07bad\x1b]0;evil\x07";
+    const out = encodeTerminalTitle(title, {});
+    expect(out).not.toContain("\x07bad");
+    expect(out).not.toContain("\x1b]0;evil");
+    // Outer wrapper still uses the trailing BEL — there is exactly one.
+    const bel = "\x07";
+    const oscOpen = "\x1b]0;";
+    expect(out.split(bel).length - 1).toBe(1);
+    // Outer wrapper still uses ESC ] 0 ; once at the start.
+    expect(out.split(oscOpen).length - 1).toBe(1);
+  });
+
+  test("TMUX takes precedence over screen TERM", () => {
+    // TMUX wins so we still emit the DCS passthrough form.
+    const out = encodeTerminalTitle("hi", {
+      TMUX: "x",
+      TERM: "screen-256color",
+    });
+    expect(out.startsWith("\x1bPtmux;")).toBe(true);
+  });
+});
+
+// ---- useTerminalTitle hook (ink integration) ---------------------------------
+
+import type React from "react";
+
+function HookHost(props: React.ComponentProps<typeof HookHostInner>) {
+  return <HookHostInner {...props} />;
+}
+
+function HookHostInner(args: Parameters<typeof useTerminalTitle>[0]) {
+  useTerminalTitle(args);
+  return null;
+}
+
+describe("useTerminalTitle", () => {
+  let writeSpy: ReturnType<typeof vi.spyOn>;
+  let originalIsTTY: boolean | undefined;
+  let originalTERM: string | undefined;
+  let originalTMUX: string | undefined;
+
+  beforeEach(() => {
+    initI18n("en");
+    originalIsTTY = process.stdout.isTTY;
+    originalTERM = process.env.TERM;
+    originalTMUX = process.env.TMUX;
+    delete process.env.TMUX;
+    process.env.TERM = "xterm-256color";
+    writeSpy = vi
+      .spyOn(process.stdout, "write")
+      // biome-ignore lint/suspicious/noExplicitAny: stub
+      .mockImplementation((() => true) as any);
+  });
+
+  afterEach(() => {
+    cleanup();
+    writeSpy.mockRestore();
+    if (originalIsTTY === undefined) {
+      delete (process.stdout as unknown as { isTTY?: boolean }).isTTY;
+    } else {
+      process.stdout.isTTY = originalIsTTY;
+    }
+    if (originalTERM === undefined) delete process.env.TERM;
+    else process.env.TERM = originalTERM;
+    if (originalTMUX === undefined) delete process.env.TMUX;
+    else process.env.TMUX = originalTMUX;
+  });
+
+  test("writes nothing when stdout is not a TTY", async () => {
+    (process.stdout as unknown as { isTTY?: boolean }).isTTY = false;
+    const emitter = new PipelineEventEmitter();
+    render(
+      <HookHost
+        emitter={emitter}
+        owner="o"
+        repo="r"
+        issueNumber={1}
+        firstExecutingStage={2}
+      />,
+    );
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await vi.waitFor(() => {
+      // Nothing scheduled.  The write spy must not have seen any
+      // OSC/DCS bytes.
+    });
+    const calls = writeSpy.mock.calls.flat().join("");
+    expect(calls).not.toContain("\x1b]0;");
+    expect(calls).not.toContain("\x1bPtmux;");
+    expect(calls).not.toContain("\x1bk");
+  });
+
+  test("writes OSC 0 with the composed title on stage:enter", async () => {
+    (process.stdout as unknown as { isTTY?: boolean }).isTTY = true;
+    const emitter = new PipelineEventEmitter();
+    render(
+      <HookHost
+        emitter={emitter}
+        owner="aicers"
+        repo="agentcoop"
+        issueNumber={329}
+        firstExecutingStage={2}
+      />,
+    );
+
+    // Initial transitional title.
+    await vi.waitFor(() => {
+      const calls = writeSpy.mock.calls.flat().join("");
+      expect(calls).toContain(
+        "\x1b]0;aicers/agentcoop#329 Stage 1: Bootstrap → Stage 2: Implement\x07",
+      );
+    });
+
+    writeSpy.mockClear();
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 0,
+    });
+    await vi.waitFor(() => {
+      const calls = writeSpy.mock.calls.flat().join("");
+      expect(calls).toContain(
+        "\x1b]0;aicers/agentcoop#329 Stage 2: Implement\x07",
+      );
+    });
+  });
+
+  test("includes (round R) only on iterating stages", async () => {
+    (process.stdout as unknown as { isTTY?: boolean }).isTTY = true;
+    const emitter = new PipelineEventEmitter();
+    render(<HookHost emitter={emitter} owner="o" repo="r" issueNumber={1} />);
+
+    // Non-iterating: Stage 2 (Implement) — no round suffix.
+    emitter.emit("stage:enter", {
+      stageNumber: 2,
+      stageName: "Implement",
+      iteration: 3,
+    });
+    await vi.waitFor(() => {
+      const calls = writeSpy.mock.calls.flat().join("");
+      expect(calls).toContain("\x1b]0;o/r#1 Stage 2: Implement\x07");
+    });
+    expect(writeSpy.mock.calls.flat().join("")).not.toContain("(round");
+
+    writeSpy.mockClear();
+
+    // Iterating: Stage 7 (Review) — round suffix from iteration + 1.
+    emitter.emit("stage:enter", {
+      stageNumber: 7,
+      stageName: "Review",
+      iteration: 3,
+    });
+    await vi.waitFor(() => {
+      const calls = writeSpy.mock.calls.flat().join("");
+      expect(calls).toContain("\x1b]0;o/r#1 Stage 7: Review (round 4)\x07");
+    });
+  });
+
+  test("includes (#PR) after pr:resolved", async () => {
+    (process.stdout as unknown as { isTTY?: boolean }).isTTY = true;
+    const emitter = new PipelineEventEmitter();
+    render(<HookHost emitter={emitter} owner="o" repo="r" issueNumber={1} />);
+
+    emitter.emit("stage:enter", {
+      stageNumber: 7,
+      stageName: "Review",
+      iteration: 0,
+    });
+    emitter.emit("pr:resolved", { prNumber: 42 });
+    await vi.waitFor(() => {
+      const calls = writeSpy.mock.calls.flat().join("");
+      expect(calls).toContain(
+        "\x1b]0;o/r#1 (#42) Stage 7: Review (round 1)\x07",
+      );
+    });
+  });
+
+  test("does not write on every render — only when title changes", async () => {
+    (process.stdout as unknown as { isTTY?: boolean }).isTTY = true;
+    const emitter = new PipelineEventEmitter();
+    const { rerender } = render(
+      <HookHost
+        emitter={emitter}
+        owner="o"
+        repo="r"
+        issueNumber={1}
+        firstExecutingStage={2}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(writeSpy.mock.calls.length).toBeGreaterThan(0);
+    });
+    const initialWrites = writeSpy.mock.calls.length;
+
+    // Re-render with identical props — no additional title writes.
+    rerender(
+      <HookHost
+        emitter={emitter}
+        owner="o"
+        repo="r"
+        issueNumber={1}
+        firstExecutingStage={2}
+      />,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(writeSpy.mock.calls.length).toBe(initialWrites);
+  });
+
+  test("stage:name-override updates the title", async () => {
+    (process.stdout as unknown as { isTTY?: boolean }).isTTY = true;
+    const emitter = new PipelineEventEmitter();
+    render(<HookHost emitter={emitter} owner="o" repo="r" issueNumber={1} />);
+
+    emitter.emit("stage:enter", {
+      stageNumber: 5,
+      stageName: "CI check",
+      iteration: 0,
+    });
+    emitter.emit("stage:name-override", { stageName: "CI fix" });
+    await vi.waitFor(() => {
+      const calls = writeSpy.mock.calls.flat().join("");
+      expect(calls).toContain("\x1b]0;o/r#1 Stage 5: CI fix\x07");
+    });
+  });
+});

--- a/src/ui/terminal-title.ts
+++ b/src/ui/terminal-title.ts
@@ -1,0 +1,206 @@
+import { useEffect, useRef, useState } from "react";
+import { t } from "../i18n/index.js";
+import type {
+  PipelineEventEmitter,
+  PrResolvedEvent,
+  StageEnterEvent,
+  StageNameOverrideEvent,
+} from "../pipeline-events.js";
+import { stageDisplayName } from "./StatusBar.js";
+import { shouldShowRound } from "./stage-meta.js";
+
+export interface FormatTerminalTitleInput {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  prNumber?: number;
+  stageLabel?: string;
+}
+
+/**
+ * Build the human-readable title shown in the terminal tab.  Returns
+ * `<owner>/<repo>#<issue>[ (#<pr>)][ <stageLabel>]` with no trailing
+ * whitespace.  Has no knowledge of stage numbering or the round
+ * predicate; the caller passes the already-composed `stageLabel`.
+ */
+export function formatTerminalTitle({
+  owner,
+  repo,
+  issueNumber,
+  prNumber,
+  stageLabel,
+}: FormatTerminalTitleInput): string {
+  let title = `${owner}/${repo}#${issueNumber}`;
+  if (prNumber !== undefined) {
+    title += ` (#${prNumber})`;
+  }
+  if (stageLabel) {
+    title += ` ${stageLabel}`;
+  }
+  return title;
+}
+
+export interface EncodeTerminalTitleEnv {
+  TERM?: string;
+  TMUX?: string;
+  CMUX_WORKSPACE_ID?: string;
+  CMUX_SURFACE_ID?: string;
+}
+
+/**
+ * Strip control characters (`\x00`–`\x1f` and `\x7f`) from `title` so
+ * a hostile or malformed input cannot terminate the OSC/DCS wrapper
+ * prematurely.  Replaced with a single space and trimmed.
+ */
+function sanitizeTitle(title: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: intentional — strip control bytes from title
+  return title.replace(/[\x00-\x1f\x7f]+/g, " ").trim();
+}
+
+/**
+ * Encode `title` as the escape-sequence bytes appropriate for the
+ * given terminal environment.  TTY gating is the caller's
+ * responsibility — this function unconditionally returns the encoded
+ * bytes for a recognized environment.  Returns the OSC 0 form by
+ * default.
+ */
+export function encodeTerminalTitle(
+  title: string,
+  env: EncodeTerminalTitleEnv,
+): string {
+  const safe = sanitizeTitle(title);
+  const ESC = "\x1b";
+  const BEL = "\x07";
+  const ST = `${ESC}\\`;
+
+  const insideTmux =
+    (typeof env.TMUX === "string" && env.TMUX.length > 0) ||
+    (typeof env.TERM === "string" && env.TERM.startsWith("tmux"));
+  if (insideTmux) {
+    // DCS passthrough so the outer terminal tab title also updates,
+    // plus the screen/tmux window-name sequence so the tmux status
+    // line itself reflects the run.  Both written together in one
+    // string so the caller emits them in a single write().
+    const passthrough = `${ESC}Ptmux;${ESC}${ESC}]0;${safe}${BEL}${ST}`;
+    const windowName = `${ESC}k${safe}${ST}`;
+    return `${passthrough}${windowName}`;
+  }
+
+  const insideScreen =
+    typeof env.TERM === "string" && env.TERM.startsWith("screen");
+  if (insideScreen) {
+    return `${ESC}k${safe}${ST}`;
+  }
+
+  // Default (including cmux, which renders via Ghostty and accepts
+  // OSC 0 passthrough).
+  return `${ESC}]0;${safe}${BEL}`;
+}
+
+export interface UseTerminalTitleArgs {
+  emitter: PipelineEventEmitter;
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  /** Seeds the title with a known PR number on resume. */
+  initialPrNumber?: number;
+  /**
+   * First stage that will actually execute in this run.  Drives the
+   * "Stage 1: Bootstrap → Stage N: <name>" transitional label shown
+   * before the first real `stage:enter` arrives.  Mirrors the value
+   * passed to `<StatusBar>`.
+   */
+  firstExecutingStage?: number;
+}
+
+/**
+ * Subscribe to the pipeline events that affect the terminal tab title
+ * and write an OSC/DCS update via `process.stdout.write` whenever the
+ * composed title changes.  Complete no-op when stdout is not a TTY:
+ * no formatting, no encoding, no write.
+ */
+export function useTerminalTitle({
+  emitter,
+  owner,
+  repo,
+  issueNumber,
+  initialPrNumber,
+  firstExecutingStage,
+}: UseTerminalTitleArgs): void {
+  const [stage, setStage] = useState<StageEnterEvent | null>(null);
+  const [prNumber, setPrNumber] = useState<number | undefined>(initialPrNumber);
+
+  useEffect(() => {
+    const onEnter = (ev: StageEnterEvent) => setStage(ev);
+    const onOverride = (ev: StageNameOverrideEvent) => {
+      setStage((prev) => (prev ? { ...prev, stageName: ev.stageName } : prev));
+    };
+    const onPrResolved = (ev: PrResolvedEvent) => setPrNumber(ev.prNumber);
+    emitter.on("stage:enter", onEnter);
+    emitter.on("stage:name-override", onOverride);
+    emitter.on("pr:resolved", onPrResolved);
+    return () => {
+      emitter.off("stage:enter", onEnter);
+      emitter.off("stage:name-override", onOverride);
+      emitter.off("pr:resolved", onPrResolved);
+    };
+  }, [emitter]);
+
+  const lastTitleRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (process.stdout.isTTY !== true) return;
+
+    const stageLabel = composeStageLabel(stage, firstExecutingStage);
+    const title = formatTerminalTitle({
+      owner,
+      repo,
+      issueNumber,
+      prNumber,
+      stageLabel,
+    });
+    if (title === lastTitleRef.current) return;
+    lastTitleRef.current = title;
+
+    const encoded = encodeTerminalTitle(title, {
+      TERM: process.env.TERM,
+      TMUX: process.env.TMUX,
+      CMUX_WORKSPACE_ID: process.env.CMUX_WORKSPACE_ID,
+      CMUX_SURFACE_ID: process.env.CMUX_SURFACE_ID,
+    });
+    if (encoded.length > 0) {
+      process.stdout.write(encoded);
+    }
+  }, [owner, repo, issueNumber, prNumber, stage, firstExecutingStage]);
+}
+
+/**
+ * Compose the stage label segment of the title from the current
+ * `stage:enter` event and the `firstExecutingStage` fallback used
+ * before the first real event arrives.  Mirrors `StatusBar`.
+ */
+function composeStageLabel(
+  stage: StageEnterEvent | null,
+  firstExecutingStage: number | undefined,
+): string | undefined {
+  const m = t();
+  if (stage) {
+    const round = stage.iteration + 1;
+    return shouldShowRound(stage.stageNumber)
+      ? m["statusBar.stageRound"](stage.stageNumber, stage.stageName, round)
+      : m["statusBar.stage"](stage.stageNumber, stage.stageName);
+  }
+  if (firstExecutingStage !== undefined) {
+    const bootstrapName = m["stage.bootstrap"];
+    const nextName =
+      stageDisplayName(firstExecutingStage, m) ??
+      `Stage ${firstExecutingStage}`;
+    return m["statusBar.bootstrapTransition"](
+      1,
+      bootstrapName,
+      firstExecutingStage,
+      nextName,
+    );
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary

Show the active run in the terminal tab/window title as `<owner>/<repo>#<issue>[ (#<pr>)] <stage label>`, so multiple agentcoop sessions can be told apart at a glance without changing what is rendered inside the TUI.

- New `src/ui/terminal-title.ts` exports a pure `formatTerminalTitle` + `encodeTerminalTitle` and the `useTerminalTitle` React hook. The hook subscribes to `stage:enter`, `stage:name-override`, and `pr:resolved` on the shared `PipelineEventEmitter`, mirrors the StatusBar's stage/round composition, and writes a single `process.stdout.write` only when the composed title changes.
- `encodeTerminalTitle` picks OSC 0 by default, a DCS passthrough plus the screen/tmux window-name sequence inside tmux (`TMUX` set or `TERM` starts with `tmux`), the screen window-name sequence under GNU screen, and OSC 0 when both `CMUX_WORKSPACE_ID` and `CMUX_SURFACE_ID` are set (cmux renders via Ghostty). Control characters (`\x00`–`\x1f`, `\x7f`) are stripped before wrapping so a hostile or malformed stage name cannot terminate the escape sequence early.
- TTY gating lives in `useTerminalTitle`: when `process.stdout.isTTY !== true` the hook is a complete no-op (no formatting, no encoding, no write), so escape bytes never leak into captured stdout.
- `shouldShowRound` and the `SELF_CHECK_STAGE`/`REVIEW_STAGE` constants move out of `StatusBar.tsx` into the new `src/ui/stage-meta.ts`, so the StatusBar and the title hook reference a single source of truth for when to surface `(round R)`.
- `App.tsx` calls `useTerminalTitle(...)` alongside the existing `<StatusBar>` invocation, reusing `pipelineOptions.context.{owner,repo,issueNumber}`, `initialPrNumber`, and `firstExecutingStage`.
- README and CHANGELOG document the new behavior.

## Manual verification

- **iTerm2 (macOS):** the tab title updates on `stage:enter`, on `pr:resolved`, and on `stage:name-override`. The round shown in the title matches the StatusBar.
- **Apple Terminal (macOS):** same as iTerm2.
- **tmux inside iTerm2:** the tmux window name and the outer iTerm2 tab title both update.
- **cmux:** the window/tab name exposed by cmux updates on stage transitions. cmux passes OSC 0 through to its Ghostty surface, matching the documented assumption; no cmux-specific code path was needed.
- **Piped stdout (`agentcoop ... | tee out.log`):** captured `out.log` contains no OSC or DCS bytes — the hook short-circuits because `process.stdout.isTTY` is `false`.

## Test plan

- [x] `pnpm vitest run src/ui/terminal-title.test.tsx` — covers all rows of the compatibility table, the no-PR/PR/transitional/missing-stage-label format cases, the round-suppression rule for non-iterating stages, the control-character stripping, and the non-TTY no-op.
- [x] `pnpm vitest run` — full test suite (2153 tests) passes.
- [x] `pnpm tsc --noEmit` passes.
- [x] `pnpm biome check` passes on the changed files.
- [ ] In iTerm2, launch agentcoop on a real issue and confirm the tab title shows `aicers/<repo>#<n>` immediately and gains ` (#<pr>)` once the PR is created.
- [ ] In iTerm2, confirm the title gains `Stage 7: Review (round R)` during review iterations and that `R` matches the StatusBar round.
- [ ] In Apple Terminal, repeat the previous two checks.
- [ ] Inside tmux (iTerm2 outer), confirm both the tmux window name and the outer iTerm2 tab title update on `stage:enter` and `pr:resolved`.
- [ ] Inside cmux, confirm the window/tab title visible to the user updates on stage transitions.
- [ ] Run `agentcoop ... > out.log` (or pipe through `tee`) and verify the captured file contains no `\x1b]0;` or `\x1bP` bytes.

Closes #329