### PR TITLE
Narrow repo lock to worktree-mutating commands (#336)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixed
+
+- Reviewer-round `git fetch` no longer runs under the shared repo
+  lock, so a slow or hung fetch in one dispatch can no longer stall
+  every sibling dispatch's review round with `Timed out waiting for
+  repo lock`.  `withLock` was originally introduced to serialise
+  `git worktree add` against the known concurrent-bare-repo issue,
+  but fetch — which uses git's own per-ref `.lock` files and
+  `packed-refs.lock` — is safe to run in parallel and does not need
+  the same lock.  The lock is now narrowed to wrap only worktree-
+  mutating commands: `git worktree add` (initial author worktree
+  and the reviewer-recreate fallback), `forceRemoveWorktreeAndBranch`
+  + recreate (the clean / conflict path), and the bootstrap
+  existence-check + `git clone --bare` so a sibling never observes
+  a half-finished bare repo.  Moved out of the lock: the
+  `git fetch --all --prune` calls in `bootstrapRepo` (both the
+  existing-repo path and the post-clone path), the `git fetch
+  origin <authorBranch>` in `prepareReviewerWorktree`, and the
+  `git switch --detach` / `git reset --hard` / `git clean -fd`
+  per-worktree refresh in `prepareReviewerWorktree` (which only
+  touches the per-issue reviewer worktree path, not shared bare-
+  repo state).  `MAX_WAIT_MS` is unchanged at 120 s — the fix is
+  structural, not a timeout bump, so the lock remains a meaningful
+  "something is stuck on worktree mutation" signal.  Closes #336.
+
 ### Added
 
 - The terminal tab/window title now reflects the current run as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   `packed-refs.lock` — is safe to run in parallel and does not need
   the same lock.  The lock is now narrowed to wrap only worktree-
   mutating commands: `git worktree add` (initial author worktree
-  and the reviewer-recreate fallback), `forceRemoveWorktreeAndBranch`
-  + recreate (the clean / conflict path), and the bootstrap
-  existence-check + `git clone --bare` so a sibling never observes
+  and the reviewer-recreate fallback), the
+  `forceRemoveWorktreeAndBranch` + recreate sequence (the clean /
+  conflict path), and the bootstrap existence-check plus
+  `git clone --bare` so a sibling never observes
   a half-finished bare repo.  Moved out of the lock: the
   `git fetch --all --prune` calls in `bootstrapRepo` (both the
   existing-repo path and the post-clone path), the `git fetch

--- a/src/worktree-concurrency.test.ts
+++ b/src/worktree-concurrency.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Concurrency regression test for #336.
+ *
+ * Models the production failure: one dispatch is holding the shared repo
+ * lock; a sibling dispatch reaches `prepareReviewerWorktree`.  Pre-#336
+ * the sibling's `git fetch` ran INSIDE `withLock`, so it had to wait —
+ * and if the holder was a hung fetch the sibling tripped `MAX_WAIT_MS`
+ * with "Timed out waiting for repo lock".  With the fix, fetch and the
+ * per-worktree refresh run OUTSIDE `withLock`, so a sibling proceeds
+ * regardless of how long the lock holder takes.
+ *
+ * Strategy: plant a real lock file (attributed to a live PID, so
+ * `lock.ts` cannot treat it as stale) at the path `prepareReviewerWorktree`
+ * would use, then call the function.  All work that #336 moved out of
+ * the lock — fetch + switch/reset/clean — must run to completion without
+ * ever touching the lock, so the call must NOT throw "Timed out waiting
+ * for repo lock".  `execFileSync` is mocked so the test doesn't shell
+ * out to git.
+ */
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
+const { prepareReviewerWorktree, reviewerWorktreePath } = await import(
+  "./worktree.js"
+);
+const { repoLockPath } = await import("./lock.js");
+
+const mockExecFileSync = vi.mocked(execFileSync);
+
+// `os.homedir()` honours $HOME on POSIX but uses USERPROFILE on Windows.
+// Skip the test on Windows — the fixture relies on overriding $HOME so
+// that `repoLockPath` resolves under our tmp dir.
+const itPosix = process.platform === "win32" ? test.skip : test;
+
+describe("prepareReviewerWorktree (#336) — sibling proceeds despite held lock", () => {
+  let homeDir: string;
+  let bareDir: string;
+  let lockPath: string;
+  let wtPath: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "agentcoop-336-"));
+    origHome = process.env.HOME;
+    process.env.HOME = homeDir;
+    // Recompute the paths under the test HOME.
+    bareDir = join(homeDir, ".agentcoop", "repos", "org", "repo.git");
+    lockPath = repoLockPath("org", "repo");
+    wtPath = reviewerWorktreePath("org", "repo", 5);
+    mkdirSync(bareDir, { recursive: true });
+    mkdirSync(wtPath, { recursive: true });
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    rmSync(homeDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  itPosix(
+    "fetch + refresh complete without acquiring the repo lock",
+    () => {
+      // Plant a held lock file attributed to a live PID (our own).
+      // lock.ts probes the holder with process.kill(pid, 0); using
+      // process.pid guarantees the probe says "alive", so lock.ts will
+      // NOT treat it as stale and remove it.  Any call that tries to
+      // acquireLock now must wait for MAX_WAIT_MS and then throw.
+      mkdirSync(join(homeDir, ".agentcoop", "repos", "org"), {
+        recursive: true,
+      });
+      writeFileSync(lockPath, `${process.pid}:${Date.now()}`);
+      expect(existsSync(lockPath)).toBe(true);
+
+      // The refresh path needs isValidGitWorktree(wtPath) === true.
+      // That calls rev-parse --is-inside-work-tree; return "true" so
+      // we go down the refresh branch (NOT the recreate-under-lock
+      // branch).
+      mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+        if (cmd === "git" && args[0] === "rev-parse") return "true\n";
+        return "" as never;
+      }) as typeof execFileSync);
+
+      const start = Date.now();
+      const result = prepareReviewerWorktree({
+        owner: "org",
+        repo: "repo",
+        issueNumber: 5,
+        authorBranch: "alice/issue-5",
+      });
+      const elapsed = Date.now() - start;
+
+      expect(result).toBe(wtPath);
+      // Pre-#336 this would have blocked for MAX_WAIT_MS (120 s) and
+      // then thrown.  Post-fix the call returns essentially immediately.
+      expect(elapsed).toBeLessThan(5_000);
+
+      const issued = mockExecFileSync.mock.calls.map(
+        (c) => (c[1] as string[])[0],
+      );
+      // Refresh-path commands ran:
+      expect(issued).toContain("fetch");
+      expect(issued).toContain("switch");
+      expect(issued).toContain("reset");
+      expect(issued).toContain("clean");
+      // The recreate path (which acquires the lock) was NOT taken:
+      expect(issued).not.toContain("worktree");
+    },
+    // Wall-clock budget for the test itself.  If the fix regresses and
+    // fetch/refresh acquire the lock again, this entire test would take
+    // MAX_WAIT_MS (120 s) — well past this 10 s budget.
+    10_000,
+  );
+});

