### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-05-17
 
 ### Added
 
@@ -530,6 +530,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Initial public release of AgentCoop.
 
+[0.5.0]: https://github.com/aicers/agentcoop/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/aicers/agentcoop/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/aicers/agentcoop/compare/0.2.0...0.3.0
 [0.2.0]: https://github.com/aicers/agentcoop/compare/0.1.0...0.2.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentcoop",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.4",


### PR DESCRIPTION
## Summary

- Bump `package.json` to `0.5.0`.
- Rename the `[Unreleased]` block in `CHANGELOG.md` to `[0.5.0] - 2026-05-17` and add the `0.4.0...0.5.0` compare link.

The 0.5.0 section captures the changes already merged on `main` since 0.4.0: the terminal tab/window title that reflects the current run (`<owner>/<repo>#<issue>[ (#<pr>)] <stage label>`), the squash-apply startup prompt now defaulting to "ask each time" instead of auto-apply, the `git fetch` / `git clone` hardening against silent dead-TCP hangs, and the repo-lock narrowing so a slow fetch in one dispatch no longer stalls reviewer rounds in sibling dispatches. No content changes — only the section heading is renamed and dated.

## Test plan

- [x] `pnpm check`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm install --frozen-lockfile` (lockfile in sync after the version bump)

Part of #344