### PR TITLE
Honor ciCheckTimeoutMinutes in Stage 9 (#346)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ This file documents recent notable changes to this project. The format of this
 file is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The Done stage (Stage 9) now honors the `ciCheckTimeoutMinutes` setting
+  when polling CI after a rebase or manual conflict resolution.  Previously
+  it always used the built-in 10-minute default, while Stages 7 and 8
+  already obeyed the setting — raising `ciCheckTimeoutMinutes` to 30
+  minutes, for example, extended the CI wait after the review and squash
+  flows but left the rebase flow capped at 10.  All three CI-polling
+  stages now share the same configured timeout.  Closes #346.
+
 ## [0.5.0] - 2026-05-17
 
 ### Added

--- a/src/config.ts
+++ b/src/config.ts
@@ -323,6 +323,23 @@ export function assembleReviewStage<T>(
   };
 }
 
+/**
+ * Assembles the Done stage definition fragment from pipeline settings.
+ *
+ * Stage 9 polls CI after a rebase or manual conflict resolution and
+ * must honor the same `ciCheckTimeoutMinutes` setting that Stages 7
+ * and 8 already use.  Keeps the minutes→ms conversion in one testable
+ * place, matching the pattern used by {@link assembleSquashStage}.
+ */
+export function assembleDoneStage<T>(
+  createHandler: (opts: { pollTimeoutMs: number }) => T,
+  settings: PipelineSettings,
+): T {
+  return createHandler({
+    pollTimeoutMs: settings.ciCheckTimeoutMinutes * 60_000,
+  });
+}
+
 export function saveConfig(config: Config): void {
   const path = configPath();
   mkdirSync(dirname(path), { recursive: true });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -229,6 +229,26 @@ describe("module exports", () => {
     expect(result.name).toBe("Squash");
   });
 
+  test("assembleDoneStage passes pollTimeoutMs to handler", async () => {
+    const { assembleDoneStage, DEFAULT_PIPELINE_SETTINGS } = await import(
+      "../dist/config.js"
+    );
+    // Use a non-default value (the issue's example) to prove that Stage 9
+    // honors `ciCheckTimeoutMinutes` like Stages 7 and 8 already do.
+    const settings = {
+      ...DEFAULT_PIPELINE_SETTINGS,
+      ciCheckTimeoutMinutes: 25,
+    };
+    let receivedOpts: { pollTimeoutMs: number } | undefined;
+    const handlerStub = { name: "Done", number: 9, handler: () => {} };
+    const result = assembleDoneStage((opts: { pollTimeoutMs: number }) => {
+      receivedOpts = opts;
+      return handlerStub;
+    }, settings);
+    expect(receivedOpts).toEqual({ pollTimeoutMs: 25 * 60_000 });
+    expect(result.name).toBe("Done");
+  });
+
   test("assembleReviewStage passes pollTimeoutMs to handler and sets autoBudget", async () => {
     const { assembleReviewStage, DEFAULT_PIPELINE_SETTINGS } = await import(
       "../dist/config.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import { createCodexAdapter } from "./codex-adapter.js";
 import type { NotificationSettings, PipelineSettings } from "./config.js";
 import {
   assembleCiCheckStage,
+  assembleDoneStage,
   assembleReviewStage,
   assembleSquashStage,
   loadConfig,
@@ -928,126 +929,135 @@ try {
     autoResumeAttempts: pipelineSettings.autoResumeAttempts,
   });
 
-  const doneStage = createDoneStageHandler({
-    events: emitter,
-    checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
-    queryPrState: async () => queryPrState(owner, repo, wt.branch),
-    prompt: createDonePromptOptions(() => tuiPrompt),
-    rebaseOntoMain: createRebaseHandler(agentA, defaultBranch),
-    pollCiAndFix: async (ctx) => {
-      return pollCiAndFix({
-        ctx,
-        agent: agentA,
-        issueTitle,
-        issueBody,
-        // Stage 9 bypasses the engine's dispatchError prompt (the
-        // Done stage consumes pollCiAndFix inline), so without this
-        // opt-in prompt the fix-exhausted, pending-timeout, and
-        // agent-error branches would silently end the session.  Ask
-        // the user whether to keep trying — `true` resumes per the
-        // semantics in `ConfirmRetryInfo`; `false` lets cleanup run.
-        confirmRetry: async (info) => {
-          if (!tuiPrompt) return false;
-          return tuiPrompt.confirmCleanup(buildDoneConfirmRetryPrompt(info));
+  const doneStage = assembleDoneStage(
+    ({ pollTimeoutMs }) =>
+      createDoneStageHandler({
+        events: emitter,
+        checkMergeable: async () => checkMergeable(owner, repo, wt.branch),
+        queryPrState: async () => queryPrState(owner, repo, wt.branch),
+        prompt: createDonePromptOptions(() => tuiPrompt),
+        rebaseOntoMain: createRebaseHandler(agentA, defaultBranch),
+        pollCiAndFix: async (ctx) => {
+          return pollCiAndFix({
+            ctx,
+            agent: agentA,
+            issueTitle,
+            issueBody,
+            pollTimeoutMs,
+            // Stage 9 bypasses the engine's dispatchError prompt (the
+            // Done stage consumes pollCiAndFix inline), so without this
+            // opt-in prompt the fix-exhausted, pending-timeout, and
+            // agent-error branches would silently end the session.  Ask
+            // the user whether to keep trying — `true` resumes per the
+            // semantics in `ConfirmRetryInfo`; `false` lets cleanup run.
+            confirmRetry: async (info) => {
+              if (!tuiPrompt) return false;
+              return tuiPrompt.confirmCleanup(
+                buildDoneConfirmRetryPrompt(info),
+              );
+            },
+          });
         },
-      });
-    },
-    cleanup: () => {
-      removeWorktree(owner, repo, issueNumber, wt.branch);
-      removeReviewerWorktree(owner, repo, issueNumber);
-    },
-    stopServices: () => {
-      if (hasDockerComposeRunning(wt.path)) {
-        stopDockerCompose(wt.path);
-      }
-    },
-    hasRunningServices: () => hasDockerComposeRunning(wt.path),
-    getSquashMergeHint: () => {
-      if (runState.squashSubStep !== "applied_via_github") return undefined;
-      const prNum = runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
-      // Read-side: silently degrade to "no comment" on transient
-      // lookup failure; this hint is purely cosmetic and the write
-      // side has its own error-propagating path.
-      let commentBody: string | undefined;
-      if (prNum !== undefined) {
-        try {
-          commentBody = findLatestCommentWithMarker(
-            owner,
-            repo,
-            prNum,
-            SQUASH_SUGGESTION_START_MARKER,
-          )?.body;
-        } catch {
-          commentBody = undefined;
-        }
-      }
-      const suggestion = parseSquashSuggestionBlock(commentBody);
-      const prUrl =
-        prNum !== undefined
-          ? `https://github.com/${owner}/${repo}/pull/${prNum}`
-          : undefined;
-      return {
-        title: suggestion?.title,
-        body: suggestion?.body,
-        prUrl,
-      };
-    },
-    onNotMerged: async (signal) => {
-      if (!tuiPrompt) return;
-      const m = t();
-
-      // Stop docker compose services.
-      if (hasDockerComposeRunning(wt.path)) {
-        const stop = await tuiPrompt.confirmCleanup(
-          m["cleanup.stopDockerCompose"],
-        );
-        if (signal?.aborted) return;
-        if (stop) stopDockerCompose(wt.path);
-      }
-
-      // Delete local worktree and branch.
-      const deleteWt = await tuiPrompt.confirmCleanup(
-        m["cleanup.deleteWorktree"],
-      );
-      if (signal?.aborted) return;
-      if (deleteWt) {
-        removeWorktree(owner, repo, issueNumber, wt.branch);
-        removeReviewerWorktree(owner, repo, issueNumber);
-      }
-
-      // Delete remote branch (only if pushed).
-      if (remoteBranchExists(owner, repo, wt.branch)) {
-        const delRemote = await tuiPrompt.confirmCleanup(
-          m["cleanup.deleteRemoteBranch"](wt.branch),
-        );
-        if (signal?.aborted) return;
-        if (delRemote) {
-          try {
-            deleteRemoteBranch(owner, repo, wt.branch);
-          } catch {
-            // Ignore — branch may already be deleted.
+        cleanup: () => {
+          removeWorktree(owner, repo, issueNumber, wt.branch);
+          removeReviewerWorktree(owner, repo, issueNumber);
+        },
+        stopServices: () => {
+          if (hasDockerComposeRunning(wt.path)) {
+            stopDockerCompose(wt.path);
           }
-        }
-      }
-
-      // Close PR (only if one exists).
-      // Refresh PR number in case it was detected during the pipeline.
-      const prNum = runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
-      if (prNum !== undefined) {
-        const close = await tuiPrompt.confirmCleanup(
-          m["cleanup.closePr"](prNum),
-        );
-        if (signal?.aborted) return;
-        if (close) {
-          try {
-            closePr(owner, repo, prNum);
-          } catch {
-            // Ignore — PR may already be closed or merged.
+        },
+        hasRunningServices: () => hasDockerComposeRunning(wt.path),
+        getSquashMergeHint: () => {
+          if (runState.squashSubStep !== "applied_via_github") return undefined;
+          const prNum =
+            runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
+          // Read-side: silently degrade to "no comment" on transient
+          // lookup failure; this hint is purely cosmetic and the write
+          // side has its own error-propagating path.
+          let commentBody: string | undefined;
+          if (prNum !== undefined) {
+            try {
+              commentBody = findLatestCommentWithMarker(
+                owner,
+                repo,
+                prNum,
+                SQUASH_SUGGESTION_START_MARKER,
+              )?.body;
+            } catch {
+              commentBody = undefined;
+            }
           }
-        }
-      }
-    },
-  });
+          const suggestion = parseSquashSuggestionBlock(commentBody);
+          const prUrl =
+            prNum !== undefined
+              ? `https://github.com/${owner}/${repo}/pull/${prNum}`
+              : undefined;
+          return {
+            title: suggestion?.title,
+            body: suggestion?.body,
+            prUrl,
+          };
+        },
+        onNotMerged: async (signal) => {
+          if (!tuiPrompt) return;
+          const m = t();
+
+          // Stop docker compose services.
+          if (hasDockerComposeRunning(wt.path)) {
+            const stop = await tuiPrompt.confirmCleanup(
+              m["cleanup.stopDockerCompose"],
+            );
+            if (signal?.aborted) return;
+            if (stop) stopDockerCompose(wt.path);
+          }
+
+          // Delete local worktree and branch.
+          const deleteWt = await tuiPrompt.confirmCleanup(
+            m["cleanup.deleteWorktree"],
+          );
+          if (signal?.aborted) return;
+          if (deleteWt) {
+            removeWorktree(owner, repo, issueNumber, wt.branch);
+            removeReviewerWorktree(owner, repo, issueNumber);
+          }
+
+          // Delete remote branch (only if pushed).
+          if (remoteBranchExists(owner, repo, wt.branch)) {
+            const delRemote = await tuiPrompt.confirmCleanup(
+              m["cleanup.deleteRemoteBranch"](wt.branch),
+            );
+            if (signal?.aborted) return;
+            if (delRemote) {
+              try {
+                deleteRemoteBranch(owner, repo, wt.branch);
+              } catch {
+                // Ignore — branch may already be deleted.
+              }
+            }
+          }
+
+          // Close PR (only if one exists).
+          // Refresh PR number in case it was detected during the pipeline.
+          const prNum =
+            runState.prNumber ?? findPrNumber(owner, repo, wt.branch);
+          if (prNum !== undefined) {
+            const close = await tuiPrompt.confirmCleanup(
+              m["cleanup.closePr"](prNum),
+            );
+            if (signal?.aborted) return;
+            if (close) {
+              try {
+                closePr(owner, repo, prNum);
+              } catch {
+                // Ignore — PR may already be closed or merged.
+              }
+            }
+          }
+        },
+      }),
+    pipelineSettings,
+  );
 
   // The `prompt` field is intentionally omitted here — it will be
   // supplied by the ink <App> component via TuiUserPrompt.


### PR DESCRIPTION
## Summary

The Done stage (Stage 9) was ignoring the user-configured `ciCheckTimeoutMinutes` setting when polling CI after a rebase or manual conflict resolution.  It always fell back to `pollCiAndFix`'s built-in 10-minute default, while Stages 7 (review) and 8 (squash) already obeyed the setting via `assembleReviewStage` / `assembleSquashStage`.  Raising `ciCheckTimeoutMinutes` to 30 minutes therefore extended the wait after the review and squash flows but silently capped the rebase flow at 10.

Changes:

- Add `assembleDoneStage` in `src/config.ts`, mirroring `assembleReviewStage` / `assembleSquashStage`, so the minutes-to-ms conversion lives in one testable place.
- Use it to thread `pollTimeoutMs: ciCheckTimeoutMinutes * 60_000` into the Done stage's inline `pollCiAndFix` callback in `src/index.ts`.  The `confirmRetry` wiring stays as-is — Stage 9 still owns its own retry prompt because it bypasses the engine's `dispatchError` fallback.
- Add a unit test that sets `ciCheckTimeoutMinutes: 25` and asserts the assembled handler receives `pollTimeoutMs: 25 * 60_000`.
- Add a `### Changed` entry under `## [Unreleased]` in `CHANGELOG.md`.

Closes #346

## Test plan

- [x] `pnpm tsc --noEmit` passes
- [x] `pnpm biome check` passes on changed files
- [x] `pnpm vitest run` passes (including the new `assembleDoneStage` test)
- [x] With `ciCheckTimeoutMinutes: 25`, the Done stage's CI poll waits up to 25 minutes before triggering the timeout `confirmRetry` prompt
- [x] With the default `ciCheckTimeoutMinutes: 10`, Stage 9 still times out at 10 minutes (no regression)
- [x] Stages 7 and 8 continue to honor the setting unchanged
- [x] On Stage 9 timeout, `buildDoneConfirmRetryPrompt` still fires and answering "yes" resumes polling with the same configured budget