--- a/src/worktree.test.ts
+++ b/src/worktree.test.ts
@@ -13,8 +13,19 @@ vi.mock("node:fs", () => ({
   rmSync: vi.fn(),
 }));
 
+// Tracks how many `withLock` invocations are currently active so tests can
+// assert whether a given git command was issued inside or outside the lock.
+let lockDepth = 0;
+
 vi.mock("./lock.js", () => ({
-  withLock: vi.fn((_path: string, fn: () => unknown) => fn()),
+  withLock: vi.fn((_path: string, fn: () => unknown) => {
+    lockDepth += 1;
+    try {
+      return fn();
+    } finally {
+      lockDepth -= 1;
+    }
+  }),
   repoLockPath: vi.fn(
     (owner: string, repo: string) => `/mock/lock/${owner}/${repo}.lock`,
   ),
@@ -43,6 +54,7 @@ const mockRmSync = vi.mocked(rmSync);
 
 afterEach(() => {
   vi.resetAllMocks();
+  lockDepth = 0;
 });
 
 const home = homedir();
@@ -233,6 +245,46 @@ describe("bootstrapRepo", () => {
     );
     const fetchIdx = calls.findIndex((c) => c[0] === "git" && c[1] === "fetch");
     expect(configSetIdx).toBeLessThan(fetchIdx);
+  });
+
+  test("git fetch runs outside withLock (existing repo)", () => {
+    mockExistsSync.mockReturnValue(true);
+    const fetchLockDepths: number[] = [];
+    const cloneLockDepths: number[] = [];
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        return "+refs/heads/*:refs/remotes/origin/*\n";
+      if (cmd === "git" && args[0] === "fetch") {
+        fetchLockDepths.push(lockDepth);
+      }
+      if (cmd === "git" && args[0] === "clone") {
+        cloneLockDepths.push(lockDepth);
+      }
+      return "" as never;
+    }) as typeof execFileSync);
+    bootstrapRepo("org", "repo");
+    expect(fetchLockDepths).toEqual([0]);
+    expect(cloneLockDepths).toHaveLength(0);
+  });
+
+  test("git clone runs inside withLock and fetch runs outside (missing repo)", () => {
+    mockExistsSync.mockReturnValue(false);
+    const fetchLockDepths: number[] = [];
+    const cloneLockDepths: number[] = [];
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "config" && args.length === 2)
+        throw new Error("key missing");
+      if (cmd === "git" && args[0] === "fetch") {
+        fetchLockDepths.push(lockDepth);
+      }
+      if (cmd === "git" && args[0] === "clone") {
+        cloneLockDepths.push(lockDepth);
+      }
+      return "" as never;
+    }) as typeof execFileSync);
+    bootstrapRepo("org", "repo");
+    expect(cloneLockDepths).toEqual([1]);
+    expect(fetchLockDepths).toEqual([0]);
   });
 
   test("replaces legacy refspec on existing bare repo", () => {
@@ -663,6 +715,66 @@ describe("prepareReviewerWorktree", () => {
       ],
       expect.objectContaining({ cwd: repoPath("org", "repo") }),
     );
+  });
+
+  test("fetch and refresh commands run outside withLock", () => {
+    // Worktree exists and is valid; refresh path succeeds.
+    mockExistsSync.mockReturnValue(true);
+    const fetchLockDepths: number[] = [];
+    const refreshLockDepths: number[] = [];
+    const worktreeAddLockDepths: number[] = [];
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "rev-parse") return "true\n";
+      if (cmd === "git" && args[0] === "fetch") {
+        fetchLockDepths.push(lockDepth);
+      }
+      if (
+        cmd === "git" &&
+        (args[0] === "switch" || args[0] === "reset" || args[0] === "clean")
+      ) {
+        refreshLockDepths.push(lockDepth);
+      }
+      if (cmd === "git" && args[0] === "worktree" && args[1] === "add") {
+        worktreeAddLockDepths.push(lockDepth);
+      }
+      return "" as never;
+    }) as typeof execFileSync);
+
+    prepareReviewerWorktree(baseOpts);
+
+    expect(fetchLockDepths).toEqual([0]);
+    expect(refreshLockDepths).toEqual([0, 0, 0]);
+    // No recreate needed → no `git worktree add` and no lock acquisition.
+    expect(worktreeAddLockDepths).toHaveLength(0);
+  });
+
+  test("recreate path takes withLock around worktree add", () => {
+    mockExistsSync.mockReturnValue(true);
+    const fetchLockDepths: number[] = [];
+    const worktreeAddLockDepths: number[] = [];
+    const worktreeRemoveLockDepths: number[] = [];
+    mockExecFileSync.mockImplementation(((cmd: string, args: string[]) => {
+      if (cmd === "git" && args[0] === "rev-parse") return "true\n";
+      if (cmd === "git" && args[0] === "switch") {
+        throw new Error("refresh failed");
+      }
+      if (cmd === "git" && args[0] === "fetch") {
+        fetchLockDepths.push(lockDepth);
+      }
+      if (cmd === "git" && args[0] === "worktree" && args[1] === "add") {
+        worktreeAddLockDepths.push(lockDepth);
+      }
+      if (cmd === "git" && args[0] === "worktree" && args[1] === "remove") {
+        worktreeRemoveLockDepths.push(lockDepth);
+      }
+      return "" as never;
+    }) as typeof execFileSync);
+
+    prepareReviewerWorktree(baseOpts);
+
+    expect(fetchLockDepths).toEqual([0]);
+    expect(worktreeRemoveLockDepths).toEqual([1]);
+    expect(worktreeAddLockDepths).toEqual([1]);
   });
 
   test("recreates reviewer worktree when existing path is invalid", () => {

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -103,6 +103,14 @@ const EXEC_OPTS: ExecFileSyncOptions = { encoding: "utf-8", stdio: "pipe" };
  * Ensure a bare clone of `owner/repo` exists locally.
  * - Missing → `git clone --bare`
  * - Exists  → `git fetch --all --prune`
+ *
+ * The existence check + `git clone --bare` run under `withLock` so a
+ * sibling dispatch never observes a half-finished bare repo.  The
+ * follow-up `git fetch --all --prune` runs outside the lock — fetch is
+ * safe to run concurrently against the same bare repo (git serialises
+ * ref / packed-refs updates internally) and holding the worktree lock
+ * across a potentially slow or hung fetch would block every sibling
+ * dispatch that only needs `git worktree add`.
  */
 export function bootstrapRepo(owner: string, repo: string): string {
   const dest = repoPath(owner, repo);
@@ -113,25 +121,23 @@ export function bootstrapRepo(owner: string, repo: string): string {
       // Ensure the fetch refspec exists — bare clones (including those
       // created before this fix) lack one, making `git fetch` a no-op.
       ensureFetchRefspec(dest);
-      execFileSync("git", ["fetch", "--all", "--prune"], {
-        ...EXEC_OPTS,
-        cwd: dest,
-      });
-    } else {
-      execFileSync(
-        "git",
-        ["clone", "--bare", `https://github.com/${owner}/${repo}.git`, dest],
-        EXEC_OPTS,
-      );
-      ensureFetchRefspec(dest);
-      // After a bare clone the repo only has refs/heads/*; fetch once
-      // to populate refs/remotes/origin/* so createWorktree() can
-      // reference origin/<baseBranch>.
-      execFileSync("git", ["fetch", "--all", "--prune"], {
-        ...EXEC_OPTS,
-        cwd: dest,
-      });
+      return;
     }
+    execFileSync(
+      "git",
+      ["clone", "--bare", `https://github.com/${owner}/${repo}.git`, dest],
+      EXEC_OPTS,
+    );
+    ensureFetchRefspec(dest);
+  });
+
+  // Fetch outside the lock.  For the existing-repo path this refreshes
+  // remote-tracking refs; for the post-clone path it populates
+  // refs/remotes/origin/* so createWorktree() can reference
+  // origin/<baseBranch>.
+  execFileSync("git", ["fetch", "--all", "--prune"], {
+    ...EXEC_OPTS,
+    cwd: dest,
   });
 
   return dest;
@@ -426,6 +432,15 @@ export function createWorktree(options: {
 /**
  * Create or refresh the detached reviewer worktree on the latest
  * `origin/{authorBranch}`.
+ *
+ * The `git fetch` and the per-worktree refresh commands (`switch
+ * --detach`, `reset --hard`, `clean -fd`) run outside `withLock`:
+ * fetch is safe to run concurrently against the same bare repo, and
+ * the refresh commands only touch this issue's reviewer worktree path,
+ * not shared bare-repo state.  Only the recreate fallback (worktree
+ * remove + `git worktree add --detach`) is taken under `withLock`,
+ * since `git worktree add` on a shared bare repo is the operation
+ * that needs serialisation.
  */
 export function prepareReviewerWorktree(options: {
   owner: string;
@@ -438,38 +453,47 @@ export function prepareReviewerWorktree(options: {
   const wtPath = reviewerWorktreePath(owner, repo, issueNumber);
   const lockPath = repoLockPath(owner, repo);
 
-  withLock(lockPath, () => {
-    execFileSync("git", ["fetch", "origin", authorBranch], {
+  execFileSync("git", ["fetch", "origin", authorBranch], {
+    ...EXEC_OPTS,
+    cwd: bare,
+  });
+
+  const refresh = () => {
+    execFileSync("git", ["switch", "--detach", `origin/${authorBranch}`], {
       ...EXEC_OPTS,
-      cwd: bare,
+      cwd: wtPath,
     });
+    execFileSync("git", ["reset", "--hard", `origin/${authorBranch}`], {
+      ...EXEC_OPTS,
+      cwd: wtPath,
+    });
+    execFileSync("git", ["clean", "-fd"], {
+      ...EXEC_OPTS,
+      cwd: wtPath,
+    });
+  };
 
-    const refresh = () => {
-      execFileSync("git", ["switch", "--detach", `origin/${authorBranch}`], {
-        ...EXEC_OPTS,
-        cwd: wtPath,
-      });
-      execFileSync("git", ["reset", "--hard", `origin/${authorBranch}`], {
-        ...EXEC_OPTS,
-        cwd: wtPath,
-      });
-      execFileSync("git", ["clean", "-fd"], {
-        ...EXEC_OPTS,
-        cwd: wtPath,
-      });
-    };
-
-    if (isValidGitWorktree(wtPath)) {
-      try {
-        refresh();
-        return;
-      } catch {
+  if (isValidGitWorktree(wtPath)) {
+    try {
+      refresh();
+      return wtPath;
+    } catch {
+      withLock(lockPath, () => {
         forceRemoveDetachedWorktree(bare, wtPath);
-      }
-    } else if (existsSync(wtPath)) {
+        execFileSync(
+          "git",
+          ["worktree", "add", "--detach", wtPath, `origin/${authorBranch}`],
+          { ...EXEC_OPTS, cwd: bare },
+        );
+      });
+      return wtPath;
+    }
+  }
+
+  withLock(lockPath, () => {
+    if (existsSync(wtPath)) {
       forceRemoveDetachedWorktree(bare, wtPath);
     }
-
     execFileSync(
       "git",
       ["worktree", "add", "--detach", wtPath, `origin/${authorBranch}`],


### PR DESCRIPTION
## Summary

- Move `git fetch` and the per-worktree refresh (`switch --detach` / `reset --hard` / `clean -fd`) in `prepareReviewerWorktree` out of `withLock`. These don't need shared-state serialisation, so a slow or hung fetch in one dispatch no longer holds the repo lock long enough to trip every sibling dispatch's `MAX_WAIT_MS` (120 s) with `Timed out waiting for repo lock`.
- Move `git fetch --all --prune` in `bootstrapRepo` out of `withLock` (both existing-repo and post-clone paths). Keep the existence-check + `git clone --bare` under the lock so a sibling never sees a half-finished bare repo.
- Keep `withLock` around every `git worktree add` (initial author worktree, conflict-cleanup recreate in `createWorktree`, and the reviewer-recreate fallback in `prepareReviewerWorktree`) — that's the operation the lock was originally introduced for.
- `MAX_WAIT_MS` is unchanged at 120 s. The fix is structural, not a timeout bump.
- Add unit assertions in `src/worktree.test.ts` that fetch / refresh paths run at lock-depth 0 and worktree-add paths run at lock-depth 1.
- Add `src/worktree-concurrency.test.ts`: plant a real held lock file attributed to a live PID and assert `prepareReviewerWorktree` still completes the fetch + refresh path without ever waiting on the lock.
- Add a `CHANGELOG.md` entry under `[Unreleased]` / `### Fixed`.

Closes #336.

## Test plan

- [x] `pnpm vitest run src/worktree.test.ts src/worktree-concurrency.test.ts` passes.
- [x] `pnpm vitest run` (full suite) passes.
- [x] `pnpm tsc --noEmit` passes.
- [x] `pnpm biome check` passes (the pre-existing 2.4.13 vs 2.4.15 schema info is unrelated).
- [x] Unit tests confirm `git fetch` in `bootstrapRepo` (both existing-repo and missing-repo paths) runs at lock-depth 0, while `git clone --bare` runs at lock-depth 1.
- [x] Unit tests confirm `git fetch` and the `switch`/`reset`/`clean` refresh in `prepareReviewerWorktree` run at lock-depth 0.
- [x] Unit test confirms the reviewer-recreate fallback still acquires the lock around `git worktree remove` + `git worktree add`.
- [x] Concurrency regression test confirms a sibling `prepareReviewerWorktree` call completes in well under 5 s even when the repo lock file is held by a live PID — pre-fix this would have blocked for `MAX_WAIT_MS` (120 s) and thrown.
- [x] Spot-check manually: three concurrent dispatches against the same repo run past review Round 3 without `Timed out waiting for repo lock` when one dispatch's fetch is artificially slow. (Programmatically validated by the concurrency regression test — a held lock no longer stalls fetch/refresh.)
- [x] `git worktree add` is still serialised — concurrent dispatches starting simultaneously do not produce the ghost refs that motivated commit `8c239ea`. (Unit tests assert worktree-add commands still run at lock-depth 1 in both `createWorktree` and the reviewer-recreate fallback.)