### PR TITLE
Default squash-apply prompt to ask, not auto-apply (#338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Added
+
+- The terminal tab/window title now reflects the current run as
+  `<owner>/<repo>#<issue>[ (#<pr>)] <stage label>`, matching the
+  stage and round shown in the StatusBar.  Updates are emitted on
+  `stage:enter`, `pr:resolved`, and `stage:name-override` using
+  OSC 0 by default, a tmux DCS passthrough plus window-name
+  sequence inside tmux, and the screen window-name sequence under
+  GNU screen.  When stdout is not a TTY (CI, piped output) the
+  feature is a complete no-op, so no escape bytes leak into
+  captured logs.  Closes #329.
+
+### Changed
+
+- The startup prompt "When a single-commit squash is suggested, apply it
+  automatically via the agent? (No = ask each time)" now defaults to **No**.
+  A bare Enter keypress therefore selects the safer "ask each time" path,
+  keeping the human in the loop for the history-rewriting step rather than
+  silently dispatching an extra agent run.  Explicitly answering Yes still
+  yields the auto-apply behaviour.  Closes #338.
+
 ### Fixed
 
 - Reviewer-round `git fetch` no longer runs under the shared repo
@@ -31,18 +52,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   repo state).  `MAX_WAIT_MS` is unchanged at 120 s — the fix is
   structural, not a timeout bump, so the lock remains a meaningful
   "something is stuck on worktree mutation" signal.  Closes #336.
-
-### Added
-
-- The terminal tab/window title now reflects the current run as
-  `<owner>/<repo>#<issue>[ (#<pr>)] <stage label>`, matching the
-  stage and round shown in the StatusBar.  Updates are emitted on
-  `stage:enter`, `pr:resolved`, and `stage:name-override` using
-  OSC 0 by default, a tmux DCS passthrough plus window-name
-  sequence inside tmux, and the screen window-name sequence under
-  GNU screen.  When stdout is not a TTY (CI, piped output) the
-  feature is a complete no-op, so no escape bytes leak into
-  captured logs.  Closes #329.
 
 ## [0.4.0] - 2026-05-09
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -461,7 +461,9 @@ try {
   // point so both the fresh-start and resume branches go through
   // the same prompt.  Routed through `promptSquashApplyPolicy` so
   // the call site is a single named target — see the helper for the
-  // semantics of "not persisted" and the default-true rationale.
+  // semantics of "not persisted" and the default-false rationale
+  // (prefer asking each time over auto-applying so the human stays
+  // in the loop for the history-rewriting step).
   params.squashApplyPolicy = await promptSquashApplyPolicy();
 
   // Resolve the per-CLI auth policy at the same shared join point.

--- a/src/startup.test.ts
+++ b/src/startup.test.ts
@@ -2818,12 +2818,20 @@ describe("runStartup — manage custom models", () => {
 // that the join-point call site exists; these tests cover the
 // prompt's own behaviour.
 describe("promptSquashApplyPolicy", () => {
-  test("default Enter (true) → 'auto'", async () => {
+  test("bare Enter follows declared default → 'ask'", async () => {
+    mockConfirm.mockImplementationOnce(
+      async (opts: { default?: boolean }) => opts.default ?? false,
+    );
+    const policy = await promptSquashApplyPolicy();
+    expect(policy).toBe("ask");
+    // Default is No so a bare Enter keeps the human in the loop.
+    expect(mockConfirm.mock.calls[0][0]).toHaveProperty("default", false);
+  });
+
+  test("explicit yes → 'auto'", async () => {
     mockConfirm.mockResolvedValueOnce(true);
     const policy = await promptSquashApplyPolicy();
     expect(policy).toBe("auto");
-    // Default is Yes so a bare Enter picks the low-friction path.
-    expect(mockConfirm.mock.calls[0][0]).toHaveProperty("default", true);
   });
 
   test("explicit no → 'ask'", async () => {

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -133,14 +133,16 @@ function agentConfigEqual(a: AgentConfig | undefined, b: AgentConfig): boolean {
  * question on either the fresh-startup or the resume path.
  *
  * Not persisted to config or `RunState`: the right answer depends on
- * the state of the current branch / PR.  Default is "let the agent
- * handle it" so a bare Enter keypress picks the low-friction path.
+ * the state of the current branch / PR.  Default is "ask each time"
+ * so a bare Enter keypress picks the safer path that keeps the human
+ * in the loop for the history-rewriting step, rather than dispatching
+ * an extra agent run without further confirmation.
  */
 export async function promptSquashApplyPolicy(): Promise<"auto" | "ask"> {
   const m = t();
   const autoApply = await confirm({
     message: m["startup.squashApplyPolicyPrompt"],
-    default: true,
+    default: false,
   });
   return autoApply ? "auto" : "ask";
 }


### PR DESCRIPTION
## Summary

Flips the default for the startup prompt _"When a single-commit squash is suggested, apply it automatically via the agent? (No = ask each time)"_ from **Yes** to **No**, so a bare Enter keypress now selects the safer "ask each time" path instead of dispatching an extra agent run that rewrites history without further confirmation.

- `src/startup.ts`: `promptSquashApplyPolicy` now passes `default: false` to `confirm`, and the surrounding doc comment is updated to explain the safety-over-friction rationale.
- `src/index.ts`: refreshed the stale "default-true rationale" comment above the shared join-point call.
- `src/startup.test.ts`: reworked the tests — bare Enter follows the declared default and yields `"ask"` (asserts `default === false`), explicit Yes still yields `"auto"`, explicit No still yields `"ask"`.
- `CHANGELOG.md`: added a `### Changed` bullet under `## [Unreleased]` describing the user-visible default flip.

No copy change was needed in `src/i18n/en.ts` or `src/i18n/ko.ts` because the existing parenthetical "(No = ask each time)" already describes both options symmetrically, and the existing `squashApplyPolicy: "auto" | "ask"` plumbing in `src/index.ts` and `src/stage-squash.ts` is untouched.

Closes #338.

## Test plan

- [x] `pnpm vitest run src/startup.test.ts -t promptSquashApplyPolicy` — all three cases pass (bare Enter → `"ask"`, explicit Yes → `"auto"`, explicit No → `"ask"`).
- [x] `pnpm vitest run` — full suite passes (2154 tests).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm biome check` — clean on the changed files.
- [x] Manual: launch the startup flow, press Enter at the squash-apply-policy prompt, and confirm `squashApplyPolicy === "ask"`. _Verified via unit test that mocks `confirm` to echo the passed-in `default` (`false`) and asserts the function returns `"ask"`; bare-Enter behavior of `@inquirer/prompts`' `confirm` is to return the `default` value._
- [x] Manual: at the same prompt, type `y` + Enter and confirm `squashApplyPolicy === "auto"`; type `n` + Enter and confirm `"ask"`. _Verified via unit tests that mock `confirm` to resolve `true` (→ `"auto"`) and `false` (→ `"ask"`)._
- [x] Verify `CHANGELOG.md` `[Unreleased]` section notes the default change.