### PR TITLE
Replace shell spawns with fs equivalents in test (#342)

### DIFF
--- a/src/git-network.test.ts
+++ b/src/git-network.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -71,10 +71,7 @@ describe("spawnWithGroupTimeout", () => {
     // dying state.
     spawnSync("/bin/sleep", ["0.2"]);
 
-    const pid = Number.parseInt(
-      spawnSync("/bin/cat", [pidFile], { encoding: "utf-8" }).stdout.trim(),
-      10,
-    );
+    const pid = Number.parseInt(readFileSync(pidFile, "utf-8").trim(), 10);
     expect(Number.isFinite(pid)).toBe(true);
 
     // `kill -0` returns 0 if the process exists and we have permission
@@ -84,7 +81,7 @@ describe("spawnWithGroupTimeout", () => {
     });
     expect(probe.status).not.toBe(0);
 
-    spawnSync("/bin/rm", ["-f", pidFile]);
+    rmSync(pidFile, { force: true });
   });
 });
 
@@ -122,7 +119,7 @@ describe("gitNetworkExec", () => {
         }),
       ).toThrow(GitNetworkTimeoutError);
     } finally {
-      spawnSync("/bin/rm", ["-rf", dest]);
+      rmSync(dest, { recursive: true, force: true });
     }
   });
 });


### PR DESCRIPTION
## Summary

Resolves the CodeQL "Unnecessary use of `cat` process" alert in `src/git-network.test.ts` by replacing `spawnSync("/bin/cat", ...)` with `fs.readFileSync`. While here, also swap two `spawnSync("/bin/rm", ...)` calls for `rmSync` since `node:fs` is already imported.

Other shell spawns in the file are intentionally left alone:
- `/bin/sleep` — replacing would require converting the test to `async`, more churn than warranted.
- `/bin/kill -0` — no strictly-better `fs`/`child_process` equivalent.
- `git` — out of scope.

Closes #342

## Test plan

- [x] `src/git-network.test.ts` no longer spawns `/bin/cat` or `/bin/rm` (only `/bin/sleep`, `/bin/kill`, `git` remain).
- [x] `pnpm vitest run src/git-network.test.ts` passes, including the descendant-cleanup test.
- [x] `pnpm biome check` is clean.
- [x] `pnpm tsc --noEmit` is clean.
- [x] CodeQL alert https://github.com/aicers/agentcoop/security/code-scanning/1 is resolved on the next scan.